### PR TITLE
chore(gantt): remove redundant Pro Forma Timeline tab

### DIFF
--- a/force-app/main/default/applications/DeliveryHub.app-meta.xml
+++ b/force-app/main/default/applications/DeliveryHub.app-meta.xml
@@ -194,7 +194,6 @@
     <tabs>Delivery_Workspace</tabs>
     <tabs>Delivery_Board</tabs>
     <tabs>Delivery_Timeline</tabs>
-    <tabs>Delivery_Pro_Forma_Timeline</tabs>
     <tabs>Delivery_Activity</tabs>
     <tabs>WorkItem__c</tabs>
     <tabs>WorkItemComment__c</tabs>

--- a/force-app/main/default/tabs/Delivery_Pro_Forma_Timeline.tab-meta.xml
+++ b/force-app/main/default/tabs/Delivery_Pro_Forma_Timeline.tab-meta.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
-    <description>Priority-grouped pro forma delivery timeline (NOW · NEXT · PLANNED · PROPOSED · HOLD)</description>
-    <label>Pro Forma Timeline</label>
-    <lwcComponent>deliveryProFormaTimeline</lwcComponent>
-    <motif>Custom67: Gears</motif>
-</CustomTab>


### PR DESCRIPTION
## Summary
- Removes the `Delivery_Pro_Forma_Timeline` tab (created during v10 port for testing) and its reference in the DeliveryHub app
- Both tabs pointed at the same `deliveryProFormaTimeline` LWC — only differences were DeveloperName/label/description
- Legacy `Delivery_Timeline` tab remains as the canonical entry point

## Test plan
- [ ] PMD green
- [ ] feature-test green
- [ ] Verify in scratch: DeliveryHub app shows single "Timeline" tab, no "Pro Forma Timeline" entry
- [ ] Verify `<c-delivery-pro-forma-timeline>` embed in Workspace still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)