### PR TITLE
feat(gantt): standalone Gantt app — chromeless URL-addressable view

### DIFF
--- a/force-app/main/default/applications/DeliveryGanttStandalone.app-meta.xml
+++ b/force-app/main/default/applications/DeliveryGanttStandalone.app-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomApplication xmlns="http://soap.sforce.com/2006/04/metadata">
+    <brand>
+        <headerColor>#1A2D4A</headerColor>
+        <shouldOverrideOrgTheme>true</shouldOverrideOrgTheme>
+    </brand>
+    <description>Standalone Lightning App that surfaces only the Pro Forma Timeline gantt. No utility bar, no secondary tabs, no App Launcher clutter — minimum Salesforce chrome for a near-fullscreen Gantt experience. Combined with the in-app Fullscreen toggle, this gives users a bookmarkable URL to land directly on the timeline.</description>
+    <formFactors>Large</formFactors>
+    <isNavAutoTempTabsDisabled>true</isNavAutoTempTabsDisabled>
+    <isNavPersonalizationDisabled>true</isNavPersonalizationDisabled>
+    <isNavTabPersistenceDisabled>true</isNavTabPersistenceDisabled>
+    <isOmniPinnedViewEnabled>false</isOmniPinnedViewEnabled>
+    <label>Delivery Gantt Standalone</label>
+    <navType>Standard</navType>
+    <tabs>Delivery_Gantt_Standalone</tabs>
+    <uiType>Lightning</uiType>
+</CustomApplication>

--- a/force-app/main/default/applications/DeliveryGanttStandalone.app-meta.xml
+++ b/force-app/main/default/applications/DeliveryGanttStandalone.app-meta.xml
@@ -4,7 +4,7 @@
         <headerColor>#1A2D4A</headerColor>
         <shouldOverrideOrgTheme>true</shouldOverrideOrgTheme>
     </brand>
-    <description>Standalone Lightning App that surfaces only the Pro Forma Timeline gantt. No utility bar, no secondary tabs, no App Launcher clutter — minimum Salesforce chrome for a near-fullscreen Gantt experience. Combined with the in-app Fullscreen toggle, this gives users a bookmarkable URL to land directly on the timeline.</description>
+    <description>Minimum-chrome standalone Lightning App for the Pro Forma Timeline gantt. No utility bar, no secondary tabs. URL: /lightning/n/Delivery_Gantt_Standalone.</description>
     <formFactors>Large</formFactors>
     <isNavAutoTempTabsDisabled>true</isNavAutoTempTabsDisabled>
     <isNavPersonalizationDisabled>true</isNavPersonalizationDisabled>

--- a/force-app/main/default/flexipages/Delivery_Gantt_Standalone.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Delivery_Gantt_Standalone.flexipage-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FlexiPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Single-region App Page hosting the Pro Forma Timeline gantt full-bleed — consumed by the Delivery Gantt Standalone app for a chromeless URL-addressable view.</description>
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentName>deliveryProFormaTimeline</componentName>
+                <identifier>c_deliveryProFormaTimeline</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>main</name>
+        <type>Region</type>
+    </flexiPageRegions>
+    <masterLabel>Gantt (Standalone)</masterLabel>
+    <template>
+        <name>flexipage:defaultAppHomeTemplate</name>
+    </template>
+    <type>AppPage</type>
+</FlexiPage>

--- a/force-app/main/default/tabs/Delivery_Gantt_Standalone.tab-meta.xml
+++ b/force-app/main/default/tabs/Delivery_Gantt_Standalone.tab-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Standalone, chromeless entry point for the Pro Forma Timeline gantt. Surfaced only via the Delivery Gantt Standalone app — URL-addressable at /lightning/n/Delivery_Gantt_Standalone.</description>
+    <flexiPage>Delivery_Gantt_Standalone</flexiPage>
+    <label>Gantt</label>
+    <motif>Custom67: Gears</motif>
+</CustomTab>


### PR DESCRIPTION
## Summary
- Adds a minimum-chrome Lightning App (`Delivery_Gantt_Standalone`) that surfaces only the Pro Forma Timeline gantt
- URL: `/lightning/n/Delivery_Gantt_Standalone` — bookmarkable, shareable, single-purpose
- No utility bar, no secondary tabs, no App Launcher clutter. Combined with the existing in-gantt Fullscreen button, this gives users a one-click path to near-fullscreen

## Metadata added
- `flexipages/Delivery_Gantt_Standalone.flexipage-meta.xml` — AppPage, single `main` region hosting `deliveryProFormaTimeline`
- `tabs/Delivery_Gantt_Standalone.tab-meta.xml` — FlexiPage-backed tab
- `applications/DeliveryGanttStandalone.app-meta.xml` — CustomApplication, `navType=Standard`, single tab, no `<utilityBar>`, `formFactors=Large`

## Test plan
- [ ] PMD green
- [ ] feature-test green (deploys the three new metadata files)
- [ ] Post-merge: install release, open App Launcher, verify "Delivery Gantt Standalone" app is visible
- [ ] Open `/lightning/n/Delivery_Gantt_Standalone` and verify: no utility bar, no other nav tabs, gantt renders full-width
- [ ] Click the in-gantt Fullscreen button — verify it still escapes the remaining Lightning header chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)