### PR TITLE
Add WorkItem.AdditionalParentIdsJson__c for DAG parenting

### DIFF
--- a/force-app/main/default/classes/DeliveryPortalController.cls
+++ b/force-app/main/default/classes/DeliveryPortalController.cls
@@ -156,7 +156,7 @@ global without sharing class DeliveryPortalController {
                        CreatedDate, EstimatedStartDevDate__c, EstimatedEndDevDate__c,
                        ProjectedUATReadyDate__c, EstimatedHoursNumber__c, TotalLoggedHoursSum__c,
                        DeveloperLookup__c, DeveloperLookup__r.Name,
-                       ParentWorkItemLookup__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
+                       ParentWorkItemLookup__c, AdditionalParentIdsJson__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
                 FROM WorkItem__c
                 WHERE ClientNetworkEntityLookup__c = :networkEntityId
                 AND StageNamePk__c IN :terminalStages
@@ -171,7 +171,7 @@ global without sharing class DeliveryPortalController {
                        CreatedDate, EstimatedStartDevDate__c, EstimatedEndDevDate__c,
                        ProjectedUATReadyDate__c, EstimatedHoursNumber__c, TotalLoggedHoursSum__c,
                        DeveloperLookup__c, DeveloperLookup__r.Name,
-                       ParentWorkItemLookup__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
+                       ParentWorkItemLookup__c, AdditionalParentIdsJson__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
                 FROM WorkItem__c
                 WHERE ClientNetworkEntityLookup__c = :networkEntityId
                 AND StageNamePk__c IN :attentionStages
@@ -186,7 +186,7 @@ global without sharing class DeliveryPortalController {
                        CreatedDate, EstimatedStartDevDate__c, EstimatedEndDevDate__c,
                        ProjectedUATReadyDate__c, EstimatedHoursNumber__c, TotalLoggedHoursSum__c,
                        DeveloperLookup__c, DeveloperLookup__r.Name,
-                       ParentWorkItemLookup__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
+                       ParentWorkItemLookup__c, AdditionalParentIdsJson__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
                 FROM WorkItem__c
                 WHERE ClientNetworkEntityLookup__c = :networkEntityId
                 AND StageNamePk__c NOT IN :terminalStages
@@ -201,7 +201,7 @@ global without sharing class DeliveryPortalController {
                        CreatedDate, EstimatedStartDevDate__c, EstimatedEndDevDate__c,
                        ProjectedUATReadyDate__c, EstimatedHoursNumber__c, TotalLoggedHoursSum__c,
                        DeveloperLookup__c, DeveloperLookup__r.Name,
-                       ParentWorkItemLookup__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
+                       ParentWorkItemLookup__c, AdditionalParentIdsJson__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
                 FROM WorkItem__c
                 WHERE ClientNetworkEntityLookup__c = :networkEntityId
                 WITH SYSTEM_MODE
@@ -227,6 +227,7 @@ global without sharing class DeliveryPortalController {
             m.put('loggedHours', wi.TotalLoggedHoursSum__c);
             m.put('developerName', wi.DeveloperLookup__c != null ? wi.DeveloperLookup__r.Name : null);
             m.put('parentWorkItemId', wi.ParentWorkItemLookup__c);
+            m.put('additionalParentIds', parseAdditionalParents(wi.AdditionalParentIdsJson__c));
             m.put('tags', wi.TagsTxt__c);
             m.put('epic', wi.EpicTxt__c);
             result.add(m);
@@ -434,6 +435,35 @@ global without sharing class DeliveryPortalController {
      * @param maxLength Maximum character length
      * @return Truncated plain text string
      */
+    /**
+     * Parse AdditionalParentIdsJson__c into a List<String>. Returns empty list
+     * if blank or malformed. Only 18-char SF Ids are passed through; other
+     * entries are dropped silently so bad data can't poison the response.
+     */
+    private static List<String> parseAdditionalParents(String json) {
+        if (String.isBlank(json)) {
+            return new List<String>();
+        }
+        try {
+            Object parsed = JSON.deserializeUntyped(json);
+            if (!(parsed instanceof List<Object>)) {
+                return new List<String>();
+            }
+            List<String> out = new List<String>();
+            for (Object o : (List<Object>) parsed) {
+                if (o instanceof String) {
+                    String s = (String) o;
+                    if (s.length() == 15 || s.length() == 18) {
+                        out.add(s);
+                    }
+                }
+            }
+            return out;
+        } catch (Exception e) {
+            return new List<String>();
+        }
+    }
+
     private static String truncateText(String text, Integer maxLength) {
         if (String.isBlank(text)) {
             return '';

--- a/force-app/main/default/classes/DeliveryPortalController.cls
+++ b/force-app/main/default/classes/DeliveryPortalController.cls
@@ -156,7 +156,7 @@ global without sharing class DeliveryPortalController {
                        CreatedDate, EstimatedStartDevDate__c, EstimatedEndDevDate__c,
                        ProjectedUATReadyDate__c, EstimatedHoursNumber__c, TotalLoggedHoursSum__c,
                        DeveloperLookup__c, DeveloperLookup__r.Name,
-                       ParentWorkItemLookup__c, AdditionalParentIdsJson__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
+                       ParentWorkItemLookup__c, AdditionalParentIdsTxt__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
                 FROM WorkItem__c
                 WHERE ClientNetworkEntityLookup__c = :networkEntityId
                 AND StageNamePk__c IN :terminalStages
@@ -171,7 +171,7 @@ global without sharing class DeliveryPortalController {
                        CreatedDate, EstimatedStartDevDate__c, EstimatedEndDevDate__c,
                        ProjectedUATReadyDate__c, EstimatedHoursNumber__c, TotalLoggedHoursSum__c,
                        DeveloperLookup__c, DeveloperLookup__r.Name,
-                       ParentWorkItemLookup__c, AdditionalParentIdsJson__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
+                       ParentWorkItemLookup__c, AdditionalParentIdsTxt__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
                 FROM WorkItem__c
                 WHERE ClientNetworkEntityLookup__c = :networkEntityId
                 AND StageNamePk__c IN :attentionStages
@@ -186,7 +186,7 @@ global without sharing class DeliveryPortalController {
                        CreatedDate, EstimatedStartDevDate__c, EstimatedEndDevDate__c,
                        ProjectedUATReadyDate__c, EstimatedHoursNumber__c, TotalLoggedHoursSum__c,
                        DeveloperLookup__c, DeveloperLookup__r.Name,
-                       ParentWorkItemLookup__c, AdditionalParentIdsJson__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
+                       ParentWorkItemLookup__c, AdditionalParentIdsTxt__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
                 FROM WorkItem__c
                 WHERE ClientNetworkEntityLookup__c = :networkEntityId
                 AND StageNamePk__c NOT IN :terminalStages
@@ -201,7 +201,7 @@ global without sharing class DeliveryPortalController {
                        CreatedDate, EstimatedStartDevDate__c, EstimatedEndDevDate__c,
                        ProjectedUATReadyDate__c, EstimatedHoursNumber__c, TotalLoggedHoursSum__c,
                        DeveloperLookup__c, DeveloperLookup__r.Name,
-                       ParentWorkItemLookup__c, AdditionalParentIdsJson__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
+                       ParentWorkItemLookup__c, AdditionalParentIdsTxt__c, TagsTxt__c, EpicTxt__c, SLATargetDate__c
                 FROM WorkItem__c
                 WHERE ClientNetworkEntityLookup__c = :networkEntityId
                 WITH SYSTEM_MODE
@@ -227,7 +227,7 @@ global without sharing class DeliveryPortalController {
             m.put('loggedHours', wi.TotalLoggedHoursSum__c);
             m.put('developerName', wi.DeveloperLookup__c != null ? wi.DeveloperLookup__r.Name : null);
             m.put('parentWorkItemId', wi.ParentWorkItemLookup__c);
-            m.put('additionalParentIds', parseAdditionalParents(wi.AdditionalParentIdsJson__c));
+            m.put('additionalParentIds', parseAdditionalParents(wi.AdditionalParentIdsTxt__c));
             m.put('tags', wi.TagsTxt__c);
             m.put('epic', wi.EpicTxt__c);
             result.add(m);
@@ -436,9 +436,12 @@ global without sharing class DeliveryPortalController {
      * @return Truncated plain text string
      */
     /**
-     * Parse AdditionalParentIdsJson__c into a List<String>. Returns empty list
-     * if blank or malformed. Only 18-char SF Ids are passed through; other
-     * entries are dropped silently so bad data can't poison the response.
+     * @description Parse AdditionalParentIdsTxt__c into a List<String>. Only 15- or 18-char
+     * Salesforce Ids are passed through; other entries are dropped silently so malformed
+     * input can't poison the REST response. Returns an empty list when the field is blank
+     * or parsing fails.
+     * @param json Raw JSON array string from AdditionalParentIdsTxt__c.
+     * @return List of valid SF Id strings; empty if blank, malformed, or no valid Ids found.
      */
     private static List<String> parseAdditionalParents(String json) {
         if (String.isBlank(json)) {

--- a/force-app/main/default/classes/DeliveryPortalController.cls
+++ b/force-app/main/default/classes/DeliveryPortalController.cls
@@ -440,15 +440,15 @@ global without sharing class DeliveryPortalController {
      * Salesforce Ids are passed through; other entries are dropped silently so malformed
      * input can't poison the REST response. Returns an empty list when the field is blank
      * or parsing fails.
-     * @param json Raw JSON array string from AdditionalParentIdsTxt__c.
+     * @param jsonText Raw JSON array string from AdditionalParentIdsTxt__c.
      * @return List of valid SF Id strings; empty if blank, malformed, or no valid Ids found.
      */
-    private static List<String> parseAdditionalParents(String json) {
-        if (String.isBlank(json)) {
+    private static List<String> parseAdditionalParents(String jsonText) {
+        if (String.isBlank(jsonText)) {
             return new List<String>();
         }
         try {
-            Object parsed = JSON.deserializeUntyped(json);
+            Object parsed = JSON.deserializeUntyped(jsonText);
             if (!(parsed instanceof List<Object>)) {
                 return new List<String>();
             }

--- a/force-app/main/default/objects/WorkItem__c/fields/AdditionalParentIdsJson__c.field-meta.xml
+++ b/force-app/main/default/objects/WorkItem__c/fields/AdditionalParentIdsJson__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AdditionalParentIdsJson__c</fullName>
+    <description>DAG: JSON array of additional parent WorkItem Ids beyond ParentWorkItemLookup__c. Enables a single work item to roll up under multiple logical parents (e.g. multiple proposals/groupings). Not a lookup — stored as a JSON array of 18-char Ids because Salesforce multi-select lookups to self require a junction object.</description>
+    <inlineHelpText>JSON array of WorkItem Ids, e.g. ["a0B...","a0B..."]. Used by the Gantt framework to roll up this item under multiple proposal parents. Leave blank for items with a single parent.</inlineHelpText>
+    <externalId>false</externalId>
+    <label>Additional Parent Ids (JSON)</label>
+    <length>4000</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/WorkItem__c/fields/AdditionalParentIdsTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/WorkItem__c/fields/AdditionalParentIdsTxt__c.field-meta.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>AdditionalParentIdsJson__c</fullName>
+    <fullName>AdditionalParentIdsTxt__c</fullName>
     <description>DAG: JSON array of additional parent WorkItem Ids beyond ParentWorkItemLookup__c. Enables a single work item to roll up under multiple logical parents (e.g. multiple proposals/groupings). Not a lookup — stored as a JSON array of 18-char Ids because Salesforce multi-select lookups to self require a junction object.</description>
     <inlineHelpText>JSON array of WorkItem Ids, e.g. ["a0B...","a0B..."]. Used by the Gantt framework to roll up this item under multiple proposal parents. Leave blank for items with a single parent.</inlineHelpText>
     <externalId>false</externalId>
-    <label>Additional Parent Ids (JSON)</label>
+    <label>Additional Parent Ids</label>
     <length>4000</length>
     <required>false</required>
     <trackTrending>false</trackTrending>


### PR DESCRIPTION
## Summary

Adds `WorkItem__c.AdditionalParentIdsJson__c` (LongTextArea, 4000 chars) so a single work item can roll up under multiple logical parents — e.g. one item shared across multiple proposals in the framework Gantt.

Rendering tree in nimbus-gantt keeps using `ParentWorkItemLookup__c` as the single rendering parent; `additionalParentIds` is a logical overlay consumed by hour rollups, dependency walkers, and the scheduler.

- New field: `AdditionalParentIdsJson__c` on WorkItem__c (JSON array of 15/18-char SF Ids)
- `DeliveryPortalController.getPortalWorkItems` now parses the JSON and emits `additionalParentIds[]` on each row
- `parseAdditionalParents` helper tolerates blank/malformed JSON — bad data can't poison the response

## Why JSON, not a junction object

Junction is better for reporting joins. JSON is faster to ship and matches the scale (hundreds of items, not millions). Can migrate to a junction later without breaking the REST shape — the client already reads `additionalParentIds[]` as an array.

## Test plan
- [ ] Deploy to a scratch org
- [ ] Verify field appears on WorkItem layout
- [ ] Populate with `["a0B...","a0B..."]` on one record
- [ ] Hit `/services/apexrest/delivery/deliveryhub/v1/api/work-items` and confirm `additionalParentIds` appears in response
- [ ] Populate with malformed JSON — confirm response still returns (empty array, no 500)
- [ ] PMD + feature-test CI gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)