### PR TITLE
fix(gantt): force-rebuild to break SF static-resource dedup

### DIFF
--- a/force-app/main/default/staticresources/nimbusganttapp.resource
+++ b/force-app/main/default/staticresources/nimbusganttapp.resource
@@ -2989,3 +2989,5 @@ var NimbusGanttApp = function(exports) {
   return exports;
 }({});
 typeof window !== "undefined" && (window.NimbusGanttApp = NimbusGanttApp.NimbusGanttApp || NimbusGanttApp);
+
+/* force-rebuild-0.179 — breaks SF package content-hash dedup that silently kept 0.178 serving the pre-#635 bundle */


### PR DESCRIPTION
## Summary
Appends a trailing comment to `nimbusganttapp.resource` to change its content hash. Zero functional code change.

## Why
`release/0.178.0.1` git tag points at the correct 120,916-byte bundle (post-PR #635), but the installed package on MF-Prod/Nimba/dh-prod serves the **stale 165,209-byte bundle** from the 0.177 era. Confirmed by `sf project retrieve StaticResource:nimbusganttapp` → MD5 mismatch against `main` HEAD.

Net effect on MF-Prod today: the Gantt renders, but without title bar, filter row, view-mode tabs, HRS/WK strip, or audit panel — all the v10 parity work in #635 is missing despite the package being labeled 0.178.

Salesforce's 2GP packaging appears to dedup static resources by content hash across versions. For whatever reason, PR #635's bundle upload got skipped at package build time, so 0.178's static-resource pointer resolves to an older blob. Forcing a fresh hash should break the dedup on next release.

## Test plan
- [ ] PMD green (no Apex/LWC changes, should be instant)
- [ ] feature-test green
- [ ] Post-release: install 0.179 on Nimba sandbox, retrieve `StaticResource:nimbusganttapp`, verify size = **121,037 bytes** (not 120,916 and NOT 165,209)
- [ ] Hard-reload `/lightning/n/delivery__Delivery_Timeline` — verify full v10 chrome is back (title bar, filter row, view tabs, HRS/WK, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)