### PR TITLE
fix(gantt): force-rebuild cloudnimbustemplatecss — second dedup victim

### DIFF
--- a/force-app/main/default/staticresources/cloudnimbustemplatecss.resource
+++ b/force-app/main/default/staticresources/cloudnimbustemplatecss.resource
@@ -799,3 +799,5 @@
           animation: mf-depth-check 0.001s linear 1 !important;
         }
       
+
+/* force-rebuild-0.180 — break SF package static-resource dedup (cloudnimbustemplatecss missed PR #635/#636 hash update) */


### PR DESCRIPTION
## Summary
Companion to merged PR #636. That PR force-hashed `nimbusganttapp.resource` to break Salesforce's 2GP static-resource content-hash dedup. `cloudnimbustemplatecss.resource` was ALSO updated in PR #635 and hit the same dedup trap — subscriber orgs still serve the old CSS blob.

Appends a trailing `/* ... */` CSS comment. Zero functional change. Just forces a new content hash so Salesforce takes the new blob on next package version.

## Evidence
Just retrieved both resources from MF-Prod post-0.179 install:

| File | MF-Prod | Repo (main) | Match? |
|---|---|---|---|
| `nimbusganttapp.resource` | 121,037 B | 121,037 B | ✅ MD5 match |
| `cloudnimbustemplatecss.resource` | **47,204 B** | **48,005 B** | ❌ stale |

Without the new CSS, the template's chrome slots (`.nga-titleBar`, `.nga-filterBar`, `.nga-viewTabs`, `.nga-hrsWkStrip`, `.nga-auditPanel`) render in the DOM but have no display rules → invisible → you see "stripped Gantt" on MF-Prod despite the JS bundle being correct.

## Test plan
- [ ] PMD green
- [ ] feature-test green
- [ ] Post-release: install 0.180 on Nimba sandbox (canary), retrieve `StaticResource:delivery__cloudnimbustemplatecss`, confirm size = **48,132 B** (not 47,204)
- [ ] Hard-reload `/lightning/n/delivery__Delivery_Timeline`, verify full v10 chrome is visible (title bar, view tabs, filter row, HRS/WK strip, audit panel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)