### PR TITLE
fix(staticresources): swap nimbusganttapp.resource to 2a2af31 (0.181 cut)

### DIFF
--- a/force-app/main/default/staticresources/nimbusganttapp.resource
+++ b/force-app/main/default/staticresources/nimbusganttapp.resource
@@ -2723,7 +2723,6 @@ var NimbusGanttApp = (function(exports) {
     });
     container.appendChild(wrap);
   }
-  let mountSeq = 0;
   const registry = [];
   function getEntry(c) {
     return registry.find((e) => e.container === c) || null;
@@ -2780,15 +2779,9 @@ var NimbusGanttApp = (function(exports) {
       IIFEApp.unmount(container);
       const templateName = options.template || "cloudnimbus";
       const mode = options.mode || "fullscreen";
-      const containerId = "nga-" + ++mountSeq;
-      try {
-        container.setAttribute("data-nga-id", containerId);
-      } catch (_e2) {
-      }
       try {
         const r = container.getBoundingClientRect();
         diag("mount:start", {
-          containerId,
           containerRect: { x: r.x, y: r.y, w: r.width, h: r.height },
           mode,
           engineVersion: options.engine && options.engine.version || "unknown",
@@ -2844,12 +2837,11 @@ var NimbusGanttApp = (function(exports) {
         const _win = typeof window !== "undefined" ? window : null;
         const eng = options.engine ?? (_win == null ? void 0 : _win.NimbusGantt) ?? null;
         if (!eng || !eng.NimbusGantt) {
-          diag("err:engine-missing", { containerId, path: "engineOnly" });
           ganttEl.style.cssText += ";padding:20px;color:#b91c1c;font-size:13px";
           ganttEl.textContent = "nimbus-gantt engine not loaded";
           registry.push({ container, cleanup: () => {
             container.innerHTML = "";
-          }, hadGantt: false, mode, containerId });
+          } });
           return { setTasks: () => {
           }, destroy: () => IIFEApp.unmount(container) };
         }
@@ -2979,57 +2971,7 @@ var NimbusGanttApp = (function(exports) {
           }
           container.innerHTML = "";
         };
-        registry.push({ container, cleanup: cleanup2, hadGantt: true, mode, containerId });
-        try {
-          const raf = typeof requestAnimationFrame === "function" ? requestAnimationFrame : (fn) => setTimeout(() => fn(Date.now()), 16);
-          raf(() => {
-            try {
-              const measure = (sel) => {
-                const e = container.querySelector(sel);
-                return e ? Math.round(e.getBoundingClientRect().height) : 0;
-              };
-              diag("mount:chrome-heights", {
-                containerId,
-                engineOnly: true,
-                root: Math.round(container.getBoundingClientRect().height),
-                titlebar: measure(".nga-titlebar"),
-                stats: measure(".nga-stats"),
-                filterbar: measure(".nga-filterbar"),
-                zoombar: measure(".nga-zoombar"),
-                audit: measure(".nga-audit"),
-                hrswkstrip: measure(".nga-hrswkstrip"),
-                contentOuter: measure(".nga-content-outer"),
-                content: measure(".nga-content")
-              });
-              const canvasEl = ganttEl.querySelector("canvas");
-              if (canvasEl) {
-                diag("mount:init-gantt", {
-                  containerId,
-                  engineOnly: true,
-                  canvasW: canvasEl.width,
-                  canvasH: canvasEl.height,
-                  cssW: Math.round(canvasEl.getBoundingClientRect().width),
-                  cssH: Math.round(canvasEl.getBoundingClientRect().height)
-                });
-                if (canvasEl.height < 64) {
-                  diag("warn:zero-height", { containerId, surface: "canvas", canvasH: canvasEl.height });
-                }
-              } else {
-                diag("warn:no-canvas", { containerId });
-              }
-              const durationMs = (typeof performance !== "undefined" && performance.now ? performance.now() : Date.now()) - mountStartedAt;
-              diag("mount:complete", {
-                containerId,
-                engineOnly: true,
-                taskCount: allTasks2.length,
-                durationMs: Math.round(durationMs)
-              });
-            } catch (err) {
-              diag("err:post-mount", { containerId, message: (err == null ? void 0 : err.message) || String(err) });
-            }
-          });
-        } catch (_e2) {
-        }
+        registry.push({ container, cleanup: cleanup2 });
         return {
           setTasks(tasks) {
             allTasks2 = tasks;
@@ -3077,7 +3019,6 @@ var NimbusGanttApp = (function(exports) {
       container.style.background = tplConfig.theme.bg;
       container.style.fontFamily = tplConfig.theme.fontFamily;
       diag("mount:styles-applied", {
-        containerId,
         propsWritten: ["display", "flex-direction", "overflow", "background", "font-family"],
         preservedConsumer: {
           height: container.style.height || "(inherits)",
@@ -3085,7 +3026,7 @@ var NimbusGanttApp = (function(exports) {
           position: container.style.position || "(inherits)"
         }
       });
-      diag("mount:data-mode", { containerId, mode });
+      diag("mount:data-mode", { mode });
       const _patchRefreshTimer = { t: null };
       const rawOnPatch = options.onPatch || (() => {
       });
@@ -3197,7 +3138,6 @@ var NimbusGanttApp = (function(exports) {
         var _a2;
         const eng = resolveEngine();
         if (!eng || !eng.NimbusGantt) {
-          diag("err:engine-missing", { containerId, path: "chrome" });
           host.style.cssText = "padding:20px;color:#b91c1c;font-size:13px";
           host.textContent = "nimbus-gantt engine not loaded";
           return;
@@ -3378,7 +3318,6 @@ var NimbusGanttApp = (function(exports) {
         const renderedSlots = [];
         slotInstances.forEach((_inst, name) => renderedSlots.push(name));
         diag("mount:slots-rendered", {
-          containerId,
           slotOrder: SLOT_ORDER,
           rendered: renderedSlots,
           features: tplConfig.features
@@ -3395,8 +3334,6 @@ var NimbusGanttApp = (function(exports) {
               return elSel ? Math.round(elSel.getBoundingClientRect().height) : 0;
             };
             diag("mount:chrome-heights", {
-              containerId,
-              engineOnly: false,
               root: Math.round(container.getBoundingClientRect().height),
               titlebar: measure(".nga-titlebar"),
               stats: measure(".nga-stats"),
@@ -3410,30 +3347,24 @@ var NimbusGanttApp = (function(exports) {
             const canvasEl = container.querySelector("canvas");
             if (canvasEl) {
               diag("mount:init-gantt", {
-                containerId,
-                engineOnly: false,
                 canvasW: canvasEl.width,
                 canvasH: canvasEl.height,
                 cssW: Math.round(canvasEl.getBoundingClientRect().width),
                 cssH: Math.round(canvasEl.getBoundingClientRect().height)
-                // pxPerWeek / visibleWeeks are engine-internal; omitted until
-                // the engine exposes a getState() surface.
               });
               if (canvasEl.height < 64) {
-                diag("warn:zero-height", { containerId, surface: "canvas", canvasH: canvasEl.height });
+                diag("warn:zero-height", { surface: "canvas", canvasH: canvasEl.height });
               }
             } else {
-              diag("warn:no-canvas", { containerId });
+              diag("warn:no-canvas", {});
             }
             const durationMs = (typeof performance !== "undefined" && performance.now ? performance.now() : Date.now()) - mountStartedAt;
             diag("mount:complete", {
-              containerId,
-              engineOnly: false,
               taskCount: allTasks.length,
               durationMs: Math.round(durationMs)
             });
           } catch (err) {
-            diag("err:post-mount", { containerId, message: (err == null ? void 0 : err.message) || String(err) });
+            diag("err:post-mount", { message: (err == null ? void 0 : err.message) || String(err) });
           }
         });
       } catch (_e2) {
@@ -3466,7 +3397,7 @@ var NimbusGanttApp = (function(exports) {
         } catch (_e2) {
         }
       };
-      registry.push({ container, cleanup, hadGantt: true, mode, containerId });
+      registry.push({ container, cleanup });
       return {
         setTasks(tasks) {
           allTasks = tasks;
@@ -3479,21 +3410,12 @@ var NimbusGanttApp = (function(exports) {
       };
     }
     static unmount(container) {
-      var _a;
       const e = getEntry(container);
-      const hadGantt = (e == null ? void 0 : e.hadGantt) ?? false;
-      const mode = (e == null ? void 0 : e.mode) ?? "unknown";
-      const containerId = (e == null ? void 0 : e.containerId) ?? (((_a = container.getAttribute) == null ? void 0 : _a.call(container, "data-nga-id")) || "unknown");
       if (e) {
         if (e.cleanup) e.cleanup();
         removeEntry(container);
       }
       container.innerHTML = "";
-      try {
-        container.removeAttribute("data-nga-id");
-      } catch (_err) {
-      }
-      diag("unmount", { containerId, hadGantt, mode });
     }
   }
   const NimbusGanttApp2 = {


### PR DESCRIPTION
## Summary
Single-file swap: replace the broken `3ffd7d3` bundle (landed in main via PR #639's premature squash-merge `3ed0e42f`) with the clean `2a2af31` bundle.

**`2a2af31` is bit-identical to the `31c066f` bisect baseline** that HQ green-lit via HEALTH_CHECK on scratch deploy `0AfO300000eLC7BKAW`. Just without the `[NGA FS-DIAG]` diagnostic-trace noise from `33896c3`.

## Why this PR supersedes #640

PR #640 carried 6 iteration commits from the debug cycle (bisect → diag-trace → clean). Rebasing on main produced conflicts because main already squash-merged the 4 earlier commits. Fresh branch off main with just the single-byte-delta is cleaner + mergeable.

PR #640 closed; this PR #641 [UPDATE ME] is the cut path.

## Empirical verification (pre-commit)
- Source `C:/Projects/nimbus-gantt/packages/app/dist/nimbus-gantt-app.iife.js`:
  - 141,106 B
  - sha256 `6e2e777514ce9c6c22cbcecf6c4b9b1e426d0a7c97dcae603b029bc0437102a5`
- Post-copy to `force-app/.../nimbusganttapp.resource`: same hash via both `sha256sum` + PowerShell `Get-FileHash`
- Already deployed to scratch `Delivery Hub__dev` via bisect cycle — HQ confirmed Standalone mounts fine (the earlier "crash" was a shallow-selector probe error)

## 0.181 content (consolidated from all iteration commits)
- Phase 0.5 mode prop + host-nav callbacks (`fa6a25e`)
- AuditPanel dedup + critical flex CSS (`c9c765d`)
- Non-destructive mount + fullscreen viewport floor (`330eba7`)
- Zoombar dedup (`2683542`)
- Opt-in diagnostic emitter v1 (`b202a85`)
- A1 stage-1 revert + AuditPanel state-gate + chrome-path scrollToDate call (`3ffd7d3`)
- Surgical revert of `9ee5426` diag-v2 surface (`31c066f`)

## Known 0.182 defect (not a 0.181 blocker)
`scrollToDate(today-14d)` fires on both SF routes and v12 React prod, but resulting `scrollLeft` doesn't match v9 gold standard (0 on SF, 108 on v12 vs v9's 740). Pre-existing on v12 React prod — not a regression. Deferred to 0.182 alongside the VF+Lightning Out Standalone full-bleed wrap (Thread B).

## EOL note
Repo has no `.gitattributes`. Git stores `nimbusganttapp.resource` as LF (141,106 B); Windows checkout expands to CRLF (~145 KB disk size). The stored LF blob is authoritative. Post-checkout PowerShell hashes will yield different values than the pre-commit LF sha256 — cosmetic, not a content divergence.

## Test plan
- [ ] Feature-test green on push (auto)
- [ ] PMD apex-scan green on push (auto)
- [ ] Post-merge: beta_create auto-fires, uploads `beta/0.181.0.2` (or next) with clean bundle
- [ ] Verify new beta tag created
- [ ] HQ dispatches `Beta - Promote (Unlocked)` → `release/0.181.0.x`
- [ ] Post-install smoke on both SF routes: `hostMode` matches route, `ngaRootChildCount > 0`, titlebar present, visible tasks > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)