### PR TITLE
fix(gantt): 0.184.1 hotfix — VF namespace + click guard

### DIFF
--- a/force-app/main/default/aura/DeliveryTimelineOut/DeliveryTimelineOut.app
+++ b/force-app/main/default/aura/DeliveryTimelineOut/DeliveryTimelineOut.app
@@ -5,5 +5,5 @@
     SLDS is loaded via <apex:slds /> in the VF page.
 -->
 <aura:application access="GLOBAL" extends="ltng:outApp">
-    <aura:dependency resource="c:deliveryProFormaTimeline" />
+    <aura:dependency resource="%%%NAMESPACE_OR_C%%%:deliveryProFormaTimeline" />
 </aura:application>

--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -471,7 +471,11 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
         const taskId = this._normalizeTaskId(arg1);
         // eslint-disable-next-line no-console
         console.log('[DH onItemClick]', { arg1Type: typeof arg1, resolvedTaskId: taskId });
-        if (!taskId) return;
+        // Guard against NG virtual group-header / bucket rows (ids like
+        // "NEXT", "NOW", "PROPOSED", "follow-on") and any non-SF-Id shape.
+        // SF Ids are 15 or 18 alphanumeric chars. Fires NavigationMixin only
+        // when the id passes this shape check — otherwise PageNotFound modal.
+        if (!taskId || !/^[a-zA-Z0-9]{15}([a-zA-Z0-9]{3})?$/.test(taskId)) return;
         this[NavigationMixin.Navigate]({
             type: 'standard__recordPage',
             attributes: {

--- a/force-app/main/default/pages/DeliveryGanttStandalone.page
+++ b/force-app/main/default/pages/DeliveryGanttStandalone.page
@@ -37,10 +37,10 @@
     <div id="gantt-loading">Loading timeline&hellip;</div>
     <div id="gantt-root"></div>
     <script>
-        $Lightning.use('c:DeliveryTimelineOut', function() {
+        $Lightning.use('%%%NAMESPACE_OR_C%%%:DeliveryTimelineOut', function() {
             document.getElementById('gantt-loading').style.display = 'none';
             $Lightning.createComponent(
-                'c:deliveryProFormaTimeline',
+                '%%%NAMESPACE_OR_C%%%:deliveryProFormaTimeline',
                 { mode: 'fullscreen' },
                 'gantt-root',
                 function(cmp) { /* mounted */ }


### PR DESCRIPTION
## Summary

Two MF-Prod regressions on the release/0.182.0.1 install.

**Fix 1 — Full_Bleed stuck on "Loading timeline…"**
`$Lightning.use('c:DeliveryTimelineOut', ...)` and `$Lightning.createComponent('c:deliveryProFormaTimeline', ...)` in the VF page + `<aura:dependency resource="c:deliveryProFormaTimeline" />` in the Aura OutApp hardcoded `c:` namespace. In subscriber orgs, `c:` resolves to the org's default namespace, not the installed `delivery` package → Lightning Out silently fails. Apex log confirmed VF rendered in 40ms with **zero SOQL** — our `getProFormaTimelineData` never fires.
**Fix:** `c:` → `%%%NAMESPACE_OR_C%%%:` CCI token. Substitutes to `c:` on scratch, `delivery:` on subscriber orgs.

**Fix 2 — "Page doesn't exist" modal on group-header click**
`NG` fires `onItemClick` with virtual group-header ids (e.g. `"NEXT"`, `"PROPOSED"`). `_handleItemClick` passed non-Id strings into `NavigationMixin.standard__recordPage` → `PageNotFound`.
**Fix:** SF-Id shape guard. Only 15/18 alphanumeric ids navigate; group headers no-op.

## Test plan
- [ ] CCI deploy LWC to `Delivery Hub__dev` scratch
- [ ] sf CLI deploy VF page + Aura OutApp to scratch
- [ ] Verify `/lightning/n/Delivery_Gantt_Full_Bleed` renders tasks on scratch (baseline)
- [ ] Click a group-header row on scratch → no modal, no navigation
- [ ] Click a real task bar → navigates to WorkItem__c record page
- [ ] Merge + beta_create autoruns
- [ ] Promote → release/0.182.0.2
- [ ] Install to MF-Prod (Glen-authorized)
- [ ] Verify Full_Bleed surface loads tasks on MF-Prod
- [ ] Verify group-header click safe on MF-Prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)