### PR TITLE
fix(gantt): 0.183.0.2 hotfix — VF runtime namespace detection

### DIFF
--- a/force-app/main/default/pages/DeliveryGanttStandalone.page
+++ b/force-app/main/default/pages/DeliveryGanttStandalone.page
@@ -37,10 +37,19 @@
     <div id="gantt-loading">Loading timeline&hellip;</div>
     <div id="gantt-root"></div>
     <script>
-        $Lightning.use('%%%NAMESPACE_OR_C%%%:DeliveryTimelineOut', function() {
+        // CCI's %%%NAMESPACE_OR_C%%% token is NOT reliably substituted inside
+        // VF-page inline JavaScript during package upload (verified 2026-04-19:
+        // the Aura OutApp dep was substituted correctly to `delivery:` but this
+        // VF inline script ended up with `c:`, breaking Full_Bleed in MF-Prod).
+        // Detecting namespace from the page URL works in both contexts:
+        //   /apex/DeliveryGanttStandalone         → ns = 'c'        (scratch/unmanaged)
+        //   /apex/delivery__DeliveryGanttStandalone → ns = 'delivery' (subscriber/namespaced)
+        var nsMatch = window.location.pathname.match(/\/apex\/([^_\/]+)__/);
+        var NG_NS = nsMatch ? nsMatch[1] : 'c';
+        $Lightning.use(NG_NS + ':DeliveryTimelineOut', function() {
             document.getElementById('gantt-loading').style.display = 'none';
             $Lightning.createComponent(
-                '%%%NAMESPACE_OR_C%%%:deliveryProFormaTimeline',
+                NG_NS + ':deliveryProFormaTimeline',
                 { mode: 'fullscreen' },
                 'gantt-root',
                 function(cmp) { /* mounted */ }


### PR DESCRIPTION
## Summary

**Root cause:** CCI token substitution is inconsistent per file type. `%%%NAMESPACE_OR_C%%%` substitutes correctly in Aura `.app` deps but NOT in VF-page inline JavaScript.

**Evidence** — retrieved installed package from MF-Prod on `release/0.183.0.1`:

```
DeliveryTimelineOut.app (installed, correct):
  <aura:dependency resource="delivery:deliveryProFormaTimeline" />

DeliveryGanttStandalone.page (installed, broken):
  $Lightning.use('c:DeliveryTimelineOut', ...)
  $Lightning.createComponent('c:deliveryProFormaTimeline', ...)
```

`c:` in a subscriber org doesn't resolve to the `delivery` package → Lightning Out silently fails → Full_Bleed stuck on "Loading timeline…" → zero Apex fires.

**Fix:** runtime namespace detection from `window.location.pathname`. Bulletproof across CCI quirks:

```
/apex/DeliveryGanttStandalone           → 'c'        (scratch/unmanaged)
/apex/delivery__DeliveryGanttStandalone → 'delivery' (subscriber)
```

Aura OutApp left alone — its `%%%NAMESPACE_OR_C%%%` substitution works correctly.

## Test plan
- [ ] Merge to main → beta_create auto-fires
- [ ] upload-beta passes → promote to release/0.183.0.2
- [ ] Install on MF-Prod (Glen-authorized)
- [ ] Hard refresh `/lightning/n/delivery__Delivery_Gantt_Full_Bleed`
- [ ] Console shows `[DH mount]` + `[cn-edit ...]` banner
- [ ] Bars render, tasks load from Apex

🤖 Generated with [Claude Code](https://claude.com/claude-code)