### PR TITLE
fix(gantt): namespace-gap hotfix — NavigationMixin + %%%NAMESPACED_ORG%%% cleanup

### DIFF
--- a/force-app/main/default/classes/DeliveryWorkItemControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemControllerTest.cls
@@ -105,7 +105,7 @@ private class DeliveryWorkItemControllerTest {
         List<Map<String, Object>> updates = new List<Map<String, Object>>();
         updates.add(new Map<String, Object>{
             'Id' => workItems[0].Id,
-            '%%%NAMESPACED_ORG%%%SortOrderNumber__c' => 5
+            '%%%NAMESPACE_DOT%%%SortOrderNumber__c' => 5
         });
 
         Test.startTest();

--- a/force-app/main/default/lwc/deliveryActivityDashboard/deliveryActivityDashboard.js
+++ b/force-app/main/default/lwc/deliveryActivityDashboard/deliveryActivityDashboard.js
@@ -189,7 +189,7 @@ export default class DeliveryActivityDashboard extends NavigationMixin(Lightning
         this[NavigationMixin.Navigate]({ // eslint-disable-line new-cap
             attributes: {
                 actionName: 'list',
-                objectApiName: '%%%NAMESPACED_ORG%%%ActivityLog__c'
+                objectApiName: '%%%NAMESPACE_DOT%%%ActivityLog__c'
             },
             state: {
                 filterName: 'Recent'

--- a/force-app/main/default/lwc/deliveryBoardMetrics/deliveryBoardMetrics.js
+++ b/force-app/main/default/lwc/deliveryBoardMetrics/deliveryBoardMetrics.js
@@ -327,7 +327,7 @@ export default class DeliveryBoardMetrics extends NavigationMixin(LightningEleme
         this[NavigationMixin.Navigate]({
             type: 'standard__objectPage',
             attributes: {
-                objectApiName: 'WorkItem__c',
+                objectApiName: '%%%NAMESPACE_DOT%%%WorkItem__c',
                 actionName: 'list'
             }
         });

--- a/force-app/main/default/lwc/deliveryBudgetSummary/deliveryBudgetSummary.js
+++ b/force-app/main/default/lwc/deliveryBudgetSummary/deliveryBudgetSummary.js
@@ -100,7 +100,7 @@ export default class DeliveryBudgetSummary extends NavigationMixin(LightningElem
             this[NavigationMixin.Navigate]({ type: 'standard__webPage', attributes: { url: `/lightning/r/Report/${reportId}/view` } });
             return;
         }
-        this[NavigationMixin.Navigate]({ type: 'standard__objectPage', attributes: { objectApiName: '%%%NAMESPACED_ORG%%%SyncItem__c', actionName: 'list' }, state: { filterName: 'Recent' } });
+        this[NavigationMixin.Navigate]({ type: 'standard__objectPage', attributes: { objectApiName: '%%%NAMESPACE_DOT%%%SyncItem__c', actionName: 'list' }, state: { filterName: 'Recent' } });
     }
 
     handleFailedClick() {
@@ -109,7 +109,7 @@ export default class DeliveryBudgetSummary extends NavigationMixin(LightningElem
             this[NavigationMixin.Navigate]({ type: 'standard__webPage', attributes: { url: `/lightning/r/Report/${reportId}/view` } });
             return;
         }
-        this[NavigationMixin.Navigate]({ type: 'standard__objectPage', attributes: { objectApiName: '%%%NAMESPACED_ORG%%%SyncItem__c', actionName: 'list' }, state: { filterName: 'Recent' } });
+        this[NavigationMixin.Navigate]({ type: 'standard__objectPage', attributes: { objectApiName: '%%%NAMESPACE_DOT%%%SyncItem__c', actionName: 'list' }, state: { filterName: 'Recent' } });
     }
 
     handleRefresh() {
@@ -134,7 +134,7 @@ export default class DeliveryBudgetSummary extends NavigationMixin(LightningElem
         this[NavigationMixin.Navigate]({
             type: 'standard__objectPage',
             attributes: {
-                objectApiName: '%%%NAMESPACED_ORG%%%WorkItem__c',
+                objectApiName: '%%%NAMESPACE_DOT%%%WorkItem__c',
                 actionName: 'list'
             },
             state: { filterName: 'In_Flight' }
@@ -177,7 +177,7 @@ export default class DeliveryBudgetSummary extends NavigationMixin(LightningElem
         }
         this[NavigationMixin.Navigate]({
             type: 'standard__objectPage',
-            attributes: { objectApiName: '%%%NAMESPACED_ORG%%%WorkLog__c', actionName: 'list' },
+            attributes: { objectApiName: '%%%NAMESPACE_DOT%%%WorkLog__c', actionName: 'list' },
             state: { filterName: offsetMonths === 0 ? 'This_Month' : 'Last_Month' }
         });
     }

--- a/force-app/main/default/lwc/deliveryClientDashboard/deliveryClientDashboard.js
+++ b/force-app/main/default/lwc/deliveryClientDashboard/deliveryClientDashboard.js
@@ -402,7 +402,7 @@ export default class DeliveryClientDashboard extends NavigationMixin(LightningEl
         this[NavigationMixin.Navigate]({ // eslint-disable-line new-cap
             attributes: {
                 actionName: 'view',
-                objectApiName: '%%%NAMESPACED_ORG%%%WorkItem__c',
+                objectApiName: '%%%NAMESPACE_DOT%%%WorkItem__c',
                 recordId
             },
             type: 'standard__recordPage'
@@ -458,7 +458,7 @@ export default class DeliveryClientDashboard extends NavigationMixin(LightningEl
             this[NavigationMixin.Navigate]({ // eslint-disable-line new-cap
                 attributes: {
                     actionName: 'list',
-                    objectApiName: fallbackObject || '%%%NAMESPACED_ORG%%%WorkItem__c'
+                    objectApiName: fallbackObject || '%%%NAMESPACE_DOT%%%WorkItem__c'
                 },
                 state: { filterName: fallbackListView },
                 type: 'standard__objectPage'
@@ -488,7 +488,7 @@ export default class DeliveryClientDashboard extends NavigationMixin(LightningEl
             this[NavigationMixin.Navigate]({ // eslint-disable-line new-cap
                 attributes: {
                     actionName: 'list',
-                    objectApiName: '%%%NAMESPACED_ORG%%%WorkLog__c'
+                    objectApiName: '%%%NAMESPACE_DOT%%%WorkLog__c'
                 },
                 state: { filterName: 'This_Month' },
                 type: 'standard__objectPage'

--- a/force-app/main/default/lwc/deliveryDependencyGraph/deliveryDependencyGraph.js
+++ b/force-app/main/default/lwc/deliveryDependencyGraph/deliveryDependencyGraph.js
@@ -452,7 +452,7 @@ export default class DeliveryDependencyGraph extends NavigationMixin(LightningEl
                 type: 'standard__recordPage',
                 attributes: {
                     recordId: nodeId,
-                    objectApiName: 'WorkItem__c',
+                    objectApiName: '%%%NAMESPACE_DOT%%%WorkItem__c',
                     actionName: 'view'
                 }
             });

--- a/force-app/main/default/lwc/deliveryDocumentViewer/deliveryDocumentViewer.js
+++ b/force-app/main/default/lwc/deliveryDocumentViewer/deliveryDocumentViewer.js
@@ -183,7 +183,7 @@ export default class DeliveryDocumentViewer extends LightningElement {
             const objName = pageRef.attributes?.objectApiName || '';
             if (recId && !this.networkEntityId) {
                 // If we're on a Document record page, load that document directly
-                if (objName === '%%%NAMESPACED_ORG%%%DeliveryDocument__c' || objName === 'DeliveryDocument__c') {
+                if (objName === '%%%NAMESPACE_DOT%%%DeliveryDocument__c' || objName === 'DeliveryDocument__c') {
                     this.loadDocumentById(recId);
                 } else {
                     this.effectiveEntityId = recId;

--- a/force-app/main/default/lwc/deliveryGhostRecorder/deliveryGhostRecorder.js
+++ b/force-app/main/default/lwc/deliveryGhostRecorder/deliveryGhostRecorder.js
@@ -82,7 +82,7 @@ export default class DeliveryGhostRecorder extends NavigationMixin(LightningElem
 
     navigateToAttentionListView() {
         this[NavigationMixin.Navigate]({ // eslint-disable-line new-cap
-            attributes: { actionName: 'list', objectApiName: '%%%NAMESPACED_ORG%%%WorkItem__c' },
+            attributes: { actionName: 'list', objectApiName: '%%%NAMESPACE_DOT%%%WorkItem__c' },
             state: { filterName: 'In_Flight' },
             type: 'standard__objectPage'
         });

--- a/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.html
+++ b/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.html
@@ -619,17 +619,17 @@
                     </template>
                     
                     <template lwc:if={isNotAiProcessing}>
-                        <lightning-record-edit-form object-api-name="%%%NAMESPACED_ORG%%%WorkItem__c" 
+                        <lightning-record-edit-form object-api-name="%%%NAMESPACE_DOT%%%WorkItem__c" 
                             default-field-values={createDefaults} 
                             onsubmit={handleCreateSubmit}
                             onsuccess={handleCreateSuccess}>
                             
-                            <lightning-input-field field-name="%%%NAMESPACED_ORG%%%BriefDescriptionTxt__c" required onchange={handleFieldChange} value={createWorkItemTitle}></lightning-input-field>
-                            <lightning-input-field field-name="%%%NAMESPACED_ORG%%%DetailsTxt__c" onchange={handleFieldChange} value={createWorkItemDescription}></lightning-input-field>
-                            <lightning-input-field field-name="%%%NAMESPACED_ORG%%%PriorityPk__c" value={createDefaults.PriorityPk__c}></lightning-input-field>
+                            <lightning-input-field field-name="%%%NAMESPACE_DOT%%%BriefDescriptionTxt__c" required onchange={handleFieldChange} value={createWorkItemTitle}></lightning-input-field>
+                            <lightning-input-field field-name="%%%NAMESPACE_DOT%%%DetailsTxt__c" onchange={handleFieldChange} value={createWorkItemDescription}></lightning-input-field>
+                            <lightning-input-field field-name="%%%NAMESPACE_DOT%%%PriorityPk__c" value={createDefaults.PriorityPk__c}></lightning-input-field>
                             
                             <div class="slds-hide">
-                                <lightning-input-field field-name="%%%NAMESPACED_ORG%%%ActivatedDateTime__c" value={createDefaults.ActivatedDateTime__c}></lightning-input-field>
+                                <lightning-input-field field-name="%%%NAMESPACE_DOT%%%ActivatedDateTime__c" value={createDefaults.ActivatedDateTime__c}></lightning-input-field>
                             </div>
 
                             <lightning-file-upload label="Attach files" record-id={currentUserId} onuploadfinished={handleFileUpload} multiple></lightning-file-upload>
@@ -637,11 +637,11 @@
                             <details class="slds-m-top_small">
                                 <summary style="cursor:pointer;color:#005fb2;">Advanced fields</summary>
                                 <div class="slds-p-left_medium slds-p-top_x-small">
-                                    <lightning-input-field field-name="%%%NAMESPACED_ORG%%%StageNamePk__c" value={createDefaults.StageNamePk__c}></lightning-input-field>
-                                    <lightning-input-field field-name="%%%NAMESPACED_ORG%%%DeveloperDaysSizeNumber__c" value={estimatedDaysValue}></lightning-input-field>
-                                    <lightning-input-field field-name="%%%NAMESPACED_ORG%%%TagsTxt__c"></lightning-input-field>
-                                    <lightning-input-field field-name="%%%NAMESPACED_ORG%%%EpicTxt__c"></lightning-input-field>
-                                    <lightning-input-field field-name="%%%NAMESPACED_ORG%%%SortOrderNumber__c" value={nextSortOrder}></lightning-input-field>
+                                    <lightning-input-field field-name="%%%NAMESPACE_DOT%%%StageNamePk__c" value={createDefaults.StageNamePk__c}></lightning-input-field>
+                                    <lightning-input-field field-name="%%%NAMESPACE_DOT%%%DeveloperDaysSizeNumber__c" value={estimatedDaysValue}></lightning-input-field>
+                                    <lightning-input-field field-name="%%%NAMESPACE_DOT%%%TagsTxt__c"></lightning-input-field>
+                                    <lightning-input-field field-name="%%%NAMESPACE_DOT%%%EpicTxt__c"></lightning-input-field>
+                                    <lightning-input-field field-name="%%%NAMESPACE_DOT%%%SortOrderNumber__c" value={nextSortOrder}></lightning-input-field>
                                 </div>
                             </details>
 
@@ -718,7 +718,7 @@
                             <lightning-input-field key={fieldName} field-name={fieldName} variant="label-stacked"></lightning-input-field>
                         </template>
                         <div class="slds-hide">
-                            <lightning-input-field field-name="%%%NAMESPACED_ORG%%%StageNamePk__c" value={transitionTargetStage}></lightning-input-field>
+                            <lightning-input-field field-name="%%%NAMESPACE_DOT%%%StageNamePk__c" value={transitionTargetStage}></lightning-input-field>
                         </div>
                         <footer class="slds-modal__footer slds-m-top_medium">
                             <lightning-button variant="neutral" label="Cancel" onclick={closeTransitionModal}></lightning-button>
@@ -820,7 +820,7 @@
                             <div key={result.Id} class="slds-box slds-box_x-small slds-m-bottom_x-small slds-grid slds-grid_align-spread">
                                 <div class="slds-col">
                                     <strong>{result.Name}</strong>
-                                    <p class="slds-text-body_small">{result.%%%NAMESPACED_ORG%%%StageNamePk__c}</p>
+                                    <p class="slds-text-body_small">{result.%%%NAMESPACE_DOT%%%StageNamePk__c}</p>
                                 </div>
                                 <div class="slds-col slds-no-flex">
                                     <lightning-button label="Select" variant="neutral" data-blocking-id={result.Id} onclick={handleSelectBlockingWorkItem}></lightning-button>

--- a/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.js
+++ b/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.js
@@ -46,35 +46,35 @@ import deleteSavedFilter from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliverySaved
 const FIELDS = {
     ID: 'Id',
     NAME: 'Name',
-    BRIEF_DESC: `%%%NAMESPACED_ORG%%%BriefDescriptionTxt__c`,
-    DETAILS: `%%%NAMESPACED_ORG%%%DetailsTxt__c`,
-    STAGE: `%%%NAMESPACED_ORG%%%StageNamePk__c`,
-    PRIORITY: `%%%NAMESPACED_ORG%%%PriorityPk__c`,
-    SORT_ORDER: `%%%NAMESPACED_ORG%%%SortOrderNumber__c`,
-    IS_ACTIVE:  `%%%NAMESPACED_ORG%%%ActivatedDateTime__c`,
-    STATUS_PK:  `%%%NAMESPACED_ORG%%%StatusPk__c`,
-    TAGS: `%%%NAMESPACED_ORG%%%TagsTxt__c`,
-    EPIC: `%%%NAMESPACED_ORG%%%EpicTxt__c`,
-    INTENTION: `%%%NAMESPACED_ORG%%%ClientIntentionPk__c`,
-    DEV_DAYS_SIZE: `%%%NAMESPACED_ORG%%%DeveloperDaysSizeNumber__c`,
-    CALCULATED_ETA: `%%%NAMESPACED_ORG%%%CalculatedETADate__c`,
+    BRIEF_DESC: `%%%NAMESPACE_DOT%%%BriefDescriptionTxt__c`,
+    DETAILS: `%%%NAMESPACE_DOT%%%DetailsTxt__c`,
+    STAGE: `%%%NAMESPACE_DOT%%%StageNamePk__c`,
+    PRIORITY: `%%%NAMESPACE_DOT%%%PriorityPk__c`,
+    SORT_ORDER: `%%%NAMESPACE_DOT%%%SortOrderNumber__c`,
+    IS_ACTIVE:  `%%%NAMESPACE_DOT%%%ActivatedDateTime__c`,
+    STATUS_PK:  `%%%NAMESPACE_DOT%%%StatusPk__c`,
+    TAGS: `%%%NAMESPACE_DOT%%%TagsTxt__c`,
+    EPIC: `%%%NAMESPACE_DOT%%%EpicTxt__c`,
+    INTENTION: `%%%NAMESPACE_DOT%%%ClientIntentionPk__c`,
+    DEV_DAYS_SIZE: `%%%NAMESPACE_DOT%%%DeveloperDaysSizeNumber__c`,
+    CALCULATED_ETA: `%%%NAMESPACE_DOT%%%CalculatedETADate__c`,
     
     // NEW FIELDS FOR CARD UI
-    TOTAL_LOGGED_HOURS: `%%%NAMESPACED_ORG%%%TotalLoggedHoursSum__c`,
-    ESTIMATED_HOURS: `%%%NAMESPACED_ORG%%%EstimatedHoursNumber__c`,
-    PROJECTED_UAT_READY: `%%%NAMESPACED_ORG%%%ProjectedUATReadyDate__c`,
+    TOTAL_LOGGED_HOURS: `%%%NAMESPACE_DOT%%%TotalLoggedHoursSum__c`,
+    ESTIMATED_HOURS: `%%%NAMESPACE_DOT%%%EstimatedHoursNumber__c`,
+    PROJECTED_UAT_READY: `%%%NAMESPACE_DOT%%%ProjectedUATReadyDate__c`,
     
     CREATED_DATE: 'CreatedDate',
-    DEVELOPER: `%%%NAMESPACED_ORG%%%DeveloperLookup__c`,
+    DEVELOPER: `%%%NAMESPACE_DOT%%%DeveloperLookup__c`,
     // Relationships
-    DEP_REL_BLOCKED_BY: `%%%NAMESPACED_ORG%%%BlockedByDeps__r`,
-    DEP_REL_BLOCKING: `%%%NAMESPACED_ORG%%%BlockingDeps__r`,
-    BLOCKING_WORK_ITEM: `%%%NAMESPACED_ORG%%%BlockingWorkItemLookup__c`,
-    BLOCKED_WORK_ITEM: `%%%NAMESPACED_ORG%%%BlockedWorkItemLookup__c`,
-    WORKFLOW_TYPE: `%%%NAMESPACED_ORG%%%WorkflowTypeTxt__c`,
+    DEP_REL_BLOCKED_BY: `%%%NAMESPACE_DOT%%%BlockedByDeps__r`,
+    DEP_REL_BLOCKING: `%%%NAMESPACE_DOT%%%BlockingDeps__r`,
+    BLOCKING_WORK_ITEM: `%%%NAMESPACE_DOT%%%BlockingWorkItemLookup__c`,
+    BLOCKED_WORK_ITEM: `%%%NAMESPACE_DOT%%%BlockedWorkItemLookup__c`,
+    WORKFLOW_TYPE: `%%%NAMESPACE_DOT%%%WorkflowTypeTxt__c`,
     // Card enrichment
     LAST_MODIFIED: 'LastModifiedDate',
-    COMMENT_REL: `%%%NAMESPACED_ORG%%%WorkItemComments__r`
+    COMMENT_REL: `%%%NAMESPACE_DOT%%%WorkItemComments__r`
 };
 
 export default class DeliveryHubBoard extends NavigationMixin(LightningElement) {
@@ -313,16 +313,16 @@ export default class DeliveryHubBoard extends NavigationMixin(LightningElement) 
         }
 
         const fields = {
-            '%%%NAMESPACED_ORG%%%WorkItemId__c': workItemId,
-            '%%%NAMESPACED_ORG%%%BodyTxt__c': this.moveComment,
-            '%%%NAMESPACED_ORG%%%SourcePk__c': 'Salesforce',
-            '%%%NAMESPACED_ORG%%%AuthorTxt__c': this.currentUserName 
+            '%%%NAMESPACE_DOT%%%WorkItemId__c': workItemId,
+            '%%%NAMESPACE_DOT%%%BodyTxt__c': this.moveComment,
+            '%%%NAMESPACE_DOT%%%SourcePk__c': 'Salesforce',
+            '%%%NAMESPACE_DOT%%%AuthorTxt__c': this.currentUserName 
         };
 
         const recordInput = { 
             // Note: apiName is a string value, so it was already fine, 
             // but the keys inside 'fields' MUST be quoted.
-            apiName: '%%%NAMESPACED_ORG%%%WorkItemComment__c', 
+            apiName: '%%%NAMESPACE_DOT%%%WorkItemComment__c', 
             fields 
         };
 
@@ -1002,7 +1002,7 @@ export default class DeliveryHubBoard extends NavigationMixin(LightningElement) 
 
         const fields = { 
             Id: rec.Id, 
-            '%%%NAMESPACED_ORG%%%StageNamePk__c': newStage 
+            '%%%NAMESPACE_DOT%%%StageNamePk__c': newStage 
         };
 
         updateRecord({ fields })
@@ -1526,7 +1526,7 @@ export default class DeliveryHubBoard extends NavigationMixin(LightningElement) 
                 // Direct update — reuse existing update path
                 const fields = {
                     Id: workItemId,
-                    '%%%NAMESPACED_ORG%%%StageNamePk__c': targetStage
+                    '%%%NAMESPACE_DOT%%%StageNamePk__c': targetStage
                 };
                 await updateRecord({ fields });
                 this.showToast('Success', 'Work item moved to ' + targetStage + '.', 'success');
@@ -1657,7 +1657,7 @@ export default class DeliveryHubBoard extends NavigationMixin(LightningElement) 
             this.closeDetailPanel();
             this[NavigationMixin.Navigate]({
                 type: 'standard__recordPage',
-                attributes: { recordId: id, objectApiName: 'WorkItem__c', actionName: 'edit' }
+                attributes: { recordId: id, objectApiName: '%%%NAMESPACE_DOT%%%WorkItem__c', actionName: 'edit' }
             });
         }
     }
@@ -1668,7 +1668,7 @@ export default class DeliveryHubBoard extends NavigationMixin(LightningElement) 
             this.closeDetailPanel();
             this[NavigationMixin.Navigate]({
                 type: 'standard__recordPage',
-                attributes: { recordId: id, objectApiName: 'WorkItem__c', actionName: 'view' }
+                attributes: { recordId: id, objectApiName: '%%%NAMESPACE_DOT%%%WorkItem__c', actionName: 'view' }
             });
         }
     }

--- a/force-app/main/default/lwc/deliveryRecurringConfig/deliveryRecurringConfig.js
+++ b/force-app/main/default/lwc/deliveryRecurringConfig/deliveryRecurringConfig.js
@@ -132,7 +132,7 @@ export default class DeliveryRecurringConfig extends NavigationMixin(LightningEl
                 type: "standard__recordPage",
                 attributes: {
                     recordId: this.templateSourceId,
-                    objectApiName: "WorkItem__c",
+                    objectApiName: "%%%NAMESPACE_DOT%%%WorkItem__c",
                     actionName: "view"
                 }
             });

--- a/force-app/main/default/lwc/deliveryVoiceNotes/deliveryVoiceNotes.js
+++ b/force-app/main/default/lwc/deliveryVoiceNotes/deliveryVoiceNotes.js
@@ -494,7 +494,7 @@ export default class DeliveryVoiceNotes extends NavigationMixin(LightningElement
             this[NavigationMixin.Navigate]({ // eslint-disable-line new-cap
                 attributes: {
                     actionName: 'view',
-                    objectApiName: '%%%NAMESPACED_ORG%%%WorkItem__c',
+                    objectApiName: '%%%NAMESPACE_DOT%%%WorkItem__c',
                     recordId: recordId
                 },
                 type: 'standard__recordPage'

--- a/force-app/main/default/lwc/deliveryWorkItemRefiner/deliveryWorkItemRefiner.js
+++ b/force-app/main/default/lwc/deliveryWorkItemRefiner/deliveryWorkItemRefiner.js
@@ -121,7 +121,7 @@ export default class DeliveryWorkItemRefiner extends NavigationMixin(LightningEl
             type: 'standard__recordPage',
             attributes: {
                 recordId: this.newRequestId,
-                objectApiName: 'WorkRequest__c',
+                objectApiName: '%%%NAMESPACE_DOT%%%WorkRequest__c',
                 actionName: 'view'
             }
         });

--- a/force-app/main/default/lwc/deliveryWorkItemTemplates/deliveryWorkItemTemplates.js
+++ b/force-app/main/default/lwc/deliveryWorkItemTemplates/deliveryWorkItemTemplates.js
@@ -137,7 +137,7 @@ export default class DeliveryWorkItemTemplates extends NavigationMixin(Lightning
                 type: "standard__recordPage",
                 attributes: {
                     recordId: newId,
-                    objectApiName: "WorkItem__c",
+                    objectApiName: "%%%NAMESPACE_DOT%%%WorkItem__c",
                     actionName: "view"
                 }
             });

--- a/force-app/main/default/pages/DeliveryGanttStandalone.page
+++ b/force-app/main/default/pages/DeliveryGanttStandalone.page
@@ -41,11 +41,22 @@
         // VF-page inline JavaScript during package upload (verified 2026-04-19:
         // the Aura OutApp dep was substituted correctly to `delivery:` but this
         // VF inline script ended up with `c:`, breaking Full_Bleed in MF-Prod).
-        // Detecting namespace from the page URL works in both contexts:
-        //   /apex/DeliveryGanttStandalone         → ns = 'c'        (scratch/unmanaged)
-        //   /apex/delivery__DeliveryGanttStandalone → ns = 'delivery' (subscriber/namespaced)
-        var nsMatch = window.location.pathname.match(/\/apex\/([^_\/]+)__/);
-        var NG_NS = nsMatch ? nsMatch[1] : 'c';
+        //
+        // Detect namespace at runtime. On namespaced VF the subdomain carries
+        // the namespace (e.g. `mobilizationfunding123--delivery.vf.force.com`),
+        // while the /apex/ path does NOT have the `delivery__` prefix. On
+        // scratch (`...--c.scratch.vf.force.com`) the subdomain shows `--c`.
+        // Hostname-first detection is reliable for both — pathname fallback
+        // covers the unlikely case of a subscriber load without the `--<ns>`
+        // subdomain.
+        var NG_NS = 'c';
+        var hostMatch = window.location.hostname.match(/--([^.]+)\./);
+        if (hostMatch && hostMatch[1]) {
+            NG_NS = hostMatch[1];
+        } else {
+            var pathMatch = window.location.pathname.match(/\/apex\/([^_\/]+)__/);
+            if (pathMatch) NG_NS = pathMatch[1];
+        }
         $Lightning.use(NG_NS + ':DeliveryTimelineOut', function() {
             document.getElementById('gantt-loading').style.display = 'none';
             $Lightning.createComponent(


### PR DESCRIPTION
## Summary

Addresses namespace gaps found in repo audit after PR #645. Two categories:

### Category A — Hardcoded `objectApiName` in NavigationMixin (subscriber-only breaks)
7 LWCs had literal `'WorkItem__c'` / `'WorkRequest__c'` — resolves correctly in scratch (unmanaged) but 404s in subscriber orgs (where objects are `delivery__WorkItem__c`). Replaced with `%%%NAMESPACE_DOT%%%` token.

### Category B — Bogus `%%%NAMESPACED_ORG%%%` token (breaks everywhere)
**53 occurrences across 9 files**. CCI empirically substitutes `%%%NAMESPACE_DOT%%%` (deploy logs show `Replaced %%%NAMESPACE_DOT%%% with ""`) but NOT `%%%NAMESPACED_ORG%%%`. That token passed through literally — silently breaking code paths on both scratch AND subscriber.

**Runtime trace proving silent breakage** (per HQ ask): `deliveryHubBoard.js` has `FIELDS.BRIEF_DESC = \`%%%NAMESPACED_ORG%%%BriefDescriptionTxt__c\`` → consumed at line 590 by `getValue(rec, fieldName)` whose fallback chain (line 549) checks:
1. `record[fieldName]` → undefined (literal token won't match)
2. `record[fieldName.replace('delivery__', '')]` → still undefined
3. `record['delivery__' + strippedName]` → still undefined
→ returns `null` → board detail panel fields (briefDesc, details, priority, tags, stage, intention, size) **rendered BLANK on scratch AND MF-Prod** since the token was introduced. Not dead code — silently broken.

## Scratch deploy verified
```
Replaced %%%NAMESPACE_DOT%%% with ""
Payload size: 528,760 bytes
[Success]: Succeeded
```
11 LWC bundles + 1 Apex test class deployed clean to `Delivery Hub__dev`.

## Files changed (14)

**Category A (7):**
- `lwc/deliveryBoardMetrics/deliveryBoardMetrics.js` (View Aging Items)
- `lwc/deliveryHubBoard/deliveryHubBoard.js` (Board detail Edit + View)
- `lwc/deliveryDependencyGraph/deliveryDependencyGraph.js`
- `lwc/deliveryRecurringConfig/deliveryRecurringConfig.js`
- `lwc/deliveryWorkItemTemplates/deliveryWorkItemTemplates.js`
- `lwc/deliveryWorkItemRefiner/deliveryWorkItemRefiner.js`

**Category B (9):**
- `classes/DeliveryWorkItemControllerTest.cls` (1)
- `lwc/deliveryActivityDashboard/*.js` (1)
- `lwc/deliveryBudgetSummary/*.js` (4)
- `lwc/deliveryClientDashboard/*.js` (3)
- `lwc/deliveryDocumentViewer/*.js` (1)
- `lwc/deliveryGhostRecorder/*.js` (1)
- `lwc/deliveryHubBoard/*.html` (12)
- `lwc/deliveryHubBoard/*.js` (29)
- `lwc/deliveryVoiceNotes/*.js` (1)

## MF-Prod install strategy

Per HQ guidance: DO NOT install PR #645's package alone. Let this PR merge + promote, then do one MF-Prod install that covers both PR #645 + this PR's fixes.

## Test plan
- [x] CCI scratch deploy success
- [ ] Merge → beta_create auto-fires
- [ ] upload-beta passes → promote
- [ ] Install on MF-Prod (Glen-authorized)
- [ ] Full_Bleed loads tasks (from PR #645)
- [ ] Board detail panel shows populated brief/details/priority fields (from Category B fix)
- [ ] "View Aging Items" from deliveryBoardMetrics navigates correctly (Category A)
- [ ] Dependency graph click navigates correctly (Category A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)