### PR TITLE
fix(gantt): today-landing stored-zero guard + __DH_HANDLE exposure

### DIFF
--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -555,7 +555,11 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
      * Locker Service / private-mode restrictions.
      */
     get _viewportStorageKey() {
-        return `dh.gantt.viewport.${this.mode || 'embedded'}`;
+        // v2 bump — evicts stuck {scrollLeft:0} entries from v1 keys that
+        // trapped users at dataset start because "0 is an explicit value" per
+        // NG precedence (explicit pixels > semantic > default). Old keys are
+        // orphaned in localStorage; eventually GC'd by browser storage limits.
+        return `dh.gantt.viewport.v2.${this.mode || 'embedded'}`;
     }
 
     _readInitialViewport() {
@@ -563,7 +567,17 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             const raw = window.localStorage.getItem(this._viewportStorageKey);
             if (!raw) return undefined;
             const parsed = JSON.parse(raw);
-            if (parsed && typeof parsed === 'object') return parsed;
+            if (!parsed || typeof parsed !== 'object') return undefined;
+            // Guard against the stored-zero trap: a fresh-first-load viewport
+            // self-persists {scrollLeft:0, scrollTop:0} which then trumps
+            // initialFocusDate on every subsequent load (0 is a valid explicit
+            // number per NG precedence). Treat all-zero scroll as "no real
+            // user pan" and fall through to initialFocusDate today-landing.
+            // Real pan positions have at least one non-zero coordinate.
+            const hasMeaningfulScroll = Number(parsed.scrollLeft) > 0
+                || Number(parsed.scrollTop) > 0;
+            if (!hasMeaningfulScroll) return undefined;
+            return parsed;
         } catch (e) { /* storage unavailable — first mount, fall through */ }
         return undefined;
     }

--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -379,6 +379,10 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             // pushing fresh tasks after a save. Older bundles may return
             // undefined; guard all handle-method calls.
             this._mountHandle = window.NimbusGanttApp.mount(container, mountConfig);
+            // Expose the handle for DevTools / keyboard-shortcut consumers
+            // (e.g. window.__DH_HANDLE.scrollToDate(new Date()) for T-for-today).
+            // Each mount overwrites; last-mounted wins if multiple instances.
+            try { window.__DH_HANDLE = this._mountHandle; } catch (e) { /* LWS proxy */ }
             this._mounted = true;
             this._installCnEditBridge();
         } catch (error) {


### PR DESCRIPTION
## Summary

Two follow-ups to PR #647 (which merged at 19:27Z but these commits were pushed after).

### `4e428773` — Stored-zero guard + v2 key bump
HQ diagnosis on MF-Prod 0.186.0.1: `initialViewport: {scrollLeft: 0, scrollTop: 68.67}` and `initialFocusDate: "2026-04-19"` both fire. Per locked NG precedence (explicit pixels > semantic > default), `scrollLeft: 0` wins → lands on dataset earliest. Self-reinforcing: fresh-load lands at 0, viewport persists `{scrollLeft: 0}`, every subsequent visit reads it, `initialFocusDate` never gets evaluated.

Fix:
1. `_readInitialViewport()` treats all-zero scroll as "no meaningful saved position" → returns `undefined` → NG falls through to `initialFocusDate` → today lands
2. Storage key bumped `dh.gantt.viewport.fullscreen` → `dh.gantt.viewport.v2.fullscreen`. Existing users stuck with `{scrollLeft:0}` in their v1 key auto-migrate (v1 key orphaned, v2 starts empty). No per-user cleanup needed.

### `3162f80f` — `window.__DH_HANDLE` exposure
Per HQ dispatch bonus surface. Glen's probe post-0.186 returned `no handle exposed` — this wires it. Unblocks future T-for-today keyboard shortcuts and devtools introspection of NG's mount handle (for `scrollToDate()` / `getViewport()` / etc.).

## Test plan
- [x] CCI scratch deploy (both commits verified in prior iteration on `fix/namespace-bulletproof-rest-url`)
- [ ] Merge → beta_create → promote
- [ ] Install → open `/lightning/n/delivery__Delivery_Gantt_Full_Bleed` in regular browser (NOT incognito — trap cleanup test)
- [ ] Full_Bleed lands on week of Apr 13 (Mon at left edge) on first load post-install
- [ ] `window.__DH_HANDLE` resolves to NG mount handle (from VF iframe DevTools context)
- [ ] Returning visits after user pan still restore their scroll position

🤖 Generated with [Claude Code](https://claude.com/claude-code)