### PR TITLE
fix(gantt): TTL-bound viewport persistence for today-landing

### DIFF
--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -555,11 +555,7 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
      * Locker Service / private-mode restrictions.
      */
     get _viewportStorageKey() {
-        // v2 bump — evicts stuck {scrollLeft:0} entries from v1 keys that
-        // trapped users at dataset start because "0 is an explicit value" per
-        // NG precedence (explicit pixels > semantic > default). Old keys are
-        // orphaned in localStorage; eventually GC'd by browser storage limits.
-        return `dh.gantt.viewport.v2.${this.mode || 'embedded'}`;
+        return `dh.gantt.viewport.v3.${this.mode || 'embedded'}`;
     }
 
     _readInitialViewport() {
@@ -568,28 +564,28 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             if (!raw) return undefined;
             const parsed = JSON.parse(raw);
             if (!parsed || typeof parsed !== 'object') return undefined;
-            // Guard against the stored-zero trap: a fresh-first-load viewport
-            // self-persists {scrollLeft:0, scrollTop:0} which then trumps
-            // initialFocusDate on every subsequent load (0 is a valid explicit
-            // number per NG precedence). Treat all-zero scroll as "no real
-            // user pan" and fall through to initialFocusDate today-landing.
-            // Real pan positions have at least one non-zero coordinate.
-            const hasMeaningfulScroll = Number(parsed.scrollLeft) > 0
-                || Number(parsed.scrollTop) > 0;
-            if (!hasMeaningfulScroll) return undefined;
-            return parsed;
+            // TTL-bounded pan memory: within 10 min of the last persist, restore
+            // the user's scroll so tab-flip feels sticky. Past that, drop it and
+            // fall through to initialFocusDate today-landing. This kills the
+            // self-reinforcing trap where every load anchored to an old pan
+            // (scrollLeft:388 pointed at "today when it was written" — once
+            // today moves on or the dataset shifts, that pixel is no longer
+            // today, and today-landing silently breaks).
+            const age = Date.now() - Number(parsed.savedAt || 0);
+            if (!Number.isFinite(age) || age < 0 || age > 600000) return undefined;
+            if (!parsed.state || typeof parsed.state !== 'object') return undefined;
+            return parsed.state;
         } catch (e) { /* storage unavailable — first mount, fall through */ }
         return undefined;
     }
 
     _handleViewportChange(state) {
-        // NG debounces the callback at 150ms; add a host-side throttle so
-        // rapid scrolls don't thrash localStorage.
         if (this._viewportWriteTimer) clearTimeout(this._viewportWriteTimer);
         this._viewportWriteTimer = setTimeout(() => {
             this._viewportWriteTimer = null;
             try {
-                window.localStorage.setItem(this._viewportStorageKey, JSON.stringify(state));
+                const payload = { state, savedAt: Date.now() };
+                window.localStorage.setItem(this._viewportStorageKey, JSON.stringify(payload));
             } catch (e) { /* storage full / disabled — swallow */ }
         }, 500);
     }


### PR DESCRIPTION
## Summary
- Stored viewport (scrollLeft:388 on MF-Prod) was trumping initialFocusDate on every return visit per NG precedence, silently breaking "land on current week"
- v3 storage key bump + 10-min TTL on persisted entry. Within window = restore user pan (tab-flip feels sticky); past window = fall through to initialFocusDate → today
- Payload shape: `{state, savedAt}` instead of raw state object

## Why the v2 stored-zero guard wasn't enough
Only guarded against `scrollLeft:0` specifically. A *non-zero* stored scrollLeft is equally stale — pixel offsets are brittle to dataset shifts, zoom changes, and the plain passage of time. On MF-Prod the stored 388 was "today when it was written"; the next day it pointed elsewhere.

## Test plan
- [ ] Install on MF-Prod, hard-refresh Full_Bleed — confirm mount log shows `initialViewport: undefined` and gantt lands on current week
- [ ] Pan left a few weeks, switch tabs, come back within 10 min — pan position restored
- [ ] Pan left, come back next day — lands on today again (TTL expired)
- [ ] Works on /lightning/n/delivery__Delivery_Gantt_Full_Bleed VF route
- [ ] Works on /lightning/n/delivery__Delivery_Gantt_Standalone FlexiPage route
- [ ] Works on embedded tab (Delivery_Timeline) — mode=embedded has its own TTL key

🤖 Generated with [Claude Code](https://claude.com/claude-code)