### PR TITLE
fix(gantt): LWS-resilient bridges (document.body + CustomEvent)

### DIFF
--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -368,21 +368,33 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
                 }
             } catch (e) { /* LWS strict — globalThis undefined */ }
             try {
-                document.dispatchEvent(new CustomEvent('dh-mount', {
+                if (typeof document !== 'undefined' && document.body) {
+                    document.body.__DH_MOUNT_STATE = mountSnapshot;
+                }
+            } catch (e) { /* body attach blocked */ }
+            try {
+                document.dispatchEvent(new CustomEvent('dh:mount-ready', {
                     detail: mountSnapshot,
                     bubbles: true,
                     composed: true,
                 }));
             } catch (e) { /* dispatchEvent unavailable */ }
-            // Capture the mount return value — NG 0.183 returns a handle with
-            // toggleChrome(), destroy(), and (expected) an update method for
-            // pushing fresh tasks after a save. Older bundles may return
-            // undefined; guard all handle-method calls.
             this._mountHandle = window.NimbusGanttApp.mount(container, mountConfig);
-            // Expose the handle for DevTools / keyboard-shortcut consumers
-            // (e.g. window.__DH_HANDLE.scrollToDate(new Date()) for T-for-today).
-            // Each mount overwrites; last-mounted wins if multiple instances.
+            // Triple-publish the mount handle for the same LWS reasons as
+            // __cnEdit — DevTools can't see `window.*` writes in strict mode.
             try { window.__DH_HANDLE = this._mountHandle; } catch (e) { /* LWS proxy */ }
+            try {
+                if (typeof document !== 'undefined' && document.body) {
+                    document.body.__DH_HANDLE = this._mountHandle;
+                }
+            } catch (e) { /* body attach blocked */ }
+            try {
+                document.dispatchEvent(new CustomEvent('dh:handle-ready', {
+                    detail: this._mountHandle,
+                    bubbles: true,
+                    composed: true,
+                }));
+            } catch (e) { /* dispatchEvent unavailable */ }
             this._mounted = true;
             this._installCnEditBridge();
         } catch (error) {
@@ -758,27 +770,53 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             }
         };
 
+        this._cnEditBridge = bridge;
+        // Triple-publish: LWS strict mode (MF-Prod, verified 2026-04-19)
+        // sandboxes `window.*` writes so they're invisible to DevTools. The
+        // console.log prints (shared channel) but `window.__cnEdit = bridge`
+        // lands in a distorted window the user can't reach. Fallbacks:
+        //   1. window.__cnEdit       — works on non-LWS orgs (scratch, older prod)
+        //   2. document.body.__cnEdit — DOM-property attach; survives LWS because
+        //                               document.body is a real Element reference
+        //   3. CustomEvent dispatch  — bridge-ready signal for consumers that
+        //                               prefer event-driven discovery
+        // Each in its own try/catch so one failure doesn't cascade.
+        try { window.__cnEdit = bridge; } catch (e) { /* LWS proxy */ }
         try {
-            window.__cnEdit = bridge;
-            this._cnEditBridge = bridge;
+            if (typeof document !== 'undefined' && document.body) {
+                document.body.__cnEdit = bridge;
+            }
+        } catch (e) { /* body attach blocked */ }
+        try {
+            document.dispatchEvent(new CustomEvent('dh:bridge-ready', {
+                detail: bridge,
+                bubbles: true,
+                composed: true,
+            }));
+        } catch (e) { /* dispatchEvent unavailable */ }
+        try {
             // eslint-disable-next-line no-console
             console.log(
-                '%c[cn-edit v' + VERSION + ' DH]%c editable timeline ready. Call %cwindow.__cnEdit.help()%c for the API.',
+                '%c[cn-edit v' + VERSION + ' DH]%c editable timeline ready. Try %cdocument.body.__cnEdit.help()%c (LWS) or %cwindow.__cnEdit.help()%c (scratch).',
                 'color:#a21caf;font-weight:bold',
+                'color:inherit',
+                'color:#a21caf;font-family:monospace',
                 'color:inherit',
                 'color:#a21caf;font-family:monospace',
                 'color:inherit'
             );
-        } catch (e) {
-            // eslint-disable-next-line no-console
-            console.warn('[cn-edit] failed to publish window.__cnEdit:', e);
-        }
+        } catch (e) { /* console unavailable */ }
     }
 
     _uninstallCnEditBridge() {
         try {
             if (typeof window !== 'undefined' && window.__cnEdit && window.__cnEdit === this._cnEditBridge) {
                 delete window.__cnEdit;
+            }
+        } catch (_e) { /* swallow */ }
+        try {
+            if (typeof document !== 'undefined' && document.body && document.body.__cnEdit === this._cnEditBridge) {
+                delete document.body.__cnEdit;
             }
         } catch (_e) { /* swallow */ }
         this._cnEditBridge = null;


### PR DESCRIPTION
## Summary
HQ probe on MF-Prod confirmed LWS strict mode distorts \`window.*\` writes from LWC code — \`console.log\` lands in the shared channel but \`window.__cnEdit = bridge\` writes into a sandboxed window DevTools can't read.

Adds two LWS-resilient publish paths alongside the existing \`window.*\` writes, for all three bridge surfaces (\`__cnEdit\`, \`__DH_HANDLE\`, \`__DH_MOUNT_STATE\`):
1. \`document.body.__X\` — DOM-property attach on a real Element ref (not proxied)
2. \`CustomEvent\` on document — \`dh:bridge-ready\`, \`dh:handle-ready\`, \`dh:mount-ready\`

Existing \`window.*\` writes kept for non-LWS orgs (scratch, older prod). Renamed legacy \`dh-mount\` → \`dh:mount-ready\` to match the new convention.

## How to verify in MF-Prod DevTools (VF iframe context)
\`\`\`js
document.body.__cnEdit                  // should be the bridge object
document.body.__cnEdit.help()           // should print API help
document.body.__DH_HANDLE               // NG mount handle
document.body.__DH_MOUNT_STATE          // last mount snapshot
document.addEventListener('dh:bridge-ready', e => console.log('got bridge', e.detail))
\`\`\`

## Related
- PR #649 (viewport TTL) addresses today-landing
- This PR addresses bridge visibility / drag diagnosability under LWS

## Test plan
- [ ] Install on MF-Prod, open Full_Bleed
- [ ] In VF iframe console: \`document.body.__cnEdit\` returns bridge object (not undefined)
- [ ] \`document.body.__cnEdit.help()\` prints API list
- [ ] \`document.body.__DH_HANDLE\` returns NG mount handle with methods
- [ ] Event listener on \`dh:bridge-ready\` fires on page load
- [ ] Scratch org still works via \`window.__cnEdit\` (non-LWS fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)