### PR TITLE
fix(gantt): guard reorder from zeroing sortOrder on empty payloads

### DIFF
--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -473,18 +473,55 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
      */
     async _handleItemReorder(arg1, payload) {
         const taskId = this._normalizeTaskId(arg1);
+        // Expanded payload logging — plain stringify so Glen can copy from
+        // console without needing to expand collapsed objects. Fields
+        // enumerated so we can spot if NG sends date info via reorder
+        // (misclassified canvas horizontal drag).
+        const p = payload || {};
         // eslint-disable-next-line no-console
-        console.log('[DH onItemReorder]', { arg1Type: typeof arg1, resolvedTaskId: taskId, payload });
+        console.log('[DH onItemReorder]', JSON.stringify({
+            arg1Type: typeof arg1,
+            resolvedTaskId: taskId,
+            newIndex: p.newIndex,
+            newParentId: p.newParentId,
+            newPriorityGroup: p.newPriorityGroup,
+            startDate: p.startDate,
+            endDate: p.endDate,
+            payloadKeys: Object.keys(p),
+        }));
         if (!taskId) { throw new Error('[DH] onItemReorder missing taskId'); }
-        const { newIndex, newParentId, newPriorityGroup } = payload || {};
-        const ops = [
-            updateWorkItemSortOrder({ workItemId: taskId, sortOrder: Number(newIndex) || 0 }),
-        ];
+        const { newIndex, newParentId, newPriorityGroup, startDate, endDate } = p;
+        // If NG smuggled date info through the reorder callback (happens when
+        // the template framework misclassifies a horizontal canvas drag as a
+        // row reorder), route to the date-edit Apex instead of corrupting
+        // sortOrder. Confirmed MF-Prod 2026-04-19: users reported "won't let
+        // me move it" when dragging bars horizontally.
+        if (startDate || endDate) {
+            await updateWorkItemDates({
+                workItemId: taskId,
+                startDate: startDate || null,
+                endDate: endDate || null,
+            });
+            this._scheduleRefetch();
+            return;
+        }
+        const ops = [];
+        // Guard: Number(undefined) is NaN, NaN || 0 is 0 — so the prior code
+        // silently zeroed sortOrder on every reorder with no newIndex. Only
+        // call the sort-order API when we have a real numeric index.
+        if (newIndex !== undefined && newIndex !== null && Number.isFinite(Number(newIndex))) {
+            ops.push(updateWorkItemSortOrder({ workItemId: taskId, sortOrder: Number(newIndex) }));
+        }
         if (newParentId !== undefined) {
             ops.push(updateWorkItemParent({ workItemId: taskId, parentId: newParentId || '' }));
         }
         if (newPriorityGroup !== undefined && newPriorityGroup !== null) {
             ops.push(updateWorkItemPriorityGroup({ workItemId: taskId, priorityGroup: newPriorityGroup }));
+        }
+        if (ops.length === 0) {
+            // eslint-disable-next-line no-console
+            console.warn('[DH onItemReorder] empty payload — skipping Apex calls to avoid corrupting sortOrder');
+            return;
         }
         await Promise.all(ops);
         this._scheduleRefetch();


### PR DESCRIPTION
## Summary
Root cause of \"won't let me move it\" in MF-Prod canvas drag.

\`_handleItemReorder\` coerced undefined \`newIndex\` to \`0\` via \`Number(newIndex) || 0\`, silently setting \`sortOrder=0\` on every reorder call that didn't include a fresh index. Confirmed 2026-04-19: six \`[DH onItemReorder]\` events fired on valid task IDs during drag attempts, but no visible movement — each call overwrote \`sortOrder\` with 0, collapsing the list to dataset default on the next refetch.

## Fixes
1. **Skip \`updateWorkItemSortOrder\` when \`newIndex\` is not a finite number.** Empty ops → warn and return (no Apex call) instead of corrupting the row.
2. **Route \`startDate\`/\`endDate\` to \`updateWorkItemDates\`** if NG's template framework misclassifies a horizontal canvas drag (date edit) as a row reorder — some v10 builds funnel both gestures through \`onItemReorder\` with different payload shapes.
3. **Expanded payload logging** — plain \`JSON.stringify\` of enumerated fields + \`payloadKeys\` so future drags produce copyable diagnostic output without DevTools object expansion.

## Test plan
- [ ] Install on MF-Prod, try dragging a bar horizontally on the canvas
- [ ] Console shows \`[DH onItemReorder]\` with full payload JSON (not collapsed)
- [ ] If payload contains \`startDate\`/\`endDate\`: date saved via \`updateWorkItemDates\`
- [ ] If payload has neither index nor dates: warn + no Apex call (sortOrder no longer zeroed)
- [ ] Sidebar row-reorder with valid \`newIndex\` still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)