### PR TITLE
fix(gantt): exit-fullscreen button inert under LWS (use webPage nav)

### DIFF
--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -677,9 +677,17 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
     }
 
     _handleExitFullscreen() {
+        // NavigationMixin standard__navItemPage with an unprefixed apiName
+        // fails silently under LWS strict mode on managed-namespace subscriber
+        // orgs — the nav "succeeds" but the target never resolves. Confirmed
+        // inert on MF-Prod 2026-04-20. standard__webPage with a direct URL
+        // routes through a different path that respects VF-iframe boundaries
+        // and honors the namespace prefix reliably.
+        const prefix = this._vfPrefix();
+        const url = `/lightning/n/${prefix}${EMBEDDED_TAB_API_NAME}`;
         this[NavigationMixin.Navigate]({
-            type: 'standard__navItemPage',
-            attributes: { apiName: EMBEDDED_TAB_API_NAME },
+            type: 'standard__webPage',
+            attributes: { url },
         });
     }
 


### PR DESCRIPTION
## Summary
Clicking "← Exit Full Screen" on the VF Full_Bleed route did nothing on MF-Prod 2026-04-20. Silent navigation failure under LWS strict mode on managed-namespace subscriber orgs.

## Root cause
\`_handleExitFullscreen\` used \`NavigationMixin.Navigate({ type: 'standard__navItemPage', attributes: { apiName: 'Delivery_Timeline' } })\` with an unprefixed \`apiName\`. On subscriber orgs, the tab's actual developer name is \`delivery__Delivery_Timeline\`, but LWS doesn't throw on the unprefixed lookup — the nav "succeeds" and target never resolves.

## Fix
Use \`standard__webPage\` with a direct URL constructed from the existing \`_vfPrefix()\` helper (which detects prefix from the CLOUDNIMBUS_CSS static-resource URL):

\`\`\`js
const prefix = this._vfPrefix(); // '' on scratch, 'delivery__' on subscriber
const url = \`/lightning/n/\${prefix}\${EMBEDDED_TAB_API_NAME}\`;
this[NavigationMixin.Navigate]({ type: 'standard__webPage', attributes: { url } });
\`\`\`

## Scope
Only \`_handleExitFullscreen\` touched. \`_handleEnterFullscreen\` left alone — users report it works, and its target resolves correctly in tests. Minimizing blast radius on a user-facing nav fix.

## Test plan
- [ ] Install on MF-Prod (subscriber)
- [ ] Open \`/lightning/n/delivery__Delivery_Gantt_Full_Bleed\`
- [ ] Click "← Exit Full Screen"
- [ ] Verify lands on \`/lightning/n/delivery__Delivery_Timeline\`
- [ ] Verify no regression on scratch (unprefixed URL resolves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)