### PR TITLE
feat(gantt): generic updateWorkItemFields Apex patch endpoint

### DIFF
--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -452,6 +452,10 @@ public with sharing class DeliveryGanttController {
      *              sObject's put() expects. LWC JSON marshals Date fields as
      *              ISO strings, but put() on a Date field requires a Date.
      *              Similarly for DateTime. Other types pass through.
+     * @param dfr Field describe for type introspection.
+     * @param raw Caller-supplied value (from a Map<String,Object> payload).
+     * @return Value coerced to the type sObject.put expects, or null when the
+     *         caller passed an empty string for a date/datetime field.
      */
     private static Object coerceFieldValue(Schema.DescribeFieldResult dfr, Object raw) {
         if (raw == null) {

--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -388,6 +388,87 @@ public with sharing class DeliveryGanttController {
         }
     }
 
+    /**
+     * @description Generic field-level patch endpoint. Applies an arbitrary
+     *              Map<String,Object> of field writes to a single WorkItem__c.
+     *              Built for NG's TaskEditModal fieldSchema — caller passes
+     *              whatever fields the template exposes (status, assignee,
+     *              parent, comments, etc.). FLS is checked per field; fields
+     *              not updateable by the running user are silently skipped
+     *              rather than failing the whole patch.
+     *              Field API names must match the WorkItem__c sObject's field
+     *              map exactly (unprefixed for package-owned fields — e.g.,
+     *              'StageNamePk__c', not 'delivery__StageNamePk__c'). Date
+     *              fields accept either Date or ISO 'YYYY-MM-DD' strings;
+     *              other types are passed through to sObject.put() as-is.
+     * @param workItemId The Salesforce record Id.
+     * @param fields Map of field API name → new value. Unknown or non-
+     *               updateable fields are skipped.
+     */
+    @AuraEnabled
+    public static void updateWorkItemFields(String workItemId, Map<String, Object> fields) {
+        if (String.isBlank(workItemId)) {
+            throw new AuraHandledException('workItemId is required');
+        }
+        if (fields == null || fields.isEmpty()) {
+            return; // nothing to do, no-op rather than error
+        }
+        try {
+            Id rid = Id.valueOf(workItemId);
+            WorkItem__c item = new WorkItem__c(Id = rid);
+            Map<String, Schema.SObjectField> fieldMap =
+                WorkItem__c.SObjectType.getDescribe().fields.getMap();
+            Boolean anyFieldAssigned = false;
+            for (String fieldKey : fields.keySet()) {
+                if (String.isBlank(fieldKey)) {
+                    continue;
+                }
+                Schema.SObjectField fToken = fieldMap.get(fieldKey.toLowerCase());
+                if (fToken == null) {
+                    continue; // unknown field — skip silently, don't fail the whole patch
+                }
+                Schema.DescribeFieldResult dfr = fToken.getDescribe();
+                if (!dfr.isUpdateable()) {
+                    continue; // FLS: caller lacks edit on this field — skip
+                }
+                Object rawValue = fields.get(fieldKey);
+                Object coerced = coerceFieldValue(dfr, rawValue);
+                item.put(fToken, coerced);
+                anyFieldAssigned = true;
+            }
+            if (!anyFieldAssigned) {
+                return; // all fields were unknown or not updateable — no DML needed
+            }
+            update item; //NOPMD - with sharing class handles CRUD; as user breaks managed package tests
+        } catch (Exception e) {
+            AuraHandledException ahe = new AuraHandledException(e.getMessage());
+            ahe.setMessage(e.getMessage());
+            throw ahe;
+        }
+    }
+
+    /**
+     * @description Coerce caller-supplied JSON-ish values into the types the
+     *              sObject's put() expects. LWC JSON marshals Date fields as
+     *              ISO strings, but put() on a Date field requires a Date.
+     *              Similarly for DateTime. Other types pass through.
+     */
+    private static Object coerceFieldValue(Schema.DescribeFieldResult dfr, Object raw) {
+        if (raw == null) {
+            return null;
+        }
+        Schema.DisplayType t = dfr.getType();
+        if (t == Schema.DisplayType.DATE && raw instanceof String) {
+            String s = (String) raw;
+            return String.isBlank(s) ? null : Date.valueOf(s);
+        }
+        if (t == Schema.DisplayType.DATETIME && raw instanceof String) {
+            String s = (String) raw;
+            return String.isBlank(s) ? null : (Datetime) JSON.deserialize('"' + s + '"', Datetime.class);
+        }
+        return raw;
+    }
+
     // ═══════════════════════════════════════════════════════════════════════
     //  PRO FORMA TIMELINE — ported from cloudnimbusllc.com /mf/delivery-timeline-v5
     // ═══════════════════════════════════════════════════════════════════════

--- a/force-app/main/default/classes/DeliveryGanttControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryGanttControllerTest.cls
@@ -585,4 +585,105 @@ private class DeliveryGanttControllerTest {
                 'Explicit PriorityGroupPk__c override wins over derivation');
         }
     }
+
+    // ── updateWorkItemFields (generic patch endpoint) ────────────────
+
+    @IsTest
+    static void testUpdateWorkItemFieldsUpdatesMultipleFieldsAtOnce() {
+        System.runAs(testUser) {
+            WorkItem__c item = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Build login page' LIMIT 1];
+            Map<String, Object> fields = new Map<String, Object>{
+                'StageNamePk__c' => 'Ready for QA',
+                'PriorityPk__c' => 'Critical',
+                'EstimatedHoursNumber__c' => 40
+            };
+
+            Test.startTest();
+            DeliveryGanttController.updateWorkItemFields(item.Id, fields);
+            Test.stopTest();
+
+            WorkItem__c updated = [
+                SELECT StageNamePk__c, PriorityPk__c, EstimatedHoursNumber__c
+                FROM WorkItem__c WHERE Id = :item.Id
+            ];
+            System.assertEquals('Ready for QA', updated.StageNamePk__c, 'Stage should update');
+            System.assertEquals('Critical', updated.PriorityPk__c, 'Priority should update');
+            System.assertEquals(40, updated.EstimatedHoursNumber__c, 'Hours should update');
+        }
+    }
+
+    @IsTest
+    static void testUpdateWorkItemFieldsCoercesIsoDateStrings() {
+        System.runAs(testUser) {
+            WorkItem__c item = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Build login page' LIMIT 1];
+            Map<String, Object> fields = new Map<String, Object>{
+                'EstimatedStartDevDate__c' => '2026-06-01',
+                'EstimatedEndDevDate__c' => '2026-06-15'
+            };
+
+            Test.startTest();
+            DeliveryGanttController.updateWorkItemFields(item.Id, fields);
+            Test.stopTest();
+
+            WorkItem__c updated = [
+                SELECT EstimatedStartDevDate__c, EstimatedEndDevDate__c
+                FROM WorkItem__c WHERE Id = :item.Id
+            ];
+            System.assertEquals(Date.newInstance(2026, 6, 1), updated.EstimatedStartDevDate__c,
+                'ISO string should coerce to Date');
+            System.assertEquals(Date.newInstance(2026, 6, 15), updated.EstimatedEndDevDate__c,
+                'ISO end string should coerce to Date');
+        }
+    }
+
+    @IsTest
+    static void testUpdateWorkItemFieldsSilentlySkipsUnknownField() {
+        System.runAs(testUser) {
+            WorkItem__c item = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Build login page' LIMIT 1];
+            Map<String, Object> fields = new Map<String, Object>{
+                'NotAFieldOnThisObject__c' => 'ignored',
+                'StageNamePk__c' => 'Done'
+            };
+
+            Test.startTest();
+            DeliveryGanttController.updateWorkItemFields(item.Id, fields);
+            Test.stopTest();
+
+            WorkItem__c updated = [SELECT StageNamePk__c FROM WorkItem__c WHERE Id = :item.Id];
+            System.assertEquals('Done', updated.StageNamePk__c,
+                'Known field should update even when map also contains unknown fields');
+        }
+    }
+
+    @IsTest
+    static void testUpdateWorkItemFieldsNoOpWhenFieldsMapEmpty() {
+        System.runAs(testUser) {
+            WorkItem__c item = [SELECT Id, StageNamePk__c FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Build login page' LIMIT 1];
+            String originalStage = item.StageNamePk__c;
+
+            Test.startTest();
+            DeliveryGanttController.updateWorkItemFields(item.Id, new Map<String, Object>());
+            DeliveryGanttController.updateWorkItemFields(item.Id, null);
+            Test.stopTest();
+
+            WorkItem__c unchanged = [SELECT StageNamePk__c FROM WorkItem__c WHERE Id = :item.Id];
+            System.assertEquals(originalStage, unchanged.StageNamePk__c,
+                'Empty/null fields map should no-op, not throw or corrupt existing values');
+        }
+    }
+
+    @IsTest
+    static void testUpdateWorkItemFieldsThrowsOnBlankId() {
+        System.runAs(testUser) {
+            Boolean threw = false;
+            Test.startTest();
+            try {
+                DeliveryGanttController.updateWorkItemFields(null, new Map<String, Object>{'StageNamePk__c' => 'Done'});
+            } catch (AuraHandledException e) {
+                threw = true;
+            }
+            Test.stopTest();
+            System.assert(threw, 'Blank/null workItemId must throw — caller contract violation');
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Pre-wires the Apex side for NG CC's upcoming TaskEditModal \`fieldSchema\` template config. When NG ships that (next round, not 0.185.4), DH can route arbitrary field writes from the template through this single endpoint instead of adding scoped endpoints per field.

## Signature
\`\`\`apex
@AuraEnabled
public static void updateWorkItemFields(String workItemId, Map<String, Object> fields)
\`\`\`

## Behavior
- Dynamic field lookup via \`WorkItem__c.SObjectType.getDescribe().fields.getMap()\`
- Per-field FLS check via \`isUpdateable()\` — non-updateable fields silently skipped (partial-write semantics, not all-or-nothing)
- Unknown fields silently skipped (template may evolve ahead of Apex)
- ISO date/datetime string coercion — LWC JSON marshals as strings, \`sObject.put()\` requires typed values
- Empty/null \`fields\` map → no-op (not an error)
- Blank \`workItemId\` → throws \`AuraHandledException\`

## Tests (5 new)
- Multiple fields at once update atomically
- ISO date strings coerce to \`Date\`
- Unknown fields silently skip, known fields still update
- Empty/null map is no-op, doesn't corrupt existing values
- Blank workItemId throws

## Why now (not with NG fieldSchema round)
Unblocks the next round — when NG tags the TaskEditModal drawer, DH can pick up and wire the schema immediately without scrambling to add Apex. Orthogonal to this demo cycle, no impact on 0.191 or 0.192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)