### PR TITLE
fix(gantt): updateWorkItemFields — namespace-aware field lookup for managed pkg

### DIFF
--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -418,12 +418,25 @@ public with sharing class DeliveryGanttController {
             WorkItem__c item = new WorkItem__c(Id = rid);
             Map<String, Schema.SObjectField> fieldMap =
                 WorkItem__c.SObjectType.getDescribe().fields.getMap();
+            // In managed-package context, fieldMap keys include the namespace
+            // prefix (e.g. "delivery__stagenamepkxc"). Callers pass unprefixed
+            // field names (e.g. "StageNamePk__c"). Index by local name so the
+            // lookup works in both namespaced-managed and unprefixed-scratch
+            // contexts — use getLocalName() which always returns the name
+            // without the package prefix. Confirmed MF-Prod 2026-04-20:
+            // namespaced upload-beta failed because direct getMap().get(lowercase)
+            // returned null for caller-supplied unprefixed keys.
+            Map<String, Schema.SObjectField> byLocalName =
+                new Map<String, Schema.SObjectField>();
+            for (Schema.SObjectField sf : fieldMap.values()) {
+                byLocalName.put(sf.getDescribe().getLocalName().toLowerCase(), sf);
+            }
             Boolean anyFieldAssigned = false;
             for (String fieldKey : fields.keySet()) {
                 if (String.isBlank(fieldKey)) {
                     continue;
                 }
-                Schema.SObjectField fToken = fieldMap.get(fieldKey.toLowerCase());
+                Schema.SObjectField fToken = byLocalName.get(fieldKey.toLowerCase());
                 if (fToken == null) {
                     continue; // unknown field — skip silently, don't fail the whole patch
                 }


### PR DESCRIPTION
## Summary
Unblocks the in-flight 0.192 beta cut. Upload-beta failed with three test failures in the new \`updateWorkItemFields\` endpoint:

\`\`\`
Apex Test Failure: testUpdateWorkItemFieldsUpdatesMultipleFieldsAtOnce
  Stage should update: Expected: Ready for QA, Actual: In Development
Apex Test Failure: testUpdateWorkItemFieldsSilentlySkipsUnknownField
  Known field should update even when map also contains unknown fields
Apex Test Failure: testUpdateWorkItemFieldsCoercesIsoDateStrings
  ISO string should coerce to Date: Expected: 2026-06-01, Actual: 2026-04-20
\`\`\`

All three traced to a single bug.

## Root cause
\`Schema.SObjectType.fields.getMap()\` returns keys with the namespace prefix in managed-package upload context:
- **Scratch (unprefixed):** key = \`'stagenamepkxc'\`
- **Managed pkg (namespaced):** key = \`'delivery__stagenamepkxc'\`

Caller passes \`'StageNamePk__c'\` unprefixed → my code lowercases to \`'stagenamepkxc'\` → direct \`fieldMap.get()\` returns null in managed context → unknown-field branch silently skipped every field → DML ran with an empty item → no fields updated → tests fail.

The cancelled feature-test (per scratch-org-conservation rule) never exercised this. Upload-beta (real namespaced packaging org) was the first true managed-context check — caught here.

## Fix
Build a second lookup map keyed by lowercase **local** name (\`getLocalName()\` strips the prefix). Works in both contexts because \`getLocalName()\` always returns the unprefixed name.

\`\`\`apex
Map<String, Schema.SObjectField> byLocalName = new Map<String, Schema.SObjectField>();
for (Schema.SObjectField sf : fieldMap.values()) {
    byLocalName.put(sf.getDescribe().getLocalName().toLowerCase(), sf);
}
// ...
Schema.SObjectField fToken = byLocalName.get(fieldKey.toLowerCase());
\`\`\`

## Impact
- Unblocks 0.192 beta upload
- Same signature, no caller changes
- Tests unchanged, will now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)