### PR TITLE
fix(gantt): refetch calls NG handle.setTasks (not nonexistent updateTasks) — reorder visual loop

### DIFF
--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -667,8 +667,15 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
         try {
             const data = await getProFormaTimelineData({ showCompleted: false });
             this._tasks = data || [];
-            if (this._mountHandle && typeof this._mountHandle.updateTasks === 'function') {
-                this._mountHandle.updateTasks(this._mapTasksForNg(this._tasks));
+            // NG 0.185.x exposes handle.setTasks (NOT updateTasks). Prior
+            // code typed the wrong method name and the typeof===function
+            // guard silently skipped it, so Apex writes landed but NG never
+            // re-rendered. Root cause of "reorder fires but visual doesn't
+            // update" on MF-Prod 2026-04-20. Keeping the typeof guard so a
+            // future NG rename doesn't throw — fallback is just the stored
+            // data waiting for the next mount cycle.
+            if (this._mountHandle && typeof this._mountHandle.setTasks === 'function') {
+                this._mountHandle.setTasks(this._mapTasksForNg(this._tasks));
             }
         } catch (error) {
             // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary
Self-inflicted wrong-method-name bug. Reorder fires Apex → Apex saves → refetch pulls fresh data → **NG never re-renders** because the method name was wrong.

## Evidence from MF-Prod 2026-04-20 console
\`\`\`
[DH onItemReorder] newIndex:3000, payloadKeys:["newIndex"]
[DH onItemReorder] newIndex:2000, newPriorityGroup:"top-priority"
[DH onItemReorder] newIndex:500, newPriorityGroup:"top-priority"
[DH onItemReorder] newIndex:4000, newPriorityGroup:"proposed"
...
\`\`\`

Reorder fires with sensible varied indices. Apex persists (SOQL query post-drag shows \`SortOrderNumber__c\` updated to 3000/3000/4000). But user sees no visual change.

## Root cause
\`\`\`js
_refetchAfterPatch() {
    ...
    if (this._mountHandle && typeof this._mountHandle.updateTasks === 'function') {
        this._mountHandle.updateTasks(this._mapTasksForNg(this._tasks));   // updateTasks !== setTasks
    }
}
\`\`\`

NG 0.185.x exposes \`handle.setTasks\`, not \`updateTasks\`. Verified:
\`\`\`
$ grep -oE "\bsetTasks[[:space:]]*[=:\(]" nimbusganttapp.resource
setTasks(
setTasks:
(no updateTasks matches)
\`\`\`

The \`typeof === 'function'\` guard silently skipped the call. Apex writes land, \`this._tasks\` gets refreshed, but NG never sees the update.

## Fix
One-line method name correction: \`updateTasks\` → \`setTasks\`. Keeps the typeof guard so future NG renames don't throw.

Complements PR #654 (server-side SOQL returned the right sortOrder values) — this PR finishes the re-render loop.

## Test plan
- [ ] Install + drag a row in the sidebar
- [ ] Row visibly moves to its new position
- [ ] Refresh the page — order is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)