### PR TITLE
fix(gantt): updateWorkItemFields — comprehensive field lookup (unblock beta)

### DIFF
--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -418,18 +418,25 @@ public with sharing class DeliveryGanttController {
             WorkItem__c item = new WorkItem__c(Id = rid);
             Map<String, Schema.SObjectField> fieldMap =
                 WorkItem__c.SObjectType.getDescribe().fields.getMap();
-            // In managed-package context, fieldMap keys include the namespace
-            // prefix (e.g. "delivery__stagenamepkxc"). Callers pass unprefixed
-            // field names (e.g. "StageNamePk__c"). Index by local name so the
-            // lookup works in both namespaced-managed and unprefixed-scratch
-            // contexts — use getLocalName() which always returns the name
-            // without the package prefix. Confirmed MF-Prod 2026-04-20:
-            // namespaced upload-beta failed because direct getMap().get(lowercase)
-            // returned null for caller-supplied unprefixed keys.
+            // Namespace-agnostic field lookup. Different contexts return
+            // different shapes from fields.getMap() and the describe calls,
+            // so index each field by every name form the caller might pass:
+            //   - map key (whatever getMap() uses in this context)
+            //   - getLocalName() (unprefixed)
+            //   - getName() (prefixed in managed context, unprefixed in scratch)
+            // Result: lookup by ANY of those forms finds the field token.
+            // Prior attempt (PR #659) indexed by getLocalName() alone and
+            // STILL failed upload-beta on 2026-04-20 — empirical evidence that
+            // managed-pkg describe behavior isn't what a simple mental model
+            // suggests. Comprehensive index sidesteps the guessing game.
             Map<String, Schema.SObjectField> byLocalName =
                 new Map<String, Schema.SObjectField>();
-            for (Schema.SObjectField sf : fieldMap.values()) {
-                byLocalName.put(sf.getDescribe().getLocalName().toLowerCase(), sf);
+            for (String mapKey : fieldMap.keySet()) {
+                Schema.SObjectField sf = fieldMap.get(mapKey);
+                Schema.DescribeFieldResult dfr = sf.getDescribe();
+                byLocalName.put(mapKey.toLowerCase(), sf);
+                byLocalName.put(dfr.getLocalName().toLowerCase(), sf);
+                byLocalName.put(dfr.getName().toLowerCase(), sf);
             }
             Boolean anyFieldAssigned = false;
             for (String fieldKey : fields.keySet()) {


### PR DESCRIPTION
## Summary
PR #659's \`getLocalName()\`-only index still failed upload-beta on 2026-04-20. Same three tests, same symptom (fields not updating in managed-pkg context). Blocks Glen's MF-Prod install — the setTasks visual-refresh fix (#660) is stuck behind this.

## Root cause (empirical, not theoretical)
Managed-pkg describe behavior doesn't match the simple "getLocalName returns unprefixed" mental model. Whether it's:
- A describe-caching issue
- A quirk specific to \`fields.getMap()\` key format in the packaging org
- Something subtle about when describes run during the pkg upload

…I don't know. And I'm done guessing.

## Fix — index by every name form
\`\`\`apex
for (String mapKey : fieldMap.keySet()) {
    Schema.SObjectField sf = fieldMap.get(mapKey);
    Schema.DescribeFieldResult dfr = sf.getDescribe();
    byLocalName.put(mapKey.toLowerCase(), sf);           // raw map key
    byLocalName.put(dfr.getLocalName().toLowerCase(), sf); // unprefixed
    byLocalName.put(dfr.getName().toLowerCase(), sf);      // full (prefixed in managed)
}
\`\`\`

Any lookup hit resolves to the same token. Sidesteps the guessing game.

## Blast radius
- Scoped to the lookup builder in \`updateWorkItemFields\`
- Tests unchanged
- Behavior identical to PR #659 intent on success
- O(3n) describe calls instead of O(n) — irrelevant for a field count of ~30

🤖 Generated with [Claude Code](https://claude.com/claude-code)