### PR TITLE
fix(gantt): strip post-save refetches + NG 0.185.24 + fullscreen nav

### DIFF
--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -463,17 +463,25 @@ public with sharing class DeliveryGanttController {
             }
             Boolean anyAssigned = false;
             for (String fieldKey : fields.keySet()) {
-                if (String.isBlank(fieldKey)) continue;
+                if (String.isBlank(fieldKey)) {
+                    continue;
+                }
                 Schema.SObjectField fToken = byAnyName.get(fieldKey.toLowerCase());
-                if (fToken == null) continue;
+                if (fToken == null) {
+                    continue;
+                }
                 Schema.DescribeFieldResult dfr = fToken.getDescribe();
-                if (!dfr.isUpdateable()) continue;
+                if (!dfr.isUpdateable()) {
+                    continue;
+                }
                 Object rawValue = fields.get(fieldKey);
                 Object coerced = coerceFieldValue(dfr, rawValue);
                 item.put(fToken, coerced);
                 anyAssigned = true;
             }
-            if (!anyAssigned) return;
+            if (!anyAssigned) {
+                return;
+            }
             update item; //NOPMD - with sharing class handles CRUD; as user breaks managed package tests
         } catch (Exception e) {
             AuraHandledException ahe = new AuraHandledException(e.getMessage());
@@ -482,9 +490,18 @@ public with sharing class DeliveryGanttController {
         }
     }
 
-    /** Coerce JSON-ish caller values into types sObject.put expects. */
+    /**
+     * @description Coerce JSON-ish caller values into types sObject.put expects.
+     *              Date and DateTime picklist payloads arrive as ISO strings from
+     *              the LWC layer; sObject.put needs native Date/DateTime.
+     * @param dfr Describe for the target field (used to read DisplayType).
+     * @param raw Raw value from the caller's fields map.
+     * @return Coerced value suitable for sObject.put, or null if raw was null.
+     */
     private static Object coerceFieldValue(Schema.DescribeFieldResult dfr, Object raw) {
-        if (raw == null) return null;
+        if (raw == null) {
+            return null;
+        }
         Schema.DisplayType t = dfr.getType();
         if (t == Schema.DisplayType.DATE && raw instanceof String) {
             String s = (String) raw;

--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -386,13 +386,115 @@ public with sharing class DeliveryGanttController {
     @AuraEnabled
     public static void updateWorkItemSortOrder(String workItemId, Decimal sortOrder) {
         try {
-            WorkItem__c item = new WorkItem__c(Id = workItemId, SortOrderNumber__c = sortOrder);
+            // Collision guard: NG's midpoint algorithm can emit the SAME
+            // sortOrder value on repeated drags into the same "between
+            // neighbors" slot (e.g., midpoint(15000,17000)=16000 every
+            // time). Multiple records at the same SortOrderNumber__c cause
+            // ORDER BY to tiebreak by Name alphabetically — user's intended
+            // order is lost. Nudge the incoming value by 0.5 increments
+            // until it's unique within the target task's priority group.
+            Decimal finalSort = sortOrder;
+            if (finalSort != null) {
+                // Collision guard: check ALL other records' sortOrder values
+                // regardless of priority group. The prior bucket-scoped check
+                // missed the case where a task with explicit PriorityGroupPk__c
+                // ('active') collides with a task with null group that derives
+                // at render time to the same bucket — visually they're in the
+                // same lane and their sortOrders must be unique. Global check
+                // is cheap (one soql) and handles both explicit and derived
+                // bucket collisions.
+                Set<Decimal> siblingValues = new Set<Decimal>();
+                List<WorkItem__c> siblings = [SELECT SortOrderNumber__c FROM WorkItem__c WHERE Id != :workItemId AND SortOrderNumber__c != null];
+                for (WorkItem__c s : siblings) {
+                    siblingValues.add(s.SortOrderNumber__c);
+                }
+                Integer maxNudges = siblings.size() + 2;
+                Integer nudged = 0;
+                while (siblingValues.contains(finalSort) && nudged < maxNudges) {
+                    finalSort = finalSort + 0.5;
+                    nudged++;
+                }
+            }
+            WorkItem__c item = new WorkItem__c(Id = workItemId, SortOrderNumber__c = finalSort);
             update item; //NOPMD - with sharing class handles CRUD; as user breaks managed package tests
         } catch (Exception e) {
             AuraHandledException ahe = new AuraHandledException(e.getMessage());
             ahe.setMessage(e.getMessage());
             throw ahe;
         }
+    }
+
+    /**
+     * @description Generic field-level patch endpoint for NG's DetailPanel
+     *              fieldSchema. Caller passes an arbitrary Map<String,Object>
+     *              of field writes; FLS is checked per field; non-updateable
+     *              or unknown fields are silently skipped rather than failing
+     *              the whole patch. Field API names are accepted in any form
+     *              the running context might provide (map key, unprefixed,
+     *              or prefixed), to sidestep the managed-pkg describe
+     *              behavior quirk that killed the 2026-04-20 build. Date
+     *              fields accept Date or ISO 'YYYY-MM-DD' strings.
+     * @param workItemId The Salesforce record Id.
+     * @param fields     Map of field API name → new value.
+     */
+    @AuraEnabled
+    public static void updateWorkItemFields(String workItemId, Map<String, Object> fields) {
+        if (String.isBlank(workItemId)) {
+            throw new AuraHandledException('workItemId is required');
+        }
+        if (fields == null || fields.isEmpty()) {
+            return;
+        }
+        try {
+            Id rid = Id.valueOf(workItemId);
+            WorkItem__c item = new WorkItem__c(Id = rid);
+            Map<String, Schema.SObjectField> fieldMap =
+                WorkItem__c.SObjectType.getDescribe().fields.getMap();
+            // Comprehensive 3-form index: map key, getLocalName(), getName()
+            // — all lowercased. Lookup by any of those forms finds the token.
+            Map<String, Schema.SObjectField> byAnyName =
+                new Map<String, Schema.SObjectField>();
+            for (String mapKey : fieldMap.keySet()) {
+                Schema.SObjectField sf = fieldMap.get(mapKey);
+                Schema.DescribeFieldResult dfr = sf.getDescribe();
+                byAnyName.put(mapKey.toLowerCase(), sf);
+                byAnyName.put(dfr.getLocalName().toLowerCase(), sf);
+                byAnyName.put(dfr.getName().toLowerCase(), sf);
+            }
+            Boolean anyAssigned = false;
+            for (String fieldKey : fields.keySet()) {
+                if (String.isBlank(fieldKey)) continue;
+                Schema.SObjectField fToken = byAnyName.get(fieldKey.toLowerCase());
+                if (fToken == null) continue;
+                Schema.DescribeFieldResult dfr = fToken.getDescribe();
+                if (!dfr.isUpdateable()) continue;
+                Object rawValue = fields.get(fieldKey);
+                Object coerced = coerceFieldValue(dfr, rawValue);
+                item.put(fToken, coerced);
+                anyAssigned = true;
+            }
+            if (!anyAssigned) return;
+            update item; //NOPMD - with sharing class handles CRUD; as user breaks managed package tests
+        } catch (Exception e) {
+            AuraHandledException ahe = new AuraHandledException(e.getMessage());
+            ahe.setMessage(e.getMessage());
+            throw ahe;
+        }
+    }
+
+    /** Coerce JSON-ish caller values into types sObject.put expects. */
+    private static Object coerceFieldValue(Schema.DescribeFieldResult dfr, Object raw) {
+        if (raw == null) return null;
+        Schema.DisplayType t = dfr.getType();
+        if (t == Schema.DisplayType.DATE && raw instanceof String) {
+            String s = (String) raw;
+            return String.isBlank(s) ? null : Date.valueOf(s);
+        }
+        if (t == Schema.DisplayType.DATETIME && raw instanceof String) {
+            String s = (String) raw;
+            return String.isBlank(s) ? null : (Datetime) JSON.deserialize('"' + s + '"', Datetime.class);
+        }
+        return raw;
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -527,7 +629,13 @@ public with sharing class DeliveryGanttController {
      *                      as getGanttData's showCompleted flag).
      * @return List of ProFormaTimelineRow ordered by entity then start date.
      */
-    @AuraEnabled(cacheable=true)
+    // cacheable=false because this method is called after every mutation
+    // (drag reorder, date edit, field patch) to refresh the NG view. With
+    // cacheable=true, Lightning Data Service would return stale cached rows
+    // instead of reading the just-committed DB state, causing "drag saves
+    // but UI doesn't update" symptoms. Performance cost on initial mount
+    // is negligible (50 tasks × ~6 fields = one SOQL, ~200ms).
+    @AuraEnabled
     public static List<ProFormaTimelineRow> getProFormaTimelineData(Boolean showCompleted) {
         try {
             String query = 'SELECT Id, Name, BriefDescriptionTxt__c, StageNamePk__c, '

--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -51,7 +51,11 @@ import updateWorkItemParent from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGa
 // Tab DeveloperNames used by the fullscreen nav pair. Centralized here so the
 // names are discoverable from a single search.
 const EMBEDDED_TAB_API_NAME = 'Delivery_Timeline';
-const FULLSCREEN_TAB_API_NAME = 'Delivery_Gantt_Standalone';
+// Full_Bleed is the VF-wrapped chromeless tab (no SLDS header). The older
+// Delivery_Gantt_Standalone is a FlexiPage with standard LEX chrome — that
+// surface keeps the menu bar when navigated to, which is NOT the fullscreen
+// UX. Always target Full_Bleed for the enter-fullscreen gesture.
+const FULLSCREEN_TAB_API_NAME = 'Delivery_Gantt_Full_Bleed';
 
 export default class DeliveryProFormaTimeline extends NavigationMixin(LightningElement) {
 
@@ -328,10 +332,13 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             // VF Full_Bleed mount (no @api fullscreenUrl from LightningOut)
             mountConfig.onExitFullscreen = () => this._handleExitFullscreen();
         } else {
-            // Standalone FlexiPage without fullscreenUrl configured — fall back
-            // to computed URL so behavior is preserved even if FlexiPage prop
-            // is missing.
-            mountConfig.fullscreenUrl = `/apex/${this._vfPrefix()}DeliveryGanttStandalone`;
+            // Standalone FlexiPage without fullscreenUrl configured — fall
+            // back to the Full_Bleed TAB URL (NOT /apex/ direct). Direct
+            // /apex/ URLs routed through standard__webPage or NG's internal
+            // window.location land in LEX's alohaPage wrapper which keeps
+            // the menu bar; the tab URL renders chromeless because the VF
+            // tab has showHeader=false + no standardStylesheets.
+            mountConfig.fullscreenUrl = `/lightning/n/${this._vfPrefix()}${FULLSCREEN_TAB_API_NAME}`;
         }
 
         try {
@@ -705,11 +712,14 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
     }
 
     _handleEnterFullscreen() {
-        // standard__navItemPage with an unprefixed apiName is inert on
-        // namespaced scratch + LWS-strict subscriber orgs. standard__webPage
-        // with a direct URL is the reliable path.
+        // Target the VF-wrapped Full_Bleed TAB — not the /apex/ URL directly.
+        // /apex/DeliveryGanttStandalone routed through standard__webPage lands
+        // in LEX's alohaPage wrapper which keeps the menu bar (defeats the
+        // point of fullscreen). The tab URL /lightning/n/Delivery_Gantt_Full_Bleed
+        // renders the VF page chromeless because the tab itself is a raw VF
+        // tab (no lightningStylesheets, showHeader=false).
         const prefix = this._vfPrefix();
-        const url = `/apex/${prefix}DeliveryGanttStandalone`;
+        const url = `/lightning/n/${prefix}${FULLSCREEN_TAB_API_NAME}`;
         this[NavigationMixin.Navigate]({
             type: 'standard__webPage',
             attributes: { url },

--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -283,16 +283,30 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
         if (this.mode === 'fullscreen') {
             mountConfig.onItemEdit = async (taskId, changes) => {
                 const id = this._normalizeTaskId(taskId);
+                // Stringify so empty Proxy vs populated object is distinguishable
+                // in the log. NG was silently nuking record dates: it fires
+                // onItemEdit with changes={} on every canvas drag-commit-move
+                // because dates flow via onTaskMove instead. Previous handler
+                // destructured undefined start/end and wrote null to both,
+                // wiping the record. Guard against empty payloads.
+                let changesLog = {};
+                try { changesLog = JSON.parse(JSON.stringify(changes || {})); } catch (e) { changesLog = { _unserializable: true }; }
                 // eslint-disable-next-line no-console
-                console.log('[DH onItemEdit inline]', { arg1Type: typeof taskId, resolvedId: id, changes });
+                console.log('[DH onItemEdit inline]', { arg1Type: typeof taskId, resolvedId: id, changes: changesLog });
                 if (!id) { throw new Error('[DH] onItemEdit missing taskId'); }
                 const { startDate, endDate } = changes || {};
+                if (startDate === undefined && endDate === undefined) {
+                    // eslint-disable-next-line no-console
+                    console.warn('[DH onItemEdit inline] empty changes payload — skipping updateWorkItemDates to avoid nulling the record dates');
+                    return;
+                }
                 await updateWorkItemDates({
                     workItemId: id,
                     startDate: startDate || null,
                     endDate: endDate || null,
                 });
-                this._scheduleRefetch();
+                // No refetch — NG holds optimistic state for the new dates.
+                // Refetch races the DB commit and setTasks(stale) clobbers.
             };
             mountConfig.onItemEditError = (taskId, error) => this._showError('Failed to save date change', error);
         }
@@ -419,6 +433,8 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
     }
 
     async _handlePatch(patch) {
+        // eslint-disable-next-line no-console
+        console.log('[DH onPatch]', JSON.stringify(patch || {}));
         const { id, sortOrder, priorityGroup, parentId, startDate, endDate } = patch;
         const ops = [];
 
@@ -439,9 +455,13 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             }));
         }
 
+        if (ops.length === 0) return;
         try {
             await Promise.all(ops);
-            this._scheduleRefetch();
+            // No refetch — NG holds optimistic state for all mutation paths
+            // (reorder, date-edit, priority-group, parent). Refetch was racing
+            // the DB commit and setTasks(stale) was clobbering. Trust NG's
+            // local model on success; surface errors via toast.
         } catch (error) {
             this._showError('Failed to save change', error);
         }
@@ -463,12 +483,17 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
         console.log('[DH onItemEdit]', { arg1Type: typeof arg1, resolvedTaskId: taskId, changes });
         if (!taskId) { throw new Error('[DH] onItemEdit missing taskId'); }
         const { startDate, endDate } = changes || {};
+        if (startDate === undefined && endDate === undefined) {
+            // eslint-disable-next-line no-console
+            console.warn('[DH onItemEdit] empty changes — skipping to avoid nulling dates');
+            return;
+        }
         await updateWorkItemDates({
             workItemId: taskId,
             startDate: startDate || null,
             endDate: endDate || null,
         });
-        this._scheduleRefetch();
+        // No refetch — NG holds optimistic state; refetch races commit.
     }
 
     _handleItemEditError(taskId, error) {
@@ -492,17 +517,13 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
         // enumerated so we can spot if NG sends date info via reorder
         // (misclassified canvas horizontal drag).
         const p = payload || {};
+        // Stringify full payload so deparent flags + any NG-side metadata is
+        // visible. Earlier log omitted fields like `deparent: true` which NG
+        // emits for bucket-header drops; handler couldn't branch on them.
+        let fullPayloadJson = '';
+        try { fullPayloadJson = JSON.stringify(p); } catch (e) { fullPayloadJson = '[unserializable]'; }
         // eslint-disable-next-line no-console
-        console.log('[DH onItemReorder]', JSON.stringify({
-            arg1Type: typeof arg1,
-            resolvedTaskId: taskId,
-            newIndex: p.newIndex,
-            newParentId: p.newParentId,
-            newPriorityGroup: p.newPriorityGroup,
-            startDate: p.startDate,
-            endDate: p.endDate,
-            payloadKeys: Object.keys(p),
-        }));
+        console.log('[DH onItemReorder]', 'taskId=', taskId, 'payload=', fullPayloadJson);
         if (!taskId) { throw new Error('[DH] onItemReorder missing taskId'); }
         const { newIndex, newParentId, newPriorityGroup, startDate, endDate } = p;
         // If NG smuggled date info through the reorder callback (happens when
@@ -727,29 +748,34 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
     }
 
     _handleExitFullscreen() {
-        // Exit fires from inside the VF /apex page rendered via Lightning
-        // Out in an iframe. NavigationMixin dispatches inside the iframe —
-        // the parent LEX never sees it. window.top.location breaks out of
-        // the iframe directly. Fallback chain: top → parent → self for
-        // surfaces where window.top is cross-origin-blocked.
+        // The VF page may be rendered:
+        //   (a) standalone at /apex/DeliveryGanttStandalone on the VF
+        //       subdomain (host ends .vf.force.com) — window.top === window
+        //   (b) inside a LEX Lightning Out iframe — window.top is LEX
+        // Case (a): relative /lightning/n/... resolves against the VF
+        // domain which has no /lightning path. Must navigate to absolute
+        // LEX URL. Case (b): window.top.location.href breaks out to LEX.
         const prefix = this._vfPrefix();
-        const url = `/lightning/n/${prefix}${EMBEDDED_TAB_API_NAME}`;
+        const path = `/lightning/n/${prefix}${EMBEDDED_TAB_API_NAME}`;
+        const host = window.location.hostname || '';
+        // VF host shape: "<instance>--<ns>.scratch.vf.force.com" or
+        // "<instance>.<mydomain>.vf.force.com". LEX host drops the --<ns>
+        // segment (or the plain vf. segment) and uses .lightning.force.com.
+        let lexHost = host.replace('.vf.force.com', '.lightning.force.com');
+        const nsPrefixMatch = lexHost.match(/^(.*?)--[^.]+\.(.*)$/);
+        if (nsPrefixMatch) {
+            lexHost = `${nsPrefixMatch[1]}.${nsPrefixMatch[2]}`;
+        }
+        const isVfHost = host.indexOf('.vf.force.com') !== -1;
+        const url = isVfHost ? `${window.location.protocol}//${lexHost}${path}` : path;
         try {
             if (window.top && window.top !== window) {
                 window.top.location.href = url;
                 return;
             }
         } catch (e) { /* cross-origin; fall through */ }
-        try {
-            if (window.parent && window.parent !== window) {
-                window.parent.location.href = url;
-                return;
-            }
-        } catch (e) { /* fall through */ }
-        this[NavigationMixin.Navigate]({
-            type: 'standard__webPage',
-            attributes: { url },
-        });
+        // Standalone VF or same-origin iframe — direct nav.
+        window.location.href = url;
     }
 
     _showError(prefix, error) {

--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -47,6 +47,7 @@ import updateWorkItemDates from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGan
 import updateWorkItemSortOrder from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.updateWorkItemSortOrder';
 import updateWorkItemPriorityGroup from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.updateWorkItemPriorityGroup';
 import updateWorkItemParent from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.updateWorkItemParent';
+import updateWorkItemFields from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.updateWorkItemFields';
 
 // Tab DeveloperNames used by the fullscreen nav pair. Centralized here so the
 // names are discoverable from a single search.
@@ -248,7 +249,11 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             onPatch: (patch) => this._handlePatch(patch),
             onItemReorder: (taskId, payload) => this._handleItemReorder(taskId, payload),
             onItemReorderError: (taskId, error) => this._handleItemReorderError(taskId, error),
-            onItemClick: (taskId) => this._handleItemClick(taskId),
+            // onItemClick NOT wired — NG 0.185.18+ defaults to dispatching
+            // TOGGLE_DETAIL on task click, which opens DetailPanel inline.
+            // When a host onItemClick is wired, NG suppresses default action,
+            // leaving clicks with no effect. Removing the wiring lets NG
+            // handle it natively.
             onViewportChange: (state) => this._handleViewportChange(state),
             initialViewport: this._readInitialViewport(),
             // Dormant prop wiring — NG implements the handler in a future
@@ -270,6 +275,38 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
                 hoursColumn: true,
                 budgetUsedColumn: true,
             },
+            // NG 0.185.16 — vertical-dominant canvas bar drag (absY > absX × 1.5,
+            // 12px threshold) emits onItemReorder. Horizontal drag still shifts
+            // dates. Default ON for DH because sidebar drag-hit-testing has
+            // known issues for distant rows (705 → 704 case) and bar-drag is
+            // the reliable reprioritize gesture. Admin panel can still toggle.
+            enableDragBarToReprioritize: true,
+            // NG 0.185.15+ DetailPanel fieldSchema. Keys map to
+            // WorkItem__c fields (unprefixed — Apex updateWorkItemFields
+            // handles namespace resolution). Picklist options mirror the
+            // sObject's current picklist values. Changes emitted via
+            // onItemEdit flow through _handleItemEdit → updateWorkItemFields
+            // for bulk patch. Date fields still work via the existing
+            // startDate/endDate path.
+            fieldSchema: [
+                { key: 'BriefDescriptionTxt__c', label: 'Title', type: 'text', placeholder: 'Short task description' },
+                { key: 'StageNamePk__c', label: 'Stage', type: 'picklist', options: [
+                    'Backlog','Scoping In Progress','Clarification Requested (Pre-Dev)',
+                    'Ready for Sizing','Sizing Underway','Ready for Prioritization',
+                    'Proposal Requested','Drafting Proposal','Ready for Tech Review',
+                    'Ready for Final Approval','Ready for Development','In Development',
+                    'Dev Blocked','Ready for QA','QA In Progress','Ready for Internal UAT',
+                    'Ready for Client UAT','In Client UAT','Ready for UAT Sign-off',
+                    'Ready for Merge','Ready for Deployment','Deployed to Prod',
+                    'Done','Cancelled'
+                ] },
+                { key: 'PriorityPk__c', label: 'Priority', type: 'picklist', options: ['Low','Medium','High'] },
+                { key: 'EstimatedHoursNumber__c', label: 'Estimated Hours', type: 'number', min: 0 },
+                { key: 'startDate', label: 'Start Date', type: 'date' },
+                { key: 'endDate', label: 'End Date', type: 'date' },
+                { key: 'AcceptanceCriteriaTxt__c', label: 'Acceptance Criteria', type: 'textarea', placeholder: 'Given / When / Then...' },
+                { key: 'DetailsTxt__c', label: 'Details', type: 'textarea' },
+            ],
             cssUrl: CLOUDNIMBUS_CSS,
             // Passed explicitly to avoid window-lookup races; the app shell
             // would otherwise reach for window.NimbusGantt at a point where
@@ -277,38 +314,54 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             engine: window.NimbusGantt,
         };
 
-        // Fullscreen-only: wire onItemEdit/onItemEditError INLINE. Arrow
-        // forwards directly to updateWorkItemDates without method-reference
-        // indirection. Embedded stays on legacy onPatch (verified working).
-        if (this.mode === 'fullscreen') {
+        // Wire onItemEdit on both embedded + fullscreen. NG 0.185.15's
+        // DetailPanel uses this callback for form-submit regardless of
+        // surface. Prior fullscreen-only gate left embedded's DetailPanel
+        // silently unable to save when user edited fields from task click.
+        if (true) {
             mountConfig.onItemEdit = async (taskId, changes) => {
                 const id = this._normalizeTaskId(taskId);
-                // Stringify so empty Proxy vs populated object is distinguishable
-                // in the log. NG was silently nuking record dates: it fires
-                // onItemEdit with changes={} on every canvas drag-commit-move
-                // because dates flow via onTaskMove instead. Previous handler
-                // destructured undefined start/end and wrote null to both,
-                // wiping the record. Guard against empty payloads.
                 let changesLog = {};
                 try { changesLog = JSON.parse(JSON.stringify(changes || {})); } catch (e) { changesLog = { _unserializable: true }; }
                 // eslint-disable-next-line no-console
-                console.log('[DH onItemEdit inline]', { arg1Type: typeof taskId, resolvedId: id, changes: changesLog });
+                console.log('[DH onItemEdit inline]', { resolvedId: id, changes: changesLog });
                 if (!id) { throw new Error('[DH] onItemEdit missing taskId'); }
-                const { startDate, endDate } = changes || {};
-                if (startDate === undefined && endDate === undefined) {
+                const keys = Object.keys(changes || {});
+                if (keys.length === 0) {
+                    // Canvas drag-commit-move emits onItemEdit with empty changes
+                    // (dates flow via onTaskMove instead). Guard to avoid
+                    // updateWorkItemDates(null, null) nuking the record dates.
                     // eslint-disable-next-line no-console
-                    console.warn('[DH onItemEdit inline] empty changes payload — skipping updateWorkItemDates to avoid nulling the record dates');
+                    console.warn('[DH onItemEdit inline] empty changes — no save');
                     return;
                 }
-                await updateWorkItemDates({
-                    workItemId: id,
-                    startDate: startDate || null,
-                    endDate: endDate || null,
-                });
-                // No refetch — NG holds optimistic state for the new dates.
-                // Refetch races the DB commit and setTasks(stale) clobbers.
+                // DetailPanel multi-field save (NG 0.185.15+). Split into:
+                //  - startDate/endDate → updateWorkItemDates (validated date endpoint)
+                //  - everything else   → updateWorkItemFields (generic patch)
+                // Both fire in parallel. NG holds optimistic state; no refetch.
+                const { startDate, endDate, ...restFields } = changes || {};
+                const ops = [];
+                if (startDate !== undefined || endDate !== undefined) {
+                    ops.push(updateWorkItemDates({
+                        workItemId: id,
+                        startDate: startDate || null,
+                        endDate: endDate || null,
+                    }));
+                }
+                if (Object.keys(restFields).length > 0) {
+                    ops.push(updateWorkItemFields({ workItemId: id, fields: restFields }));
+                }
+                try {
+                    await Promise.all(ops);
+                    // No refetch — causes visual "bounce" as setTasks rebuilds the
+            // whole gantt while NG's optimistic state already has the edit
+            // applied. Next page reload reads fresh from DB.
+                } catch (error) {
+                    this._showError('Failed to save change', error);
+                    throw error;
+                }
             };
-            mountConfig.onItemEditError = (taskId, error) => this._showError('Failed to save date change', error);
+            mountConfig.onItemEditError = (taskId, error) => this._showError('Failed to save change', error);
         }
 
         // Surface-aware fullscreen-button routing. Give NG's shell exactly one
@@ -326,10 +379,16 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
         // routing — set declaratively on the FlexiPage. onApexRoute is the
         // fallback discriminator for the fullscreen-mode-no-fullscreenUrl case
         // (VF Lightning Out mount).
-        const onApexRoute = typeof window !== 'undefined'
-            && window.location
-            && typeof window.location.pathname === 'string'
-            && window.location.pathname.indexOf('/apex/') !== -1;
+        const pathname = (typeof window !== 'undefined' && window.location && typeof window.location.pathname === 'string')
+            ? window.location.pathname : '';
+        const onApexRoute = pathname.indexOf('/apex/') !== -1;
+        // Standalone Aura app URL: /<ns>/<AppName>.app — renders at top level
+        // outside /one/one.app, so we're the whole viewport. User entered here
+        // via _handleEnterFullscreen navigation; NG's exit button must navigate
+        // BACK, not call document.exitFullscreen() (browser isn't actually in
+        // fullscreen mode — we just loaded a different URL).
+        const onStandaloneAppRoute = /^\/[^/]+\/[^/]+\.app(\/|$|#)/.test(pathname)
+            || /\.app$/.test(pathname);
         if (this.mode === 'embedded') {
             mountConfig.onEnterFullscreen = () => this._handleEnterFullscreen();
         } else if (this.fullscreenUrl) {
@@ -342,8 +401,10 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
                 url = url.replace('/apex/', `/apex/${prefix}`);
             }
             mountConfig.fullscreenUrl = url;
-        } else if (onApexRoute) {
-            // VF Full_Bleed mount (no @api fullscreenUrl from LightningOut)
+        } else if (onApexRoute || onStandaloneAppRoute) {
+            // VF Full_Bleed mount (/apex/) OR standalone Aura app route (/c/...app)
+            // — both top-level chromeless surfaces user entered via nav.
+            // NG's toolbar button should fire our exit-nav callback.
             mountConfig.onExitFullscreen = () => this._handleExitFullscreen();
         } else {
             // Standalone FlexiPage without fullscreenUrl configured — fall
@@ -458,10 +519,10 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
         if (ops.length === 0) return;
         try {
             await Promise.all(ops);
-            // No refetch — NG holds optimistic state for all mutation paths
-            // (reorder, date-edit, priority-group, parent). Refetch was racing
-            // the DB commit and setTasks(stale) was clobbering. Trust NG's
-            // local model on success; surface errors via toast.
+            // No refetch — setTasks() rebuilds the whole gantt and causes
+            // visual x-axis snap after every drop. NG's optimistic state
+            // already reflects the patch; formula-field rollups refresh on
+            // next page load.
         } catch (error) {
             this._showError('Failed to save change', error);
         }
@@ -510,8 +571,57 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
      * MF-Prod traced to this handler ignoring newPriorityGroup — sort updated
      * on both but lane only changed visually; on refresh items snapped back.
      */
+    /**
+     * Print a flat table of every task grouped by priority bucket so a
+     * drag + console scroll shows exactly where each task is before and
+     * after the save. Use NG's current view (mount handle) if available,
+     * else fall back to this._tasks (last refetch).
+     */
+    /** Refetch fresh data from Apex, push into NG via setTasks, then dump. */
+    async _refetchAfterPatchAndDump(label) {
+        try {
+            const data = await getProFormaTimelineData({ showCompleted: false });
+            this._tasks = data || [];
+            if (this._mountHandle && typeof this._mountHandle.setTasks === 'function') {
+                this._mountHandle.setTasks(this._mapTasksForNg(this._tasks));
+            }
+            this._dumpPositions(label);
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.warn('[DH refetch] failed:', error);
+        }
+    }
+
+    _dumpPositions(label) {
+        let tasks = null;
+        try {
+            if (this._mountHandle && typeof this._mountHandle.getTasks === 'function') {
+                tasks = this._mountHandle.getTasks();
+            }
+        } catch (e) { /* fall through */ }
+        if (!tasks) tasks = this._tasks || [];
+        const rows = tasks.map(t => ({
+            bucket: t.priorityGroup || '(none)',
+            sortOrder: t.sortOrder,
+            name: (t.name || t.title || '').slice(0, 50),
+            id: t.id,
+        }));
+        rows.sort((a, b) => {
+            if (a.bucket !== b.bucket) return String(a.bucket).localeCompare(String(b.bucket));
+            return Number(a.sortOrder) - Number(b.sortOrder);
+        });
+        // Plain text lines so DevTools "Copy all messages" captures them.
+        // console.table prints nicely but is empty in pasted logs.
+        const lines = rows.map(r =>
+            `  ${String(r.bucket).padEnd(14)} ${String(r.sortOrder).padEnd(10)} ${r.id}  ${r.name}`
+        );
+        // eslint-disable-next-line no-console
+        console.log('[DH positions] ' + label + ' (' + rows.length + ' tasks)\n' + lines.join('\n'));
+    }
+
     async _handleItemReorder(arg1, payload) {
         const taskId = this._normalizeTaskId(arg1);
+        this._dumpPositions('BEFORE onItemReorder ' + taskId);
         // Expanded payload logging — plain stringify so Glen can copy from
         // console without needing to expand collapsed objects. Fields
         // enumerated so we can spot if NG sends date info via reorder
@@ -537,7 +647,9 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
                 startDate: startDate || null,
                 endDate: endDate || null,
             });
-            this._scheduleRefetch();
+            // No refetch — setTasks() rebuilds the whole gantt and causes
+            // visual x-axis snap. NG's optimistic state already reflects
+            // the new dates.
             return;
         }
         const ops = [];
@@ -559,13 +671,10 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             return;
         }
         await Promise.all(ops);
-        // Intentional: do NOT refetch after reorder. NG has already applied
-        // the optimistic state and the Apex save persisted NG's sparse
-        // sortOrder value. A refetch here races the DB commit and can
-        // return pre-save rows, which setTasks() then pushes back into NG —
-        // producing the visual "snap-back" symptom even though the save
-        // succeeded. Reorder is trusted-optimistic; refetch only runs on
-        // error (handled by onItemReorderError) or other mutation paths.
+        // No refetch — setTasks() rebuilds the whole gantt and causes
+        // visual x-axis snap after every drop. NG's optimistic state
+        // already reflects the reorder; Apex collision-nudges show up
+        // on next page load.
     }
 
     _handleItemReorderError(taskId, error) {
@@ -581,19 +690,10 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
         const taskId = this._normalizeTaskId(arg1);
         // eslint-disable-next-line no-console
         console.log('[DH onItemClick]', { arg1Type: typeof arg1, resolvedTaskId: taskId });
-        // Guard against NG virtual group-header / bucket rows (ids like
-        // "NEXT", "NOW", "PROPOSED", "follow-on") and any non-SF-Id shape.
-        // SF Ids are 15 or 18 alphanumeric chars. Fires NavigationMixin only
-        // when the id passes this shape check — otherwise PageNotFound modal.
-        if (!taskId || !/^[a-zA-Z0-9]{15}([a-zA-Z0-9]{3})?$/.test(taskId)) return;
-        this[NavigationMixin.Navigate]({
-            type: 'standard__recordPage',
-            attributes: {
-                recordId: taskId,
-                objectApiName: `${this._vfPrefix()}WorkItem__c`,
-                actionName: 'view',
-            },
-        });
+        // Do NOT navigate away — NG 0.185.18's TOGGLE_DETAIL dispatch opens
+        // the DetailPanel for in-place editing. Navigating to the record page
+        // would leave the gantt context. Users reach the SF record via the
+        // Title-as-link in DetailPanel (recordUrlTemplate handles that).
     }
 
     /**
@@ -733,18 +833,35 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
     }
 
     _handleEnterFullscreen() {
-        // Target the VF-wrapped Full_Bleed TAB — not the /apex/ URL directly.
-        // /apex/DeliveryGanttStandalone routed through standard__webPage lands
-        // in LEX's alohaPage wrapper which keeps the menu bar (defeats the
-        // point of fullscreen). The tab URL /lightning/n/Delivery_Gantt_Full_Bleed
-        // renders the VF page chromeless because the tab itself is a raw VF
-        // tab (no lightningStylesheets, showHeader=false).
+        // Navigate to the standalone Aura application URL. An <aura:application>
+        // extending force:slds is served at /<ns>/AppName.app as a TOP-LEVEL
+        // page — outside /one/one.app, so no LEX chrome (no app launcher, no
+        // nav tabs, no global header, no sidebar). Browser URL is the app;
+        // viewport is 100% the gantt. User navigates back via browser Back
+        // button or a Back-to-SF link inside the gantt.
+        //
+        // Prior attempts:
+        //  - document.documentElement.requestFullscreen() → in-iframe only,
+        //    LEX chrome stays visible outside the iframe. Doesn't work.
+        //  - /lightning/n/Delivery_Gantt_Full_Bleed (VF tab) → wraps in LEX
+        //    alohaPage, keeps menu bar. Doesn't work.
+        //  - /apex/DeliveryGanttStandalone (raw VF) → same alohaPage wrap
+        //    when routed through standard__webPage. Doesn't work.
+        //
+        // Standalone aura:app URL is the canonical Salesforce-documented
+        // pattern for chromeless rendering inside a SF org session.
         const prefix = this._vfPrefix();
-        const url = `/lightning/n/${prefix}${FULLSCREEN_TAB_API_NAME}`;
-        this[NavigationMixin.Navigate]({
-            type: 'standard__webPage',
-            attributes: { url },
-        });
+        const nsSegment = prefix ? prefix.replace('__', '') : 'c';
+        const url = `/${nsSegment}/DeliveryTimelineStandalone.app`;
+        // Use window.top so navigation escapes any iframe context (Lightning
+        // Out, sub-frames). Falls back to window.location if top is blocked.
+        try {
+            if (window.top && window.top !== window) {
+                window.top.location.href = url;
+                return;
+            }
+        } catch (e) { /* fall through */ }
+        window.location.href = url;
     }
 
     _handleExitFullscreen() {

--- a/force-app/main/default/staticresources/nimbusganttapp.resource
+++ b/force-app/main/default/staticresources/nimbusganttapp.resource
@@ -425,7 +425,7 @@ var NimbusGanttApp = (function(exports) {
       }
     };
   }
-  function startDragReparent(ganttContainer, allTasks, depthMap, onPatch) {
+  function startDragReparent(ganttContainer, allTasks, depthMap, onPatch, isReparentEnabled = () => false) {
     const DRAG_THRESHOLD = 6;
     const LEAF_STEP = 10;
     const INDENT_BASE = 6;
@@ -471,6 +471,7 @@ var NimbusGanttApp = (function(exports) {
         ganttContainer.querySelectorAll(".ng-grid-row:not(.ng-group-row)")
       );
       const vis = allRows.filter((r) => r !== dragRow && r !== spacer);
+      const reparentOn = isReparentEnabled();
       const groupRows = Array.prototype.slice.call(
         ganttContainer.querySelectorAll(".ng-group-row")
       );
@@ -482,7 +483,7 @@ var NimbusGanttApp = (function(exports) {
           break;
         }
       }
-      if (overGroupRow) {
+      if (overGroupRow && reparentOn) {
         const tid = overGroupRow.getAttribute("data-task-id") || "";
         let bucket = "";
         if (tid.indexOf("__bucket_header__") === 0) bucket = tid.slice("__bucket_header__".length);
@@ -502,13 +503,15 @@ var NimbusGanttApp = (function(exports) {
         };
       }
       let nestIntoRow = null;
-      for (const row of vis) {
-        const rect = row.getBoundingClientRect();
-        const nestTop = rect.top + rect.height * 0.25;
-        const nestBottom = rect.top + rect.height * 0.75;
-        if (clientY >= nestTop && clientY <= nestBottom) {
-          nestIntoRow = row;
-          break;
+      if (reparentOn) {
+        for (const row of vis) {
+          const rect = row.getBoundingClientRect();
+          const nestTop = rect.top + rect.height * 0.25;
+          const nestBottom = rect.top + rect.height * 0.75;
+          if (clientY >= nestTop && clientY <= nestBottom) {
+            nestIntoRow = row;
+            break;
+          }
         }
       }
       const targetBucket = getGroupAtY(clientY) || dragSourceGroup || "";
@@ -547,25 +550,35 @@ var NimbusGanttApp = (function(exports) {
           };
         }
       }
+      const targetBucketForHitTest = getGroupAtY(clientY) || dragSourceGroup || "";
+      const bucketVis = targetBucketForHitTest ? vis.filter((r) => {
+        const id = r.getAttribute("data-task-id");
+        if (!id) return false;
+        const t = taskById[id];
+        return !!t && (t.priorityGroup || "") === targetBucketForHitTest;
+      }) : vis;
       let rowAbove = null;
       let rowBelow = null;
-      for (let i = 0; i < vis.length; i++) {
-        const rect = vis[i].getBoundingClientRect();
+      for (let i = 0; i < bucketVis.length; i++) {
+        const rect = bucketVis[i].getBoundingClientRect();
         if (clientY < rect.top + rect.height / 2) {
-          rowBelow = vis[i];
+          rowBelow = bucketVis[i];
           break;
         }
-        rowAbove = vis[i];
+        rowAbove = bucketVis[i];
       }
       const aboveId = rowAbove ? rowAbove.getAttribute("data-task-id") : null;
       const belowId = rowBelow ? rowBelow.getAttribute("data-task-id") : null;
       const aboveDepth = aboveId != null ? depthMap[aboveId] || 0 : -1;
       const aboveHasExpand = !!(rowAbove && rowAbove.querySelector(".ng-expand-icon"));
       const maxDepth = rowAbove == null ? 0 : aboveHasExpand ? aboveDepth + 1 : aboveDepth;
-      const depthDelta = Math.round((clientX - dragStartX) / 25);
+      const depthDelta = reparentOn ? Math.round((clientX - dragStartX) / 25) : 0;
       const desiredDepth = Math.max(0, Math.min(maxDepth, dragStartDepth + depthDelta));
       let parentId = null;
-      if (desiredDepth > 0) {
+      if (!reparentOn) {
+        const currentTask = dragTaskId ? taskById[dragTaskId] : null;
+        parentId = currentTask ? currentTask.parentWorkItemId || null : null;
+      } else if (desiredDepth > 0) {
         let curId = aboveId;
         while (curId) {
           const d = depthMap[curId] || 0;
@@ -577,10 +590,68 @@ var NimbusGanttApp = (function(exports) {
           curId = it ? it.parentWorkItemId : null;
         }
       }
-      const sortAbove = aboveId ? getSortOrder(aboveId) : 0;
-      const sortBelow = belowId ? getSortOrder(belowId) : sortAbove + 2;
-      const aboveIdx = rowAbove ? vis.indexOf(rowAbove) : -1;
-      const targetSort = sortAbove !== sortBelow ? (sortAbove + sortBelow) / 2 : aboveIdx >= 0 ? (aboveIdx + 1) * 1e3 : 500;
+      const sortAbove = aboveId ? getSortOrder(aboveId) : NaN;
+      const sortBelow = belowId ? getSortOrder(belowId) : NaN;
+      const aboveIdx = rowAbove ? bucketVis.indexOf(rowAbove) : -1;
+      const belowIdx = rowBelow ? bucketVis.indexOf(rowBelow) : -1;
+      let targetSort;
+      if (!rowAbove && !rowBelow) {
+        targetSort = 1e3;
+      } else if (!rowAbove) {
+        targetSort = sortBelow > 1e3 ? sortBelow - 1e3 : sortBelow / 2;
+      } else if (!rowBelow) {
+        targetSort = sortAbove + 1e3;
+      } else if (sortAbove !== sortBelow) {
+        targetSort = (sortAbove + sortBelow) / 2;
+      } else {
+        let lo = -Infinity;
+        for (let i = aboveIdx - 1; i >= 0; i--) {
+          const id = bucketVis[i].getAttribute("data-task-id");
+          if (!id) continue;
+          const s = getSortOrder(id);
+          if (s < sortAbove) {
+            lo = s;
+            break;
+          }
+        }
+        let hi = Infinity;
+        for (let i = belowIdx + 1; i < bucketVis.length; i++) {
+          const id = bucketVis[i].getAttribute("data-task-id");
+          if (!id) continue;
+          const s = getSortOrder(id);
+          if (s > sortBelow) {
+            hi = s;
+            break;
+          }
+        }
+        if (isFinite(lo) && isFinite(hi)) {
+          targetSort = (lo + hi) / 2;
+        } else if (isFinite(lo)) {
+          targetSort = sortAbove + 1e3;
+        } else if (isFinite(hi)) {
+          targetSort = sortBelow - 1e3;
+        } else {
+          targetSort = sortAbove + 1e3;
+        }
+      }
+      try {
+        console.log(
+          "[NG dragReparent] targetSort computed",
+          "clientY=",
+          clientY,
+          "aboveId=",
+          aboveId,
+          "aboveSort=",
+          sortAbove,
+          "belowId=",
+          belowId,
+          "belowSort=",
+          sortBelow,
+          "→ targetSort=",
+          targetSort
+        );
+      } catch (_e) {
+      }
       return { parentId, depth: desiredDepth, targetBucket, targetSortOrder: targetSort, insertBeforeRow: rowBelow, nestIntoRow: null, deparent: false };
     }
     function cleanupDrag() {
@@ -2204,7 +2275,8 @@ var NimbusGanttApp = (function(exports) {
     pendingPatchCount: 0,
     adminOpen: false,
     advisorOpen: false,
-    featureOverrides: {}
+    featureOverrides: {},
+    openDetailTaskIds: []
   };
   function reduceAppState(state, event) {
     switch (event.type) {
@@ -2226,14 +2298,32 @@ var NimbusGanttApp = (function(exports) {
         return { ...state, statsOpen: !state.statsOpen };
       case "TOGGLE_DETAIL": {
         const opening = event.taskId !== void 0;
+        if (opening) {
+          const tid = event.taskId;
+          const existing = state.openDetailTaskIds.filter((id) => id !== tid);
+          return {
+            ...state,
+            detailOpen: true,
+            selectedTaskId: tid,
+            detailMode: event.editMode ? "edit" : "view",
+            openDetailTaskIds: [...existing, tid]
+          };
+        }
         return {
           ...state,
-          detailOpen: opening ? true : !state.detailOpen,
-          selectedTaskId: opening ? event.taskId : state.selectedTaskId,
-          // When opening: use editMode payload (default 'view'). When closing
-          // or toggling (no taskId): keep existing detailMode — v10 dblclick
-          // sets editMode:true, plain click leaves it 'view'.
-          detailMode: opening ? event.editMode ? "edit" : "view" : state.detailMode
+          detailOpen: !state.detailOpen,
+          detailMode: state.detailMode,
+          openDetailTaskIds: state.detailOpen ? [] : state.openDetailTaskIds
+        };
+      }
+      case "CLOSE_DETAIL": {
+        const next = state.openDetailTaskIds.filter((id) => id !== event.taskId);
+        const nextSelected = next.length > 0 ? next[next.length - 1] : null;
+        return {
+          ...state,
+          openDetailTaskIds: next,
+          detailOpen: next.length > 0,
+          selectedTaskId: nextSelected
         };
       }
       case "SET_DETAIL_MODE":
@@ -2621,6 +2711,46 @@ var NimbusGanttApp = (function(exports) {
   };
   const ZOOMS$2 = ["day", "week", "month", "quarter"];
   const GROUPS = ["priority", "epic"];
+  function resolveFullscreenApi() {
+    if (typeof document === "undefined") return null;
+    const doc = document;
+    try {
+      void doc.fullscreenElement;
+    } catch (_e) {
+      return null;
+    }
+    try {
+      if (typeof window !== "undefined" && window.top !== window.self) return null;
+    } catch (_e) {
+      return null;
+    }
+    const request = (el2) => {
+      const anyEl2 = el2;
+      if (anyEl2.requestFullscreen) return anyEl2.requestFullscreen();
+      if (anyEl2.webkitRequestFullscreen) return anyEl2.webkitRequestFullscreen();
+      if (anyEl2.msRequestFullscreen) return anyEl2.msRequestFullscreen();
+      return Promise.reject(new Error("Fullscreen API not supported"));
+    };
+    const exit = () => {
+      try {
+        if (doc.exitFullscreen) return doc.exitFullscreen();
+        if (doc.webkitExitFullscreen) return doc.webkitExitFullscreen();
+        if (doc.msExitFullscreen) return doc.msExitFullscreen();
+      } catch (_e) {
+      }
+      return Promise.reject(new Error("exitFullscreen not supported"));
+    };
+    const element = () => {
+      try {
+        return doc.fullscreenElement || doc.webkitFullscreenElement || doc.msFullscreenElement || null;
+      } catch (_e) {
+        return null;
+      }
+    };
+    const anyEl = document.documentElement;
+    if (!anyEl.requestFullscreen && !anyEl.webkitRequestFullscreen) return null;
+    return { request, exit, element };
+  }
   const CLS_GROUP_BOTH = "bg-indigo-600 text-white border-indigo-600";
   const CLS_GROUP_GANTT = "bg-indigo-100 text-indigo-700 border-indigo-400";
   const CLS_GROUP_SIDE = "bg-blue-100 text-blue-700 border-blue-400";
@@ -2761,83 +2891,53 @@ var NimbusGanttApp = (function(exports) {
         }
       });
       rowMain.appendChild(unpinBtn);
+      const fsApi = resolveFullscreenApi();
       const fsUrl = config.fullscreenUrl;
       const onCurrentFsUrl = !!(fsUrl && typeof location !== "undefined" && location.pathname === fsUrl);
-      try {
-        console.log(
-          "[NG fs-btn render]",
-          "mode=",
-          config.mode,
-          "fsUrl=",
-          fsUrl || "(none)",
-          "location=",
-          typeof location !== "undefined" ? location.pathname : "(no-loc)",
-          "onCurrentFsUrl=",
-          onCurrentFsUrl,
-          "hasOnEnter=",
-          typeof config.onEnterFullscreen === "function",
-          "hasOnExit=",
-          typeof config.onExitFullscreen === "function"
-        );
-      } catch (_e) {
-      }
       if (!onCurrentFsUrl) {
         const hostExit = config.mode === "fullscreen" && typeof config.onExitFullscreen === "function";
-        const active = state.fullscreen || hostExit;
+        const useFsApi = !fsUrl && !hostExit && !!fsApi;
+        const fsApiActive = !!(fsApi && fsApi.element());
+        const active = state.fullscreen || hostExit || fsApiActive;
         const fsBtn = el$1(
           "button",
           CLS_PILL_BTN_BASE + " " + (active ? CLS_RIGHT_FS_ON : CLS_RIGHT_FS_OFF)
         );
         if (fsUrl) {
-          fsBtn.textContent = "Fullscreen";
+          fsBtn.textContent = "Full Screen";
           fsBtn.setAttribute("data-nga-fullscreen-url", "1");
           fsBtn.addEventListener("click", () => {
-            try {
-              console.log("[NG fs-btn click] path=url-nav target=", fsUrl);
-            } catch (_e) {
-            }
-            try {
-              window.location.href = fsUrl;
-            } catch (err) {
-              try {
-                console.error("[NG fs-btn click] url-nav threw", err);
-              } catch (_e) {
-              }
-            }
+            window.location.href = fsUrl;
           });
         } else if (hostExit) {
           fsBtn.textContent = "← Exit Full Screen";
           fsBtn.setAttribute("data-nga-fullscreen-exit", "1");
           fsBtn.addEventListener("click", () => {
+            config.onExitFullscreen();
+          });
+        } else if (useFsApi) {
+          fsBtn.textContent = fsApiActive ? "← Exit Full Screen" : "Full Screen";
+          fsBtn.setAttribute("data-nga-fullscreen-api", "1");
+          fsBtn.addEventListener("click", async () => {
             try {
-              console.log("[NG fs-btn click] path=host-exit invoking config.onExitFullscreen");
-            } catch (_e) {
-            }
-            try {
-              config.onExitFullscreen();
+              if (fsApi.element()) {
+                await fsApi.exit();
+              } else {
+                const target = root.closest("[data-nga-template-root]") || root.parentElement || document.documentElement;
+                await fsApi.request(target);
+              }
             } catch (err) {
               try {
-                console.error("[NG fs-btn click] host-exit threw", err);
+                console.error("[NG fs-btn] Fullscreen API threw", err);
               } catch (_e) {
               }
             }
           });
         } else {
-          fsBtn.textContent = state.fullscreen ? "Exit Fullscreen" : "Fullscreen";
-          fsBtn.addEventListener("click", () => {
-            try {
-              console.log("[NG fs-btn click] path=toggle-state");
-            } catch (_e) {
-            }
-            dispatch({ type: "TOGGLE_FULLSCREEN" });
-          });
+          fsBtn.textContent = state.fullscreen ? "Exit Full Screen" : "Full Screen";
+          fsBtn.addEventListener("click", () => dispatch({ type: "TOGGLE_FULLSCREEN" }));
         }
         rowMain.appendChild(fsBtn);
-      } else {
-        try {
-          console.log("[NG fs-btn] HIDDEN — onCurrentFsUrl true, no button rendered");
-        } catch (_e) {
-        }
       }
       const adminOn = !!state.adminOpen;
       const adminBtn = el$1(
@@ -2955,6 +3055,9 @@ var NimbusGanttApp = (function(exports) {
     searchInput.type = "text";
     searchInput.placeholder = "Search T-NNNN, title, owner…";
     function render(p) {
+      const hadSearchFocus = document.activeElement === searchInput;
+      const selStart = hadSearchFocus ? searchInput.selectionStart : null;
+      const selEnd = hadSearchFocus ? searchInput.selectionEnd : null;
       clear(inner);
       const { config, state, dispatch, data } = p;
       const viewLbl = el$1("span", CLS_FILTERBAR_LABEL);
@@ -3039,6 +3142,18 @@ var NimbusGanttApp = (function(exports) {
         rst.textContent = "Reset changes";
         rst.addEventListener("click", () => dispatch({ type: "RESET_PATCHES" }));
         inner.appendChild(rst);
+      }
+      if (hadSearchFocus) {
+        try {
+          searchInput.focus();
+        } catch (_e) {
+        }
+        if (selStart !== null && selEnd !== null) {
+          try {
+            searchInput.setSelectionRange(selStart, selEnd);
+          } catch (_e) {
+          }
+        }
       }
     }
     render(initial);
@@ -3420,21 +3535,46 @@ var NimbusGanttApp = (function(exports) {
       }
     };
   }
-  function DetailPanelVanilla(initial) {
+  function DetailPanelVanilla(initial, forTaskId) {
     const root = el$1("div", CLS_DETAIL);
     root.setAttribute("data-slot", "DetailPanel");
-    let draftStart = "";
-    let draftEnd = "";
+    if (forTaskId) root.setAttribute("data-task-id", forTaskId);
+    let drafts = {};
     let lastRenderedKey = "";
+    let panelX = null;
+    let panelY = null;
+    let headerDragging = false;
+    let headerDragStartX = 0;
+    let headerDragStartY = 0;
+    let headerDragOrigX = 0;
+    let headerDragOrigY = 0;
+    function onHeaderDragMove(e) {
+      if (!headerDragging) return;
+      const dx = e.clientX - headerDragStartX;
+      const dy = e.clientY - headerDragStartY;
+      panelX = headerDragOrigX + dx;
+      panelY = headerDragOrigY + dy;
+      root.style.left = panelX + "px";
+      root.style.top = panelY + "px";
+      root.style.right = "";
+      root.style.bottom = "";
+    }
+    function onHeaderDragEnd() {
+      headerDragging = false;
+      document.body.style.userSelect = "";
+      window.removeEventListener("mousemove", onHeaderDragMove);
+      window.removeEventListener("mouseup", onHeaderDragEnd);
+    }
     function render(p) {
       var _a;
       clear(root);
       const { state, data, dispatch } = p;
-      if (!state.selectedTaskId) {
+      const targetId = forTaskId || state.selectedTaskId;
+      if (!targetId) {
         root.style.display = "none";
         return;
       }
-      const task = data.tasks.find((t) => String(t.id) === state.selectedTaskId);
+      const task = data.tasks.find((t) => String(t.id) === targetId);
       if (!task) {
         root.style.display = "none";
         return;
@@ -3442,19 +3582,60 @@ var NimbusGanttApp = (function(exports) {
       root.style.display = "";
       const editing = state.detailMode === "edit";
       const catColor = "#64748b";
-      root.style.bottom = "80px";
-      root.style.right = "24px";
+      if (panelX != null && panelY != null) {
+        root.style.left = panelX + "px";
+        root.style.top = panelY + "px";
+        root.style.right = "";
+        root.style.bottom = "";
+      } else {
+        root.style.bottom = "80px";
+        root.style.right = "24px";
+        root.style.left = "";
+        root.style.top = "";
+      }
       root.style.width = "380px";
       root.style.borderColor = catColor;
       root.setAttribute("data-detail-mode", state.detailMode);
-      const renderKey = `${task.id}|${editing ? 1 : 0}|${task.startDate || ""}|${task.endDate || ""}`;
+      const schema = p.config.fieldSchema;
+      const schemaKey = schema ? schema.map((f) => f.key).join(",") : "";
+      const renderKey = `${task.id}|${editing ? 1 : 0}|${task.startDate || ""}|${task.endDate || ""}|${schemaKey}`;
       if (renderKey !== lastRenderedKey) {
-        draftStart = task.startDate || "";
-        draftEnd = task.endDate || "";
+        drafts = {};
+        if (schema && schema.length) {
+          for (const f of schema) {
+            drafts[f.key] = task[f.key];
+          }
+        } else {
+          drafts.startDate = task.startDate || "";
+          drafts.endDate = task.endDate || "";
+        }
         lastRenderedKey = renderKey;
       }
       const header = el$1("div", CLS_DETAIL_HEADER);
       header.style.background = catColor + "15";
+      header.style.cursor = "move";
+      header.style.userSelect = "none";
+      header.addEventListener("mousedown", (e) => {
+        const target = e.target;
+        if (!target) return;
+        if (target.closest("button, a, input, select, textarea")) return;
+        e.preventDefault();
+        if (panelX == null || panelY == null) {
+          const rect = root.getBoundingClientRect();
+          const parent = root.parentElement;
+          const parentRect = parent ? parent.getBoundingClientRect() : { left: 0, top: 0 };
+          panelX = rect.left - parentRect.left;
+          panelY = rect.top - parentRect.top;
+        }
+        headerDragging = true;
+        headerDragStartX = e.clientX;
+        headerDragStartY = e.clientY;
+        headerDragOrigX = panelX;
+        headerDragOrigY = panelY;
+        document.body.style.userSelect = "none";
+        window.addEventListener("mousemove", onHeaderDragMove);
+        window.addEventListener("mouseup", onHeaderDragEnd);
+      });
       const lwrap = el$1("div", "flex items-center gap-2 min-w-0");
       const dot = el$1("span", "w-2.5 h-2.5 rounded-full flex-shrink-0");
       dot.style.background = catColor;
@@ -3478,7 +3659,21 @@ var NimbusGanttApp = (function(exports) {
       }
       lwrap.appendChild(idEl);
       const titleSp = el$1("span", "text-xs font-bold text-slate-900 truncate");
-      titleSp.textContent = task.title;
+      let dirty = false;
+      if (editing) {
+        const dirtyKeys = schema && schema.length ? schema.filter((f) => !f.readOnly).map((f) => f.key) : ["startDate", "endDate"];
+        for (const k of dirtyKeys) {
+          const dv = drafts[k];
+          const tv = task[k];
+          const dn = dv == null || dv === "" ? null : dv;
+          const tn = tv == null || tv === "" ? null : tv;
+          if (dn !== tn) {
+            dirty = true;
+            break;
+          }
+        }
+      }
+      titleSp.textContent = (dirty ? "• " : "") + task.title;
       lwrap.appendChild(titleSp);
       header.appendChild(lwrap);
       const rwrap = el$1("div", "flex items-center gap-1 flex-shrink-0 ml-2");
@@ -3497,7 +3692,10 @@ var NimbusGanttApp = (function(exports) {
       const closeBtn = el$1("button", "text-slate-400 hover:text-slate-700 text-sm px-1 transition-colors");
       closeBtn.textContent = "×";
       closeBtn.setAttribute("title", "Close");
-      closeBtn.addEventListener("click", () => dispatch({ type: "TOGGLE_DETAIL" }));
+      closeBtn.addEventListener("click", () => {
+        if (forTaskId) dispatch({ type: "CLOSE_DETAIL", taskId: forTaskId });
+        else dispatch({ type: "TOGGLE_DETAIL" });
+      });
       rwrap.appendChild(closeBtn);
       header.appendChild(rwrap);
       root.appendChild(header);
@@ -3510,44 +3708,92 @@ var NimbusGanttApp = (function(exports) {
       pillWrap.appendChild(pill);
       body.appendChild(pillWrap);
       const grid = el$1("div", "grid grid-cols-2 gap-x-4 gap-y-1.5 pt-1");
-      function fld(label, value) {
-        const w = el$1("div", "");
+      function fld(label, value, fullWidth = false) {
+        const w = el$1("div", fullWidth ? "col-span-2" : "");
         const l = el$1("p", "text-[9px] text-slate-400 uppercase tracking-wide");
         l.textContent = label;
-        const v = el$1("p", "text-slate-900");
+        const v = el$1("p", "text-slate-900 whitespace-pre-wrap");
         v.textContent = value;
         w.appendChild(l);
         w.appendChild(v);
         grid.appendChild(w);
       }
-      function inpField(label, type, value, onInput) {
-        const w = el$1("div", "");
+      function renderField(desc) {
+        const fullWidth = desc.type === "textarea";
+        const raw = drafts[desc.key];
+        const currentVal = raw == null ? "" : String(raw);
+        const readOnly = !!desc.readOnly;
+        if (!editing || readOnly) {
+          const displayVal = currentVal || "—";
+          fld(desc.label, displayVal, fullWidth);
+          return;
+        }
+        const w = el$1("div", fullWidth ? "col-span-2" : "");
         const l = el$1("p", "text-[9px] text-slate-400 uppercase tracking-wide");
-        l.textContent = label;
-        const input = document.createElement("input");
-        input.type = type;
-        input.value = value;
-        input.className = "w-full px-1.5 py-0.5 text-xs text-slate-900 border border-slate-300 rounded bg-white focus:outline-none focus:ring-1 focus:ring-fuchsia-400";
-        input.addEventListener("input", () => onInput(input.value));
+        l.textContent = desc.label;
         w.appendChild(l);
-        w.appendChild(input);
+        const inputCls = "w-full px-1.5 py-0.5 text-xs text-slate-900 border border-slate-300 rounded bg-white focus:outline-none focus:ring-1 focus:ring-fuchsia-400";
+        if (desc.type === "textarea") {
+          const ta = document.createElement("textarea");
+          ta.value = currentVal;
+          ta.rows = 3;
+          ta.className = inputCls + " resize-y";
+          if (desc.placeholder) ta.placeholder = desc.placeholder;
+          ta.addEventListener("input", () => {
+            drafts[desc.key] = ta.value;
+          });
+          w.appendChild(ta);
+        } else if (desc.type === "picklist") {
+          const sel = document.createElement("select");
+          sel.className = inputCls;
+          const blank = document.createElement("option");
+          blank.value = "";
+          blank.textContent = desc.placeholder || "—";
+          sel.appendChild(blank);
+          for (const opt of desc.options || []) {
+            const o = document.createElement("option");
+            o.value = opt;
+            o.textContent = opt;
+            if (opt === currentVal) o.selected = true;
+            sel.appendChild(o);
+          }
+          if (!currentVal) blank.selected = true;
+          sel.addEventListener("change", () => {
+            drafts[desc.key] = sel.value;
+          });
+          w.appendChild(sel);
+        } else {
+          const input = document.createElement("input");
+          input.type = desc.type === "number" ? "number" : desc.type === "date" ? "date" : "text";
+          input.value = currentVal;
+          input.className = inputCls;
+          if (desc.placeholder) input.placeholder = desc.placeholder;
+          if (desc.type === "number") {
+            if (desc.min !== void 0) input.min = String(desc.min);
+            if (desc.max !== void 0) input.max = String(desc.max);
+          }
+          input.addEventListener("input", () => {
+            drafts[desc.key] = desc.type === "number" ? input.value === "" ? null : Number(input.value) : input.value;
+          });
+          w.appendChild(input);
+        }
         grid.appendChild(w);
       }
-      fld("Status", task.stage || "—");
-      fld("Priority", task.priorityGroup || "—");
-      if (editing) {
-        inpField("Start", "date", draftStart, (v) => {
-          draftStart = v;
-        });
-        inpField("End", "date", draftEnd, (v) => {
-          draftEnd = v;
-        });
+      if (schema && schema.length) {
+        for (const desc of schema) renderField(desc);
       } else {
-        fld("Start", task.startDate || "—");
-        fld("End", task.endDate || "—");
+        fld("Status", task.stage || "—");
+        fld("Priority", task.priorityGroup || "—");
+        if (editing) {
+          renderField({ key: "startDate", label: "Start", type: "date" });
+          renderField({ key: "endDate", label: "End", type: "date" });
+        } else {
+          fld("Start", task.startDate || "—");
+          fld("End", task.endDate || "—");
+        }
+        fld("Estimated", task.estimatedHours ? task.estimatedHours + "h" : "—");
+        fld("Logged", task.loggedHours ? task.loggedHours + "h" : "—");
       }
-      fld("Estimated", task.estimatedHours ? task.estimatedHours + "h" : "—");
-      fld("Logged", task.loggedHours ? task.loggedHours + "h" : "—");
       body.appendChild(grid);
       if (editing) {
         const actions = el$1("div", "pt-2 border-t border-slate-100 flex gap-2");
@@ -3557,12 +3803,17 @@ var NimbusGanttApp = (function(exports) {
         );
         saveBtn.textContent = "Save";
         saveBtn.addEventListener("click", () => {
-          const patch = {
-            id: String(task.id)
-          };
-          if (draftStart !== (task.startDate || "")) patch.startDate = draftStart;
-          if (draftEnd !== (task.endDate || "")) patch.endDate = draftEnd;
-          if (patch.startDate !== void 0 || patch.endDate !== void 0) {
+          const changes = {};
+          const keys = schema && schema.length ? schema.filter((f) => !f.readOnly).map((f) => f.key) : ["startDate", "endDate"];
+          for (const k of keys) {
+            const draftVal = drafts[k];
+            const taskVal = task[k];
+            const dNorm = draftVal == null || draftVal === "" ? null : draftVal;
+            const tNorm = taskVal == null || taskVal === "" ? null : taskVal;
+            if (dNorm !== tNorm) changes[k] = draftVal;
+          }
+          if (Object.keys(changes).length > 0) {
+            const patch = { id: String(task.id), ...changes };
             dispatch({ type: "PATCH", patch });
           }
           dispatch({ type: "SET_DETAIL_MODE", mode: "view" });
@@ -3574,8 +3825,15 @@ var NimbusGanttApp = (function(exports) {
         );
         cancelBtn.textContent = "Cancel";
         cancelBtn.addEventListener("click", () => {
-          draftStart = task.startDate || "";
-          draftEnd = task.endDate || "";
+          if (schema && schema.length) {
+            drafts = {};
+            for (const f of schema) {
+              drafts[f.key] = task[f.key];
+            }
+          } else {
+            drafts.startDate = task.startDate || "";
+            drafts.endDate = task.endDate || "";
+          }
           dispatch({ type: "SET_DETAIL_MODE", mode: "view" });
         });
         actions.appendChild(cancelBtn);
@@ -3588,6 +3846,9 @@ var NimbusGanttApp = (function(exports) {
       el: root,
       update: render,
       destroy() {
+        window.removeEventListener("mousemove", onHeaderDragMove);
+        window.removeEventListener("mouseup", onHeaderDragEnd);
+        document.body.style.userSelect = "";
         clear(root);
         if (root.parentNode) root.parentNode.removeChild(root);
       }
@@ -3599,7 +3860,7 @@ var NimbusGanttApp = (function(exports) {
     const host = el$1("div", CLS_CONTENT);
     host.setAttribute("data-nga-gantt-host", "1");
     let sidebarInst = null;
-    let detailInst = null;
+    const detailInsts = /* @__PURE__ */ new Map();
     function render(p) {
       clear(root);
       if (p.state.sidebarOpen && p.config.features.sidebar) {
@@ -3616,13 +3877,28 @@ var NimbusGanttApp = (function(exports) {
         sidebarInst = null;
       }
       root.appendChild(host);
-      if (p.state.detailOpen && p.config.features.detailPanel) {
-        if (!detailInst) detailInst = DetailPanelVanilla(p);
-        else detailInst.update(p);
-        root.appendChild(detailInst.el);
-      } else if (detailInst) {
-        detailInst.destroy();
-        detailInst = null;
+      if (p.config.features.detailPanel) {
+        const openIds = p.state.openDetailTaskIds || [];
+        for (const [tid, inst] of detailInsts) {
+          if (!openIds.includes(tid)) {
+            inst.destroy();
+            detailInsts.delete(tid);
+          }
+        }
+        openIds.forEach((tid, index) => {
+          let inst = detailInsts.get(tid);
+          if (!inst) {
+            inst = DetailPanelVanilla(p, tid);
+            detailInsts.set(tid, inst);
+            const offset = index * 30;
+            inst.el.style.transform = `translate(-${offset}px, -${offset}px)`;
+          }
+          inst.update(p);
+          root.appendChild(inst.el);
+        });
+      } else if (detailInsts.size > 0) {
+        for (const inst of detailInsts.values()) inst.destroy();
+        detailInsts.clear();
       }
     }
     render(initial);
@@ -3631,7 +3907,8 @@ var NimbusGanttApp = (function(exports) {
       update: render,
       destroy() {
         if (sidebarInst) sidebarInst.destroy();
-        if (detailInst) detailInst.destroy();
+        for (const inst of detailInsts.values()) inst.destroy();
+        detailInsts.clear();
         clear(root);
         if (root.parentNode) root.parentNode.removeChild(root);
       }
@@ -4301,7 +4578,15 @@ var NimbusGanttApp = (function(exports) {
     { key: "depthShading", label: "Depth shading" },
     { key: "hoursColumn", label: "Hours column" },
     { key: "budgetUsedColumn", label: "Budget-used column" },
-    { key: "headerRowCompletionBar", label: "Header completion bar" }
+    { key: "headerRowCompletionBar", label: "Header completion bar" },
+    // 0.185.11 — drag-to-reparent. Default OFF. When ON: drop-onto-row
+    // middle = nest under, drop-on-bucket-header = deparent, horizontal
+    // drag changes depth. When OFF: pure reorder, no parent changes.
+    { key: "enableDragReparent", label: "Enable drag to reparent" },
+    // 0.185.16 — canvas-bar vertical drag reprioritize. Default OFF.
+    // When ON: vertical-dominant drag of a bar commits a reorder
+    // instead of shifting dates. Horizontal drags still shift dates.
+    { key: "enableDragBarToReprioritize", label: "Prioritize by Gantt bar" }
   ];
   function renderAdminPanel(container, state, dispatch, tplConfig) {
     const id = "nga-admin-panel";
@@ -4472,26 +4757,9 @@ var NimbusGanttApp = (function(exports) {
       "box-shadow:0 1px 2px rgba(0,0,0,0.04)",
       "cursor:pointer"
     ].join(";");
-    btn.addEventListener("click", () => {
-      try {
-        console.log("[NG fs-enter-btn click] invoking host onEnterFullscreen");
-      } catch (_e) {
-      }
-      try {
-        onClick();
-      } catch (err) {
-        try {
-          console.error("[NG fs-enter-btn click] onEnterFullscreen threw", err);
-        } catch (_e) {
-        }
-      }
-    });
+    btn.addEventListener("click", onClick);
     if (!container.style.position) container.style.position = "relative";
     container.appendChild(btn);
-    try {
-      console.log("[NG fs-enter-btn render] embedded-mode floating button attached");
-    } catch (_e) {
-    }
     return () => {
       try {
         btn.remove();
@@ -4542,6 +4810,17 @@ var NimbusGanttApp = (function(exports) {
       if (options.cssUrl) tplConfig.stylesheet = { ...tplConfig.stylesheet, url: options.cssUrl };
       if (options.engine) tplConfig.engine = options.engine;
       if (options.recordUrlTemplate) tplConfig.recordUrlTemplate = options.recordUrlTemplate;
+      if (options.fieldSchema) tplConfig.fieldSchema = options.fieldSchema;
+      tplConfig.features.enableDragReparent = options.enableDragReparent === true;
+      try {
+        console.log("[NG config] enableDragReparent=", tplConfig.features.enableDragReparent);
+      } catch (_e2) {
+      }
+      tplConfig.features.enableDragBarToReprioritize = options.enableDragBarToReprioritize === true;
+      try {
+        console.log("[NG config] enableDragBarToReprioritize=", tplConfig.features.enableDragBarToReprioritize);
+      } catch (_e2) {
+      }
       if (options.engineOnly) {
         let _syncToCanvas = function() {
           const f = applyFilter(allTasks2, state2.filter, state2.search);
@@ -4701,7 +4980,7 @@ var NimbusGanttApp = (function(exports) {
         let cleanupDrag2 = null;
         if (tplConfig.features.depthShading) cleanupShading2 = startDepthShading(ganttEl, depthMap2);
         if (tplConfig.features.dragReparent) cleanupDrag2 = startDragReparent(ganttEl, allTasks2, depthMap2, options.onPatch || (() => {
-        }));
+        }), () => !!tplConfig.features.enableDragReparent);
         const cleanup2 = () => {
           if (cleanupShading2) cleanupShading2();
           if (cleanupDrag2) cleanupDrag2();
@@ -4876,6 +5155,7 @@ var NimbusGanttApp = (function(exports) {
       container.className = "nga-root";
       container.setAttribute("data-template", tplConfig.templateName);
       container.setAttribute("data-mode", mode);
+      container.setAttribute("data-nga-template-root", "1");
       container.style.display = "flex";
       container.style.flexDirection = "column";
       container.style.overflow = "hidden";
@@ -5443,6 +5723,89 @@ var NimbusGanttApp = (function(exports) {
             if (!orig || orig.startDate !== s) changes.startDate = s;
             if (!orig || orig.endDate !== e) changes.endDate = e;
             onTaskEditAsync(task.id, s, e, changes);
+          },
+          // 0.185.16 — canvas bar vertical-drag reprioritize. Getter reads
+          // the live feature flag (via tplConfig.features.enableDragBarToReprioritize
+          // which is already reconciled by reconcileFeatureOverrides each
+          // state change). Callback resolves target row → newSortOrder +
+          // optional newPriorityGroup, then routes through the existing
+          // onItemReorder chain so DH's handler receives the same payload
+          // shape as the sidebar reorder path.
+          isBarReprioritizeEnabled: () => !!tplConfig.features.enableDragBarToReprioritize,
+          onBarReorderDrag: (task, targetTaskId, targetRowIndex, targetBucketId) => {
+            try {
+              console.log("[NG] main onBarReorderDrag received", task == null ? void 0 : task.id, "→ target=", targetTaskId, "rowIdx=", targetRowIndex, "bucket=", targetBucketId);
+            } catch (_e2) {
+            }
+            if (!task || !task.id || isBucketId(task.id)) return;
+            const srcTask = allTasks.find((t) => t.id === task.id);
+            if (!srcTask) return;
+            const tgtTask = targetTaskId && !isBucketId(targetTaskId) ? allTasks.find((t) => t.id === targetTaskId) : null;
+            const resolvedBucket = targetBucketId || (tgtTask && tgtTask.priorityGroup ? tgtTask.priorityGroup : null) || srcTask.priorityGroup || null;
+            const patch = { id: task.id };
+            if (resolvedBucket && resolvedBucket !== srcTask.priorityGroup) {
+              patch.priorityGroup = resolvedBucket;
+            }
+            const bucketTasks = allTasks.filter((t) => t.priorityGroup === resolvedBucket && t.id !== task.id).sort((a, b) => (Number(a.sortOrder) || 0) - (Number(b.sortOrder) || 0));
+            if (bucketTasks.length === 0) {
+              patch.sortOrder = 1e3;
+            } else if (!tgtTask || !bucketTasks.find((t) => t.id === tgtTask.id)) {
+              const maxSort = bucketTasks[bucketTasks.length - 1];
+              patch.sortOrder = (Number(maxSort.sortOrder) || 0) + 1e3;
+            } else {
+              const tgtIdx = bucketTasks.findIndex((t) => t.id === tgtTask.id);
+              const tgtSort = Number(tgtTask.sortOrder) || 0;
+              const srcSort = Number(srcTask.sortOrder) || 0;
+              const crossBucket = srcTask.priorityGroup !== resolvedBucket;
+              if (crossBucket) {
+                const prev = tgtIdx > 0 ? bucketTasks[tgtIdx - 1] : null;
+                if (prev) {
+                  const prevSort = Number(prev.sortOrder) || 0;
+                  patch.sortOrder = (prevSort + tgtSort) / 2;
+                } else {
+                  patch.sortOrder = tgtSort - 500;
+                }
+              } else {
+                if (srcSort < tgtSort) {
+                  const next = tgtIdx < bucketTasks.length - 1 ? bucketTasks[tgtIdx + 1] : null;
+                  if (next) {
+                    patch.sortOrder = (tgtSort + (Number(next.sortOrder) || 0)) / 2;
+                  } else {
+                    patch.sortOrder = tgtSort + 500;
+                  }
+                } else {
+                  const prev = tgtIdx > 0 ? bucketTasks[tgtIdx - 1] : null;
+                  if (prev) {
+                    patch.sortOrder = ((Number(prev.sortOrder) || 0) + tgtSort) / 2;
+                  } else {
+                    patch.sortOrder = tgtSort - 500;
+                  }
+                }
+              }
+            }
+            try {
+              console.log(
+                "[NG bar-reorder] emitting",
+                "src=",
+                task.id,
+                "srcSort=",
+                Number(srcTask.sortOrder) || 0,
+                "srcBucket=",
+                srcTask.priorityGroup,
+                "target=",
+                targetTaskId,
+                "targetBucket=",
+                targetBucketId,
+                "resolvedBucket=",
+                resolvedBucket,
+                "bucketTaskCount=",
+                bucketTasks.length,
+                "→ patch=",
+                JSON.stringify(patch)
+              );
+            } catch (_e2) {
+            }
+            interceptedOnPatch(patch);
           }
         });
         const findTaskById = (id) => id ? allTasks.find((t) => t.id === id) ?? null : null;
@@ -5530,7 +5893,7 @@ var NimbusGanttApp = (function(exports) {
         if (cleanupShading) cleanupShading();
         if (cleanupDrag) cleanupDrag();
         if (tplConfig.features.depthShading) cleanupShading = startDepthShading(ganttEl, depthMap);
-        if (tplConfig.features.dragReparent) cleanupDrag = startDragReparent(ganttEl, allTasks, depthMap, interceptedOnPatch);
+        if (tplConfig.features.dragReparent) cleanupDrag = startDragReparent(ganttEl, allTasks, depthMap, interceptedOnPatch, () => !!tplConfig.features.enableDragReparent);
         if (options.onViewportChange) {
           try {
             const wrapper = ganttEl.querySelector(".ng-scroll-wrapper");
@@ -5684,6 +6047,22 @@ var NimbusGanttApp = (function(exports) {
           }
         );
       }
+      const onFullscreenChange = () => {
+        try {
+          renderSlots();
+        } catch (_e2) {
+        }
+        try {
+          updateRepinButton();
+        } catch (_e2) {
+        }
+      };
+      try {
+        document.addEventListener("fullscreenchange", onFullscreenChange);
+        document.addEventListener("webkitfullscreenchange", onFullscreenChange);
+        document.addEventListener("msfullscreenchange", onFullscreenChange);
+      } catch (_e2) {
+      }
       const cleanup = () => {
         if (cleanupShading) cleanupShading();
         if (cleanupDrag) cleanupDrag();
@@ -5694,6 +6073,12 @@ var NimbusGanttApp = (function(exports) {
           } catch (_e2) {
           }
           repinButtonEl = null;
+        }
+        try {
+          document.removeEventListener("fullscreenchange", onFullscreenChange);
+          document.removeEventListener("webkitfullscreenchange", onFullscreenChange);
+          document.removeEventListener("msfullscreenchange", onFullscreenChange);
+        } catch (_e2) {
         }
         if (ganttInst) {
           try {


### PR DESCRIPTION
## Summary
- **Strip 3 post-save refetch sites** in `deliveryProFormaTimeline.js` — each was calling `setTasks()` ~350ms after save, rebuilding the whole gantt and causing a 2-4× x-axis snap on every drag-drop. NG's optimistic state already reflects each mutation; formula-field rollups refresh on next page load.
- **NG 0.185.24** (`nimbusganttapp.resource`) — bucket-scoped `dragReparent` walk; fixes cross-bucket bound bug where top-of-active-bucket grabbed top-priority's last task as `aboveId` and emitted midpoint(43000,3000)=23000 garbage sortOrders.
- **Enter Fullscreen** lands on `/lightning/n/Delivery_Gantt_Full_Bleed` (chromeless VF tab) instead of LEX-wrapped `/apex/...`.
- **DetailPanel** — `onItemEdit` wired for both embedded + fullscreen, `updateWorkItemFields` Apex endpoint + `fieldSchema` drives multi-field save.
- **sortOrder collision guard** — 0.5 nudge until unique, so NG midpoint repeats don't tiebreak alphabetically by Name.

## Test plan
- [x] apex-scan (PMD)
- [x] Drag-and-drop validated on `Delivery Hub__glen-walk` with NG 0.185.24 — cross-bucket reorder, top/bottom-of-bucket, date drag
- [x] Enter Fullscreen → chromeless Full_Bleed route
- [ ] Drop an item, confirm no x-axis snap