### PR TITLE
fix(gantt): ship Standalone Aura + default headerless + flip hours widget

### DIFF
--- a/force-app/main/default/aura/DeliveryTimelineStandalone/DeliveryTimelineStandalone.app
+++ b/force-app/main/default/aura/DeliveryTimelineStandalone/DeliveryTimelineStandalone.app
@@ -1,0 +1,22 @@
+<!--
+    True-fullscreen standalone host for deliveryProFormaTimeline.
+    Accessed directly at /c/DeliveryTimelineStandalone.app (unnamespaced)
+    or /<namespace>/DeliveryTimelineStandalone.app (namespaced). Renders
+    as top-level page OUTSIDE /one/one.app, so no LEX chrome appears —
+    the entire viewport is the gantt.
+
+    Unlike DeliveryTimelineOut.app (extends ltng:outApp) which is a
+    Lightning Out bootstrap target for VF embedding, this app is a
+    standalone app you navigate to directly. `force:slds` injects SLDS
+    styles globally so the LWC's lightning-* primitives render natively.
+
+    The `c:` namespace is context-sensitive in Aura — it resolves to the
+    package's own namespace when installed as a managed package, and to
+    the custom (unnamespaced) namespace in scratch orgs. So `c:delivery
+    ProFormaTimeline` renders the local package's LWC in both contexts
+    without needing a CumulusCI namespace token (which can't be used as
+    an XML element-name prefix anyway).
+-->
+<aura:application extends="force:slds" access="GLOBAL">
+    <c:deliveryProFormaTimeline mode="fullscreen" />
+</aura:application>

--- a/force-app/main/default/aura/DeliveryTimelineStandalone/DeliveryTimelineStandalone.app-meta.xml
+++ b/force-app/main/default/aura/DeliveryTimelineStandalone/DeliveryTimelineStandalone.app-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <description>True-fullscreen standalone host for deliveryProFormaTimeline — accessed directly at /c/DeliveryTimelineStandalone.app, renders outside /one/one.app so no LEX chrome</description>
+</AuraDefinitionBundle>

--- a/force-app/main/default/lwc/deliveryBudgetSummary/deliveryBudgetSummary.html
+++ b/force-app/main/default/lwc/deliveryBudgetSummary/deliveryBudgetSummary.html
@@ -35,15 +35,15 @@
                             <lightning-icon icon-name="standard:log_a_call" size="medium"></lightning-icon>
                         </div>
                         <div class="slds-media__body">
-                            <div class="slds-text-heading_large slds-var-m-bottom_xx-small" style="cursor: pointer;" onclick={handleHoursEnteredThisMonthClick}>
-                                <strong>{metrics.hoursLoggedThisMonth}</strong>
+                            <div class="slds-text-heading_large slds-var-m-bottom_xx-small" style="cursor: pointer;" onclick={handleHoursPerformedThisMonthClick}>
+                                <strong>{metrics.hoursThisMonth}</strong>
                             </div>
-                            <div class="slds-text-title_caps slds-text-color_weak">Hours Entered This Month</div>
-                            <div class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small" style="cursor: pointer; text-decoration: underline;" onclick={handleHoursPerformedThisMonthClick}>
-                                {metrics.hoursThisMonth} hours performed
+                            <div class="slds-text-title_caps slds-text-color_weak">Hours Performed This Month</div>
+                            <div class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small" style="cursor: pointer; text-decoration: underline;" onclick={handleHoursEnteredThisMonthClick}>
+                                {metrics.hoursLoggedThisMonth} hours entered
                             </div>
                             <div class="slds-text-body_small slds-text-color_weak">
-                                Last Month: <span style="cursor: pointer; text-decoration: underline;" onclick={handleHoursEnteredLastMonthClick}>{metrics.hoursLoggedLastMonth} entered</span> · <span style="cursor: pointer; text-decoration: underline;" onclick={handleHoursPerformedLastMonthClick}>{metrics.hoursLastMonth} performed</span>
+                                Last Month: <span style="cursor: pointer; text-decoration: underline;" onclick={handleHoursPerformedLastMonthClick}>{metrics.hoursLastMonth} performed</span> · <span style="cursor: pointer; text-decoration: underline;" onclick={handleHoursEnteredLastMonthClick}>{metrics.hoursLoggedLastMonth} entered</span>
                             </div>
                         </div>
                     </div>

--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -168,7 +168,9 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
     }
 
     _installFullscreenChromeHide() {
-        if (this.mode !== 'fullscreen') return;
+        // Default both embedded and fullscreen modes to chrome-hidden.
+        // Glen's spec: one Timeline tab, opens headerless by default.
+        // A future toggle will let users reveal the SF page header.
         if (document.getElementById('dh-gantt-fs-chrome-hide')) return;
         const style = document.createElement('style');
         style.id = 'dh-gantt-fs-chrome-hide';


### PR DESCRIPTION
## Summary
Three bundled fixes:

1. **Fullscreen fixed on MF-Prod** — `DeliveryTimelineStandalone.app` Aura bundle was never committed, so `/<ns>/DeliveryTimelineStandalone.app` 404'd on every non-glen-walk org. Now tracked. Rewrote invalid `<%%%NAMESPACE_OR_C%%%:...>` tag (XML parse error) to `<c:deliveryProFormaTimeline>` — `c:` in Aura resolves correctly in both managed and unmanaged contexts.
2. **Embedded Timeline tab defaults to header-hidden** — step 1 toward Glen's "one tab, chromeless default" UX spec. SLDS page header + FlexiPage chrome suppressed on mount.
3. **Home widget flipped** — `Hours Performed This Month` is now the big number, `hours entered` is the clickable sub-label. Last Month line reorders to match.

## Test plan
- [x] Deployed to `Delivery Hub__glen-walk`
- [x] apex-scan (PMD)
- [ ] Glen verifies on glen-walk before prod install