### PR TITLE
fix(gantt): Aura namespace token + hide Full_Bleed tab + toggleHeader

### DIFF
--- a/force-app/main/default/applications/DeliveryHub.app-meta.xml
+++ b/force-app/main/default/applications/DeliveryHub.app-meta.xml
@@ -194,7 +194,6 @@
     <tabs>Delivery_Workspace</tabs>
     <tabs>Delivery_Board</tabs>
     <tabs>Delivery_Timeline</tabs>
-    <tabs>Delivery_Gantt_Full_Bleed</tabs>
     <tabs>Delivery_Activity</tabs>
     <tabs>WorkItem__c</tabs>
     <tabs>WorkItemComment__c</tabs>

--- a/force-app/main/default/aura/DeliveryTimelineStandalone/DeliveryTimelineStandalone.app
+++ b/force-app/main/default/aura/DeliveryTimelineStandalone/DeliveryTimelineStandalone.app
@@ -5,18 +5,15 @@
     as top-level page OUTSIDE /one/one.app, so no LEX chrome appears —
     the entire viewport is the gantt.
 
-    Unlike DeliveryTimelineOut.app (extends ltng:outApp) which is a
-    Lightning Out bootstrap target for VF embedding, this app is a
-    standalone app you navigate to directly. `force:slds` injects SLDS
-    styles globally so the LWC's lightning-* primitives render natively.
-
-    The `c:` namespace is context-sensitive in Aura — it resolves to the
-    package's own namespace when installed as a managed package, and to
-    the custom (unnamespaced) namespace in scratch orgs. So `c:delivery
-    ProFormaTimeline` renders the local package's LWC in both contexts
-    without needing a CumulusCI namespace token (which can't be used as
-    an XML element-name prefix anyway).
+    Uses the CumulusCI %%%NAMESPACE_OR_C%%% token so `cci task run deploy`
+    substitutes the actual namespace before deploy:
+      unmanaged scratch → <c:deliveryProFormaTimeline/>
+      namespaced scratch/managed package → <delivery:deliveryProFormaTimeline/>
+    A literal `c:` prefix does NOT reliably resolve to the package namespace
+    in Aura managed-package contexts (unlike LWC where `c:` always works).
+    Note: `sf project deploy` does not perform this substitution and will
+    fail with an XML parse error — always deploy via cci for this file.
 -->
 <aura:application extends="force:slds" access="GLOBAL">
-    <c:deliveryProFormaTimeline mode="fullscreen" />
+    <%%%NAMESPACE_OR_C%%%:deliveryProFormaTimeline mode="fullscreen" />
 </aura:application>

--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -947,6 +947,7 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             '  __cnEdit.reorder(id, newIndex)',
             '  __cnEdit.setParent(id, parentId|null)',
             '  __cnEdit.scrollToDate(date) -> scroll timeline to focus on date (NG 0.185.1+)',
+            '  __cnEdit.toggleHeader()   -> show/hide the Salesforce page header chrome',
             '  __cnEdit.submit(note?)    -> no-op (DH writes every patch immediately)',
             '  __cnEdit.reset()          -> no-op (reload page to refetch)',
             '',
@@ -987,6 +988,18 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             },
             setParent: function (id, parentId) {
                 return self._handlePatch({ id: id, parentId: parentId || null });
+            },
+            toggleHeader: function () {
+                // Toggles the SLDS page header / FlexiPage chrome hide-CSS.
+                // Embedded Timeline tab opens header-hidden; call this from
+                // the console to reveal the SF chrome (and call again to
+                // hide). A proper toolbar button in NG is TBD.
+                if (document.getElementById('dh-gantt-fs-chrome-hide')) {
+                    self._uninstallFullscreenChromeHide();
+                    return { ok: true, headerVisible: true };
+                }
+                self._installFullscreenChromeHide();
+                return { ok: true, headerVisible: false };
             },
             scrollToDate: function (date) {
                 // NG 0.185.1+ exposes scrollToDate on the mount handle.


### PR DESCRIPTION
## Summary
Follow-up to #667:

1. **Aura fullscreen app** — `DeliveryTimelineStandalone.app` element tag uses `%%%NAMESPACE_OR_C%%%` token so cci substitutes the actual namespace at deploy/package time. Previous literal `<c:...>` was at risk of not resolving to the package namespace at runtime in managed package context on MF-Prod. Verified token substitution works via `cci task run deploy`.
2. **Delivery Hub app** — `Delivery_Gantt_Full_Bleed` tab removed from the app's tab list. The orphan VF tab is no longer part of the single-Timeline-tab UX; keeps the metadata around for anyone who has direct `/lightning/n/` URLs pinned.
3. **toggleHeader() bridge** — Embedded Timeline tab opens header-hidden (per Glen's one-tab UX). Added `__cnEdit.toggleHeader()` as a console-callable toggle so you can reveal/hide the SF page header without a reload. NG-side toolbar button is TBD.

## Test plan
- [x] Deployed to `Delivery Hub__glen-walk`
- [x] apex-scan (PMD)
- [ ] Click **Full Screen** from Timeline tab on glen-walk — gantt should render at `/delivery/DeliveryTimelineStandalone.app` (or `/c/...` unnamespaced). Run `document.body.__cnEdit.toggleHeader()` to reveal the SF header, run again to hide.