### PR TITLE
feat(gantt): Show/Hide Header toggle in NG TitleBar (NG 0.185.26)

### DIFF
--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -96,6 +96,7 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
     _mountHandle = null;
     _refetchTimer = null;
     _viewportWriteTimer = null;
+    _headerVisible = false;
 
     async connectedCallback() {
         // Fullscreen FlexiPage route renders a Salesforce-injected SLDS page-header
@@ -196,6 +197,33 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
         if (s && s.parentNode) s.parentNode.removeChild(s);
     }
 
+    // Builds the host-contributed TitleBar buttons (NG 0.185.26+
+    // titleBarButtons slot). DH contributes a Show/Hide Header toggle.
+    // Full Screen stays owned by NG via the existing fullscreen contract.
+    _buildHostTitleBarButtons() {
+        return [{
+            id: 'dh-show-header',
+            label: this._headerVisible ? 'Hide Header' : 'Show Header',
+            pressed: this._headerVisible,
+            onClick: () => this._toggleHeaderChrome(),
+        }];
+    }
+
+    // Flips the SLDS page-header hide-CSS and re-pushes the TitleBar
+    // buttons so NG updates the button label + pressed state in place.
+    _toggleHeaderChrome() {
+        if (document.getElementById('dh-gantt-fs-chrome-hide')) {
+            this._uninstallFullscreenChromeHide();
+            this._headerVisible = true;
+        } else {
+            this._installFullscreenChromeHide();
+            this._headerVisible = false;
+        }
+        if (this._mountHandle && typeof this._mountHandle.setTitleBarButtons === 'function') {
+            this._mountHandle.setTitleBarButtons(this._buildHostTitleBarButtons());
+        }
+    }
+
     // CLOUDNIMBUS_CSS resolves to `/resource/{ts}/cloudnimbustemplatecss` in a
     // non-namespaced scratch and `/resource/{ts}/delivery__cloudnimbustemplatecss`
     // in a subscriber org. Used to build the VF fullscreen URL so it resolves
@@ -251,6 +279,10 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             onPatch: (patch) => this._handlePatch(patch),
             onItemReorder: (taskId, payload) => this._handleItemReorder(taskId, payload),
             onItemReorderError: (taskId, error) => this._handleItemReorderError(taskId, error),
+            // NG 0.185.26 — generic TitleBar button slot. DH contributes a
+            // Show/Hide Header toggle that reveals the SF page-header chrome
+            // that the Timeline tab hides by default.
+            titleBarButtons: this._buildHostTitleBarButtons(),
             // onItemClick NOT wired — NG 0.185.18+ defaults to dispatching
             // TOGGLE_DETAIL on task click, which opens DetailPanel inline.
             // When a host onItemClick is wired, NG suppresses default action,
@@ -991,15 +1023,10 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             },
             toggleHeader: function () {
                 // Toggles the SLDS page header / FlexiPage chrome hide-CSS.
-                // Embedded Timeline tab opens header-hidden; call this from
-                // the console to reveal the SF chrome (and call again to
-                // hide). A proper toolbar button in NG is TBD.
-                if (document.getElementById('dh-gantt-fs-chrome-hide')) {
-                    self._uninstallFullscreenChromeHide();
-                    return { ok: true, headerVisible: true };
-                }
-                self._installFullscreenChromeHide();
-                return { ok: true, headerVisible: false };
+                // Shared code path with the NG TitleBar button (0.185.26
+                // titleBarButtons slot). Console still works as a backup.
+                self._toggleHeaderChrome();
+                return { ok: true, headerVisible: self._headerVisible };
             },
             scrollToDate: function (date) {
                 // NG 0.185.1+ exposes scrollToDate on the mount handle.

--- a/force-app/main/default/staticresources/nimbusganttapp.resource
+++ b/force-app/main/default/staticresources/nimbusganttapp.resource
@@ -2898,6 +2898,22 @@ var NimbusGanttApp = (function(exports) {
         }
       });
       rowMain.appendChild(unpinBtn);
+      const hostBtns = config.titleBarButtons || [];
+      hostBtns.forEach((b) => {
+        const cls = CLS_PILL_BTN_BASE + " " + (b.pressed ? CLS_PILL_BTN_ACTIVE_BLUE : CLS_PILL_BTN_IDLE_BLUE);
+        const btn = el$1("button", cls);
+        btn.type = "button";
+        btn.textContent = b.label;
+        if (b.title) btn.title = b.title;
+        btn.setAttribute("data-nga-host-btn", b.id);
+        btn.addEventListener("click", () => {
+          try {
+            b.onClick();
+          } catch (_e) {
+          }
+        });
+        rowMain.appendChild(btn);
+      });
       const fsApi = resolveFullscreenApi();
       const fsUrl = config.fullscreenUrl;
       const onCurrentFsUrl = !!(fsUrl && typeof location !== "undefined" && location.pathname === fsUrl);
@@ -4827,6 +4843,7 @@ var NimbusGanttApp = (function(exports) {
       if (options.engine) tplConfig.engine = options.engine;
       if (options.recordUrlTemplate) tplConfig.recordUrlTemplate = options.recordUrlTemplate;
       if (options.fieldSchema) tplConfig.fieldSchema = options.fieldSchema;
+      if (options.titleBarButtons) tplConfig.titleBarButtons = options.titleBarButtons;
       tplConfig.features.enableDragReparent = options.enableDragReparent === true;
       try {
         console.log("[NG config] enableDragReparent=", tplConfig.features.enableDragReparent);
@@ -6210,6 +6227,14 @@ var NimbusGanttApp = (function(exports) {
             if (typeof x === "number") (_d2 = (_c2 = gi.scrollManager) == null ? void 0 : _c2.scrollToX) == null ? void 0 : _d2.call(_c2, Math.max(0, x));
           } catch (_e2) {
           }
+        },
+        /** 0.185.26 — runtime update of host-supplied TitleBar buttons. Pass
+         *  the full desired array (not a diff); replacing `pressed` state on
+         *  an existing button is the typical use. Re-renders slots so the
+         *  TitleBar picks up the new array immediately — no remount. */
+        setTitleBarButtons(buttons) {
+          tplConfig.titleBarButtons = buttons;
+          renderSlots();
         },
         /** 0.185 — visual-only revert. Restores `original` on every buffered
          *  task and clears the buffer. Host never sees a callback. Use when


### PR DESCRIPTION
## Summary
Pulls nimbus-gantt `534321d` (0.185.26) into DH static resource and wires the new `titleBarButtons` slot. Timeline tab now renders a **Show/Hide Header** button in the TitleBar next to Full Screen. Clicking toggles the SF page-header hide-CSS in place — no reload, no route change. Button label + pressed state flip via the 0.185.26 `setTitleBarButtons` handle verb.

Kept `__cnEdit.toggleHeader()` as a console backup; it now shares the `_toggleHeaderChrome()` code path with the button.

Bundle:
- 257,039 bytes
- sha256 `9e40a74e0049ec1a6ad71a0019a5f75dd36c783a8993c70167904857ba61c444`

## Test plan
- [x] Deployed to `Delivery Hub__glen-walk`
- [x] apex-scan (PMD)
- [ ] Timeline tab opens headerless; click **Show Header** → SF header appears, label flips to **Hide Header**; click again → header hidden, label flips back