### PR TITLE
feat(gantt): NG 0.185.27 deps read-side + ctx-menu probe

### DIFF
--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -43,6 +43,7 @@ import NIMBUS_GANTT_APP from '@salesforce/resourceUrl/nimbusganttapp';
 import CLOUDNIMBUS_CSS from '@salesforce/resourceUrl/cloudnimbustemplatecss';
 import USER_ID from '@salesforce/user/Id';
 import getProFormaTimelineData from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.getProFormaTimelineData';
+import getGanttDependencies from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.getGanttDependencies';
 import updateWorkItemDates from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.updateWorkItemDates';
 import updateWorkItemSortOrder from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.updateWorkItemSortOrder';
 import updateWorkItemPriorityGroup from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.updateWorkItemPriorityGroup';
@@ -93,6 +94,7 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
     _scriptLoaded = false;
     _mounted = false;
     _tasks = [];
+    _dependencies = [];
     _mountHandle = null;
     _refetchTimer = null;
     _viewportWriteTimer = null;
@@ -235,14 +237,35 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
 
     async _loadAndMount() {
         try {
-            const data = await getProFormaTimelineData({ showCompleted: false });
+            // Parallel-fetch tasks + dependencies. Dependencies include
+            // completed-dependent tasks (showCompleted:true) so dangling
+            // arrows don't disappear when the target task is hidden — v0
+            // NG renders them gracefully.
+            const [data, deps] = await Promise.all([
+                getProFormaTimelineData({ showCompleted: false }),
+                getGanttDependencies({ showCompleted: true }),
+            ]);
             this._tasks = data || [];
+            this._dependencies = this._mapDependenciesForNg(deps);
             // Give DOM a tick to render the container
             await new Promise(resolve => setTimeout(resolve, 0));
             this._mount();
         } catch (error) {
             this._showError('Failed to load work items', error);
         }
+    }
+
+    // Apex DTO field is `dependencyType`; NG core expects `type`. Cheapest
+    // fix is client-side map — renaming the Apex field would force a
+    // managed-package upload. Default 'FS' when the DTO is missing it so
+    // old records still render.
+    _mapDependenciesForNg(raw) {
+        return (raw || []).map(d => ({
+            id: d.id,
+            source: d.source,
+            target: d.target,
+            type: d.dependencyType || d.type || 'FS',
+        }));
     }
 
     _mount() {
@@ -263,6 +286,18 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
         const mountConfig = {
             mode: this.mode,
             tasks,
+            // NG 0.185.27 — dependencies pipe re-opened. Render arrows
+            // between predecessor/successor bars per WorkItemDependency__c.
+            dependencies: this._dependencies,
+            // 2026-04-21 probe — NG CC found onTaskContextMenu appears to
+            // already be wired in 0.185.27 (IIFEApp.ts:768-781 + :2006-2018).
+            // Log-only to confirm it fires in Locker/LWS context. If this
+            // logs on right-click over a task bar in glen-walk, the full
+            // right-click UX is DH-only (no NG release needed).
+            onTaskContextMenu: (task, pos) => {
+                // eslint-disable-next-line no-console
+                console.log('[DH ctx-probe]', (task && task.id) || task, pos);
+            },
             // Save-path routing is mode-conditional:
             //
             //   Embedded (Delivery_Timeline tab): NG emits legacy onPatch for

--- a/force-app/main/default/staticresources/nimbusganttapp.resource
+++ b/force-app/main/default/staticresources/nimbusganttapp.resource
@@ -4860,7 +4860,7 @@ var NimbusGanttApp = (function(exports) {
           const g = state2.groupBy === "epic" ? buildTasks(buildTasksEpic(f)) : buildTasks(f);
           const gi = inst;
           if (typeof gi.setData === "function") {
-            gi.setData(g, []);
+            gi.setData(g, allDependencies2);
             try {
               gi.expandAll();
             } catch (_e2) {
@@ -4887,6 +4887,7 @@ var NimbusGanttApp = (function(exports) {
         }
         injectLegacyNgCss();
         let allTasks2 = options.tasks || [];
+        let allDependencies2 = options.dependencies || [];
         const state2 = { ...INITIAL_STATE };
         const depthMap2 = buildDepthMap(allTasks2);
         const filtered = applyFilter(allTasks2, state2.filter, state2.search);
@@ -4898,7 +4899,7 @@ var NimbusGanttApp = (function(exports) {
         };
         const inst = new eng.NimbusGantt(ganttEl, {
           tasks: gtasks,
-          dependencies: [],
+          dependencies: allDependencies2,
           columns: buildGanttCols(tplConfig.features),
           theme: V3_THEME,
           rowHeight: 32,
@@ -4983,7 +4984,7 @@ var NimbusGanttApp = (function(exports) {
             getBucket: (task) => task.groupId || null
           }));
         }
-        inst.setData(gtasks, []);
+        inst.setData(gtasks, allDependencies2);
         try {
           inst.expandAll();
         } catch (_e2) {
@@ -5030,6 +5031,16 @@ var NimbusGanttApp = (function(exports) {
         return {
           setTasks(tasks) {
             allTasks2 = tasks;
+            _syncToCanvas();
+          },
+          /** 0.185.27 — full replace of tasks AND dependencies. Pass the
+           *  new deps array when the host has a fresh set (e.g. after Apex
+           *  refresh pulls both timeline data and getGanttDependencies in
+           *  parallel). Passing `undefined` leaves the existing deps alone
+           *  — equivalent to `setTasks(tasks)`. */
+          setData(tasks, dependencies) {
+            allTasks2 = tasks;
+            if (dependencies !== void 0) allDependencies2 = dependencies;
             _syncToCanvas();
           },
           /** Called by NimbusGanttAppReact when the React filter/search state changes. */
@@ -5089,6 +5100,7 @@ var NimbusGanttApp = (function(exports) {
         state = { ...state, zoom: options.initialViewport.zoom };
       }
       let allTasks = options.tasks || [];
+      let allDependencies = options.dependencies || [];
       const patchLog = [];
       const _viewportEmitTimer = { t: null };
       function emitViewport() {
@@ -5698,7 +5710,7 @@ var NimbusGanttApp = (function(exports) {
         let lastHoveredTaskId = null;
         ganttInst = new Ctor(ganttEl, {
           tasks: gtasks,
-          dependencies: [],
+          dependencies: allDependencies,
           columns: buildGanttCols(tplConfig.features),
           theme: V3_THEME,
           rowHeight: 32,
@@ -5890,7 +5902,7 @@ var NimbusGanttApp = (function(exports) {
             getBucketProgress: bucketProgressFn
           }));
         }
-        ganttInst.setData(gtasks, []);
+        ganttInst.setData(gtasks, allDependencies);
         try {
           ganttInst.expandAll();
         } catch (_e2) {
@@ -5954,7 +5966,7 @@ var NimbusGanttApp = (function(exports) {
           }
           const gi = ganttInst;
           if (typeof gi.setData === "function") {
-            gi.setData(gtasks, []);
+            gi.setData(gtasks, allDependencies);
             try {
               gi.expandAll();
             } catch (_e2) {
@@ -6131,6 +6143,23 @@ var NimbusGanttApp = (function(exports) {
       return {
         setTasks(tasks) {
           allTasks = tasks;
+          depthMap = buildDepthMap(allTasks);
+          const live = tplConfig.features.liveDataUpdate !== false;
+          if (live && ganttInst && state.viewMode === "gantt") {
+            refreshGantt();
+          } else {
+            rebuildView();
+          }
+        },
+        /** 0.185.27 — full replace of tasks AND dependencies. Pass the
+         *  new deps array when the host has a fresh set (e.g. after Apex
+         *  refresh pulls both `getProFormaTimelineData` + `getGanttDependencies`
+         *  in parallel). Passing `undefined` leaves the existing deps alone —
+         *  equivalent to calling `setTasks(tasks)` alone. Routes through the
+         *  same liveDataUpdate-gated refresh path as setTasks. */
+        setData(tasks, dependencies) {
+          allTasks = tasks;
+          if (dependencies !== void 0) allDependencies = dependencies;
           depthMap = buildDepthMap(allTasks);
           const live = tplConfig.features.liveDataUpdate !== false;
           if (live && ganttInst && state.viewMode === "gantt") {


### PR DESCRIPTION
## Summary
Pulls nimbus-gantt \`26d2eae\` (0.185.27) into DH static resource and wires the re-opened dependencies pipe:

- `getGanttDependencies` Apex parallel-fetched with `getProFormaTimelineData` in `_loadAndMount()`
- `_mapDependenciesForNg` maps Apex \`dependencyType\` → NG \`type\` (defaults to FS)
- \`dependencies\` passed into \`NimbusGanttApp.mount(...)\`
- Arrows render automatically for any existing \`WorkItemDependency__c\` records

Also includes log-only \`onTaskContextMenu\` probe. Probe result: **LEX/Locker swallows canvas contextmenu on glen-walk (2026-04-21)** — NG 0.185.28 will ship a pointerdown-fallback; probe stays in place to light up the moment it lands.

Bundle:
- 258,650 bytes
- sha256 \`4d2ac01fbcbc28a28289f02dd9b6454bddbfd60f627d35858753aa85465f1414\`

Write-side (Apex create/delete + popover + task picker) is a follow-up PR after NG 0.185.28 drops.

## Test plan
- [x] Deployed to \`Delivery Hub__glen-walk\`; probe confirmed silent
- [x] apex-scan (PMD)
- [ ] Arrows render between linked tasks once any \`WorkItemDependency__c\` record exists