### PR TITLE
fix(sync): skip VersionData inline when too large for PayloadTxt

### DIFF
--- a/force-app/main/default/classes/DeliveryContentDocLinkTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryContentDocLinkTriggerHandler.cls
@@ -82,11 +82,24 @@ public without sharing class DeliveryContentDocLinkTriggerHandler {
             Map<String, Object> payload = new Map<String, Object>();
             payload.put('Title', cv.Title);
             payload.put('PathOnClient', cv.PathOnClient);
-            payload.put('SourceId', cv.Id); 
-            
-            // ARCHITECTURE WARNING: Long Text Area limits are ~131k characters. 
+            payload.put('SourceId', cv.Id);
+            payload.put('FileExtension', cv.FileExtension);
+            payload.put('FileType', cv.FileType);
+
+            // PayloadTxt__c is a Long Text Area (131,072 char cap). A base64-
+            // encoded binary pushes serialized payload past the limit for
+            // anything ~95 KB+ (see MF-Prod ghost-recorder attachment failure
+            // 2026-04-21). Inline bytes only when they fit with envelope
+            // headroom; otherwise mark the row so the receiver fetches
+            // VersionData via ContentVersion SOQL on the source side.
             if (cv.VersionData != null) {
-                payload.put('VersionData', EncodingUtil.base64Encode(cv.VersionData));
+                String encoded = EncodingUtil.base64Encode(cv.VersionData);
+                if (encoded.length() < 90000) {
+                    payload.put('VersionData', encoded);
+                } else {
+                    payload.put('VersionDataTooLarge', true);
+                    payload.put('ContentSize', encoded.length());
+                }
             }
 
             if (reqs != null && !reqs.isEmpty()) {


### PR DESCRIPTION
## Summary
- `DeliveryContentDocumentLinkTrigger` was failing ContentDocumentLink insert on MF-Prod with `STRING_TOO_LONG` / `CANNOT_INSERT_UPDATE_ACTIVATE_ENTITY` whenever a user attached any file ~95 KB+ to a WorkItem.
- Root cause: `DeliveryContentDocLinkTriggerHandler.cls` serializes the full base64-encoded binary (`VersionData`) into `SyncItem__c.PayloadTxt__c` (Long Text Area, 131,072 char cap). A 158 KB PNG + envelope = ~211 KB = over the cap = DML rollback, user sees \"File Attachment Failed\" toast.
- Fix: only inline `VersionData` when encoded length < 90,000 chars (leaves envelope headroom). Otherwise mark `VersionDataTooLarge=true` + `ContentSize` so the receiver can fetch the binary via ContentVersion SOQL on the source side.

## Reproduction (MF-Prod, 2026-04-21)
- Jose tried attaching a 158 KB `Transaction Breakdown Bug.png` via Ghost Recorder.
- Work item was created, but `linkFilesAndSync` failed at
  `DeliveryWorkItemController.linkFilesAndSync:212` → cascade from
  `DeliveryContentDocLinkTriggerHandler.handleAfterInsert:115` →
  `STRING_TOO_LONG: [delivery__PayloadTxt__c]`.

## Test plan
- [x] Small file (<65 KB raw): still inlined as before
- [x] Large file (>65 KB raw): payload marks VersionDataTooLarge, insert succeeds
- [ ] Verify on MF-Prod after install — Jose to re-try the original screenshot
- [ ] apex-scan passes (no System.debug in Apex)

Receiver-side handler for `VersionDataTooLarge` is a follow-up; this PR unblocks the local-side DML failure so the ContentDocumentLink insert stops rolling back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)