### PR TITLE
feat(sync): cross-org file bytes via authenticated pull callout (best-practice rewrite)

### DIFF
--- a/force-app/main/default/classes/DeliveryContentDocLinkTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryContentDocLinkTriggerHandler.cls
@@ -40,7 +40,7 @@ public without sharing class DeliveryContentDocLinkTriggerHandler {
      *              to either skip verification or defer to a post-insert job.
      */
     @TestVisible
-    private static final Integer MAX_SYNC_HASH_BYTES = 4_000_000;
+    private static final Integer MAX_SYNC_HASH_BYTES = 4000000;
 
     /**
      * @description Evaluates ContentDocumentLink records inserted on Work Items,

--- a/force-app/main/default/classes/DeliveryContentDocLinkTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryContentDocLinkTriggerHandler.cls
@@ -4,10 +4,43 @@
  * @description Handler for ContentDocumentLinkTrigger.
  * Evaluates files attached to Work Items and creates Outbound Ledger entries (SyncItem__c)
  * feeding them into the Unified Sync Architecture.
+ *
+ * CROSS-ORG FILE BYTE TRANSPORT — metadata-only pattern (2026-04-21 rewrite):
+ *   Prior behavior inlined base64(VersionData) into SyncItem__c.PayloadTxt__c, a
+ *   Long Text Area field with a 131,072 character cap. Base64 expansion (4/3) +
+ *   envelope overhead made anything ~95 KB+ fail DML with STRING_TOO_LONG. The
+ *   previous band-aid (PR #672) silently skipped VersionData over a 90,000 char
+ *   encoded threshold — the receiver never saw the bytes.
+ *
+ *   Current behavior emits a metadata-only payload: title, size, sha256 (when
+ *   bytes are cheaply digestible), source ContentVersion Id, and a transport
+ *   marker. The receiver sees FileTransport=pull-callout and issues an
+ *   authenticated HTTP callout back to the source org's /delivery/fileBytes
+ *   REST endpoint to fetch the actual bytes on demand. This is the standard
+ *   metadata + binary-by-reference pattern. See DeliveryFileBytesResource and
+ *   DeliveryFileBytesFetcher.
+ *
+ *   Future ceiling: Winter '26 API v65 introduces an Http pattern that can
+ *   stream ContentVersion bytes without loading them into Apex heap, raising
+ *   the per-file ceiling from 12 MB (async heap) to ~16 MB. This org is still
+ *   on API v61 (see sfdx-project.json / cumulusci.yml). Upgrade path is
+ *   documented at https://developer.salesforce.com/blogs/2025/09/winter26-developers.
+ *
  * @author Cloud Nimbus LLC
  */
 @SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity')
 public without sharing class DeliveryContentDocLinkTriggerHandler {
+
+    /**
+     * @description Maximum ContentVersion size (in bytes) for which we will
+     *              compute a SHA-256 in the trigger synchronously. Sync Apex
+     *              heap is 6 MB; we stay well under to leave room for the
+     *              trigger's other work. Files above this threshold ship with
+     *              Sha256=null and Oversized=true so the receiver can choose
+     *              to either skip verification or defer to a post-insert job.
+     */
+    @TestVisible
+    private static final Integer MAX_SYNC_HASH_BYTES = 4_000_000;
 
     /**
      * @description Evaluates ContentDocumentLink records inserted on Work Items,
@@ -16,7 +49,7 @@ public without sharing class DeliveryContentDocLinkTriggerHandler {
      */
     @SuppressWarnings('PMD.NcssMethodCount')
     public static void handleAfterInsert(List<ContentDocumentLink> newLinks) {
-        
+
         // ==========================================
         // ECHO SUPPRESSION: Abort if Downloading
         // ==========================================
@@ -42,7 +75,8 @@ public without sharing class DeliveryContentDocLinkTriggerHandler {
 
         // 3. Query the actual File Data
         List<ContentVersion> cvs = [
-            SELECT Id, ContentDocumentId, Title, VersionData, PathOnClient, FileExtension, FileType
+            SELECT Id, ContentDocumentId, Title, VersionData, PathOnClient,
+                   FileExtension, FileType, ContentSize
             FROM ContentVersion
             WHERE ContentDocumentId IN :docToWorkItemMap.keySet()
             AND IsLatest = true
@@ -56,8 +90,8 @@ public without sharing class DeliveryContentDocLinkTriggerHandler {
         // 4. Query Routes (WorkRequest__c Bridge) exactly like DeliverySyncEngine
         Set<Id> workItemIds = new Set<Id>(docToWorkItemMap.values());
         List<WorkRequest__c> connections = [
-            SELECT Id, WorkItemId__c, RemoteWorkItemIdTxt__c, DeliveryEntityLookup__c 
-            FROM WorkRequest__c 
+            SELECT Id, WorkItemId__c, RemoteWorkItemIdTxt__c, DeliveryEntityLookup__c
+            FROM WorkRequest__c
             WHERE WorkItemId__c IN :workItemIds AND StatusPk__c != 'Inactive'
             WITH SYSTEM_MODE
         ];
@@ -71,22 +105,39 @@ public without sharing class DeliveryContentDocLinkTriggerHandler {
             routes.get(tId).add(r);
         }
 
-        // 5. Generate SyncItem__c Payloads
+        // 5. Generate SyncItem__c Payloads — metadata only, bytes via pull callout.
         List<SyncItem__c> itemsToInsert = new List<SyncItem__c>();
 
         for (ContentVersion cv : cvs) {
             Id tId = docToWorkItemMap.get(cv.ContentDocumentId);
             List<WorkRequest__c> reqs = routes.get(tId);
 
-            // Build base payload
+            // Build metadata-only payload. No VersionData key — the receiver
+            // issues an authenticated callout to /delivery/fileBytes to fetch
+            // the actual bytes after it sees FileTransport=pull-callout.
             Map<String, Object> payload = new Map<String, Object>();
             payload.put('Title', cv.Title);
             payload.put('PathOnClient', cv.PathOnClient);
-            payload.put('SourceId', cv.Id); 
-            
-            // ARCHITECTURE WARNING: Long Text Area limits are ~131k characters. 
-            if (cv.VersionData != null) {
-                payload.put('VersionData', EncodingUtil.base64Encode(cv.VersionData));
+            payload.put('SourceId', cv.Id);
+            payload.put('ContentDocumentId', cv.ContentDocumentId);
+            payload.put('FileExtension', cv.FileExtension);
+            payload.put('FileType', cv.FileType);
+            payload.put('ContentSize', cv.ContentSize);
+            payload.put('FileTransport', 'pull-callout');
+
+            // Cheap integrity hash when the file is small enough to digest
+            // synchronously without blowing the 6 MB sync heap. Larger files
+            // are flagged Oversized=true and ship without a sha256 — the
+            // receiver MAY verify sha256 post-fetch but does not require it.
+            Boolean oversized = cv.ContentSize != null && cv.ContentSize > MAX_SYNC_HASH_BYTES;
+            if (!oversized && cv.VersionData != null) {
+                Blob digest = Crypto.generateDigest('SHA-256', cv.VersionData);
+                payload.put('Sha256', EncodingUtil.convertToHex(digest));
+            } else {
+                payload.put('Sha256', null);
+                if (oversized) {
+                    payload.put('Oversized', true);
+                }
             }
 
             if (reqs != null && !reqs.isEmpty()) {
@@ -99,7 +150,7 @@ public without sharing class DeliveryContentDocLinkTriggerHandler {
                         routed = true;
                     }
                 }
-                
+
                 // HUB MODEL (Vendor Hub): Fallback if routes exist but are blank
                 if (!routed) {
                     itemsToInsert.add(createFileItem(cv, tId, null, tId, payload));
@@ -113,7 +164,7 @@ public without sharing class DeliveryContentDocLinkTriggerHandler {
         // 6. Execute DML and Enqueue Processor
         if (!itemsToInsert.isEmpty()) {
             Database.insert(itemsToInsert, AccessLevel.SYSTEM_MODE);
-            
+
             if (!System.isQueueable() && !System.isFuture()) {
                 Integer maxJobs = Test.isRunningTest() ? 1 : Limits.getLimitQueueableJobs();
                 if (Limits.getQueueableJobs() < maxJobs) {
@@ -139,15 +190,15 @@ public without sharing class DeliveryContentDocLinkTriggerHandler {
         item.WorkItemLookup__c = workItemId;
         item.RequestLookup__c = reqId;
         item.ObjectTypePk__c = 'ContentVersion';
-        
+
         // FIX: Inject Global Traceability to prevent downstream loop failures
-        item.GlobalSourceIdTxt__c = cv.Id; 
-        
+        item.GlobalSourceIdTxt__c = cv.Id;
+
         Map<String, Object> payload = basePayload.clone();
         payload.put('TargetId', targetId);
         payload.put('GlobalSourceId', cv.Id);
         payload.put('SenderOrgId', UserInfo.getOrganizationId());
-        
+
         item.PayloadTxt__c = JSON.serialize(payload);
         return item;
     }

--- a/force-app/main/default/classes/DeliveryContentDocLinkTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryContentDocLinkTriggerHandlerTest.cls
@@ -3,6 +3,8 @@
  * @license      BSL 1.1 — See LICENSE.md
  * @description Tests for DeliveryContentDocLinkTriggerHandler covering outbound
  *              file sync ledger creation for Work Item and non-Work Item attachments.
+ *              Post 2026-04-21 rewrite: payload is metadata-only; verifies
+ *              FileTransport=pull-callout and Sha256 population.
  * @author Cloud Nimbus LLC
  */
 @IsTest
@@ -16,7 +18,7 @@ private class DeliveryContentDocLinkTriggerHandlerTest {
             // 1. Prevent infinite test queues
             DeliverySyncEngine.isSyncContext = false; // Ensure it's false to allow outbound sync
 
-            // 2. Setup Routing Data (This is what was missing!)
+            // 2. Setup Routing Data
             NetworkEntity__c vendor = new NetworkEntity__c(
                 Name = 'Test Vendor',
                 IntegrationEndpointUrlTxt__c = 'https://example.com/api',
@@ -55,12 +57,32 @@ private class DeliveryContentDocLinkTriggerHandlerTest {
             );
 
             Test.startTest();
-            insert link; 
+            insert link;
             Test.stopTest();
 
-            // 5. Verify the Unified Ledger successfully generated an item!
-            List<SyncItem__c> items = [SELECT Id, ObjectTypePk__c FROM SyncItem__c WHERE ObjectTypePk__c = 'ContentVersion'];
-            System.assertEquals(1, items.size(), 'Should have generated exactly 1 Sync Item for the attached file');
+            // 5. Verify the Unified Ledger successfully generated an item.
+            List<SyncItem__c> items = [
+                SELECT Id, ObjectTypePk__c, PayloadTxt__c
+                FROM SyncItem__c
+                WHERE ObjectTypePk__c = 'ContentVersion'
+            ];
+            System.assertEquals(1, items.size(),
+                'Should have generated exactly 1 Sync Item for the attached file');
+
+            // 6. Verify metadata-only payload shape
+            Map<String, Object> payload = (Map<String, Object>) JSON.deserializeUntyped(items[0].PayloadTxt__c);
+            System.assertEquals('pull-callout', payload.get('FileTransport'),
+                'Payload should flag FileTransport=pull-callout so receiver pulls bytes');
+            System.assertEquals(false, payload.containsKey('VersionData'),
+                'Payload must NOT inline base64 VersionData anymore');
+            System.assertNotEquals(null, payload.get('Sha256'),
+                'Small files should carry a Sha256 digest for integrity checking');
+            System.assertEquals(64, ((String) payload.get('Sha256')).length(),
+                'Sha256 should be 64 hex characters');
+            System.assertNotEquals(null, payload.get('ContentDocumentId'),
+                'Payload should include ContentDocumentId so receiver can call back');
+            System.assertEquals(cv.Id, (String) payload.get('SourceId'),
+                'SourceId should be the source ContentVersion Id');
         }
     }
 
@@ -93,6 +115,61 @@ private class DeliveryContentDocLinkTriggerHandlerTest {
             // Should completely ignore files attached to Accounts
             List<SyncItem__c> items = [SELECT Id FROM SyncItem__c WHERE ObjectTypePk__c = 'ContentVersion'];
             System.assertEquals(0, items.size(), 'Should not generate a Sync Item for non-workItem files');
+        }
+    }
+
+    /**
+     * @description Regression guard: the old 131k cap made anything > ~95 KB
+     *              fail with STRING_TOO_LONG because the payload inlined bytes.
+     *              With the metadata-only rewrite, even a multi-KB payload
+     *              should insert cleanly because PayloadTxt__c now carries only
+     *              metadata, not base64 bytes.
+     */
+    @IsTest
+    static void testLargeFilePayloadInsertsWithoutStringTooLong() {
+        System.runAs(testUser) {
+            DeliverySyncEngine.isSyncContext = false;
+
+            WorkItem__c workItem = new WorkItem__c();
+            insert workItem;
+
+            // Make a file that — pre-rewrite — would have exploded the Long Text
+            // field once base64-encoded (roughly 95 KB encoded).
+            String payloadBody = '';
+            String blockOf1k = '';
+            for (Integer i = 0; i < 1024; i++) {
+                blockOf1k += 'a';
+            }
+            for (Integer i = 0; i < 80; i++) {
+                payloadBody += blockOf1k;
+            }
+            ContentVersion cv = new ContentVersion(
+                Title = 'Large File',
+                PathOnClient = 'LargeFile.bin',
+                VersionData = Blob.valueOf(payloadBody)
+            );
+            insert cv;
+
+            cv = [SELECT Id, ContentDocumentId FROM ContentVersion WHERE Id = :cv.Id LIMIT 1];
+
+            ContentDocumentLink link = new ContentDocumentLink(
+                ContentDocumentId = cv.ContentDocumentId,
+                LinkedEntityId = workItem.Id,
+                ShareType = 'V',
+                Visibility = 'AllUsers'
+            );
+
+            Test.startTest();
+            insert link;
+            Test.stopTest();
+
+            List<SyncItem__c> items = [
+                SELECT Id, PayloadTxt__c FROM SyncItem__c
+                WHERE ObjectTypePk__c = 'ContentVersion'
+            ];
+            System.assertEquals(1, items.size(), 'Should insert a sync item for a large file');
+            System.assert(items[0].PayloadTxt__c.length() < 5000,
+                'Metadata-only payload should be well under the 131k cap (actual: ' + items[0].PayloadTxt__c.length() + ')');
         }
     }
 }

--- a/force-app/main/default/classes/DeliveryFileBytesFetcher.cls
+++ b/force-app/main/default/classes/DeliveryFileBytesFetcher.cls
@@ -1,0 +1,228 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Queueable job that fetches ContentVersion bytes from a peer
+ *              Delivery Hub org via authenticated HTTP GET, inserts a local
+ *              ContentVersion + ContentDocumentLink, and closes out the
+ *              originating SyncItem__c.
+ *
+ *              Enqueued by DeliverySyncItemIngestor when an inbound
+ *              ContentVersion payload arrives with FileTransport="pull-callout"
+ *              (metadata-only; bytes live on the sender). See
+ *              DeliveryContentDocLinkTriggerHandler for the sender half and
+ *              DeliveryFileBytesResource for the REST endpoint it calls back to.
+ *
+ *              Heap ceiling: async Apex heap is 12 MB. VersionData is held in
+ *              heap while the insert runs, so the effective cross-org file
+ *              limit is ~12 MB until the org moves to Winter '26 API v65's
+ *              streaming Http pattern.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.AvoidGlobalModifier')
+global inherited sharing class DeliveryFileBytesFetcher implements Queueable, Database.AllowsCallouts {
+
+    /** @description The SyncItem__c row whose payload describes the desired fetch. */
+    private final Id syncItemId;
+    /** @description Resolved local parent WorkItem Id for the resulting ContentDocumentLink. */
+    private final Id localParentWorkItemId;
+
+    /**
+     * @description Queueable constructor.
+     * @param syncItemId The inbound SyncItem__c carrying the metadata-only payload.
+     * @param localParentWorkItemId Resolved local WorkItem Id the file should link to.
+     */
+    global DeliveryFileBytesFetcher(Id syncItemId, Id localParentWorkItemId) {
+        this.syncItemId = syncItemId;
+        this.localParentWorkItemId = localParentWorkItemId;
+    }
+
+    /**
+     * @description Executes the fetch: authenticated callout, sha256 verify
+     *              (when supplied), ContentVersion insert, ContentDocumentLink
+     *              insert. Marks SyncItem status Synced on success, Failed on
+     *              any error so the retry engine can pick it up.
+     * @param ctx Standard QueueableContext
+     */
+    @SuppressWarnings('PMD.NcssMethodCount, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity')
+    global void execute(QueueableContext ctx) {
+        // Suppress triggers that would try to re-emit this inbound file.
+        DeliverySyncEngine.setSyncContext();
+
+        SyncItem__c item = null;
+        try {
+            List<SyncItem__c> rows = [
+                SELECT Id, PayloadTxt__c, ObjectTypePk__c, StatusPk__c,
+                       RetryCountNumber__c, WorkItemLookup__c
+                FROM SyncItem__c
+                WHERE Id = :syncItemId
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ];
+            if (rows.isEmpty()) {
+                return;
+            }
+            item = rows[0];
+
+            Map<String, Object> payload = (Map<String, Object>) JSON.deserializeUntyped(item.PayloadTxt__c);
+
+            String senderOrgId = (String) payload.get('SenderOrgId');
+            String contentDocumentId = (String) payload.get('ContentDocumentId');
+            String expectedSha = (String) payload.get('Sha256');
+            String title = (String) payload.get('Title');
+            String pathOnClient = (String) payload.get('PathOnClient');
+
+            if (String.isBlank(contentDocumentId)) {
+                failItem(item, 'Pull-callout payload missing ContentDocumentId');
+                return;
+            }
+            if (String.isBlank(senderOrgId)) {
+                failItem(item, 'Pull-callout payload missing SenderOrgId — cannot resolve source endpoint');
+                return;
+            }
+
+            NetworkEntity__c sourceEntity = resolveSourceEntity(senderOrgId);
+            if (sourceEntity == null) {
+                failItem(item, 'No registered NetworkEntity found for sender org ' + senderOrgId);
+                return;
+            }
+            if (String.isBlank(sourceEntity.IntegrationEndpointUrlTxt__c)) {
+                failItem(item, 'Source entity ' + sourceEntity.Id + ' has no IntegrationEndpointUrlTxt__c — cannot pull bytes');
+                return;
+            }
+            if (String.isBlank(sourceEntity.ApiKeyTxt__c) || String.isBlank(sourceEntity.HmacSecretTxt__c)) {
+                failItem(item, 'Source entity ' + sourceEntity.Id + ' missing ApiKeyTxt__c/HmacSecretTxt__c — cannot authenticate pull');
+                return;
+            }
+
+            // Perform the callout
+            HttpResponse res = performCallout(sourceEntity, contentDocumentId);
+            if (res.getStatusCode() >= 400) {
+                failItem(item, 'File-bytes callout failed (' + res.getStatusCode() + '): ' + res.getBody());
+                return;
+            }
+
+            Blob bytes = res.getBodyAsBlob();
+            if (bytes == null || bytes.size() == 0) {
+                failItem(item, 'File-bytes callout returned empty body');
+                return;
+            }
+
+            // Verify sha256 when the sender supplied one. Absent/null is tolerated
+            // (sender flagged the file Oversized, or is a legacy sender).
+            if (String.isNotBlank(expectedSha)) {
+                String actualSha = EncodingUtil.convertToHex(Crypto.generateDigest('SHA-256', bytes));
+                if (!actualSha.equalsIgnoreCase(expectedSha)) {
+                    failItem(item, 'File-bytes integrity check failed — expected ' + expectedSha + ' got ' + actualSha);
+                    return;
+                }
+            }
+
+            // Insert ContentVersion locally
+            ContentVersion cv = new ContentVersion(
+                Title = title,
+                PathOnClient = String.isNotBlank(pathOnClient) ? pathOnClient : (String.isNotBlank(title) ? title : 'file.bin'),
+                VersionData = bytes,
+                Origin = 'H'
+            );
+            Database.insert(cv, AccessLevel.SYSTEM_MODE);
+
+            // Link to the local parent Work Item
+            if (localParentWorkItemId != null) {
+                Id cdId = [SELECT ContentDocumentId FROM ContentVersion WHERE Id = :cv.Id WITH SYSTEM_MODE LIMIT 1].ContentDocumentId;
+                ContentDocumentLink cdl = new ContentDocumentLink(
+                    ContentDocumentId = cdId,
+                    LinkedEntityId = localParentWorkItemId,
+                    ShareType = 'V',
+                    Visibility = 'AllUsers'
+                );
+                Database.insert(cdl, AccessLevel.SYSTEM_MODE);
+            }
+
+            // Mark the inbound sync row complete
+            item.StatusPk__c = 'Synced';
+            item.ErrorLogTxt__c = null;
+            item.LocalRecordIdTxt__c = cv.Id;
+            Database.update(item, AccessLevel.SYSTEM_MODE);
+
+        } catch (Exception e) {
+            if (item != null) {
+                failItem(item, 'Pull-callout exception: ' + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * @description Builds and sends the authenticated HTTP GET to the source org's
+     *              /fileBytes endpoint. Signs the request with HMAC-SHA256 over
+     *              contentDocumentId|timestamp using the peer's shared secret.
+     * @param sourceEntity Peer NetworkEntity__c with endpoint/api-key/hmac-secret fields populated.
+     * @param contentDocumentId ContentDocumentId on the source org to fetch.
+     * @return Raw HttpResponse from the callout.
+     */
+    private HttpResponse performCallout(NetworkEntity__c sourceEntity, String contentDocumentId) {
+        String baseUrl = sourceEntity.IntegrationEndpointUrlTxt__c.removeEnd('/');
+        String endpoint;
+        // The IntegrationEndpointUrlTxt__c field in the wild is stored either as
+        // the org base (e.g. https://my-org.my.salesforce.com) or already pointed
+        // at the sync service path. Normalize both into the /fileBytes/<id>
+        // endpoint under /services/apexrest/delivery.
+        String lowerBase = baseUrl.toLowerCase();
+        if (lowerBase.contains('/services/apexrest')) {
+            // Strip anything past /services/apexrest and rebuild
+            endpoint = baseUrl.substringBefore('/services/apexrest')
+                + '/services/apexrest/delivery/fileBytes/' + contentDocumentId;
+        } else {
+            endpoint = baseUrl + '/services/apexrest/delivery/fileBytes/' + contentDocumentId;
+        }
+
+        String timestamp = String.valueOf(Datetime.now().getTime() / 1000L);
+        String signingString = contentDocumentId + '|' + timestamp;
+        String signature = DeliveryCryptoService.computeHMAC(sourceEntity.HmacSecretTxt__c, signingString);
+
+        HttpRequest hreq = new HttpRequest();
+        hreq.setEndpoint(endpoint);
+        hreq.setMethod('GET');
+        hreq.setHeader('X-Api-Key', sourceEntity.ApiKeyTxt__c);
+        hreq.setHeader('X-Timestamp', timestamp);
+        hreq.setHeader('X-Signature', signature);
+        hreq.setHeader('Accept', 'application/octet-stream');
+        hreq.setTimeout(120000);
+
+        return new Http().send(hreq);
+    }
+
+    /**
+     * @description Resolves the NetworkEntity__c representing the source org of
+     *              the inbound payload. Handles both OrgIdTxt__c and legacy
+     *              RemoteExternalIdTxt__c matches, and both 15/18-char Org Ids.
+     * @param senderOrgId 15 or 18 char Organization Id advertised by the sender.
+     * @return The NetworkEntity__c with endpoint/api-key/hmac fields, or null.
+     */
+    private NetworkEntity__c resolveSourceEntity(String senderOrgId) {
+        String baseOrgId = senderOrgId.length() >= 15 ? senderOrgId.substring(0, 15) + '%' : senderOrgId;
+        List<NetworkEntity__c> entities = [
+            SELECT Id, IntegrationEndpointUrlTxt__c, ApiKeyTxt__c, HmacSecretTxt__c
+            FROM NetworkEntity__c
+            WHERE (OrgIdTxt__c LIKE :baseOrgId OR RemoteExternalIdTxt__c LIKE :baseOrgId)
+            AND ConnectionStatusPk__c = 'Connected'
+            WITH SYSTEM_MODE
+            ORDER BY CreatedDate ASC
+            LIMIT 1
+        ];
+        return entities.isEmpty() ? null : entities[0];
+    }
+
+    /**
+     * @description Marks the SyncItem__c row Failed with a structured error and
+     *              increments retry counter so DeliverySyncItemProcessor-style
+     *              retry sweeps can pick it up.
+     * @param item SyncItem__c row being processed.
+     * @param message Error message.
+     */
+    private void failItem(SyncItem__c item, String message) {
+        item.StatusPk__c = 'Failed';
+        item.ErrorLogTxt__c = message;
+        item.RetryCountNumber__c = (item.RetryCountNumber__c == null ? 0 : item.RetryCountNumber__c) + 1;
+        Database.update(item, AccessLevel.SYSTEM_MODE);
+    }
+}

--- a/force-app/main/default/classes/DeliveryFileBytesFetcher.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryFileBytesFetcher.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryFileBytesFetcherTest.cls
+++ b/force-app/main/default/classes/DeliveryFileBytesFetcherTest.cls
@@ -10,7 +10,18 @@
 @IsTest
 private class DeliveryFileBytesFetcherTest {
 
-    private static final String PEER_ORG_ID = '00D000000000001';
+    // Payload tokens — the fetcher stores these into text fields
+    // (OrgIdTxt__c, LocalRecordIdTxt__c, etc.) and passes ContentDocumentId
+    // through the callout URL. None are parsed as Salesforce Ids, so any
+    // non-empty string works and Id-shaped literals aren't needed.
+    private static final String PEER_ORG_ID = 'peer-org-test-1';
+    private static final String UNREG_ORG_ID = 'peer-org-unregistered';
+    private static final String SRC_CV = 'remote-cv-src-1';
+    private static final String SRC_CV_ORPHAN = 'remote-cv-src-orphan';
+    private static final String CD_HAPPY = 'remote-cd-happy';
+    private static final String CD_SHA_MISMATCH = 'remote-cd-sha-mismatch';
+    private static final String CD_HTTP_500 = 'remote-cd-http-500';
+    private static final String CD_ORPHAN = 'remote-cd-orphan';
     private static final String TEST_BYTES = 'received bytes payload';
 
     @TestSetup
@@ -37,11 +48,14 @@ private class DeliveryFileBytesFetcherTest {
     /**
      * @description Builds a Queued inbound SyncItem__c with the desired
      *              pull-callout payload and returns its Id.
+     * @param sourceCdId Remote org's ContentDocumentId embedded in the payload.
+     * @param sha256 Expected sha256 hex digest of the bytes the fetcher will pull.
+     * @return Id of the inserted SyncItem__c record.
      */
     private static Id insertInboundItem(String sourceCdId, String sha256) {
         WorkItem__c wi = [SELECT Id FROM WorkItem__c LIMIT 1];
         Map<String, Object> payload = new Map<String, Object>{
-            'SourceId' => '068000000000001',
+            'SourceId' => SRC_CV,
             'ContentDocumentId' => sourceCdId,
             'SenderOrgId' => PEER_ORG_ID,
             'Title' => 'Received File',
@@ -55,7 +69,7 @@ private class DeliveryFileBytesFetcherTest {
             ObjectTypePk__c = 'ContentVersion',
             PayloadTxt__c = JSON.serialize(payload),
             WorkItemLookup__c = wi.Id,
-            RemoteExternalIdTxt__c = '068000000000001'
+            RemoteExternalIdTxt__c = SRC_CV
         );
         insert item;
         return item.Id;
@@ -63,7 +77,7 @@ private class DeliveryFileBytesFetcherTest {
 
     @IsTest
     static void testHappyPathInsertsContentVersionAndLink() {
-        String cdId = '069000000000100AAA';
+        String cdId = CD_HAPPY;
         String expectedSha = EncodingUtil.convertToHex(
             Crypto.generateDigest('SHA-256', Blob.valueOf(TEST_BYTES))
         );
@@ -92,7 +106,7 @@ private class DeliveryFileBytesFetcherTest {
 
     @IsTest
     static void testSha256MismatchFailsItem() {
-        String cdId = '069000000000200AAA';
+        String cdId = CD_SHA_MISMATCH;
         // Intentionally supply the wrong expected hash
         String wrongSha = '0'.repeat(64);
         Id syncId = insertInboundItem(cdId, wrongSha);
@@ -114,7 +128,7 @@ private class DeliveryFileBytesFetcherTest {
 
     @IsTest
     static void testCalloutHttp500FailsItem() {
-        String cdId = '069000000000300AAA';
+        String cdId = CD_HTTP_500;
         String expectedSha = EncodingUtil.convertToHex(
             Crypto.generateDigest('SHA-256', Blob.valueOf(TEST_BYTES))
         );
@@ -138,9 +152,9 @@ private class DeliveryFileBytesFetcherTest {
     static void testUnknownSenderOrgFailsItem() {
         WorkItem__c wi = [SELECT Id FROM WorkItem__c LIMIT 1];
         Map<String, Object> payload = new Map<String, Object>{
-            'SourceId' => '068000000000999',
-            'ContentDocumentId' => '069000000000999AAA',
-            'SenderOrgId' => '00D000000000ZZZ', // not a registered peer
+            'SourceId' => SRC_CV_ORPHAN,
+            'ContentDocumentId' => CD_ORPHAN,
+            'SenderOrgId' => UNREG_ORG_ID, // not a registered peer
             'Title' => 'Orphan',
             'FileTransport' => 'pull-callout',
             'Sha256' => null
@@ -151,7 +165,7 @@ private class DeliveryFileBytesFetcherTest {
             ObjectTypePk__c = 'ContentVersion',
             PayloadTxt__c = JSON.serialize(payload),
             WorkItemLookup__c = wi.Id,
-            RemoteExternalIdTxt__c = '068000000000999'
+            RemoteExternalIdTxt__c = SRC_CV_ORPHAN
         );
         insert item;
 

--- a/force-app/main/default/classes/DeliveryFileBytesFetcherTest.cls
+++ b/force-app/main/default/classes/DeliveryFileBytesFetcherTest.cls
@@ -1,0 +1,204 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Tests for DeliveryFileBytesFetcher — mocks the peer-org
+ *              callout, verifies happy path (ContentVersion insert + CDL +
+ *              SyncItem Synced), sha256 integrity mismatch, and endpoint-
+ *              missing failure path.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryFileBytesFetcherTest {
+
+    private static final String PEER_ORG_ID = '00D000000000001';
+    private static final String TEST_BYTES = 'received bytes payload';
+
+    @TestSetup
+    static void makeData() {
+        // Prevent cascade triggers during setup
+        DeliverySyncEngine.setSyncContext();
+
+        NetworkEntity__c peer = new NetworkEntity__c(
+            Name = 'Source Peer Org',
+            EntityTypePk__c = 'Vendor',
+            StatusPk__c = 'Active',
+            ConnectionStatusPk__c = 'Connected',
+            OrgIdTxt__c = PEER_ORG_ID,
+            ApiKeyTxt__c = 'peer-api-key',
+            HmacSecretTxt__c = 'peer-hmac-secret',
+            IntegrationEndpointUrlTxt__c = 'https://peer.example.com'
+        );
+        insert peer;
+
+        WorkItem__c wi = new WorkItem__c(BriefDescriptionTxt__c = 'Host WI');
+        insert wi;
+    }
+
+    /**
+     * @description Builds a Queued inbound SyncItem__c with the desired
+     *              pull-callout payload and returns its Id.
+     */
+    private static Id insertInboundItem(String sourceCdId, String sha256) {
+        WorkItem__c wi = [SELECT Id FROM WorkItem__c LIMIT 1];
+        Map<String, Object> payload = new Map<String, Object>{
+            'SourceId' => '068000000000001',
+            'ContentDocumentId' => sourceCdId,
+            'SenderOrgId' => PEER_ORG_ID,
+            'Title' => 'Received File',
+            'PathOnClient' => 'received.txt',
+            'Sha256' => sha256,
+            'FileTransport' => 'pull-callout'
+        };
+        SyncItem__c item = new SyncItem__c(
+            DirectionPk__c = 'Inbound',
+            StatusPk__c = 'Queued',
+            ObjectTypePk__c = 'ContentVersion',
+            PayloadTxt__c = JSON.serialize(payload),
+            WorkItemLookup__c = wi.Id,
+            RemoteExternalIdTxt__c = '068000000000001'
+        );
+        insert item;
+        return item.Id;
+    }
+
+    @IsTest
+    static void testHappyPathInsertsContentVersionAndLink() {
+        String cdId = '069000000000100AAA';
+        String expectedSha = EncodingUtil.convertToHex(
+            Crypto.generateDigest('SHA-256', Blob.valueOf(TEST_BYTES))
+        );
+        Id syncId = insertInboundItem(cdId, expectedSha);
+        WorkItem__c wi = [SELECT Id FROM WorkItem__c LIMIT 1];
+
+        Test.setMock(HttpCalloutMock.class, new MockBytes(200, TEST_BYTES));
+
+        Test.startTest();
+        System.enqueueJob(new DeliveryFileBytesFetcher(syncId, wi.Id));
+        Test.stopTest();
+
+        SyncItem__c after = [SELECT StatusPk__c, LocalRecordIdTxt__c, ErrorLogTxt__c FROM SyncItem__c WHERE Id = :syncId];
+        System.assertEquals('Synced', after.StatusPk__c,
+            'SyncItem should be Synced after successful fetch. Error: ' + after.ErrorLogTxt__c);
+        System.assertNotEquals(null, after.LocalRecordIdTxt__c,
+            'SyncItem should record the new ContentVersion Id');
+
+        List<ContentDocumentLink> cdls = [
+            SELECT Id, ContentDocumentId FROM ContentDocumentLink
+            WHERE LinkedEntityId = :wi.Id
+        ];
+        System.assertEquals(1, cdls.size(),
+            'A ContentDocumentLink should tie the new file to the WorkItem');
+    }
+
+    @IsTest
+    static void testSha256MismatchFailsItem() {
+        String cdId = '069000000000200AAA';
+        // Intentionally supply the wrong expected hash
+        String wrongSha = '0'.repeat(64);
+        Id syncId = insertInboundItem(cdId, wrongSha);
+        WorkItem__c wi = [SELECT Id FROM WorkItem__c LIMIT 1];
+
+        Test.setMock(HttpCalloutMock.class, new MockBytes(200, TEST_BYTES));
+
+        Test.startTest();
+        System.enqueueJob(new DeliveryFileBytesFetcher(syncId, wi.Id));
+        Test.stopTest();
+
+        SyncItem__c after = [SELECT StatusPk__c, ErrorLogTxt__c FROM SyncItem__c WHERE Id = :syncId];
+        System.assertEquals('Failed', after.StatusPk__c,
+            'Integrity mismatch should fail the item so the retry engine can act');
+        System.assertNotEquals(null, after.ErrorLogTxt__c, 'Error log should describe the mismatch');
+        System.assert(after.ErrorLogTxt__c.containsIgnoreCase('integrity'),
+            'Error should mention integrity failure. Was: ' + after.ErrorLogTxt__c);
+    }
+
+    @IsTest
+    static void testCalloutHttp500FailsItem() {
+        String cdId = '069000000000300AAA';
+        String expectedSha = EncodingUtil.convertToHex(
+            Crypto.generateDigest('SHA-256', Blob.valueOf(TEST_BYTES))
+        );
+        Id syncId = insertInboundItem(cdId, expectedSha);
+        WorkItem__c wi = [SELECT Id FROM WorkItem__c LIMIT 1];
+
+        Test.setMock(HttpCalloutMock.class, new MockBytes(500, 'server exploded'));
+
+        Test.startTest();
+        System.enqueueJob(new DeliveryFileBytesFetcher(syncId, wi.Id));
+        Test.stopTest();
+
+        SyncItem__c after = [SELECT StatusPk__c, ErrorLogTxt__c FROM SyncItem__c WHERE Id = :syncId];
+        System.assertEquals('Failed', after.StatusPk__c,
+            'HTTP >= 400 should move the row to Failed');
+        System.assert(after.ErrorLogTxt__c.contains('500'),
+            'Error log should surface the HTTP status');
+    }
+
+    @IsTest
+    static void testUnknownSenderOrgFailsItem() {
+        WorkItem__c wi = [SELECT Id FROM WorkItem__c LIMIT 1];
+        Map<String, Object> payload = new Map<String, Object>{
+            'SourceId' => '068000000000999',
+            'ContentDocumentId' => '069000000000999AAA',
+            'SenderOrgId' => '00D000000000ZZZ', // not a registered peer
+            'Title' => 'Orphan',
+            'FileTransport' => 'pull-callout',
+            'Sha256' => null
+        };
+        SyncItem__c item = new SyncItem__c(
+            DirectionPk__c = 'Inbound',
+            StatusPk__c = 'Queued',
+            ObjectTypePk__c = 'ContentVersion',
+            PayloadTxt__c = JSON.serialize(payload),
+            WorkItemLookup__c = wi.Id,
+            RemoteExternalIdTxt__c = '068000000000999'
+        );
+        insert item;
+
+        // No callout should even fire — but set a mock just in case
+        Test.setMock(HttpCalloutMock.class, new MockBytes(200, TEST_BYTES));
+
+        Test.startTest();
+        System.enqueueJob(new DeliveryFileBytesFetcher(item.Id, wi.Id));
+        Test.stopTest();
+
+        SyncItem__c after = [SELECT StatusPk__c, ErrorLogTxt__c FROM SyncItem__c WHERE Id = :item.Id];
+        System.assertEquals('Failed', after.StatusPk__c,
+            'Unregistered sender org should fail the row with a clear error');
+        System.assert(after.ErrorLogTxt__c.containsIgnoreCase('NetworkEntity'),
+            'Error should mention NetworkEntity resolution failure. Was: ' + after.ErrorLogTxt__c);
+    }
+
+    /**
+     * @description Mock HttpCalloutMock that returns a configurable status
+     *              code and body. Used to simulate both happy-path and
+     *              error-path responses from the peer /fileBytes endpoint.
+     */
+    private class MockBytes implements HttpCalloutMock {
+        /** @description HTTP status to return. */
+        private final Integer status;
+        /** @description Response body to return. */
+        private final String body;
+        /**
+         * @description Builds a mock with the given status and body.
+         * @param status HTTP status code.
+         * @param body Response body as a string.
+         */
+        public MockBytes(Integer status, String body) {
+            this.status = status;
+            this.body = body;
+        }
+        /**
+         * @description Returns the pre-configured mock HttpResponse.
+         * @param req Ignored — any inbound request is answered.
+         * @return Mock HttpResponse.
+         */
+        public HttpResponse respond(HttpRequest req) {
+            HttpResponse res = new HttpResponse();
+            res.setStatusCode(status);
+            res.setHeader('Content-Type', 'application/octet-stream');
+            res.setBodyAsBlob(Blob.valueOf(body));
+            return res;
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryFileBytesFetcherTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryFileBytesFetcherTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryFileBytesResource.cls
+++ b/force-app/main/default/classes/DeliveryFileBytesResource.cls
@@ -43,92 +43,106 @@ global without sharing class DeliveryFileBytesResource {
     global static void handleGet() {
         RestRequest req = RestContext.request;
         RestResponse res = RestContext.response;
-
         try {
-            // 1. Extract ContentDocumentId from path or query string
             String contentDocumentId = extractContentDocumentId(req);
             if (String.isBlank(contentDocumentId)) {
                 writeJsonError(res, 400, 'Missing contentDocumentId');
                 return;
             }
-
-            // 2. Resolve caller from X-Api-Key
-            String apiKey = req.headers.get('X-Api-Key');
-            if (String.isBlank(apiKey)) {
-                writeJsonError(res, 401, 'Missing X-Api-Key');
-                return;
+            NetworkEntity__c caller = authenticateCaller(req, res, contentDocumentId);
+            if (caller == null) {
+                return; // authenticateCaller has already written the error
             }
-
-            List<NetworkEntity__c> entities = [
-                SELECT Id, HmacSecretTxt__c, ConnectionStatusPk__c
-                FROM NetworkEntity__c
-                WHERE ApiKeyTxt__c = :apiKey
-                AND ConnectionStatusPk__c = 'Connected'
-                WITH SYSTEM_MODE
-                LIMIT 1
-            ];
-            if (entities.isEmpty()) {
-                writeJsonError(res, 401, 'Invalid API key or entity not connected');
-                return;
-            }
-
-            String hmacSecret = entities[0].HmacSecretTxt__c;
-            if (String.isBlank(hmacSecret)) {
-                // Binary transfer requires HMAC — refuse anonymous callers even
-                // if their API key is otherwise valid.
-                writeJsonError(res, 401, 'Peer entity has no HMAC secret configured — refusing to serve bytes');
-                return;
-            }
-
-            // 3. HMAC check (body + timestamp + contentDocumentId)
-            String timestamp = req.headers.get('X-Timestamp');
-            String signature = req.headers.get('X-Signature');
-            if (String.isBlank(timestamp) || String.isBlank(signature)) {
-                writeJsonError(res, 401, 'Missing X-Timestamp or X-Signature');
-                return;
-            }
-
-            // Reject timestamps outside the skew window to prevent replay
-            if (!isTimestampFresh(timestamp)) {
-                writeJsonError(res, 401, 'Request timestamp outside tolerance window');
-                return;
-            }
-
-            String signingString = contentDocumentId + '|' + timestamp;
-            if (!DeliveryCryptoService.verifyHMAC(hmacSecret, signingString, signature)) {
-                writeJsonError(res, 401, 'Invalid signature');
-                return;
-            }
-
-            // 4. Lookup the latest ContentVersion for this ContentDocumentId
-            List<ContentVersion> cvs = [
-                SELECT Id, VersionData, FileType, Title, ContentSize
-                FROM ContentVersion
-                WHERE ContentDocumentId = :contentDocumentId
-                AND IsLatest = true
-                WITH SYSTEM_MODE
-                LIMIT 1
-            ];
-            if (cvs.isEmpty()) {
-                writeJsonError(res, 404, 'ContentDocumentId not found');
-                return;
-            }
-
-            // 5. Stream bytes back
-            ContentVersion cv = cvs[0];
-            res.statusCode = 200;
-            res.addHeader('Content-Type', 'application/octet-stream');
-            if (String.isNotBlank(cv.Title)) {
-                res.addHeader('X-File-Title', cv.Title);
-            }
-            if (cv.ContentSize != null) {
-                res.addHeader('X-File-Size', String.valueOf(cv.ContentSize));
-            }
-            res.responseBody = cv.VersionData;
-
+            streamLatestBytes(res, contentDocumentId);
         } catch (Exception e) {
             writeJsonError(res, 500, e.getMessage());
         }
+    }
+
+    /**
+     * @description Resolves the caller via X-Api-Key, verifies the HMAC
+     *              signature + timestamp freshness, and returns the matching
+     *              NetworkEntity__c. Writes a 401 JSON error to `res` and
+     *              returns null on any failure.
+     * @param req The inbound REST request.
+     * @param res The REST response, written to on auth failure.
+     * @param contentDocumentId The contentDocumentId from the URL, part of
+     *              the signing string.
+     * @return Authenticated NetworkEntity__c, or null if auth failed.
+     */
+    private static NetworkEntity__c authenticateCaller(RestRequest req, RestResponse res, String contentDocumentId) {
+        String apiKey = req.headers.get('X-Api-Key');
+        if (String.isBlank(apiKey)) {
+            writeJsonError(res, 401, 'Missing X-Api-Key');
+            return null;
+        }
+        List<NetworkEntity__c> entities = [
+            SELECT Id, HmacSecretTxt__c, ConnectionStatusPk__c
+            FROM NetworkEntity__c
+            WHERE ApiKeyTxt__c = :apiKey
+            AND ConnectionStatusPk__c = 'Connected'
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (entities.isEmpty()) {
+            writeJsonError(res, 401, 'Invalid API key or entity not connected');
+            return null;
+        }
+        String hmacSecret = entities[0].HmacSecretTxt__c;
+        if (String.isBlank(hmacSecret)) {
+            // Binary transfer requires HMAC — refuse anonymous callers even
+            // if their API key is otherwise valid.
+            writeJsonError(res, 401, 'Peer entity has no HMAC secret configured — refusing to serve bytes');
+            return null;
+        }
+        String timestamp = req.headers.get('X-Timestamp');
+        String signature = req.headers.get('X-Signature');
+        if (String.isBlank(timestamp) || String.isBlank(signature)) {
+            writeJsonError(res, 401, 'Missing X-Timestamp or X-Signature');
+            return null;
+        }
+        if (!isTimestampFresh(timestamp)) {
+            writeJsonError(res, 401, 'Request timestamp outside tolerance window');
+            return null;
+        }
+        String signingString = contentDocumentId + '|' + timestamp;
+        if (!DeliveryCryptoService.verifyHMAC(hmacSecret, signingString, signature)) {
+            writeJsonError(res, 401, 'Invalid signature');
+            return null;
+        }
+        return entities[0];
+    }
+
+    /**
+     * @description Looks up the latest ContentVersion bytes for the supplied
+     *              ContentDocumentId and writes them to the response. Writes
+     *              a 404 if no ContentVersion exists.
+     * @param res The REST response.
+     * @param contentDocumentId The ContentDocumentId to stream.
+     */
+    private static void streamLatestBytes(RestResponse res, String contentDocumentId) {
+        List<ContentVersion> cvs = [
+            SELECT Id, VersionData, FileType, Title, ContentSize
+            FROM ContentVersion
+            WHERE ContentDocumentId = :contentDocumentId
+            AND IsLatest = true
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (cvs.isEmpty()) {
+            writeJsonError(res, 404, 'ContentDocumentId not found');
+            return;
+        }
+        ContentVersion cv = cvs[0];
+        res.statusCode = 200;
+        res.addHeader('Content-Type', 'application/octet-stream');
+        if (String.isNotBlank(cv.Title)) {
+            res.addHeader('X-File-Title', cv.Title);
+        }
+        if (cv.ContentSize != null) {
+            res.addHeader('X-File-Size', String.valueOf(cv.ContentSize));
+        }
+        res.responseBody = cv.VersionData;
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryFileBytesResource.cls
+++ b/force-app/main/default/classes/DeliveryFileBytesResource.cls
@@ -1,0 +1,187 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description REST resource exposing ContentVersion.VersionData bytes to
+ *              authenticated peer orgs. Half of the cross-org "metadata +
+ *              binary-by-reference" file-sync pattern — the other half is
+ *              DeliveryContentDocLinkTriggerHandler (sender) and
+ *              DeliveryFileBytesFetcher (receiver).
+ *
+ *              URL: /services/apexrest/delivery/fileBytes/<ContentDocumentId>
+ *
+ *              Authentication:
+ *                - X-Api-Key header MUST match a Connected NetworkEntity__c.ApiKeyTxt__c
+ *                - X-Timestamp header MUST be within 5 minutes of server clock
+ *                - X-Signature header MUST equal HMAC-SHA256(entity.HmacSecretTxt__c,
+ *                  contentDocumentId + '|' + timestamp)
+ *
+ *              Heap ceiling: Apex sync heap is 6 MB, async 12 MB. This endpoint
+ *              streams via RestContext.response.responseBody, which requires the
+ *              full VersionData blob in heap. Files above ~6 MB will fail with
+ *              LimitException. Winter '26 API v65 added an Http callout pattern
+ *              for ContentDocumentId that bypasses heap, raising the effective
+ *              ceiling to 16 MB; adopting that would require raising the org's
+ *              sourceApiVersion past 61.0 and porting the @RestResource code
+ *              path to the new Http APIs. See
+ *              https://developer.salesforce.com/blogs/2025/09/winter26-developers.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.StdCyclomaticComplexity, PMD.CyclomaticComplexity, PMD.AvoidGlobalModifier')
+@RestResource(urlMapping='/fileBytes/*')
+global without sharing class DeliveryFileBytesResource {
+
+    /** @description HMAC skew tolerance (seconds) for replay protection. */
+    @TestVisible
+    private static final Long TIMESTAMP_SKEW_SECONDS = 300L;
+
+    /**
+     * @description Handles GET /fileBytes/<contentDocumentId>. Returns the
+     *              bytes of the latest ContentVersion for the given
+     *              ContentDocumentId, gated by HMAC-authenticated peer org.
+     */
+    @HttpGet
+    global static void handleGet() {
+        RestRequest req = RestContext.request;
+        RestResponse res = RestContext.response;
+
+        try {
+            // 1. Extract ContentDocumentId from path or query string
+            String contentDocumentId = extractContentDocumentId(req);
+            if (String.isBlank(contentDocumentId)) {
+                writeJsonError(res, 400, 'Missing contentDocumentId');
+                return;
+            }
+
+            // 2. Resolve caller from X-Api-Key
+            String apiKey = req.headers.get('X-Api-Key');
+            if (String.isBlank(apiKey)) {
+                writeJsonError(res, 401, 'Missing X-Api-Key');
+                return;
+            }
+
+            List<NetworkEntity__c> entities = [
+                SELECT Id, HmacSecretTxt__c, ConnectionStatusPk__c
+                FROM NetworkEntity__c
+                WHERE ApiKeyTxt__c = :apiKey
+                AND ConnectionStatusPk__c = 'Connected'
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ];
+            if (entities.isEmpty()) {
+                writeJsonError(res, 401, 'Invalid API key or entity not connected');
+                return;
+            }
+
+            String hmacSecret = entities[0].HmacSecretTxt__c;
+            if (String.isBlank(hmacSecret)) {
+                // Binary transfer requires HMAC — refuse anonymous callers even
+                // if their API key is otherwise valid.
+                writeJsonError(res, 401, 'Peer entity has no HMAC secret configured — refusing to serve bytes');
+                return;
+            }
+
+            // 3. HMAC check (body + timestamp + contentDocumentId)
+            String timestamp = req.headers.get('X-Timestamp');
+            String signature = req.headers.get('X-Signature');
+            if (String.isBlank(timestamp) || String.isBlank(signature)) {
+                writeJsonError(res, 401, 'Missing X-Timestamp or X-Signature');
+                return;
+            }
+
+            // Reject timestamps outside the skew window to prevent replay
+            if (!isTimestampFresh(timestamp)) {
+                writeJsonError(res, 401, 'Request timestamp outside tolerance window');
+                return;
+            }
+
+            String signingString = contentDocumentId + '|' + timestamp;
+            if (!DeliveryCryptoService.verifyHMAC(hmacSecret, signingString, signature)) {
+                writeJsonError(res, 401, 'Invalid signature');
+                return;
+            }
+
+            // 4. Lookup the latest ContentVersion for this ContentDocumentId
+            List<ContentVersion> cvs = [
+                SELECT Id, VersionData, FileType, Title, ContentSize
+                FROM ContentVersion
+                WHERE ContentDocumentId = :contentDocumentId
+                AND IsLatest = true
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ];
+            if (cvs.isEmpty()) {
+                writeJsonError(res, 404, 'ContentDocumentId not found');
+                return;
+            }
+
+            // 5. Stream bytes back
+            ContentVersion cv = cvs[0];
+            res.statusCode = 200;
+            res.addHeader('Content-Type', 'application/octet-stream');
+            if (String.isNotBlank(cv.Title)) {
+                res.addHeader('X-File-Title', cv.Title);
+            }
+            if (cv.ContentSize != null) {
+                res.addHeader('X-File-Size', String.valueOf(cv.ContentSize));
+            }
+            res.responseBody = cv.VersionData;
+
+        } catch (Exception e) {
+            writeJsonError(res, 500, e.getMessage());
+        }
+    }
+
+    /**
+     * @description Pulls the ContentDocumentId from either the trailing path
+     *              segment (/fileBytes/069...) or a ?contentDocumentId=... query.
+     * @param req The REST request
+     * @return ContentDocumentId as a String, or null/blank if absent.
+     */
+    private static String extractContentDocumentId(RestRequest req) {
+        String fromQuery = req.params != null ? req.params.get('contentDocumentId') : null;
+        if (String.isNotBlank(fromQuery)) {
+            return fromQuery;
+        }
+        String uri = req.requestURI != null ? req.requestURI : '';
+        Integer slashIdx = uri.lastIndexOf('/');
+        if (slashIdx >= 0 && slashIdx < uri.length() - 1) {
+            String tail = uri.substring(slashIdx + 1);
+            // Ignore the literal resource name when the path has no id
+            if (tail.equalsIgnoreCase('fileBytes')) {
+                return null;
+            }
+            return tail;
+        }
+        return null;
+    }
+
+    /**
+     * @description Validates that the supplied timestamp (epoch seconds string)
+     *              is within TIMESTAMP_SKEW_SECONDS of now. Protects against
+     *              captured-request replay.
+     * @param timestamp X-Timestamp header value (epoch seconds as string)
+     * @return True if the timestamp is parseable and within tolerance.
+     */
+    private static Boolean isTimestampFresh(String timestamp) {
+        try {
+            Long ts = Long.valueOf(timestamp);
+            Long now = Datetime.now().getTime() / 1000L;
+            Long delta = Math.abs(now - ts);
+            return delta <= TIMESTAMP_SKEW_SECONDS;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * @description Writes a JSON error body and status code to the REST response.
+     * @param res REST response to populate
+     * @param code HTTP status code
+     * @param message Short error message
+     */
+    private static void writeJsonError(RestResponse res, Integer code, String message) {
+        res.statusCode = code;
+        res.addHeader('Content-Type', 'application/json');
+        res.responseBody = Blob.valueOf(JSON.serialize(new Map<String, String>{ 'error' => message }));
+    }
+}

--- a/force-app/main/default/classes/DeliveryFileBytesResource.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryFileBytesResource.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryFileBytesResourceTest.cls
+++ b/force-app/main/default/classes/DeliveryFileBytesResourceTest.cls
@@ -1,0 +1,208 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Tests for DeliveryFileBytesResource — verifies HMAC auth,
+ *              timestamp skew rejection, 404 for unknown ContentDocumentIds,
+ *              and happy-path bytes delivery.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryFileBytesResourceTest {
+
+    private static final String TEST_API_KEY = 'test-api-key-12345';
+    private static final String TEST_HMAC_SECRET = 'shhh-test-secret';
+
+    @TestSetup
+    static void makeData() {
+        NetworkEntity__c peer = new NetworkEntity__c(
+            Name = 'Peer Org',
+            EntityTypePk__c = 'Client',
+            StatusPk__c = 'Active',
+            ConnectionStatusPk__c = 'Connected',
+            ApiKeyTxt__c = TEST_API_KEY,
+            HmacSecretTxt__c = TEST_HMAC_SECRET,
+            IntegrationEndpointUrlTxt__c = 'https://peer.example.com'
+        );
+        insert peer;
+
+        ContentVersion cv = new ContentVersion(
+            Title = 'Asset',
+            PathOnClient = 'asset.bin',
+            VersionData = Blob.valueOf('hello bytes')
+        );
+        insert cv;
+    }
+
+    private static String firstContentDocumentId() {
+        return [SELECT ContentDocumentId FROM ContentVersion LIMIT 1].ContentDocumentId;
+    }
+
+    private static RestRequest buildRequest(String contentDocumentId, String apiKey, String timestamp, String signature) {
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/delivery/fileBytes/' + (contentDocumentId == null ? '' : contentDocumentId);
+        req.httpMethod = 'GET';
+        if (apiKey != null) {
+            req.headers.put('X-Api-Key', apiKey);
+        }
+        if (timestamp != null) {
+            req.headers.put('X-Timestamp', timestamp);
+        }
+        if (signature != null) {
+            req.headers.put('X-Signature', signature);
+        }
+        return req;
+    }
+
+    private static String signFor(String contentDocumentId, String timestamp) {
+        return DeliveryCryptoService.computeHMAC(TEST_HMAC_SECRET, contentDocumentId + '|' + timestamp);
+    }
+
+    @IsTest
+    static void testHappyPathReturnsBytes() {
+        String cdId = firstContentDocumentId();
+        String ts = String.valueOf(Datetime.now().getTime() / 1000L);
+        String sig = signFor(cdId, ts);
+
+        RestContext.request = buildRequest(cdId, TEST_API_KEY, ts, sig);
+        RestContext.response = new RestResponse();
+
+        Test.startTest();
+        DeliveryFileBytesResource.handleGet();
+        Test.stopTest();
+
+        System.assertEquals(200, RestContext.response.statusCode,
+            'Valid HMAC + known ContentDocumentId should return 200');
+        System.assertNotEquals(null, RestContext.response.responseBody,
+            'Response body should carry the bytes');
+        System.assertEquals('hello bytes', RestContext.response.responseBody.toString(),
+            'Response body should match the original VersionData');
+    }
+
+    @IsTest
+    static void testMissingApiKeyReturns401() {
+        String cdId = firstContentDocumentId();
+        String ts = String.valueOf(Datetime.now().getTime() / 1000L);
+        String sig = signFor(cdId, ts);
+
+        RestContext.request = buildRequest(cdId, null, ts, sig);
+        RestContext.response = new RestResponse();
+
+        Test.startTest();
+        DeliveryFileBytesResource.handleGet();
+        Test.stopTest();
+
+        System.assertEquals(401, RestContext.response.statusCode,
+            'Missing X-Api-Key should reject with 401');
+    }
+
+    @IsTest
+    static void testInvalidApiKeyReturns401() {
+        String cdId = firstContentDocumentId();
+        String ts = String.valueOf(Datetime.now().getTime() / 1000L);
+        String sig = signFor(cdId, ts);
+
+        RestContext.request = buildRequest(cdId, 'wrong-key', ts, sig);
+        RestContext.response = new RestResponse();
+
+        Test.startTest();
+        DeliveryFileBytesResource.handleGet();
+        Test.stopTest();
+
+        System.assertEquals(401, RestContext.response.statusCode,
+            'Unknown API key should be rejected with 401');
+    }
+
+    @IsTest
+    static void testBadHmacReturns401() {
+        String cdId = firstContentDocumentId();
+        String ts = String.valueOf(Datetime.now().getTime() / 1000L);
+
+        RestContext.request = buildRequest(cdId, TEST_API_KEY, ts, 'nonsense-signature');
+        RestContext.response = new RestResponse();
+
+        Test.startTest();
+        DeliveryFileBytesResource.handleGet();
+        Test.stopTest();
+
+        System.assertEquals(401, RestContext.response.statusCode,
+            'Bad HMAC should be rejected with 401');
+    }
+
+    @IsTest
+    static void testStaleTimestampReturns401() {
+        String cdId = firstContentDocumentId();
+        // One hour in the past — well beyond the 300s skew window
+        String staleTs = String.valueOf((Datetime.now().getTime() / 1000L) - 3600L);
+        String sig = signFor(cdId, staleTs);
+
+        RestContext.request = buildRequest(cdId, TEST_API_KEY, staleTs, sig);
+        RestContext.response = new RestResponse();
+
+        Test.startTest();
+        DeliveryFileBytesResource.handleGet();
+        Test.stopTest();
+
+        System.assertEquals(401, RestContext.response.statusCode,
+            'Stale timestamp should fail replay-protection check');
+    }
+
+    @IsTest
+    static void testUnknownContentDocumentIdReturns404() {
+        // Made-up ContentDocumentId prefix 069 with valid shape
+        String fakeCdId = '069000000000000AAA';
+        String ts = String.valueOf(Datetime.now().getTime() / 1000L);
+        String sig = signFor(fakeCdId, ts);
+
+        RestContext.request = buildRequest(fakeCdId, TEST_API_KEY, ts, sig);
+        RestContext.response = new RestResponse();
+
+        Test.startTest();
+        DeliveryFileBytesResource.handleGet();
+        Test.stopTest();
+
+        System.assertEquals(404, RestContext.response.statusCode,
+            'Unknown ContentDocumentId should return 404');
+    }
+
+    @IsTest
+    static void testPeerWithoutHmacSecretIsRefused() {
+        NetworkEntity__c peer = [SELECT Id FROM NetworkEntity__c LIMIT 1];
+        peer.HmacSecretTxt__c = null;
+        update peer;
+
+        String cdId = firstContentDocumentId();
+        String ts = String.valueOf(Datetime.now().getTime() / 1000L);
+
+        RestContext.request = buildRequest(cdId, TEST_API_KEY, ts, 'whatever');
+        RestContext.response = new RestResponse();
+
+        Test.startTest();
+        DeliveryFileBytesResource.handleGet();
+        Test.stopTest();
+
+        System.assertEquals(401, RestContext.response.statusCode,
+            'Binary transfer must require HMAC — peer without secret should be refused');
+    }
+
+    @IsTest
+    static void testMissingContentDocumentIdReturns400() {
+        String ts = String.valueOf(Datetime.now().getTime() / 1000L);
+        String sig = signFor('', ts);
+
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/delivery/fileBytes';
+        req.httpMethod = 'GET';
+        req.headers.put('X-Api-Key', TEST_API_KEY);
+        req.headers.put('X-Timestamp', ts);
+        req.headers.put('X-Signature', sig);
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        Test.startTest();
+        DeliveryFileBytesResource.handleGet();
+        Test.stopTest();
+
+        System.assertEquals(400, RestContext.response.statusCode,
+            'Missing ContentDocumentId should return 400');
+    }
+}

--- a/force-app/main/default/classes/DeliveryFileBytesResourceTest.cls
+++ b/force-app/main/default/classes/DeliveryFileBytesResourceTest.cls
@@ -148,8 +148,11 @@ private class DeliveryFileBytesResourceTest {
 
     @IsTest
     static void testUnknownContentDocumentIdReturns404() {
-        // Made-up ContentDocumentId prefix 069 with valid shape
-        String fakeCdId = '069000000000000AAA';
+        // SOQL `WHERE ContentDocumentId = :x` requires valid Id format, so
+        // build one dynamically from the ContentDocument key prefix rather
+        // than hardcoding '069...' — same pattern used in
+        // DeliveryHubBoardControllerTest.
+        String fakeCdId = ContentDocument.SObjectType.getDescribe().getKeyPrefix() + '000000000001';
         String ts = String.valueOf(Datetime.now().getTime() / 1000L);
         String sig = signFor(fakeCdId, ts);
 

--- a/force-app/main/default/classes/DeliveryFileBytesResourceTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryFileBytesResourceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -37,8 +37,25 @@ public without sharing class DeliverySyncItemIngestor {
             throw new IllegalArgumentException('Invalid Object Type: ' + objectType);
         }
 
-        String sourceId = (String) payload.get('SourceId'); 
-        String targetId = (String) payload.get('TargetId'); 
+        // Cross-org file-byte transport (2026-04-21 rewrite):
+        //   New senders emit metadata-only ContentVersion payloads with
+        //   FileTransport="pull-callout" and NO VersionData. Route those to
+        //   DeliveryFileBytesFetcher which fetches bytes via authenticated
+        //   callout to the source org. Legacy inline-bytes payloads
+        //   (VersionData present) continue to flow through the generic
+        //   mapFields/insert path below for 30d backward compat.
+        if (objectType.equalsIgnoreCase('ContentVersion')
+                && 'pull-callout'.equalsIgnoreCase(String.valueOf(payload.get('FileTransport')))) {
+            return handlePullCalloutFile(payload);
+        }
+        if (objectType.equalsIgnoreCase('ContentVersion') && payload.containsKey('VersionData')) {
+            System.debug(LoggingLevel.WARN,
+                'Deprecated: inbound ContentVersion with inline VersionData. ' +
+                'Senders should emit FileTransport="pull-callout" — legacy path retained for 30d backward compat.');
+        }
+
+        String sourceId = (String) payload.get('SourceId');
+        String targetId = (String) payload.get('TargetId');
         
         // Extract Traceability & Identity IDs from the incoming payload
         String globalSourceId = (String) payload.get('GlobalSourceId'); 
@@ -330,6 +347,106 @@ public without sharing class DeliverySyncItemIngestor {
             AccessLevel.SYSTEM_MODE
         );
         return !existing.isEmpty();
+    }
+
+    /**
+     * @description Handles the "metadata + binary-by-reference" inbound file
+     *              path. Resolves the local parent WorkItem, inserts an
+     *              inbound SyncItem__c ledger row carrying the metadata, and
+     *              enqueues DeliveryFileBytesFetcher to pull the bytes from
+     *              the source org via authenticated callout. Idempotent per
+     *              GlobalSourceId — duplicate inbounds (e.g. re-polls) re-use
+     *              the existing ledger row rather than forking new fetchers.
+     * @param payload Deserialized ContentVersion metadata payload.
+     * @return The SyncItem__c Id that owns this fetch (sync row Id, not the
+     *         eventual ContentVersion Id — that populates once bytes arrive).
+     */
+    @SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity')
+    private static Id handlePullCalloutFile(Map<String, Object> payload) {
+        String sourceId = (String) payload.get('SourceId');
+        String targetId = (String) payload.get('TargetId');
+        String globalSourceId = (String) payload.get('GlobalSourceId');
+        Id localParentId = resolveParentWorkItem(targetId);
+
+        // Idempotency: de-dupe by (GlobalSourceId or SourceId) — if we already
+        // have an inbound ledger row for this file we do NOT re-enqueue the
+        // fetcher. This mirrors the create-once semantics the generic inbound
+        // path gets for free via findLocalId.
+        String dedupeKey = String.isNotBlank(globalSourceId) ? globalSourceId : sourceId;
+        if (String.isNotBlank(dedupeKey)) {
+            List<SyncItem__c> existing = [
+                SELECT Id FROM SyncItem__c
+                WHERE DirectionPk__c = 'Inbound'
+                AND ObjectTypePk__c = 'ContentVersion'
+                AND (GlobalSourceIdTxt__c = :dedupeKey OR RemoteExternalIdTxt__c = :dedupeKey)
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ];
+            if (!existing.isEmpty()) {
+                return existing[0].Id;
+            }
+        }
+
+        SyncItem__c ledger = new SyncItem__c(
+            DirectionPk__c = 'Inbound',
+            StatusPk__c = 'Queued',
+            ObjectTypePk__c = 'ContentVersion',
+            RemoteExternalIdTxt__c = sourceId,
+            GlobalSourceIdTxt__c = globalSourceId,
+            WorkItemLookup__c = localParentId,
+            PayloadTxt__c = JSON.serialize(payload)
+        );
+        Database.insert(ledger, AccessLevel.SYSTEM_MODE);
+
+        // Enqueue the callout Queueable unless we're in a context that
+        // already has pending callouts pending commit (avoid nested queueable
+        // limit). Tests rely on Test.startTest/stopTest boundaries to flush.
+        if (Limits.getQueueableJobs() < Limits.getLimitQueueableJobs()) {
+            System.enqueueJob(new DeliveryFileBytesFetcher(ledger.Id, localParentId));
+        }
+
+        return ledger.Id;
+    }
+
+    /**
+     * @description Resolves a metadata payload's TargetId into a local
+     *              WorkItem Id, walking bridge → ledger → direct-id fallback.
+     * @param targetRef Identifier string from payload.TargetId (bridge
+     *                  RemoteWorkItemIdTxt__c, ledger RemoteExternalIdTxt__c,
+     *                  or a local Id as last resort).
+     * @return Local WorkItem Id, or null when nothing resolves.
+     */
+    private static Id resolveParentWorkItem(String targetRef) {
+        if (String.isBlank(targetRef)) {
+            return null;
+        }
+        WorkRequest__c bridge = findWorkItemBridge(targetRef);
+        if (bridge != null && bridge.WorkItemId__c != null) {
+            return bridge.WorkItemId__c;
+        }
+        List<SyncItem__c> ledger = [
+            SELECT LocalRecordIdTxt__c FROM SyncItem__c
+            WHERE RemoteExternalIdTxt__c = :targetRef
+            AND ObjectTypePk__c = 'WorkItem__c'
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (!ledger.isEmpty()) {
+            try {
+                return (Id) ledger[0].LocalRecordIdTxt__c;
+            } catch (Exception e) {
+                System.debug(LoggingLevel.FINE, 'Invalid ledger LocalRecordIdTxt__c: ' + e.getMessage());
+            }
+        }
+        try {
+            Id castId = (Id) targetRef;
+            if (castId.getSobjectType().getDescribe().getName().endsWithIgnoreCase('WorkItem__c')) {
+                return castId;
+            }
+        } catch (Exception e) {
+            System.debug(LoggingLevel.FINE, 'TargetId not a local WorkItem Id: ' + e.getMessage());
+        }
+        return null;
     }
 
     // Helper to grab both the Work Item ID and the Request ID

--- a/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
@@ -326,11 +326,11 @@ private class DeliverySyncItemIngestorTest {
             WorkItem__c wi = [SELECT Id FROM WorkItem__c LIMIT 1];
 
             Map<String, Object> payload = new Map<String, Object>{
-                'SourceId' => '068999000000001',
+                'SourceId' => 'REMOTE-CV-PULL-ABC',
                 'TargetId' => 'REMOTE-123', // matches WorkRequest.RemoteWorkItemIdTxt__c
                 'GlobalSourceId' => 'GSID-ABC',
-                'SenderOrgId' => '00D000000000002',
-                'ContentDocumentId' => '069999000000001AAA',
+                'SenderOrgId' => 'REMOTE-ORG-PULL-ABC',
+                'ContentDocumentId' => 'REMOTE-CD-PULL-ABC',
                 'Title' => 'Pulled file',
                 'PathOnClient' => 'pulled.txt',
                 'FileTransport' => 'pull-callout',
@@ -374,11 +374,11 @@ private class DeliverySyncItemIngestorTest {
     static void testInboundContentVersionPullCalloutIdempotent() {
         System.runAs(testUser) {
             Map<String, Object> payload = new Map<String, Object>{
-                'SourceId' => '068999000000002',
+                'SourceId' => 'REMOTE-CV-PULL-DUPE',
                 'TargetId' => 'REMOTE-123',
                 'GlobalSourceId' => 'GSID-DUPE',
-                'SenderOrgId' => '00D000000000002',
-                'ContentDocumentId' => '069999000000002AAA',
+                'SenderOrgId' => 'REMOTE-ORG-PULL-DUPE',
+                'ContentDocumentId' => 'REMOTE-CD-PULL-DUPE',
                 'Title' => 'Dup file',
                 'PathOnClient' => 'dup.txt',
                 'FileTransport' => 'pull-callout',

--- a/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
@@ -344,10 +344,11 @@ private class DeliverySyncItemIngestorTest {
 
             Test.startTest();
             Id resultId = DeliverySyncItemIngestor.processInboundItem('ContentVersion', payload);
-            Test.stopTest();
 
+            // Assert the ingestor's write state BEFORE Test.stopTest() flushes
+            // the enqueued fetcher (which would otherwise transition the row
+            // to Failed or Synced depending on peer-resolution outcome).
             System.assertNotEquals(null, resultId, 'Should return the ledger row Id');
-
             SyncItem__c ledger = [
                 SELECT Id, DirectionPk__c, StatusPk__c, ObjectTypePk__c,
                        WorkItemLookup__c, GlobalSourceIdTxt__c
@@ -360,7 +361,11 @@ private class DeliverySyncItemIngestorTest {
             System.assertEquals(wi.Id, ledger.WorkItemLookup__c, 'Ledger should point at the resolved local WorkItem');
             System.assertEquals('GSID-ABC', ledger.GlobalSourceIdTxt__c, 'GlobalSourceId should be recorded for idempotency');
 
-            // No ContentVersion should have been inserted in-band — the fetcher does that
+            Test.stopTest();
+
+            // No ContentVersion should have been inserted in-band — the fetcher
+            // would have failed its lookup for the unregistered sender org and
+            // written ErrorLogTxt__c rather than creating a ContentVersion.
             Integer cvCount = [SELECT COUNT() FROM ContentVersion WHERE Title = 'Pulled file'];
             System.assertEquals(0, cvCount, 'Ingestor must not insert ContentVersion directly in the pull-callout path');
         }

--- a/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
@@ -312,4 +312,122 @@ private class DeliverySyncItemIngestorTest {
             System.assertEquals(clientEntity.Id, insertedWorkItem.ClientNetworkEntityLookup__c, 'The Ingestor should have automatically stamped the ClientNetworkEntityLookup__c based on the SenderOrgId in the payload.');
         }
     }
+
+    /**
+     * @description Verifies the pull-callout ContentVersion branch: an inbound
+     *              metadata-only payload should create a Queued inbound ledger
+     *              row keyed to the local WorkItem — no ContentVersion insert
+     *              attempted in-band. The DeliveryFileBytesFetcher Queueable
+     *              takes it from there (covered by its own test).
+     */
+    @IsTest
+    static void testInboundContentVersionPullCalloutCreatesLedger() {
+        System.runAs(testUser) {
+            WorkItem__c wi = [SELECT Id FROM WorkItem__c LIMIT 1];
+
+            Map<String, Object> payload = new Map<String, Object>{
+                'SourceId' => '068999000000001',
+                'TargetId' => 'REMOTE-123', // matches WorkRequest.RemoteWorkItemIdTxt__c
+                'GlobalSourceId' => 'GSID-ABC',
+                'SenderOrgId' => '00D000000000002',
+                'ContentDocumentId' => '069999000000001AAA',
+                'Title' => 'Pulled file',
+                'PathOnClient' => 'pulled.txt',
+                'FileTransport' => 'pull-callout',
+                'Sha256' => '0'.repeat(64)
+            };
+
+            // Set a mock so the enqueued DeliveryFileBytesFetcher (if it runs)
+            // doesn't crash the test. We're only validating ingestor behaviour
+            // here; the fetcher is covered by its own test class.
+            Test.setMock(HttpCalloutMock.class, new MockBytesQuiet(500, 'noop'));
+
+            Test.startTest();
+            Id resultId = DeliverySyncItemIngestor.processInboundItem('ContentVersion', payload);
+            Test.stopTest();
+
+            System.assertNotEquals(null, resultId, 'Should return the ledger row Id');
+
+            SyncItem__c ledger = [
+                SELECT Id, DirectionPk__c, StatusPk__c, ObjectTypePk__c,
+                       WorkItemLookup__c, GlobalSourceIdTxt__c
+                FROM SyncItem__c
+                WHERE Id = :resultId
+            ];
+            System.assertEquals('Inbound', ledger.DirectionPk__c, 'Should be inbound');
+            System.assertEquals('Queued', ledger.StatusPk__c, 'Should be Queued awaiting the fetcher');
+            System.assertEquals('ContentVersion', ledger.ObjectTypePk__c, 'Object type should be ContentVersion');
+            System.assertEquals(wi.Id, ledger.WorkItemLookup__c, 'Ledger should point at the resolved local WorkItem');
+            System.assertEquals('GSID-ABC', ledger.GlobalSourceIdTxt__c, 'GlobalSourceId should be recorded for idempotency');
+
+            // No ContentVersion should have been inserted in-band — the fetcher does that
+            Integer cvCount = [SELECT COUNT() FROM ContentVersion WHERE Title = 'Pulled file'];
+            System.assertEquals(0, cvCount, 'Ingestor must not insert ContentVersion directly in the pull-callout path');
+        }
+    }
+
+    /**
+     * @description Second pull-callout inbound with the same GlobalSourceId
+     *              should NOT create a duplicate ledger row (idempotency).
+     */
+    @IsTest
+    static void testInboundContentVersionPullCalloutIdempotent() {
+        System.runAs(testUser) {
+            Map<String, Object> payload = new Map<String, Object>{
+                'SourceId' => '068999000000002',
+                'TargetId' => 'REMOTE-123',
+                'GlobalSourceId' => 'GSID-DUPE',
+                'SenderOrgId' => '00D000000000002',
+                'ContentDocumentId' => '069999000000002AAA',
+                'Title' => 'Dup file',
+                'PathOnClient' => 'dup.txt',
+                'FileTransport' => 'pull-callout',
+                'Sha256' => null
+            };
+
+            Test.setMock(HttpCalloutMock.class, new MockBytesQuiet(500, 'noop'));
+
+            Test.startTest();
+            Id first = DeliverySyncItemIngestor.processInboundItem('ContentVersion', payload);
+            Id second = DeliverySyncItemIngestor.processInboundItem('ContentVersion', payload);
+            Test.stopTest();
+
+            System.assertEquals(first, second, 'Duplicate inbound should return existing ledger Id');
+            Integer count = [SELECT COUNT() FROM SyncItem__c WHERE GlobalSourceIdTxt__c = 'GSID-DUPE'];
+            System.assertEquals(1, count, 'Only one ledger row should exist for a given GlobalSourceId');
+        }
+    }
+
+    /**
+     * @description Minimal HttpCalloutMock for the pull-callout path —
+     *              tests that exercise the ingestor enqueue a fetcher
+     *              Queueable; this mock lets that Queueable fail cleanly
+     *              instead of crashing the test harness.
+     */
+    private class MockBytesQuiet implements HttpCalloutMock {
+        /** @description HTTP status to return. */
+        private final Integer status;
+        /** @description Response body to return. */
+        private final String body;
+        /**
+         * @description Builds a quiet mock with the given status and body.
+         * @param status HTTP status code.
+         * @param body Response body as a string.
+         */
+        public MockBytesQuiet(Integer status, String body) {
+            this.status = status;
+            this.body = body;
+        }
+        /**
+         * @description Returns the pre-configured mock HttpResponse.
+         * @param req Ignored.
+         * @return Mock HttpResponse.
+         */
+        public HttpResponse respond(HttpRequest req) {
+            HttpResponse res = new HttpResponse();
+            res.setStatusCode(status);
+            res.setBodyAsBlob(Blob.valueOf(body));
+            return res;
+        }
+    }
 }

--- a/unpackaged/post/testSuites/DH.testSuite-meta.xml
+++ b/unpackaged/post/testSuites/DH.testSuite-meta.xml
@@ -4,6 +4,8 @@
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryGanttControllerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliverySlackServiceTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryContentDocLinkTriggerHandlerTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryFileBytesResourceTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryFileBytesFetcherTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryGhostControllerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubBoardControllerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubCalloutServiceTest</testClassName>


### PR DESCRIPTION
## Summary

Rewrites Delivery Hub's cross-org file sync from the legacy **base64-into-`SyncItem__c.PayloadTxt__c`** anti-pattern (capped at 131,072 chars, ~95 KB ceiling) to the industry-standard **metadata + binary-by-reference** transport via authenticated pull callout.

The band-aid from PR #672 (skip `VersionData` when encoded length > 90,000 chars) is removed — it's no longer needed, because bytes are no longer inlined at all. The receiver now fetches bytes on demand from the sender's new `/services/apexrest/delivery/fileBytes/<contentDocumentId>` endpoint.

## What changed

### Sender side — `DeliveryContentDocLinkTriggerHandler.cls`
- Stops serializing `VersionData` into `PayloadTxt__c`.
- New payload shape: `Title`, `PathOnClient`, `SourceId`, `ContentDocumentId`, `FileExtension`, `FileType`, `ContentSize`, `Sha256`, `SenderOrgId`, `TargetId`, `GlobalSourceId`, `FileTransport: "pull-callout"`.
- Computes `Sha256` via `Crypto.generateDigest` only when file is small enough to fit sync heap (< 4 MB); larger files ship with `Sha256: null` + `Oversized: true`.
- Header comment references this rewrite's rationale and the Winter '26 v65 upgrade path.

### New — `DeliveryFileBytesResource.cls` (`@RestResource(urlMapping='/fileBytes/*')`)
- HTTP `GET` handler.
- Auth = X-Api-Key + HMAC-SHA256 over `contentDocumentId + '|' + timestamp` using `NetworkEntity__c.HmacSecretTxt__c`.
- Timestamp skew: 300s window (replay protection).
- Returns:
  - `200` + `application/octet-stream` body on success
  - `400` for missing contentDocumentId
  - `401` for missing/invalid API key, missing/bad HMAC, stale timestamp, or peer without HMAC secret
  - `404` for unknown contentDocumentId
- Uses `WITH SYSTEM_MODE` on all SOQL per CLAUDE.md.

### New — `DeliveryFileBytesFetcher.cls` (`Queueable, Database.AllowsCallouts`)
- Enqueued by ingestor when inbound ContentVersion payload carries `FileTransport="pull-callout"`.
- Resolves source org via `NetworkEntity__c` lookup by `SenderOrgId`.
- Signs the callback request and invokes the peer's `/fileBytes/<cdId>` endpoint.
- Verifies `Sha256` when sender supplied one, inserts `ContentVersion` + `ContentDocumentLink` locally, marks SyncItem `Synced`.
- Failures flip SyncItem to `Failed` with structured `ErrorLogTxt__c` so the retry engine can pick it up.

### Receiver side — `DeliverySyncItemIngestor.cls`
- Routes `ContentVersion` payloads with `FileTransport="pull-callout"` to a new `handlePullCalloutFile` path that creates a Queued inbound ledger row and enqueues `DeliveryFileBytesFetcher`.
- Idempotent per `GlobalSourceId` (duplicate polls don't re-enqueue fetches).
- **Backward compat**: if the payload still contains a `VersionData` key (legacy sender), it flows through the pre-existing `mapFields`/insert path. A deprecation `WARN` log fires so admins can see who's still on the old path. Intended to be removed after a 30-day bake.

### Tests
- `DeliveryContentDocLinkTriggerHandlerTest` — rewritten to assert metadata-only shape (`FileTransport`, `Sha256`, absence of `VersionData`); new regression test proves a ~80 KB payload inserts cleanly (pre-rewrite would have STRING_TOO_LONG'd).
- `DeliveryFileBytesResourceTest` — 8 cases: happy path, missing/invalid API key, bad HMAC, stale timestamp, unknown contentDocumentId, peer-without-secret, missing contentDocumentId path.
- `DeliveryFileBytesFetcherTest` — happy path, sha256 mismatch, HTTP 500, unregistered sender. All use `HttpCalloutMock`.
- `DeliverySyncItemIngestorTest` — two new tests cover the pull-callout branch (ledger creation + idempotency).
- Both new test classes added to `unpackaged/post/testSuites/DH.testSuite-meta.xml`.

## Architecture note

There's no open-source hub-and-spoke file broker on AppExchange — this is novel architecture for the DH ecosystem. Once bedded in, the pattern generalizes to other large-payload cross-org sync (attachments, large JSON blobs, etc.).

## Post-install config required

1. Every peer `NetworkEntity__c` that should be allowed to fetch bytes from this org MUST have both `ApiKeyTxt__c` and `HmacSecretTxt__c` populated. (Existing sync already uses HMAC; this endpoint reuses the same secret.)
2. On the SENDER side, the bytes-fetch callback uses the same `ApiKeyTxt__c` / `HmacSecretTxt__c` stored on the NetworkEntity representing the peer — no additional secret provisioning.
3. Callout endpoint allowlist: the peer's base URL (from `IntegrationEndpointUrlTxt__c`) must be in **Setup → Remote Site Settings** (or an equivalent Named Credential). No new entries beyond what the existing sync flow already requires.

## Deferred — not in this PR

- **Named Credentials**: the existing sync flow uses per-entity `HmacSecretTxt__c` on NetworkEntity__c, not Named Credentials. This PR follows that convention. Migration to Named Credentials would be a separate refactor touching `DeliverySyncItemProcessor` + the new fetcher + onboarding UX.
- **Winter '26 API v65 streaming Http**: would raise the file ceiling from ~12 MB (async heap) to ~16 MB and remove the heap pressure on `DeliveryFileBytesResource`. Blocked by the project's `sourceApiVersion: "61.0"` in `sfdx-project.json` and `cumulusci.yml`; upgrading is out of scope here.
- **IP allowlisting / mTLS**: HMAC + short timestamp window is the protection layer. IP allowlisting would require Named Credentials or platform-level firewall; documented as a future hardening step.
- **Deprecation removal**: the legacy VersionData-in-payload ingestion branch is retained for 30 days. Remove in a follow-up once all peer orgs have upgraded.

## Test plan

- [ ] CI feature-test on namespaced scratch org (PMD + Apex tests)
- [ ] `cci task run deploy --path force-app/main/default/classes` to an unmerged scratch, run new test classes directly
- [ ] End-to-end smoke between MF-Prod and Nimba after promote: upload a file > 95 KB (ghost-recorder attachment) and confirm it arrives intact on the peer
- [ ] Verify `DeliveryFileBytesResource` endpoint is reachable: `GET /services/apexrest/delivery/fileBytes/<cdId>` with X-Api-Key + X-Timestamp + X-Signature returns 200 + bytes

Fixes the root cause addressed by the band-aid in PR #672.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>