### PR TITLE
fix(gantt): right-click dep create/delete works on MF-Prod (FLS + refetch)

### DIFF
--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -355,7 +355,11 @@ public with sharing class DeliveryGanttController {
                 BlockedWorkItemLookup__c = blockedId,
                 TypePk__c = resolvedType
             );
-            insert row;
+            // SYSTEM_MODE: running user on subscriber orgs (e.g. MF-Prod) may
+            // lack Edit FLS on delivery__BlockingWorkItemLookup__c /
+            // delivery__BlockedWorkItemLookup__c. Plain insert strips those
+            // fields and fails with REQUIRED_FIELD_MISSING.
+            Database.insert(new List<WorkItemDependency__c>{ row }, AccessLevel.SYSTEM_MODE);
             GanttDependency dto = new GanttDependency();
             dto.id = row.Id;
             dto.source = blockingId;
@@ -382,7 +386,7 @@ public with sharing class DeliveryGanttController {
                 throw new AuraHandledException('depId is required');
             }
             WorkItemDependency__c row = new WorkItemDependency__c(Id = depId);
-            delete row;
+            Database.delete(new List<WorkItemDependency__c>{ row }, true, AccessLevel.SYSTEM_MODE);
         } catch (AuraHandledException ahe) {
             throw ahe;
         } catch (Exception e) {

--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -1116,16 +1116,24 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             const setTasksType = this._mountHandle ? typeof this._mountHandle.setTasks : 'no handle';
             // eslint-disable-next-line no-console
             console.log('[DH refetch] handle.setTasks typeof=', setTasksType);
-            if (this._mountHandle && typeof this._mountHandle.setTasks === 'function') {
-                const mapped = this._mapTasksForNg(this._tasks);
+            const mapped = this._mapTasksForNg(this._tasks);
+            // Re-filter deps against the refreshed task set so arrows whose
+            // endpoints just dropped out of view (completed, date-cleared)
+            // don't throw in DependencyRenderer. Map returns a new array
+            // reference, which NG relies on for layoutMap invalidation.
+            const deps = this._mapDependenciesForNg(this._dependencies || []);
+            this._dependencies = deps;
+            if (this._mountHandle && typeof this._mountHandle.setData === 'function') {
                 // eslint-disable-next-line no-console
-                console.log('[DH refetch] calling setTasks with', mapped.length, 'tasks');
+                console.log('[DH refetch] calling setData with', mapped.length, 'tasks,', deps.length, 'deps');
+                this._mountHandle.setData(mapped, deps);
+            } else if (this._mountHandle && typeof this._mountHandle.setTasks === 'function') {
+                // eslint-disable-next-line no-console
+                console.log('[DH refetch] setData unavailable — calling setTasks only with', mapped.length, 'tasks');
                 this._mountHandle.setTasks(mapped);
-                // eslint-disable-next-line no-console
-                console.log('[DH refetch] setTasks returned');
             } else {
                 // eslint-disable-next-line no-console
-                console.warn('[DH refetch] NG handle missing setTasks — visual state will not refresh');
+                console.warn('[DH refetch] NG handle missing setData/setTasks — visual state will not refresh');
             }
         } catch (error) {
             // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary
Two fixes that together make the right-click "Add predecessor"/"Add successor" flow work on MF-Prod:

**1. FLS stripping → SYSTEM_MODE**
Plain `insert`/`delete` in `createWorkItemDependency` / `deleteWorkItemDependency` respected FLS. Running user on MF-Prod lacks Edit on `delivery__BlockingWorkItemLookup__c` / `delivery__BlockedWorkItemLookup__c`, so those fields got stripped before DML → `REQUIRED_FIELD_MISSING`. Switch to `Database.insert/delete(..., AccessLevel.SYSTEM_MODE)` to match the pattern used by other gantt writes that already work on MF-Prod.

**2. Refetch preserves arrows (setData over setTasks)**
`_refetchAfterPatch` was calling `setTasks(tasks)` only, leaving NG to guess whether existing deps still apply. Per nimbus-gantt cb09aee2 (v0.185.34), `setData(tasks, deps)` with a new array reference is what invalidates the internal `layoutMap` — without it, an arrow added via the picker could vanish on the next task-only refetch (e.g. a drag). Also re-filters deps through `_mapDependenciesForNg` so arrows pointing at tasks that dropped out of view don't blow up `DependencyRenderer`.

## Why this is safe
- `@AuraEnabled` controller already gated to users who can interact with the gantt; we just stop per-field FLS from silently dropping required lookups.
- Other gantt mutations (date edits, reprioritize, reorder) already run SYSTEM_MODE on MF-Prod.
- `_mapDependenciesForNg` tolerates both raw-Apex (`dependencyType`) and already-mapped (`type`) shapes, so re-running it on an already-mapped array is a no-op rename plus a re-filter.

## Repro (MF-Prod, current build)
1. Open Delivery Gantt, right-click a task, "Add successor (this blocks)"
2. Pick another task.
3. Before: `Insert failed ... REQUIRED_FIELD_MISSING, Required fields are missing: [Blocked Work Item, Blocking Work Item]`
4. After: dependency writes, arrow renders optimistically, survives the next drag-triggered refetch.

## Test plan
- [ ] CI feature-test green
- [ ] After beta install on MF-Prod, right-click → "Add successor" → pick task → arrow appears and persists across refresh
- [ ] Right-click → "Remove predecessor" → arrow disappears and stays gone across refresh
- [ ] Drag-to-reorder a bar after adding a dep → arrow still visible after refetch completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)