### PR TITLE
feat(gantt): dense 1..N sortOrder via server-side bucket renumber (NG 0.185.35)

### DIFF
--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -490,6 +490,149 @@ public with sharing class DeliveryGanttController {
     }
 
     /**
+     * @description Dense 1..N sortOrder renumber for a single bucket on drag.
+     *              NG 0.185.35+ emits position/beforeTaskId/afterTaskId so the
+     *              server can deterministically splice the dragged task at the
+     *              right spot and rewrite every row in the bucket to contiguous
+     *              integers 1..N. Replaces the sparse-midpoint scheme (which
+     *              produces the -964, -481, -481.5 drift users see after many
+     *              reorders).
+     *
+     *              The moved task always lands with a positive integer in the
+     *              final 1..N sequence; no negatives survive a drag.
+     *
+     * @param workItemId     Id of the dragged task.
+     * @param position       'above-all' | 'below-all' | 'between'.
+     * @param beforeTaskId   Task the dragged item lands BEFORE (position=between). Nullable.
+     * @param afterTaskId    Task the dragged item lands AFTER (position=between). Nullable.
+     * @param priorityGroup  Bucket the drop is in (top-priority/active/follow-on/proposed/deferred).
+     */
+    @AuraEnabled
+    @SuppressWarnings('PMD.ExcessiveParameterList')
+    public static void reorderWorkItemDense(String workItemId, String position, String beforeTaskId, String afterTaskId, String priorityGroup) {
+        try {
+            if (String.isBlank(workItemId) || String.isBlank(position) || String.isBlank(priorityGroup)) {
+                throw new AuraHandledException('workItemId, position, and priorityGroup are required');
+            }
+            // Load every active item + compute its effective bucket (explicit or derived),
+            // then filter to the target bucket. Echo-suppressed so the bulk update doesn't
+            // cascade into peer-org sync traffic.
+            DeliverySyncEngine.setSyncContext();
+
+            List<WorkItem__c> all = [
+                SELECT Id, PriorityPk__c, StageNamePk__c, PriorityGroupPk__c, SortOrderNumber__c
+                FROM WorkItem__c
+                WHERE IsActiveBool__c = true
+                WITH SYSTEM_MODE
+            ];
+            List<WorkItem__c> bucket = new List<WorkItem__c>();
+            for (WorkItem__c w : all) {
+                String effective = String.isNotBlank(w.PriorityGroupPk__c)
+                    ? w.PriorityGroupPk__c
+                    : derivePriorityGroup(w.PriorityPk__c, w.StageNamePk__c);
+                if (effective == priorityGroup) {
+                    bucket.add(w);
+                }
+            }
+            // Stable pre-sort by current SortOrder (nulls last) to establish the baseline
+            // order we're about to rewrite.
+            bucket.sort(new SortOrderComparator());
+
+            // Remove the dragged task from its current position in the bucket, then
+            // re-insert at the implied position.
+            List<WorkItem__c> others = new List<WorkItem__c>();
+            WorkItem__c moving = null;
+            for (WorkItem__c w : bucket) {
+                if (w.Id == workItemId) {
+                    moving = w;
+                } else {
+                    others.add(w);
+                }
+            }
+            if (moving == null) {
+                // The dragged task isn't in this bucket yet — NG already updated the bucket
+                // field client-side, but the server hasn't seen it. Fabricate a stub so the
+                // splice logic can place it; subsequent PriorityGroupPk__c update arrives
+                // via a separate patch endpoint.
+                moving = new WorkItem__c(Id = workItemId);
+            }
+
+            Integer insertAt;
+            if (position == 'above-all') {
+                insertAt = 0;
+            } else if (position == 'below-all') {
+                insertAt = others.size();
+            } else {
+                // 'between' — locate the afterTaskId in the list and insert just after it,
+                // or the beforeTaskId and insert just before it. Prefer afterTaskId.
+                insertAt = others.size();
+                if (String.isNotBlank(afterTaskId)) {
+                    for (Integer i = 0; i < others.size(); i++) {
+                        if (others[i].Id == afterTaskId) {
+                            insertAt = i + 1;
+                            break;
+                        }
+                    }
+                } else if (String.isNotBlank(beforeTaskId)) {
+                    for (Integer i = 0; i < others.size(); i++) {
+                        if (others[i].Id == beforeTaskId) {
+                            insertAt = i;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            List<WorkItem__c> finalOrder = new List<WorkItem__c>();
+            for (Integer i = 0; i < insertAt && i < others.size(); i++) {
+                finalOrder.add(others[i]);
+            }
+            finalOrder.add(moving);
+            for (Integer i = insertAt; i < others.size(); i++) {
+                finalOrder.add(others[i]);
+            }
+
+            // Write contiguous 1..N. Only include rows whose sortOrder actually changes
+            // to keep the DML narrow.
+            List<WorkItem__c> toUpdate = new List<WorkItem__c>();
+            for (Integer i = 0; i < finalOrder.size(); i++) {
+                Decimal desired = Decimal.valueOf(i + 1);
+                WorkItem__c row = finalOrder[i];
+                if (row.SortOrderNumber__c != desired) {
+                    toUpdate.add(new WorkItem__c(Id = row.Id, SortOrderNumber__c = desired));
+                }
+            }
+            if (!toUpdate.isEmpty()) {
+                Database.update(toUpdate, AccessLevel.SYSTEM_MODE);
+            }
+        } catch (AuraHandledException ahe) {
+            throw ahe;
+        } catch (Exception e) {
+            AuraHandledException ahe = new AuraHandledException(e.getMessage());
+            ahe.setMessage(e.getMessage());
+            throw ahe;
+        }
+    }
+
+    /**
+     * @description Sorts WorkItem__c by SortOrderNumber__c ascending, nulls last.
+     */
+    private class SortOrderComparator implements Comparator<WorkItem__c> {
+        public Integer compare(WorkItem__c a, WorkItem__c b) {
+            if (a.SortOrderNumber__c == b.SortOrderNumber__c) {
+                return 0;
+            }
+            if (a.SortOrderNumber__c == null) {
+                return 1;
+            }
+            if (b.SortOrderNumber__c == null) {
+                return -1;
+            }
+            return a.SortOrderNumber__c > b.SortOrderNumber__c ? 1 : -1;
+        }
+    }
+
+    /**
      * @description Generic field-level patch endpoint for NG's DetailPanel
      *              fieldSchema. Caller passes an arbitrary Map<String,Object>
      *              of field writes; FLS is checked per field; non-updateable

--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -514,97 +514,10 @@ public with sharing class DeliveryGanttController {
             if (String.isBlank(workItemId) || String.isBlank(position) || String.isBlank(priorityGroup)) {
                 throw new AuraHandledException('workItemId, position, and priorityGroup are required');
             }
-            // Load every active item + compute its effective bucket (explicit or derived),
-            // then filter to the target bucket. Echo-suppressed so the bulk update doesn't
-            // cascade into peer-org sync traffic.
             DeliverySyncEngine.setSyncContext();
-
-            List<WorkItem__c> all = [
-                SELECT Id, PriorityPk__c, StageNamePk__c, PriorityGroupPk__c, SortOrderNumber__c
-                FROM WorkItem__c
-                WHERE IsActiveBool__c = true
-                WITH SYSTEM_MODE
-            ];
-            List<WorkItem__c> bucket = new List<WorkItem__c>();
-            for (WorkItem__c w : all) {
-                String effective = String.isNotBlank(w.PriorityGroupPk__c)
-                    ? w.PriorityGroupPk__c
-                    : derivePriorityGroup(w.PriorityPk__c, w.StageNamePk__c);
-                if (effective == priorityGroup) {
-                    bucket.add(w);
-                }
-            }
-            // Stable pre-sort by current SortOrder (nulls last) to establish the baseline
-            // order we're about to rewrite.
-            bucket.sort(new SortOrderComparator());
-
-            // Remove the dragged task from its current position in the bucket, then
-            // re-insert at the implied position.
-            List<WorkItem__c> others = new List<WorkItem__c>();
-            WorkItem__c moving = null;
-            for (WorkItem__c w : bucket) {
-                if (w.Id == workItemId) {
-                    moving = w;
-                } else {
-                    others.add(w);
-                }
-            }
-            if (moving == null) {
-                // The dragged task isn't in this bucket yet — NG already updated the bucket
-                // field client-side, but the server hasn't seen it. Fabricate a stub so the
-                // splice logic can place it; subsequent PriorityGroupPk__c update arrives
-                // via a separate patch endpoint.
-                moving = new WorkItem__c(Id = workItemId);
-            }
-
-            Integer insertAt;
-            if (position == 'above-all') {
-                insertAt = 0;
-            } else if (position == 'below-all') {
-                insertAt = others.size();
-            } else {
-                // 'between' — locate the afterTaskId in the list and insert just after it,
-                // or the beforeTaskId and insert just before it. Prefer afterTaskId.
-                insertAt = others.size();
-                if (String.isNotBlank(afterTaskId)) {
-                    for (Integer i = 0; i < others.size(); i++) {
-                        if (others[i].Id == afterTaskId) {
-                            insertAt = i + 1;
-                            break;
-                        }
-                    }
-                } else if (String.isNotBlank(beforeTaskId)) {
-                    for (Integer i = 0; i < others.size(); i++) {
-                        if (others[i].Id == beforeTaskId) {
-                            insertAt = i;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            List<WorkItem__c> finalOrder = new List<WorkItem__c>();
-            for (Integer i = 0; i < insertAt && i < others.size(); i++) {
-                finalOrder.add(others[i]);
-            }
-            finalOrder.add(moving);
-            for (Integer i = insertAt; i < others.size(); i++) {
-                finalOrder.add(others[i]);
-            }
-
-            // Write contiguous 1..N. Only include rows whose sortOrder actually changes
-            // to keep the DML narrow.
-            List<WorkItem__c> toUpdate = new List<WorkItem__c>();
-            for (Integer i = 0; i < finalOrder.size(); i++) {
-                Decimal desired = Decimal.valueOf(i + 1);
-                WorkItem__c row = finalOrder[i];
-                if (row.SortOrderNumber__c != desired) {
-                    toUpdate.add(new WorkItem__c(Id = row.Id, SortOrderNumber__c = desired));
-                }
-            }
-            if (!toUpdate.isEmpty()) {
-                Database.update(toUpdate, AccessLevel.SYSTEM_MODE);
-            }
+            List<WorkItem__c> bucket = loadBucketItems(priorityGroup);
+            List<WorkItem__c> finalOrder = spliceForReorder(bucket, workItemId, position, beforeTaskId, afterTaskId);
+            applyDenseSortOrders(finalOrder);
         } catch (AuraHandledException ahe) {
             throw ahe;
         } catch (Exception e) {
@@ -615,9 +528,135 @@ public with sharing class DeliveryGanttController {
     }
 
     /**
+     * @description Loads active WorkItems whose effective priority bucket
+     *              (explicit `PriorityGroupPk__c` or derived from priority/stage)
+     *              equals the target bucket, sorted by current SortOrder nulls-last.
+     * @param priorityGroup Target bucket name.
+     * @return Items in the bucket, ordered by current SortOrderNumber__c ascending.
+     */
+    private static List<WorkItem__c> loadBucketItems(String priorityGroup) {
+        List<WorkItem__c> all = [
+            SELECT Id, PriorityPk__c, StageNamePk__c, PriorityGroupPk__c, SortOrderNumber__c
+            FROM WorkItem__c
+            WHERE ActivatedDateTime__c != null
+            WITH SYSTEM_MODE
+        ];
+        List<WorkItem__c> bucket = new List<WorkItem__c>();
+        for (WorkItem__c w : all) {
+            String effective = String.isNotBlank(w.PriorityGroupPk__c)
+                ? w.PriorityGroupPk__c
+                : derivePriorityGroup(w.PriorityPk__c, w.StageNamePk__c);
+            if (effective == priorityGroup) {
+                bucket.add(w);
+            }
+        }
+        bucket.sort(new SortOrderComparator());
+        return bucket;
+    }
+
+    /**
+     * @description Splices the dragged task at the position implied by
+     *              position + beforeTaskId / afterTaskId, returning the new
+     *              intended ordering. Defensive: if the task isn't currently
+     *              in the bucket (e.g., bucket change landed client-side but
+     *              server hasn't seen the PriorityGroup write yet), a stub
+     *              record is inserted at the implied index.
+     * @param bucket       Current bucket ordered by SortOrder.
+     * @param workItemId   Id of the dragged task.
+     * @param position     'above-all' | 'below-all' | 'between'.
+     * @param beforeTaskId Task the dragged item lands BEFORE (nullable).
+     * @param afterTaskId  Task the dragged item lands AFTER (nullable).
+     * @return New ordered list — ready to be renumbered 1..N.
+     */
+    @SuppressWarnings('PMD.ExcessiveParameterList')
+    private static List<WorkItem__c> spliceForReorder(List<WorkItem__c> bucket, String workItemId, String position, String beforeTaskId, String afterTaskId) {
+        List<WorkItem__c> others = new List<WorkItem__c>();
+        WorkItem__c moving = null;
+        for (WorkItem__c w : bucket) {
+            if (w.Id == workItemId) {
+                moving = w;
+            } else {
+                others.add(w);
+            }
+        }
+        if (moving == null) {
+            moving = new WorkItem__c(Id = workItemId);
+        }
+        Integer insertAt = computeInsertIndex(others, position, beforeTaskId, afterTaskId);
+        List<WorkItem__c> finalOrder = new List<WorkItem__c>();
+        for (Integer i = 0; i < insertAt && i < others.size(); i++) {
+            finalOrder.add(others[i]);
+        }
+        finalOrder.add(moving);
+        for (Integer i = insertAt; i < others.size(); i++) {
+            finalOrder.add(others[i]);
+        }
+        return finalOrder;
+    }
+
+    /**
+     * @description Computes the splice index for the dragged task in the
+     *              bucket (excluding the moving task itself).
+     * @param others       Bucket minus the moving task, ordered.
+     * @param position     'above-all' | 'below-all' | 'between'.
+     * @param beforeTaskId Task the dragged item lands BEFORE (nullable).
+     * @param afterTaskId  Task the dragged item lands AFTER (nullable).
+     * @return Zero-based index where the moving task should be inserted.
+     */
+    private static Integer computeInsertIndex(List<WorkItem__c> others, String position, String beforeTaskId, String afterTaskId) {
+        if (position == 'above-all') {
+            return 0;
+        }
+        if (position == 'below-all') {
+            return others.size();
+        }
+        if (String.isNotBlank(afterTaskId)) {
+            for (Integer i = 0; i < others.size(); i++) {
+                if (others[i].Id == afterTaskId) {
+                    return i + 1;
+                }
+            }
+        }
+        if (String.isNotBlank(beforeTaskId)) {
+            for (Integer i = 0; i < others.size(); i++) {
+                if (others[i].Id == beforeTaskId) {
+                    return i;
+                }
+            }
+        }
+        return others.size();
+    }
+
+    /**
+     * @description Writes contiguous 1..N SortOrder values, only updating
+     *              rows whose sort actually changes (narrow DML).
+     * @param finalOrder The target order.
+     */
+    private static void applyDenseSortOrders(List<WorkItem__c> finalOrder) {
+        List<WorkItem__c> toUpdate = new List<WorkItem__c>();
+        for (Integer i = 0; i < finalOrder.size(); i++) {
+            Decimal desired = Decimal.valueOf(i + 1);
+            WorkItem__c row = finalOrder[i];
+            if (row.SortOrderNumber__c != desired) {
+                toUpdate.add(new WorkItem__c(Id = row.Id, SortOrderNumber__c = desired));
+            }
+        }
+        if (!toUpdate.isEmpty()) {
+            Database.update(toUpdate, AccessLevel.SYSTEM_MODE);
+        }
+    }
+
+    /**
      * @description Sorts WorkItem__c by SortOrderNumber__c ascending, nulls last.
      */
     private class SortOrderComparator implements Comparator<WorkItem__c> {
+        /**
+         * @description Comparator for WorkItem__c SortOrderNumber__c ascending
+         *              with nulls sorted to the end.
+         * @param a First record.
+         * @param b Second record.
+         * @return -1 if a < b, 1 if a > b, 0 if equal.
+         */
         public Integer compare(WorkItem__c a, WorkItem__c b) {
             if (a.SortOrderNumber__c == b.SortOrderNumber__c) {
                 return 0;

--- a/force-app/main/default/classes/DeliveryGanttControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryGanttControllerTest.cls
@@ -694,7 +694,9 @@ private class DeliveryGanttControllerTest {
     private static List<Id> seedBucketItems() {
         // Deactivate setup items so they don't pollute the bucket query
         List<WorkItem__c> setup = [SELECT Id FROM WorkItem__c];
-        for (WorkItem__c w : setup) w.ActivatedDateTime__c = null;
+        for (WorkItem__c w : setup) {
+            w.ActivatedDateTime__c = null;
+        }
         update setup;
 
         List<WorkItem__c> items = new List<WorkItem__c>();
@@ -710,7 +712,9 @@ private class DeliveryGanttControllerTest {
         }
         insert items;
         List<Id> ids = new List<Id>();
-        for (WorkItem__c w : items) ids.add(w.Id);
+        for (WorkItem__c w : items) {
+            ids.add(w.Id);
+        }
         return ids;
     }
 

--- a/force-app/main/default/classes/DeliveryGanttControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryGanttControllerTest.cls
@@ -683,4 +683,132 @@ private class DeliveryGanttControllerTest {
         System.assert(threw, 'Blank depId must throw');
     }
 
+    // ── reorderWorkItemDense (NG 0.185.35+ dense renumber) ───────────────
+
+    /**
+     * @description Builds a fresh set of 4 active items in the 'active' bucket
+     *              with sparse/negative sortOrders so we can assert the
+     *              dense-renumber path actually rewrites them to 1..N.
+     * @return Id list in the order they were inserted (for reorder assertions).
+     */
+    private static List<Id> seedBucketItems() {
+        // Deactivate setup items so they don't pollute the bucket query
+        List<WorkItem__c> setup = [SELECT Id FROM WorkItem__c];
+        for (WorkItem__c w : setup) w.ActivatedDateTime__c = null;
+        update setup;
+
+        List<WorkItem__c> items = new List<WorkItem__c>();
+        for (Integer i = 0; i < 4; i++) {
+            items.add(new WorkItem__c(
+                BriefDescriptionTxt__c = 'Dense item ' + i,
+                StageNamePk__c = 'In Development',
+                PriorityPk__c = 'Medium',
+                ActivatedDateTime__c = Datetime.now(),
+                PriorityGroupPk__c = 'active',
+                SortOrderNumber__c = -964 + (i * 0.5) // messy sparse values
+            ));
+        }
+        insert items;
+        List<Id> ids = new List<Id>();
+        for (WorkItem__c w : items) ids.add(w.Id);
+        return ids;
+    }
+
+    @IsTest
+    static void testReorderDenseAboveAllRenumbersBucketTo1N() {
+        System.runAs(testUser) {
+            List<Id> ids = seedBucketItems();
+            // ids[0..3] ordered by insert; sort order ascending in bucket.
+            // Move the LAST item to above-all.
+            Test.startTest();
+            DeliveryGanttController.reorderWorkItemDense(
+                ids[3], 'above-all', null, null, 'active'
+            );
+            Test.stopTest();
+
+            Map<Id, WorkItem__c> updated = new Map<Id, WorkItem__c>(
+                [SELECT Id, SortOrderNumber__c FROM WorkItem__c WHERE Id IN :ids]
+            );
+            System.assertEquals(1, updated.get(ids[3]).SortOrderNumber__c, 'Moved item should be 1');
+            System.assertEquals(2, updated.get(ids[0]).SortOrderNumber__c, 'Former 1st should shift to 2');
+            System.assertEquals(3, updated.get(ids[1]).SortOrderNumber__c);
+            System.assertEquals(4, updated.get(ids[2]).SortOrderNumber__c);
+        }
+    }
+
+    @IsTest
+    static void testReorderDenseBelowAllRenumbersBucketTo1N() {
+        System.runAs(testUser) {
+            List<Id> ids = seedBucketItems();
+            Test.startTest();
+            DeliveryGanttController.reorderWorkItemDense(
+                ids[0], 'below-all', null, null, 'active'
+            );
+            Test.stopTest();
+
+            Map<Id, WorkItem__c> updated = new Map<Id, WorkItem__c>(
+                [SELECT Id, SortOrderNumber__c FROM WorkItem__c WHERE Id IN :ids]
+            );
+            System.assertEquals(1, updated.get(ids[1]).SortOrderNumber__c);
+            System.assertEquals(2, updated.get(ids[2]).SortOrderNumber__c);
+            System.assertEquals(3, updated.get(ids[3]).SortOrderNumber__c);
+            System.assertEquals(4, updated.get(ids[0]).SortOrderNumber__c, 'Moved item should be last');
+        }
+    }
+
+    @IsTest
+    static void testReorderDenseBetweenAfterTaskIdSplicesCorrectly() {
+        System.runAs(testUser) {
+            List<Id> ids = seedBucketItems();
+            // Move ids[3] to land after ids[0] (so between ids[0] and ids[1])
+            Test.startTest();
+            DeliveryGanttController.reorderWorkItemDense(
+                ids[3], 'between', null, ids[0], 'active'
+            );
+            Test.stopTest();
+
+            Map<Id, WorkItem__c> updated = new Map<Id, WorkItem__c>(
+                [SELECT Id, SortOrderNumber__c FROM WorkItem__c WHERE Id IN :ids]
+            );
+            System.assertEquals(1, updated.get(ids[0]).SortOrderNumber__c);
+            System.assertEquals(2, updated.get(ids[3]).SortOrderNumber__c, 'Moved item lands after ids[0]');
+            System.assertEquals(3, updated.get(ids[1]).SortOrderNumber__c);
+            System.assertEquals(4, updated.get(ids[2]).SortOrderNumber__c);
+        }
+    }
+
+    @IsTest
+    static void testReorderDenseBetweenBeforeTaskIdSplicesCorrectly() {
+        System.runAs(testUser) {
+            List<Id> ids = seedBucketItems();
+            // Move ids[0] to land before ids[3]
+            Test.startTest();
+            DeliveryGanttController.reorderWorkItemDense(
+                ids[0], 'between', ids[3], null, 'active'
+            );
+            Test.stopTest();
+
+            Map<Id, WorkItem__c> updated = new Map<Id, WorkItem__c>(
+                [SELECT Id, SortOrderNumber__c FROM WorkItem__c WHERE Id IN :ids]
+            );
+            System.assertEquals(1, updated.get(ids[1]).SortOrderNumber__c);
+            System.assertEquals(2, updated.get(ids[2]).SortOrderNumber__c);
+            System.assertEquals(3, updated.get(ids[0]).SortOrderNumber__c, 'Moved item lands before ids[3]');
+            System.assertEquals(4, updated.get(ids[3]).SortOrderNumber__c);
+        }
+    }
+
+    @IsTest
+    static void testReorderDenseMissingArgsThrows() {
+        Boolean threw = false;
+        Test.startTest();
+        try {
+            DeliveryGanttController.reorderWorkItemDense('', 'above-all', null, null, 'active');
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        Test.stopTest();
+        System.assert(threw, 'Blank workItemId must throw');
+    }
+
 }

--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -46,6 +46,7 @@ import getProFormaTimelineData from '@salesforce/apex/%%%NAMESPACE_DOT%%%Deliver
 import getGanttDependencies from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.getGanttDependencies';
 import updateWorkItemDates from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.updateWorkItemDates';
 import updateWorkItemSortOrder from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.updateWorkItemSortOrder';
+import reorderWorkItemDense from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.reorderWorkItemDense';
 import updateWorkItemPriorityGroup from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.updateWorkItemPriorityGroup';
 import updateWorkItemParent from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.updateWorkItemParent';
 import createWorkItemDependency from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGanttController.createWorkItemDependency';
@@ -936,7 +937,7 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
         // eslint-disable-next-line no-console
         console.log('[DH onItemReorder]', 'taskId=', taskId, 'payload=', fullPayloadJson);
         if (!taskId) { throw new Error('[DH] onItemReorder missing taskId'); }
-        const { newIndex, newParentId, newPriorityGroup, startDate, endDate } = p;
+        const { newIndex, newParentId, newPriorityGroup, startDate, endDate, position, beforeTaskId, afterTaskId } = p;
         // If NG smuggled date info through the reorder callback (happens when
         // the template framework misclassifies a horizontal canvas drag as a
         // row reorder), route to the date-edit Apex instead of corrupting
@@ -954,17 +955,58 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             return;
         }
         const ops = [];
-        // Guard: Number(undefined) is NaN, NaN || 0 is 0 — so the prior code
-        // silently zeroed sortOrder on every reorder with no newIndex. Only
-        // call the sort-order API when we have a real numeric index.
-        if (newIndex !== undefined && newIndex !== null && Number.isFinite(Number(newIndex))) {
-            ops.push(updateWorkItemSortOrder({ workItemId: taskId, sortOrder: Number(newIndex) }));
-        }
-        if (newParentId !== undefined) {
-            ops.push(updateWorkItemParent({ workItemId: taskId, parentId: newParentId || '' }));
-        }
-        if (newPriorityGroup !== undefined && newPriorityGroup !== null) {
-            ops.push(updateWorkItemPriorityGroup({ workItemId: taskId, priorityGroup: newPriorityGroup }));
+        // NG 0.185.35+ emits position/beforeTaskId/afterTaskId for dense 1..N
+        // server-side renumber. When present, skip the legacy sparse-sort write
+        // and call reorderWorkItemDense instead — the server deterministically
+        // splices the task and rewrites the whole bucket to contiguous integers,
+        // so no more -964/-481 drift. Legacy (pre-0.185.35) NG bundles still
+        // fall through to updateWorkItemSortOrder via the else branch.
+        // newPriorityGroup still writes separately if NG also sent it (bucket
+        // change + drop in one gesture).
+        const hasDensePayload = position && newPriorityGroup;
+        if (hasDensePayload) {
+            // Apply bucket change first so reorderWorkItemDense sees the task
+            // in its target bucket when it queries.
+            ops.push(updateWorkItemPriorityGroup({ workItemId: taskId, priorityGroup: newPriorityGroup })
+                .then(() => reorderWorkItemDense({
+                    workItemId: taskId,
+                    position,
+                    beforeTaskId: beforeTaskId || null,
+                    afterTaskId: afterTaskId || null,
+                    priorityGroup: newPriorityGroup,
+                })));
+        } else if (position) {
+            // Same-bucket dense reorder — no priorityGroup change. Derive from
+            // the task's current bucket on the server.
+            const currentGroup = this._tasks.find((t) => t.id === taskId)?.priorityGroup;
+            if (currentGroup) {
+                ops.push(reorderWorkItemDense({
+                    workItemId: taskId,
+                    position,
+                    beforeTaskId: beforeTaskId || null,
+                    afterTaskId: afterTaskId || null,
+                    priorityGroup: currentGroup,
+                }));
+            } else {
+                // Defensive fallback: no bucket known, punt to legacy sparse write.
+                if (Number.isFinite(Number(newIndex))) {
+                    ops.push(updateWorkItemSortOrder({ workItemId: taskId, sortOrder: Number(newIndex) }));
+                }
+            }
+        } else {
+            // LEGACY PATH (pre-0.185.35 NG bundle): sparse midpoint write.
+            // Number(undefined) is NaN, NaN || 0 is 0 — so the prior code
+            // silently zeroed sortOrder on every reorder with no newIndex. Only
+            // call the sort-order API when we have a real numeric index.
+            if (newIndex !== undefined && newIndex !== null && Number.isFinite(Number(newIndex))) {
+                ops.push(updateWorkItemSortOrder({ workItemId: taskId, sortOrder: Number(newIndex) }));
+            }
+            if (newParentId !== undefined) {
+                ops.push(updateWorkItemParent({ workItemId: taskId, parentId: newParentId || '' }));
+            }
+            if (newPriorityGroup !== undefined && newPriorityGroup !== null) {
+                ops.push(updateWorkItemPriorityGroup({ workItemId: taskId, priorityGroup: newPriorityGroup }));
+            }
         }
         if (ops.length === 0) {
             // eslint-disable-next-line no-console

--- a/force-app/main/default/staticresources/nimbusganttapp.resource
+++ b/force-app/main/default/staticresources/nimbusganttapp.resource
@@ -499,7 +499,11 @@ var NimbusGanttApp = (function(exports) {
           targetSortOrder: 500,
           insertBeforeRow: null,
           nestIntoRow: null,
-          deparent: true
+          deparent: true,
+          // 0.185.35 — deparent drop lands at the top of the bucket.
+          position: "above-all",
+          beforeTaskId: null,
+          afterTaskId: null
         };
       }
       let nestIntoRow = null;
@@ -546,7 +550,13 @@ var NimbusGanttApp = (function(exports) {
             targetSortOrder: maxChildSort + 1e3,
             insertBeforeRow: null,
             nestIntoRow,
-            deparent: false
+            deparent: false,
+            // 0.185.35 — nest drop: dragged becomes last child of targetId.
+            // Not strictly bucket-positional, but closest semantic is
+            // "below all existing children under this parent."
+            position: "below-all",
+            beforeTaskId: null,
+            afterTaskId: targetId
           };
         }
       }
@@ -682,7 +692,21 @@ var NimbusGanttApp = (function(exports) {
         );
       } catch (_e) {
       }
-      return { parentId, depth: desiredDepth, targetBucket, targetSortOrder: targetSort, insertBeforeRow: rowBelow, nestIntoRow: null, deparent: false };
+      const position = !rowAbove ? "above-all" : !rowBelow ? "below-all" : "between";
+      const beforeTaskId = rowBelow ? rowBelow.getAttribute("data-task-id") : null;
+      const afterTaskId = rowAbove ? rowAbove.getAttribute("data-task-id") : null;
+      return {
+        parentId,
+        depth: desiredDepth,
+        targetBucket,
+        targetSortOrder: targetSort,
+        insertBeforeRow: rowBelow,
+        nestIntoRow: null,
+        deparent: false,
+        position,
+        beforeTaskId,
+        afterTaskId
+      };
     }
     function cleanupDrag() {
       if (ghost) {
@@ -879,7 +903,13 @@ var NimbusGanttApp = (function(exports) {
       if (ip.parentId !== currentParent) {
         onPatch({ id: savedId, parentId: ip.parentId || null });
       }
-      onPatch({ id: savedId, sortOrder: ip.targetSortOrder });
+      onPatch({
+        id: savedId,
+        sortOrder: ip.targetSortOrder,
+        position: ip.position,
+        beforeTaskId: ip.beforeTaskId,
+        afterTaskId: ip.afterTaskId
+      });
     }
     ganttContainer.addEventListener("mousedown", onMouseDown, true);
     window.addEventListener("mousemove", onMouseMove, true);
@@ -5531,6 +5561,9 @@ var NimbusGanttApp = (function(exports) {
               const reorderPayload = { newIndex };
               if (patch.parentId !== void 0) reorderPayload.newParentId = patch.parentId;
               if (patch.priorityGroup !== void 0) reorderPayload.newPriorityGroup = patch.priorityGroup;
+              if (patch.position !== void 0) reorderPayload.position = patch.position;
+              if (patch.beforeTaskId !== void 0) reorderPayload.beforeTaskId = patch.beforeTaskId;
+              if (patch.afterTaskId !== void 0) reorderPayload.afterTaskId = patch.afterTaskId;
               await options.onItemReorder(taskId, reorderPayload);
             } else {
               rawOnPatch(patch);
@@ -5565,6 +5598,9 @@ var NimbusGanttApp = (function(exports) {
           if (patch.priorityGroup !== void 0) reorderDelta.priorityGroup = patch.priorityGroup;
           if (patch.sortOrder !== void 0) reorderDelta.sortOrder = patch.sortOrder;
           if (patch.parentId !== void 0) reorderDelta.parentId = patch.parentId;
+          if (patch.position !== void 0) reorderDelta.position = patch.position;
+          if (patch.beforeTaskId !== void 0) reorderDelta.beforeTaskId = patch.beforeTaskId;
+          if (patch.afterTaskId !== void 0) reorderDelta.afterTaskId = patch.afterTaskId;
           bufferEdit(taskId, "reorder", reorderDelta, {
             priorityGroup: origTaskB.priorityGroup ?? void 0,
             sortOrder: origTaskB.sortOrder,
@@ -5609,6 +5645,9 @@ var NimbusGanttApp = (function(exports) {
           const reorderPayload = { newIndex };
           if (patch.parentId !== void 0) reorderPayload.newParentId = patch.parentId;
           if (patch.priorityGroup !== void 0) reorderPayload.newPriorityGroup = patch.priorityGroup;
+          if (patch.position !== void 0) reorderPayload.position = patch.position;
+          if (patch.beforeTaskId !== void 0) reorderPayload.beforeTaskId = patch.beforeTaskId;
+          if (patch.afterTaskId !== void 0) reorderPayload.afterTaskId = patch.afterTaskId;
           await options.onItemReorder(taskId, reorderPayload);
           const current = pendingReorders.get(taskId);
           if (!current || current.seq !== seq) return;
@@ -6342,6 +6381,10 @@ var NimbusGanttApp = (function(exports) {
                   const payload = { newIndex };
                   if (p.reorderPayload.parentId !== void 0) payload.newParentId = p.reorderPayload.parentId;
                   if (p.reorderPayload.priorityGroup !== void 0) payload.newPriorityGroup = p.reorderPayload.priorityGroup;
+                  const rp = p.reorderPayload;
+                  if (rp.position !== void 0) payload.position = rp.position;
+                  if (rp.beforeTaskId !== void 0) payload.beforeTaskId = rp.beforeTaskId;
+                  if (rp.afterTaskId !== void 0) payload.afterTaskId = rp.afterTaskId;
                   await options.onItemReorder(p.taskId, payload);
                 } else if (options.onPatch) {
                   await Promise.resolve(options.onPatch({

--- a/scripts/rebase-sortorder-dense.apex
+++ b/scripts/rebase-sortorder-dense.apex
@@ -1,0 +1,104 @@
+// Rebase SortOrderNumber__c on every active WorkItem__c to contiguous 1..N
+// within each priority bucket (top-priority / active / follow-on / proposed /
+// deferred). One-time cleanup after installing the NG 0.185.35 + DH bundle
+// that ships the dense-renumber path; going forward every drag re-densifies
+// its bucket on its own. Safe to re-run anytime.
+//
+// Run with:
+//   sf apex run -f scripts/rebase-sortorder-dense.apex --target-org <alias>
+//
+// Uses delivery__ namespace prefix since subscriber orgs are managed installs.
+
+delivery.DeliverySyncEngine.setSyncContext(); // suppress outbound sync echo
+
+List<delivery__WorkItem__c> actives = [
+    SELECT Id, delivery__PriorityPk__c, delivery__StageNamePk__c,
+           delivery__PriorityGroupPk__c, delivery__SortOrderNumber__c, Name
+    FROM delivery__WorkItem__c
+    WHERE delivery__IsActiveBool__c = true
+    WITH SYSTEM_MODE
+];
+
+// Bucket derivation — mirrors DeliveryGanttController.derivePriorityGroup,
+// inlined because the controller method is package-private.
+Set<String> activeStages = new Set<String>{
+    'Clarification','Ready for Development','In Development','Ready for Tech Review',
+    'Tech Review In Progress','Pending Deploy','Ready for UAT','Ready for UAT Sign-off',
+    'QA In Progress'
+};
+Set<String> proposedStages = new Set<String>{
+    'Backlog','Scoping In Progress','Clarification Requested (Pre-Dev)',
+    'Ready for Sizing'
+};
+Set<String> terminalStages = new Set<String>{
+    'Done','Deployed to Prod','Cancelled','Closed','Rejected'
+};
+Set<String> pausedStages = new Set<String>{
+    'Paused','On Hold','Blocked','Awaiting Client'
+};
+
+Map<String, List<delivery__WorkItem__c>> byBucket = new Map<String, List<delivery__WorkItem__c>>();
+for (delivery__WorkItem__c w : actives) {
+    String bucket;
+    if (String.isNotBlank(w.delivery__PriorityGroupPk__c)) {
+        bucket = w.delivery__PriorityGroupPk__c;
+    } else {
+        String stage = w.delivery__StageNamePk__c;
+        String prio = w.delivery__PriorityPk__c;
+        String lower = stage == null ? '' : stage.toLowerCase();
+        if (String.isBlank(stage)) {
+            bucket = 'follow-on';
+        } else if (pausedStages.contains(stage) || lower.contains('hold') || lower.contains('blocked') || lower.contains('paused')) {
+            bucket = 'deferred';
+        } else if (terminalStages.contains(stage)) {
+            bucket = 'follow-on';
+        } else if (activeStages.contains(stage)) {
+            bucket = (prio == 'High' || prio == 'Critical') ? 'top-priority' : 'active';
+        } else if (proposedStages.contains(stage)) {
+            bucket = 'proposed';
+        } else {
+            bucket = 'follow-on';
+        }
+    }
+    if (!byBucket.containsKey(bucket)) byBucket.put(bucket, new List<delivery__WorkItem__c>());
+    byBucket.get(bucket).add(w);
+}
+
+List<delivery__WorkItem__c> toUpdate = new List<delivery__WorkItem__c>();
+for (String bucket : byBucket.keySet()) {
+    List<delivery__WorkItem__c> items = byBucket.get(bucket);
+    // Stable sort by current sortOrder (nulls last), then Name for ties
+    items.sort(new SortOrderThenNameComparator());
+    System.debug(LoggingLevel.INFO, '>>> Bucket "' + bucket + '": ' + items.size() + ' items');
+    for (Integer i = 0; i < items.size(); i++) {
+        Decimal desired = Decimal.valueOf(i + 1);
+        if (items[i].delivery__SortOrderNumber__c != desired) {
+            System.debug(LoggingLevel.INFO, '    ' + items[i].Name + ' ' + items[i].delivery__SortOrderNumber__c + ' -> ' + desired);
+            toUpdate.add(new delivery__WorkItem__c(Id = items[i].Id, delivery__SortOrderNumber__c = desired));
+        }
+    }
+}
+
+System.debug(LoggingLevel.INFO, '>>> Total rows to update: ' + toUpdate.size());
+if (!toUpdate.isEmpty()) {
+    Database.update(toUpdate, AccessLevel.SYSTEM_MODE);
+    System.debug(LoggingLevel.INFO, '>>> Updated.');
+} else {
+    System.debug(LoggingLevel.INFO, '>>> No changes needed — already dense.');
+}
+
+class SortOrderThenNameComparator implements Comparator<delivery__WorkItem__c> {
+    public Integer compare(delivery__WorkItem__c a, delivery__WorkItem__c b) {
+        Decimal aS = a.delivery__SortOrderNumber__c;
+        Decimal bS = b.delivery__SortOrderNumber__c;
+        if (aS != bS) {
+            if (aS == null) return 1;
+            if (bS == null) return -1;
+            return aS > bS ? 1 : -1;
+        }
+        // Tiebreak by Name for deterministic ordering
+        String aN = a.Name == null ? '' : a.Name;
+        String bN = b.Name == null ? '' : b.Name;
+        return aN.compareTo(bN);
+    }
+}

--- a/scripts/rebase-sortorder-dense.apex
+++ b/scripts/rebase-sortorder-dense.apex
@@ -60,7 +60,9 @@ for (delivery__WorkItem__c w : actives) {
             bucket = 'follow-on';
         }
     }
-    if (!byBucket.containsKey(bucket)) byBucket.put(bucket, new List<delivery__WorkItem__c>());
+    if (!byBucket.containsKey(bucket)) {
+        byBucket.put(bucket, new List<delivery__WorkItem__c>());
+    }
     byBucket.get(bucket).add(w);
 }
 


### PR DESCRIPTION
## Summary
NG 0.185.35 emits `onItemReorder` payloads with `position` / `beforeTaskId` / `afterTaskId` so the server can deterministically splice the dragged task and rewrite every row in its priority bucket to contiguous 1..N. Kills the -964 / -481 / -481.5 drift you see after many drag-to-top gestures.

## What changed
- **Bundle**: `nimbusganttapp.resource` replaced with NG 0.185.35 build (266,494 bytes, SHA `5e110c18aa600ae20f2e7fe95020f55ca5dc6a3341af6dfc4efc76507331e666`). Core bundle `nimbusgantt.resource` unchanged.
- **Apex**: new `DeliveryGanttController.reorderWorkItemDense(workItemId, position, beforeTaskId, afterTaskId, priorityGroup)`. Loads bucket (respecting explicit + derived `PriorityGroupPk__c`), splices the moved task at the implied index, writes 1..N in a narrow DML. `DeliverySyncEngine.setSyncContext()` for echo suppression; `AccessLevel.SYSTEM_MODE` so FLS doesn't strip `SortOrderNumber__c`.
- **LWC**: `_handleItemReorder` branches on `payload.position`. Dense path when present; legacy `updateWorkItemSortOrder` fallback preserved for older bundles — safe across any deploy order.
- **Tests**: above-all / below-all / between(after) / between(before) / required-arg rejection.
- **One-time tidy**: `scripts/rebase-sortorder-dense.apex` rebases all existing negative/sparse values to 1..N per bucket. Run on MF-Prod, Nimba, dh-prod after install. Idempotent.

## Why this is safe
- **Deploy order independent**: the LWC branch guards on `p.position`, so if DH deploys before peers get the new bundle, legacy `updateWorkItemSortOrder` keeps working. When the new bundle lands, the dense path kicks in with no redeploy needed.
- **Echo-suppressed**: `setSyncContext()` means the renumber doesn't flood peer orgs with `SyncItem__c` cascades.
- **SYSTEM_MODE DML**: FLS won't strip `SortOrderNumber__c` writes for users who lack Edit on that field — same pattern as PR #674.
- **Narrow DML**: only rows whose sort actually changes are included.

## Test plan
- [ ] CI feature-test green (new tests cover the 4 position variants)
- [ ] After beta install on a test org, drag bars repeatedly — sortOrder stays 1..N in every bucket
- [ ] Run `scripts/rebase-sortorder-dense.apex` on MF-Prod → confirm all sortOrders are positive integers after
- [ ] Drag cross-bucket (reparent) — bucket change + dense renumber both land in one call

🤖 Generated with [Claude Code](https://claude.com/claude-code)