### PR TITLE
chore: repo hygiene sweep - gitignore + audit report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,30 @@ $RECYCLE.BIN/
 .project
 .settings.claude/worktrees/
 .claude/worktrees/
+.claude/scheduled_tasks.lock
+
+# One-off describe / audit / dump artifacts (ad-hoc CLI output, not project data)
+# Keep these at repo root so scripts can write them, but don't let them pollute git.
+wi-*.json
+wl-*.json
+wr-*.json
+ne-*.json
+dd-*.json
+mfp-*.json
+mfprod-*.json
+mf-*.csv
+snap.json
+tmp-*.json
+*-describe.json
+*-clean.json
+
+# Ad-hoc audit / gap reports written at repo root
+MORNING_GAPS_REPORT.md
+/AUDIT_*.md
+/GAPS_*.md
+/REPORT_*.md
+
+# Temp dump directories from CLI tooling
+/mfp-dump/
+/scripts/mfp-check/
+/scripts/scratch-verify/


### PR DESCRIPTION
## Summary

Safe-fix branch from a repo hygiene sweep run against `main` on 2026-04-23.
Applied exactly one change: expanded `.gitignore` to cover the ad-hoc CLI
artifacts that have been accumulating at the repo root. No files deleted,
no code logic touched. Everything else is report-only below, per scope.

Companion in-flight PRs are NOT touched: #676 (release v0.99) and the
`test/code-coverage-sweep-0423` test sweep.

## Safe fix applied

`.gitignore` now covers:

- `wi-*.json`, `wl-*.json`, `wr-*.json`, `ne-*.json`, `dd-*.json` (describe dumps)
- `mfp-*.json`, `mfprod-*.json` (org audit exports)
- `snap.json`, `tmp-*.json`, `*-describe.json`, `*-clean.json`
- `mf-*.csv` (MF work-item exports)
- `MORNING_GAPS_REPORT.md`, `/AUDIT_*.md`, `/GAPS_*.md`, `/REPORT_*.md`
- `/mfp-dump/`, `/scripts/mfp-check/`, `/scripts/scratch-verify/`
- `.claude/scheduled_tasks.lock`

Verified via `git check-ignore -v` that each known offender now matches.
No disk deletions - files stay where scripts put them, just invisible to git.

## Audit report

### Mandatory invariants

| # | Invariant | Result | Notes |
|---|---|---|---|
| 1 | No `<type>Checkbox</type>` fields | PASS | 0 matches in `force-app/main/default/objects/**` or `customMetadata/**`. DateTime-toggle pattern holds. |
| 2 | Field naming suffix conventions | PASS (1 outlier) | Only non-conforming custom field across all 35 objects: `WorkflowTypeMdt__c` on `WorkRequest__c`. Intentional (`__mdt` semantic marker baked into name). No fix - rename would be data loss. |
| 3 | No `WITH USER_MODE` | PASS | 0 matches in apex. |
| 4 | No `SeeAllData=true` | PASS | 0 matches. |
| 5 | No `--no-verify` / `--no-gpg-sign` / test skips in workflows | PASS | Only "skip" in `.github/workflows/feature_test.yml` is a historical comment explaining a removed filter. |
| 6 | `.getName()` vs `.getLocalName()` | REVIEW | 15 call sites across 11 classes. Most are `getSObjectType().getDescribe().getName()` compared via `endsWithIgnoreCase('WorkItem__c')`, which is namespace-safe by construction. `UserInfo.getName()` (5 sites) is a separate API - returns username, not field/object name - not in scope. Recommend a follow-up pass on `DeliverySyncEngine` lines 279/309 and `DeliverySyncItemIngestor` lines 304/343 where `getName()` output is concatenated into SOQL - if a subscriber org runs namespaced, these need `getLocalName()` or a `stripNamespace` helper (the ingestor already has `stripNamespace` - line 304 uses it; lines 343/567 do not). |
| 7 | No emoji in code/docs | FAIL - review-only | 2 LWC JS files carry emoji in user-facing strings: `deliveryHubBoard/deliveryHubBoard.js:872,890` (stage-change icons) and `deliveryWorkItemStageGateWarning/deliveryWorkItemStageGateWarning.js:58,62` (FAST TRACK / OVER BUDGET alert strings). These look intentional for UX but CLAUDE.md forbids emoji "unless explicitly requested." Flagging only - unclear whether a PM previously signed off. |
| 8 | Repo-root artifact pollution | FIXED | See above. 40+ untracked artifacts now gitignored. |
| 9 | LWC hygiene (`{!expr}`, `@api X = true`, `$A`) | PASS | 0 unary `{!expr}` in LWC templates, 0 `@api` boolean props defaulting to true, 0 `$A` references (the single match in `deliveryProFormaTimeline.js:1316` is a comment reminding that `$A` is banned). |
| 10 | Apex class name = 40 chars | PASS | Longest class name across all 234 `.cls` files fits within 40 chars. |
| 11 | `Database.query()` with binds | PASS | 11 call sites reviewed - all use `:boundVar` or construct SOQL from whitelisted field CSVs. Most carry `// NOPMD` with a justification comment. |
| 12 | Inline `/* eslint */` comments | FAIL - review-only | 3 LWC JS files: `deliveryClientOnboarding.js:8`, `deliveryBudgetSummary.js:1`, `deliveryGuide.js:1`. CLAUDE.md says pre-commit hook strips these, so either the hook is not running on these files or they pre-date the rule. Recommend moving to `force-app/main/default/lwc/.eslintrc.json` and deleting the inline disables in a separate PR. |

### Non-mandatory (report only)

**`@SuppressWarnings` count**: 80+ occurrences across production and test code. Heavy usage on `PMD.ApexCRUDViolation`, `PMD.CyclomaticComplexity`, `PMD.ExcessiveParameterList`. The CRUD suppressions are frequently on AuraEnabled methods that use `WITH SYSTEM_MODE` - justified but would benefit from a one-line `// justified because...` comment per suppression. No action this PR.

**Test class parity**: 5 production classes have no sibling `*Test.cls`:

- `DeliveryDocActionRestApi`
- `DeliveryDocGenerationService`
- `DeliveryNotificationPreferenceService` (being addressed in `test/code-coverage-sweep-0423` - DO NOT duplicate)
- `DeliveryWorkItemCommentTriggerHandler`
- `DeliveryWorkItemDependenciesController`

**Documentation gaps** (confirmed present):

- No `docs/INVOICE_ENGINE.md` (despite invoice sync being the headline feature of the in-flight v0.99 release)
- No `docs/SYNC_ENGINE.md` (big architectural piece, spread across `SYNC_API_GUIDE.md` + README)
- No `README.md` in `force-app/main/default/lwc/deliveryDocumentViewer/`
- No scheduler doc (`DeliveryHubScheduler` + `DeliveryHubPoller` behavior)

**Missing `-meta.xml` sidecars**: 0 found. Every `.cls` has its `.cls-meta.xml`.

**Dead code / duplicate logic**: Out of scope for a 45-minute pass - would need call-graph tooling to be safe about subscriber orgs calling `global` methods.

## Recommended follow-up PRs (in priority order)

1. Remove inline `/* eslint-disable */` from the 3 LWC JS files; fold the rules into `force-app/main/default/lwc/.eslintrc.json`.
2. Decide emoji policy for `deliveryHubBoard` and `deliveryWorkItemStageGateWarning` - either formally whitelist in CLAUDE.md or replace with SLDS icons.
3. Add `docs/INVOICE_ENGINE.md` and `docs/SYNC_ENGINE.md`; add `README.md` to `deliveryDocumentViewer` LWC.
4. Audit `DeliverySyncItemIngestor.cls:343` and `:567` for `getName()` - `stripNamespace` helper already exists in the same file; just wrap the call sites.
5. Close the 4 remaining test parity gaps (excluding the one already in flight).

## Test plan

- [ ] CI `feature-test` green
- [ ] CI `apex-scan` green (PMD)
- [ ] `git check-ignore -v` spot-checks for representative artifact filenames

No code changes means no functional regression surface.
