### PR TITLE
fix(picklist): ship Pending value in fresh v0.200 beta

### DIFF
--- a/force-app/main/default/objects/SyncItem__c/fields/StatusPk__c.field-meta.xml
+++ b/force-app/main/default/objects/SyncItem__c/fields/StatusPk__c.field-meta.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>StatusPk__c</fullName>
-    <description>The current processing state. Values: Queued, Staged, Pending, Processing, Synced, Failed</description>
-    <inlineHelpText>Queued: Waiting for push. Staged: Waiting for client poll. Pending: Inbound held awaiting parent resolution. Synced: Successfully delivered. Failed: See Error Log.</inlineHelpText>
+    <description>The current processing state. Values: Queued, Staged, Pending, Processing, Synced, Failed. Pending added in v0.200 for WorkLog-before-parent race recovery (see DeliverySyncItemPendingResolver).</description>
+    <inlineHelpText>Queued: Waiting for push. Staged: Waiting for client poll. Pending: Inbound held awaiting parent resolution (v0.200+). Processing: In-flight to receiver. Synced: Successfully delivered. Failed: See Error Log.</inlineHelpText>
     <label>Status</label>
     <required>false</required>
     <trackTrending>false</trackTrending>


### PR DESCRIPTION
## Summary

- The `release/0.200.0.1` beta tag was built from a snapshot that predated PR #676's `SyncItem__c.StatusPk__c = 'Pending'` picklist addition. Subscriber orgs installed the code (ingestor, resolver, ParentRefTxt__c field) but NOT the picklist value, so every inbound WorkLog-before-parent path throws `INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST`.
- **Nimba → dh-prod sync is blocked** until a fresh beta with the Pending value lands. 96 Outbound Failed WorkLogs are queued waiting on this.
- This PR tightens the field description + inline help to force a metadata-touch on `StatusPk__c`, which re-upserts it into the beta package on merge.

## Why not just wait for the current auto-triggered beta?

The merge of PR #678 already kicked a fresh beta-create on commit `6328f4a4`. But since this PR's changes are to the same field, merging it guarantees the picklist gets packaged, and the PR provides an auditable trail if anyone needs to trace why 0.200.0.1 shipped without the value.

## Test plan

- [ ] CI apex-scan passes (metadata-only change; no code)
- [ ] CI feature-test passes (no behavioral change)
- [ ] On merge: beta-create succeeds
- [ ] Install fresh beta on dh-prod + Nimba + MF-Prod
- [ ] Verify `delivery__SyncItem__c.StatusPk__c` picklist includes Pending on all three orgs
- [ ] Requeue the 96 Failed Outbound WorkLogs on Nimba → watch them flow through to dh-prod
- [ ] dh-prod April hours climbs to ~129.5h
- [ ] Regenerate DOC-000002 with full April hours + seeded vendor/client contacts