### PR TITLE
fix(pdf): live-rebuild snapshot when SnapshotTxt__c is null

### DIFF
--- a/force-app/main/default/classes/DeliveryDocumentPdfController.cls
+++ b/force-app/main/default/classes/DeliveryDocumentPdfController.cls
@@ -204,8 +204,8 @@ public without sharing class DeliveryDocumentPdfController {
             return;
         }
 
-        String query = 'SELECT Id, Name, TemplatePk__c, NetworkEntityId__r.Name, '
-            + 'PeriodStartDate__c, PeriodEndDate__c, '
+        String query = 'SELECT Id, Name, TemplatePk__c, NetworkEntityId__c, NetworkEntityId__r.Name, '
+            + 'PeriodStartDate__c, PeriodEndDate__c, CreatedDate, '
             + 'StatusPk__c, TotalHoursNumber__c, TotalCurrency__c, '
             + 'SnapshotTxt__c, AiNarrativeTxt__c, TermsTxt__c, '
             + 'DueDateDate__c, MetadataTxt__c, ViewedDateTime__c '
@@ -253,8 +253,27 @@ public without sharing class DeliveryDocumentPdfController {
             formattedPeriod = formatDate(doc.PeriodStartDate__c) + ' \u2013 ' + formatDate(doc.PeriodEndDate__c);
         }
 
+        // Prefer the frozen snapshot. If it's missing (observed 2026-04-23 on
+        // DOC-000002 where both SnapshotTxt__c and MetadataTxt__c inserted null
+        // for reasons not yet diagnosed), fall back to rebuilding from live data
+        // so the PDF still renders something useful instead of a blank page.
+        // No DB write — snapshot is held in memory for this render only.
+        Map<String, Object> snapshot = null;
         if (String.isNotBlank(doc.SnapshotTxt__c)) {
-            Map<String, Object> snapshot = (Map<String, Object>) JSON.deserializeUntyped(doc.SnapshotTxt__c);
+            snapshot = (Map<String, Object>) JSON.deserializeUntyped(doc.SnapshotTxt__c);
+        } else if (doc.NetworkEntityId__c != null) {
+            try {
+                snapshot = DeliveryDocGenerationService.buildSnapshot(
+                    doc.NetworkEntityId__c, doc.TemplatePk__c,
+                    doc.PeriodStartDate__c, doc.PeriodEndDate__c
+                );
+            } catch (Exception e) {
+                // Rebuild best-effort — swallow and continue so the page still
+                // renders the fields we have directly from the doc record.
+                System.debug(LoggingLevel.WARN, 'Live snapshot rebuild failed: ' + e.getMessage());
+            }
+        }
+        if (snapshot != null) {
             // Format generated-at as a readable date (not raw ISO timestamp)
             String rawGenAt = (String) snapshot.get('generatedAt');
             if (String.isNotBlank(rawGenAt)) {
@@ -264,6 +283,10 @@ public without sharing class DeliveryDocumentPdfController {
                 } catch (Exception e) {
                     generatedAt = rawGenAt;
                 }
+            } else if (doc.CreatedDate != null) {
+                // Live rebuilds won't have a generatedAt key — fall back to the
+                // doc's own CreatedDate so the header doesn't render blank.
+                generatedAt = formatDate(doc.CreatedDate.date());
             }
             parseEntity(snapshot);
             parseWorkItems(snapshot);

--- a/force-app/main/default/classes/DeliveryDocumentPdfControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryDocumentPdfControllerTest.cls
@@ -451,48 +451,6 @@ private class DeliveryDocumentPdfControllerTest {
     }
 
     /**
-     * @description Defense-in-depth: when both SnapshotTxt__c is null AND the
-     * document has no NetworkEntityId (nothing to rebuild from), the controller
-     * should render empty snapshot-driven fields without throwing.
-     */
-    @isTest
-    static void testRenderWithBothNullSnapshotAndNullEntityRendersEmpty() {
-        System.runAs(testUser) {
-            NetworkEntity__c entity = getEntity();
-
-            Id docId = DeliveryDocumentController.generateDocument(
-                entity.Id, 'Invoice',
-                Date.newInstance(2026, 3, 1), Date.newInstance(2026, 3, 31), null
-            );
-
-            DeliveryDocument__c doc = [
-                SELECT Id, SnapshotTxt__c, NetworkEntityId__c
-                FROM DeliveryDocument__c WHERE Id = :docId LIMIT 1
-            ];
-            doc.SnapshotTxt__c = null;
-            doc.NetworkEntityId__c = null;
-            update doc;
-
-            Test.startTest();
-            Test.setCurrentPage(Page.DeliveryDocumentPdf);
-            ApexPages.currentPage().getParameters().put('id', docId);
-
-            DeliveryDocumentPdfController ctrl = new DeliveryDocumentPdfController();
-            Test.stopTest();
-
-            // Doc still exists — just no snapshot-derived content.
-            System.assertEquals(true, ctrl.getHasDocument(),
-                'Doc record itself should still load');
-            System.assertEquals(false, ctrl.getHasWorkItems(),
-                'No work items when rebuild impossible');
-            System.assertEquals(false, ctrl.getHasWorkLogs(),
-                'No work logs when rebuild impossible');
-            System.assertEquals(null, ctrl.entityName,
-                'Entity name is unset when there is no snapshot and nothing to rebuild from');
-        }
-    }
-
-    /**
      * @description Verify getHasUnpaidInvoices and formattedDueDate with no due date.
      */
     @isTest

--- a/force-app/main/default/classes/DeliveryDocumentPdfControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryDocumentPdfControllerTest.cls
@@ -409,6 +409,90 @@ private class DeliveryDocumentPdfControllerTest {
     }
 
     /**
+     * @description Defense-in-depth: when SnapshotTxt__c is null (observed
+     * 2026-04-23 on DOC-000002 where the frozen snapshot never got written),
+     * the controller should rebuild from live data via DeliveryDocGenerationService
+     * so the PDF renders something useful instead of a blank page.
+     */
+    @isTest
+    static void testRenderWithNullSnapshotFallsBackToLiveRebuild() {
+        System.runAs(testUser) {
+            NetworkEntity__c entity = getEntity();
+
+            Id docId = DeliveryDocumentController.generateDocument(
+                entity.Id, 'Invoice',
+                Date.newInstance(2026, 3, 1), Date.newInstance(2026, 3, 31), null
+            );
+
+            // Simulate the observed bug — null out the frozen snapshot on the
+            // doc record before rendering.
+            DeliveryDocument__c doc = [
+                SELECT Id, SnapshotTxt__c, NetworkEntityId__c
+                FROM DeliveryDocument__c WHERE Id = :docId LIMIT 1
+            ];
+            doc.SnapshotTxt__c = null;
+            update doc;
+
+            Test.startTest();
+            Test.setCurrentPage(Page.DeliveryDocumentPdf);
+            ApexPages.currentPage().getParameters().put('id', docId);
+
+            DeliveryDocumentPdfController ctrl = new DeliveryDocumentPdfController();
+            Test.stopTest();
+
+            System.assertEquals(true, ctrl.getHasDocument(), 'Should still have loaded the doc');
+            System.assertEquals('PDF Test Corp', ctrl.entityName,
+                'Entity name should populate from the live rebuild when snapshot is null');
+            System.assertEquals(true, ctrl.getHasWorkItems(),
+                'Work items should populate from the live rebuild when snapshot is null');
+            System.assertEquals(true, ctrl.getHasWorkLogs(),
+                'Work logs should populate from the live rebuild when snapshot is null');
+        }
+    }
+
+    /**
+     * @description Defense-in-depth: when both SnapshotTxt__c is null AND the
+     * document has no NetworkEntityId (nothing to rebuild from), the controller
+     * should render empty snapshot-driven fields without throwing.
+     */
+    @isTest
+    static void testRenderWithBothNullSnapshotAndNullEntityRendersEmpty() {
+        System.runAs(testUser) {
+            NetworkEntity__c entity = getEntity();
+
+            Id docId = DeliveryDocumentController.generateDocument(
+                entity.Id, 'Invoice',
+                Date.newInstance(2026, 3, 1), Date.newInstance(2026, 3, 31), null
+            );
+
+            DeliveryDocument__c doc = [
+                SELECT Id, SnapshotTxt__c, NetworkEntityId__c
+                FROM DeliveryDocument__c WHERE Id = :docId LIMIT 1
+            ];
+            doc.SnapshotTxt__c = null;
+            doc.NetworkEntityId__c = null;
+            update doc;
+
+            Test.startTest();
+            Test.setCurrentPage(Page.DeliveryDocumentPdf);
+            ApexPages.currentPage().getParameters().put('id', docId);
+
+            DeliveryDocumentPdfController ctrl = new DeliveryDocumentPdfController();
+            Test.stopTest();
+
+            // Doc still exists — just no snapshot-derived content.
+            System.assertEquals(true, ctrl.getHasDocument(),
+                'Doc record itself should still load');
+            System.assertEquals(false, ctrl.getHasWorkItems(),
+                'No work items when rebuild impossible');
+            System.assertEquals(false, ctrl.getHasWorkLogs(),
+                'No work logs when rebuild impossible');
+            System.assertEquals(null, ctrl.entityName,
+                'Entity name is unset when there is no snapshot and nothing to rebuild from');
+        }
+    }
+
+    /**
      * @description Verify getHasUnpaidInvoices and formattedDueDate with no due date.
      */
     @isTest


### PR DESCRIPTION
## Summary
- Observed today (2026-04-23): DOC-000002 on dh-prod inserted with both `SnapshotTxt__c` and `MetadataTxt__c` null. Root cause not diagnosed (DOC-000000 from March is fine via the same code path).
- Symptom: `DeliveryDocumentPdfController` at line 256 guards the entire parse chain behind `if (String.isNotBlank(doc.SnapshotTxt__c))`. When the snapshot is null, `SOLD TO`, `RATE`, `INVOICE DATE`, all work items, and all time logs render blank — only `SUBTOTAL` survives because it reads `TotalCurrency__c` directly.
- Defense in depth: when `SnapshotTxt__c` is blank at render time, call `DeliveryDocGenerationService.buildSnapshot(NetworkEntityId__c, TemplatePk__c, PeriodStartDate__c, PeriodEndDate__c)` to rebuild from live data. Same method the generator uses. In-memory only, no DB write. Wrapped in try/catch so any failure silently falls back to the pre-existing blank-snapshot behavior instead of throwing.
- Also adds a `CreatedDate` fallback for `generatedAt` (live rebuilds don't populate that key) and pulls `NetworkEntityId__c` + `CreatedDate` onto the SOQL.
- `MetadataTxt__c` path already degrades gracefully via its existing `isNotBlank` guard — no change needed.

## Scope
- `DeliveryDocumentPdfController.cls`: SOQL + snapshot fallback block (29 lines added).
- `DeliveryDocumentPdfControllerTest.cls`: two new tests (82 lines added).
- Does not touch `DeliveryDocGenerationService` — consumed as an API.
- Does not touch the v0.200 release branch or any in-flight picklist work.

## Test plan
- [ ] `testRenderWithNullSnapshotFallsBackToLiveRebuild` — null `SnapshotTxt__c`, valid NetworkEntityId + period; assert `entityName`, `getHasWorkItems()`, `getHasWorkLogs()` all populate from the live rebuild.
- [ ] `testRenderWithBothNullSnapshotAndNullEntityRendersEmpty` — both null → no fallback possible → no exception, snapshot-driven fields stay empty, `getHasDocument()` still true.
- [ ] Existing 13 tests remain green.
- [ ] Manual smoke (post-merge, post-release): open DOC-000002 on dh-prod and confirm the PDF now renders entity/work items/time logs instead of only SUBTOTAL.

## Risk
- Low. The new branch only executes when `SnapshotTxt__c` is null — the existing happy path is byte-identical.
- `buildSnapshot` was already `@TestVisible` and `public static`, and is the same method `generateDocument` calls, so behavior is pre-validated.
- Rebuild exception is caught; worst case the page renders the same blank state it does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)