### PR TITLE
fix(sync): ingestor skips non-editable fields (formula, system-managed)

### DIFF
--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -551,15 +551,24 @@ public without sharing class DeliverySyncItemIngestor {
             // Ensure the system fields are ignored during standard field mapping
             if (key == 'SourceId' || key == 'TargetId' || key == 'GlobalSourceId' || key == 'SenderOrgId') { continue; }
             
-            String searchKey = stripNamespace(key).toLowerCase(); 
+            String searchKey = stripNamespace(key).toLowerCase();
             if (cleanNameIndex.containsKey(searchKey)) {
                 SObjectField field = cleanNameIndex.get(searchKey);
                 Object val = payload.get(key);
+                Schema.DescribeFieldResult dfr = field.getDescribe();
+                // Skip fields the receiver can't write — formula, calculated, auto-number,
+                // read-only system fields. Sender serializes the full record; we only
+                // persist the subset that is writable locally. Without this guard, a
+                // payload containing SLAStatusTxt__c (formula) causes DML failure with
+                // "Field X is not editable". Must come before the null branch because
+                // record.put(field, null) on a non-writable field also throws.
+                if (dfr.isCalculated()) { continue; }
+                if (!dfr.isUpdateable() && !dfr.isCreateable()) { continue; }
                 if (val == null) {
                     record.put(field, null);
                     continue;
                 }
-                Schema.DisplayType dtype = field.getDescribe().getType();
+                Schema.DisplayType dtype = dfr.getType();
                 if (dtype == Schema.DisplayType.DATE) {
                     record.put(field, Date.valueOf((String)val));
                 } else if (dtype == Schema.DisplayType.DATETIME) {

--- a/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
@@ -469,6 +469,112 @@ private class DeliverySyncItemIngestorTest {
     }
 
     /**
+     * @description Regression guard for MF-Prod failure mode (2026-04-22):
+     *              17 Inbound SyncItems stuck Failed with
+     *              "Field delivery__SLAStatusTxt__c is not editable" because
+     *              the sender serializes the full record — including the
+     *              formula-calculated SLA status — and the receiver blindly
+     *              called record.put() on every payload key that matched a
+     *              target field. The fix skips fields where isCalculated()
+     *              is true. This test asserts: (a) the insert succeeds even
+     *              with a formula-field key in the payload, and (b) the
+     *              local record's SLA status reflects the local formula
+     *              evaluation — not the sender's serialized value.
+     */
+    @IsTest
+    static void testMapFieldsSkipsCalculatedFormulaFields() {
+        System.runAs(testUser) {
+            // SLATargetDate__c today → formula resolves to "At Risk" (within 2d)
+            // Sender sends a stale / wrong "Breached" value for the formula —
+            // the receiver must ignore it and let its own formula recompute.
+            Map<String, Object> payload = new Map<String, Object>{
+                'SourceId' => 'REMOTE-FORMULA-SKIP-001',
+                'BriefDescriptionTxt__c' => 'Formula skip test',
+                'StageNamePk__c' => 'In Development',
+                'SLATargetDate__c' => String.valueOf(Date.today().addDays(1)),
+                'SLAStatusTxt__c' => 'Breached' // sender's stale formula value
+            };
+
+            Test.startTest();
+            Id resultId = DeliverySyncItemIngestor.processInboundItem('WorkItem__c', payload);
+            Test.stopTest();
+
+            System.assertNotEquals(null, resultId,
+                'Insert must succeed despite payload containing formula field');
+            WorkItem__c wi = [
+                SELECT BriefDescriptionTxt__c, SLAStatusTxt__c, SLATargetDate__c
+                FROM WorkItem__c WHERE Id = :resultId
+            ];
+            System.assertEquals('Formula skip test', wi.BriefDescriptionTxt__c,
+                'Writable field should persist');
+            // Formula should have evaluated locally — never equals the sender's "Breached"
+            // because the local SLATargetDate__c is +1 day (At Risk) and stage is active.
+            System.assertNotEquals('Breached', wi.SLAStatusTxt__c,
+                'Formula field must reflect local evaluation, not the sender payload');
+        }
+    }
+
+    /**
+     * @description System-maintained fields like CreatedDate are not
+     *              createable/updateable by normal users and will throw
+     *              "is not editable" at DML time if blindly put(). The
+     *              guard skips when both isCreateable() and isUpdateable()
+     *              are false.
+     */
+    @IsTest
+    static void testMapFieldsSkipsSystemMaintainedFields() {
+        System.runAs(testUser) {
+            DateTime fabricated = DateTime.newInstance(2000, 1, 1);
+            Map<String, Object> payload = new Map<String, Object>{
+                'SourceId' => 'REMOTE-SYS-FIELD-001',
+                'BriefDescriptionTxt__c' => 'System field skip test',
+                'CreatedDate' => fabricated.format('yyyy-MM-dd\'T\'HH:mm:ss.SSS\'Z\'')
+            };
+
+            Test.startTest();
+            Id resultId = DeliverySyncItemIngestor.processInboundItem('WorkItem__c', payload);
+            Test.stopTest();
+
+            System.assertNotEquals(null, resultId,
+                'Insert must succeed despite payload containing system field');
+            WorkItem__c wi = [SELECT CreatedDate, BriefDescriptionTxt__c FROM WorkItem__c WHERE Id = :resultId];
+            System.assertEquals('System field skip test', wi.BriefDescriptionTxt__c);
+            // Local CreatedDate should be ~now, definitely not year 2000
+            System.assert(wi.CreatedDate > fabricated.addYears(5),
+                'CreatedDate must reflect local system time, not the payload value');
+        }
+    }
+
+    /**
+     * @description Regression fence: the guard must not interfere with
+     *              normal writable-field mapping for a well-formed payload.
+     */
+    @IsTest
+    static void testMapFieldsWritesWritableFieldsNormally() {
+        System.runAs(testUser) {
+            Map<String, Object> payload = new Map<String, Object>{
+                'SourceId' => 'REMOTE-WRITABLE-ONLY-001',
+                'BriefDescriptionTxt__c' => 'All writable fields',
+                'PriorityPk__c' => 'High',
+                'StageNamePk__c' => 'In Development'
+            };
+
+            Test.startTest();
+            Id resultId = DeliverySyncItemIngestor.processInboundItem('WorkItem__c', payload);
+            Test.stopTest();
+
+            System.assertNotEquals(null, resultId, 'Insert must succeed');
+            WorkItem__c wi = [
+                SELECT BriefDescriptionTxt__c, PriorityPk__c, StageNamePk__c
+                FROM WorkItem__c WHERE Id = :resultId
+            ];
+            System.assertEquals('All writable fields', wi.BriefDescriptionTxt__c);
+            System.assertEquals('High', wi.PriorityPk__c);
+            System.assertEquals('In Development', wi.StageNamePk__c);
+        }
+    }
+
+    /**
      * @description Minimal HttpCalloutMock for the pull-callout path —
      *              tests that exercise the ingestor enqueue a fetcher
      *              Queueable; this mock lets that Queueable fail cleanly


### PR DESCRIPTION
## Observed failure (MF-Prod, 2026-04-22)

17 Inbound SyncItems stuck in \`StatusPk__c = 'Failed'\` since 2026-04-06 with:

\`\`\`
Sync Failed (500): {"error":"Field delivery__SLAStatusTxt__c is not editable"}
\`\`\`

\`SLAStatusTxt__c\` is a **formula field** on \`WorkItem__c\`. A sender org serializes the full record (formula output included) into the SyncItem payload; the receiver's \`mapFields()\` loop blindly called \`record.put(field, val)\` for every payload key that resolved to a target field, and the subsequent upsert died at DML time.

Same failure mode would hit any inbound payload that echoes back:
- formula / rollup fields
- auto-number fields
- system audit fields (CreatedDate, LastModifiedDate, etc.)
- any \`isCreateable() == false && isUpdateable() == false\` field

## Fix

In \`DeliverySyncItemIngestor.mapFields\`, describe each matched field and skip it if:
- \`isCalculated()\` is true, **or**
- both \`isCreateable()\` and \`isUpdateable()\` are false

Skip happens **before** the null branch because \`record.put(field, null)\` on a non-writable field also throws.

\`\`\`apex
Schema.DescribeFieldResult dfr = field.getDescribe();
if (dfr.isCalculated()) { continue; }
if (!dfr.isUpdateable() && !dfr.isCreateable()) { continue; }
\`\`\`

## Tests added

\`DeliverySyncItemIngestorTest.cls\`:

- \`testMapFieldsSkipsCalculatedFormulaFields\` — payload with \`SLAStatusTxt__c\` + \`SLATargetDate__c\`; insert succeeds; local formula recomputes; sender's \"Breached\" value is discarded.
- \`testMapFieldsSkipsSystemMaintainedFields\` — payload with fabricated \`CreatedDate\` (year 2000); insert succeeds; local \`CreatedDate\` reflects system time.
- \`testMapFieldsWritesWritableFieldsNormally\` — regression fence: the guard does not interfere with \`BriefDescriptionTxt__c\` / \`PriorityPk__c\` / \`StageNamePk__c\`.

Existing ingestor tests (12 of them including \`testProcessInboundWorkItemUpdateDownstreamEdge\`, the stale-ledger tests, and the pull-callout ContentVersion tests) are unchanged — the writable-field path through mapFields is untouched.

## Post-install cleanup (NOT shipped here)

After the release carrying this fix is installed on MF-Prod, the 17 chronic Failed rows will not auto-heal — they need a one-time requeue:

\`\`\`apex
Datetime cutoff = // install timestamp
List<delivery__SyncItem__c> stuck = [
  SELECT Id FROM delivery__SyncItem__c
  WHERE delivery__StatusPk__c = 'Failed'
    AND delivery__DirectionPk__c = 'Inbound'
    AND CreatedDate < :cutoff
    AND delivery__ErrorLogTxt__c LIKE '%is not editable%'
];
for (delivery__SyncItem__c si : stuck) { si.delivery__StatusPk__c = 'Staged'; }
update stuck;
\`\`\`

That's a separate script to be run post-install on MF-Prod.

## Risk

Low. The guard is strictly additive — it can only short-circuit a \`record.put()\` call that would have thrown anyway. Writable-field behaviour is unchanged (same branch logic past the new skip).

## Test plan

- [ ] \`cci task run run_tests --test DeliverySyncItemIngestorTest\` passes (3 new + 12 existing = 15)
- [ ] feature-test CI job green
- [ ] upload-beta green
- [ ] Post-install on MF-Prod: run the requeue script above; verify the 17 rows transition Staged → Synced on the next poll