### PR TITLE
fix(sync): unrestrict StatusPk so Pending lands on subscriber upgrade

### DIFF
--- a/force-app/main/default/objects/SyncItem__c/fields/StatusPk__c.field-meta.xml
+++ b/force-app/main/default/objects/SyncItem__c/fields/StatusPk__c.field-meta.xml
@@ -8,7 +8,14 @@
     <trackTrending>false</trackTrending>
     <type>Picklist</type>
     <valueSet>
-        <restricted>true</restricted>
+        <!-- Intentionally non-restricted: Salesforce unlocked packages do not
+             reliably propagate NEW restricted-picklist values to subscribers on
+             upgrade. Setting restricted=false lets new values (like Pending added
+             in v0.200) be accepted via DML on subscribers that upgrade, even when
+             the describe API hasn't refreshed. Integrity is enforced at the Apex
+             service layer (DeliverySyncEngine / DeliverySyncItemIngestor) where
+             the status transitions are gated. -->
+        <restricted>false</restricted>
         <valueSetDefinition>
             <sorted>false</sorted>
             <value>


### PR DESCRIPTION
## The bug

\`04tQr000000UosDIAS\` (release/0.203.0.1) shipped with \`Pending\` in the \`SyncItem__c.StatusPk__c\` valueSetDefinition and installed successfully on all 3 orgs. After install, the picklist on dh-prod / Nimba / MF-Prod **still rejects DML writes of Pending** with \`INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST\`. Verified via canary apex.

This is a documented Salesforce quirk: unlocked packages don't reliably merge NEW restricted-picklist values into a subscriber's value definition on upgrade. SF treats the subscriber's picklist as potentially-customized and preserves it.

## The fix

Toggle \`<restricted>true</restricted>\` → \`<restricted>false</restricted>\` on just this one field. DML will accept \`Pending\` even when the describe hasn't merged. Integrity is enforced at the Apex service layer — the only code paths that write to this field set enumerated values (\`Staged\`, \`Pending\`, \`Synced\`, \`Failed\`, \`Processing\`).

## Alternatives considered

- **GlobalValueSet migration**: correct long-term. Requires schema migration (convert inline valueSetDefinition → valueSetName reference). Too much change for a hot fix.
- **Manual add via Setup UI**: impossible — subscribers can't modify package-owned restricted picklists.
- **Re-install**: same install, same behavior.

## Unblocks

- 96 Nimba Outbound Failed WorkLogs waiting to retry into dh-prod
- v0.200's entire Pending-queue recovery pattern (currently inert on subscriber orgs)

## Follow-up

Revisit with GlobalValueSet migration for \`SyncItem__c.StatusPk__c\` (+ any other restricted picklists we ship) so future value additions propagate cleanly under restriction. Roadmap item, not urgent.