### PR TITLE
fix(sync): mapFields guard schema-only + unrestrict 3 HIGH-churn picklists

### DIFF
--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -556,14 +556,14 @@ public without sharing class DeliverySyncItemIngestor {
                 SObjectField field = cleanNameIndex.get(searchKey);
                 Object val = payload.get(key);
                 Schema.DescribeFieldResult dfr = field.getDescribe();
-                // Skip fields the receiver can't write — formula, calculated, auto-number,
-                // read-only system fields. Sender serializes the full record; we only
-                // persist the subset that is writable locally. Without this guard, a
-                // payload containing SLAStatusTxt__c (formula) causes DML failure with
-                // "Field X is not editable". Must come before the null branch because
-                // record.put(field, null) on a non-writable field also throws.
+                // Skip formula/calculated fields only. `isCalculated()` is schema-inherent
+                // — safe across permission contexts. Do NOT guard on `isUpdateable()` or
+                // `isCreateable()` here: those depend on running-user FLS, which differs
+                // between scratch org (admin, all perms) and packaging org / subscriber
+                // (narrower perms). A guard that used those broke upload-beta in PR #681
+                // because the packaging-org test user reported every field as non-writable.
+                // Let DML surface actual FLS errors; they're real and user-context-specific.
                 if (dfr.isCalculated()) { continue; }
-                if (!dfr.isUpdateable() && !dfr.isCreateable()) { continue; }
                 if (val == null) {
                     record.put(field, null);
                     continue;

--- a/force-app/main/default/objects/ActivityLog__c/fields/ActionTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/ActivityLog__c/fields/ActionTypePk__c.field-meta.xml
@@ -7,7 +7,10 @@
     <required>false</required>
     <type>Picklist</type>
     <valueSet>
-        <restricted>true</restricted>
+        <!-- Non-restricted: unlocked packages don't reliably propagate new values
+             on subscriber upgrade when restricted=true (SF Known Issue
+             a028c00000qPzYUAA0). Integrity enforced at the service layer. -->
+        <restricted>false</restricted>
         <valueSetDefinition>
             <sorted>false</sorted>
             <value><fullName>Navigation</fullName><default>true</default><label>Navigation</label></value>

--- a/force-app/main/default/objects/NotificationPreference__c/fields/EventTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/NotificationPreference__c/fields/EventTypePk__c.field-meta.xml
@@ -7,7 +7,10 @@
     <required>false</required>
     <type>Picklist</type>
     <valueSet>
-        <restricted>true</restricted>
+        <!-- Non-restricted: unlocked packages don't reliably propagate new values
+             on subscriber upgrade when restricted=true (SF Known Issue
+             a028c00000qPzYUAA0). Integrity enforced at the service layer. -->
+        <restricted>false</restricted>
         <valueSetDefinition>
             <sorted>false</sorted>
             <value><fullName>Stage_Change</fullName><default>true</default><label>Stage Change</label></value>

--- a/force-app/main/default/objects/SyncItem__c/fields/ObjectTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/SyncItem__c/fields/ObjectTypePk__c.field-meta.xml
@@ -8,7 +8,10 @@
     <trackTrending>false</trackTrending>
     <type>Picklist</type>
     <valueSet>
-        <restricted>true</restricted>
+        <!-- Non-restricted: unlocked packages don't reliably propagate new values
+             on subscriber upgrade when restricted=true (SF Known Issue
+             a028c00000qPzYUAA0). Integrity enforced at the service layer. -->
+        <restricted>false</restricted>
         <valueSetDefinition>
             <sorted>false</sorted>
             <value>


### PR DESCRIPTION
Bundled fix to unblock the beta-create pipeline.

## Fix 1: mapFields guard schema-only

PR #681 used `isUpdateable()` / `isCreateable()` as the \"non-writable\" guard. Those are user-FLS-dependent, not schema-inherent. Scratch admin has full FLS → feature-test passes. Packaging-org test user has narrower FLS → guard fires for legit writable fields → nothing gets written → **14 apex tests failed on upload-beta** for run 24856329295.

Keep only `isCalculated()` which IS schema-inherent. Drops the `isUpdateable()`/`isCreateable()` guard.

Restores these failing tests:
- DeliveryHubPollerTest.testPollUpdatesSuccess
- DeliveryHubSyncServiceTest.{testCommentInsertWithIdempotency, testGatewayEchoSuppressionStaleOutboundDoesNotBlock, testWorkItemUpdateViaService}
- DeliverySyncItemIngestorTest.{testMapFieldsSkipsCalculatedFormulaFields, testMapFieldsSkipsSystemMaintainedFields, testMapFieldsWritesWritableFieldsNormally, testProcessInboundCommentInsert*Edge, testProcessInboundWorkItemAutoParentsClient, testProcessInboundWorkItemUpdateDownstreamEdge, testProcessInboundWorkLogResolvesParentViaLedger, testStaleLedgerEntrySkippedFavorsActiveRecord, testTargetIdPointingAtDeletedRecordFallsThroughToInsert, testUpdateWithSparsePayloadStillAllowed}
- DeliverySyncItemPendingResolverTest.testPendingResolvesWhenParentArrivesLater

Formula-field skip (original intent of PR #681) still works via `isCalculated()`. `SLAStatusTxt__c` and other formula fields won't cause DML to throw.

## Fix 2: unrestrict 3 HIGH-churn picklists (Phase 1)

Per research report `research-restricted-picklist-propagation.md`: SF unlocked packages don't reliably propagate new picklist values to subscribers on upgrade when `restricted=true` (Known Issue a028c00000qPzYUAA0). DH has been bit 3 times now. Preemptively unrestrict the 3 other HIGH-churn fields flagged:

- `SyncItem__c.ObjectTypePk__c`
- `NotificationPreference__c.EventTypePk__c`
- `ActivityLog__c.ActionTypePk__c`

Integrity enforced at the Apex service layer.

## Follow-up

Phase 2: migrate those 4 fields (StatusPk was done in PR #682) to GlobalValueSet for proper integrity + propagation. Dedicated PR.