### PR TITLE
fix(sync): wrap mapFields per-field put in try/catch

### DIFF
--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -556,27 +556,32 @@ public without sharing class DeliverySyncItemIngestor {
                 SObjectField field = cleanNameIndex.get(searchKey);
                 Object val = payload.get(key);
                 Schema.DescribeFieldResult dfr = field.getDescribe();
-                // Skip formula/calculated fields only. `isCalculated()` is schema-inherent
-                // — safe across permission contexts. Do NOT guard on `isUpdateable()` or
-                // `isCreateable()` here: those depend on running-user FLS, which differs
-                // between scratch org (admin, all perms) and packaging org / subscriber
-                // (narrower perms). A guard that used those broke upload-beta in PR #681
-                // because the packaging-org test user reported every field as non-writable.
-                // Let DML surface actual FLS errors; they're real and user-context-specific.
+                // Schema-inherent skip: formula/calculated fields. `isCalculated()` is
+                // safe across all permission contexts. Do NOT use `isUpdateable()`/
+                // `isCreateable()` — those are user-FLS-dependent and will false-positive
+                // on legit writable fields in non-admin contexts (bit us in PR #681).
                 if (dfr.isCalculated()) { continue; }
-                if (val == null) {
-                    record.put(field, null);
-                    continue;
-                }
-                Schema.DisplayType dtype = dfr.getType();
-                if (dtype == Schema.DisplayType.DATE) {
-                    record.put(field, Date.valueOf((String)val));
-                } else if (dtype == Schema.DisplayType.DATETIME) {
-                    record.put(field, (DateTime)JSON.deserialize('"' + val + '"', DateTime.class));
-                } else if (dtype == Schema.DisplayType.BASE64) {
-                    record.put(field, EncodingUtil.base64Decode((String)val));
-                } else {
-                    record.put(field, val);
+                // Defensively wrap each put: system-maintained fields (CreatedDate,
+                // SystemModstamp, auto-numbers) and any other platform-immutable field
+                // throw SObjectException on put. We swallow per-field so one bad payload
+                // key doesn't strand the whole record. Logged at FINE for forensics.
+                try {
+                    if (val == null) {
+                        record.put(field, null);
+                        continue;
+                    }
+                    Schema.DisplayType dtype = dfr.getType();
+                    if (dtype == Schema.DisplayType.DATE) {
+                        record.put(field, Date.valueOf((String)val));
+                    } else if (dtype == Schema.DisplayType.DATETIME) {
+                        record.put(field, (DateTime)JSON.deserialize('"' + val + '"', DateTime.class));
+                    } else if (dtype == Schema.DisplayType.BASE64) {
+                        record.put(field, EncodingUtil.base64Decode((String)val));
+                    } else {
+                        record.put(field, val);
+                    }
+                } catch (Exception putEx) {
+                    System.debug(LoggingLevel.FINE, 'mapFields skipped ' + key + ': ' + putEx.getMessage());
                 }
             }
         }


### PR DESCRIPTION
Follow-up to PR #683 — that squash-merge only included the initial commit and missed the try/catch refinement. Main's current ingestor skips only `isCalculated()`, leaving `CreatedDate` / `SystemModstamp` / auto-number writes to throw `SObjectException: Field X is not writeable`.

Per-field try/catch in `mapFields` handles any platform-immutable field regardless of permission context. Restores `testMapFieldsSkipsSystemMaintainedFields` on upload-beta.

One bad payload key no longer strands the whole record. Logged at FINE level so debug logs retain forensics without spamming prod.