### PR TITLE
fix(sync): align WorkLog outbound scope to parent WorkItem scope

### DIFF
--- a/force-app/main/default/classes/DeliveryWorkLogTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryWorkLogTriggerHandler.cls
@@ -203,11 +203,22 @@ public with sharing class DeliveryWorkLogTriggerHandler {
             return;
         }
 
+        // Align WorkLog outbound scope to the upstream-client edge defined in
+        // DeliverySyncEngine.captureChanges. A WorkLog is eligible for outbound
+        // sync if and only if its parent WorkItem would itself push upstream —
+        // i.e. the parent's ClientNetworkEntityLookup__c has EntityTypePk__c
+        // IN ('Client','Both') AND a populated IntegrationEndpointUrlTxt__c.
+        // Without the EntityTypePk__c + endpoint guard, WorkLogs were shipped
+        // to orgs that never received the parent WorkItem (T-0129: 8.5h of
+        // time landed on dh-prod as orphaned inbound SyncItems with no local
+        // parent to resolve against — permanently unbillable until manual
+        // hand-firing of the parent outbound).
         Map<Id, WorkItem__c> clientWorkItems = new Map<Id, WorkItem__c>([
             SELECT Id, ClientNetworkEntityLookup__c
             FROM WorkItem__c
             WHERE Id IN :workItemIds
             AND ClientNetworkEntityLookup__c != null
+            AND ClientNetworkEntityLookup__r.EntityTypePk__c IN ('Client', 'Both')
             AND ClientNetworkEntityLookup__r.IntegrationEndpointUrlTxt__c != null
             WITH SYSTEM_MODE
         ]);

--- a/force-app/main/default/classes/DeliveryWorkLogTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkLogTriggerHandlerTest.cls
@@ -297,6 +297,102 @@ private class DeliveryWorkLogTriggerHandlerTest {
         }
     }
 
+    // ── Parent-scope alignment tests (align-worklog-parent-sync-scope) ─
+
+    @IsTest
+    static void testWorkLogOnDisconnectedParent_DoesNotPushOutbound() {
+        // T-0129 regression: parent WorkItem tagged to a NetworkEntity that
+        // looks connected (has an integration endpoint) but whose EntityTypePk__c
+        // is NOT 'Client' or 'Both' — so DeliverySyncEngine.captureChanges would
+        // NOT push the parent upstream. Before this fix, the WorkLog trigger
+        // used a more permissive filter (endpoint-only, no EntityType check) and
+        // pushed WorkLogs that landed on the downstream org with no resolvable
+        // parent — the 8.5h phantom ledger problem.
+        System.runAs(testUser) {
+            NetworkEntity__c vendorTypedClient = new NetworkEntity__c(
+                Name = 'Mobilization Funding Prod (T-0129)',
+                EntityTypePk__c = 'Vendor', // NOT Client/Both → parent WorkItem would not push upstream
+                StatusPk__c = 'Active',
+                IntegrationEndpointUrlTxt__c = 'https://mf-prod.example.com'
+            );
+            insert vendorTypedClient;
+
+            WorkItem__c disconnectedWorkItem = new WorkItem__c(
+                BriefDescriptionTxt__c = 'Disconnected Parent',
+                StageNamePk__c = 'In Development',
+                ClientNetworkEntityLookup__c = vendorTypedClient.Id
+            );
+            insert disconnectedWorkItem;
+
+            // Master-detail requires a WorkRequest parent for the WorkLog.
+            WorkRequest__c req = new WorkRequest__c(
+                WorkItemId__c = disconnectedWorkItem.Id,
+                DeliveryEntityLookup__c = vendorTypedClient.Id,
+                QuotedHoursNumber__c = 5,
+                HourlyRateCurrency__c = 100,
+                StatusPk__c = 'Accepted'
+            );
+            insert req;
+
+            Test.startTest();
+            insert new WorkLog__c(
+                RequestId__c          = req.Id,
+                WorkItemLookup__c     = disconnectedWorkItem.Id,
+                HoursLoggedNumber__c  = 4.5,
+                WorkDateDate__c       = Date.today(),
+                WorkDescriptionTxt__c = 'Time against disconnected parent'
+            );
+            Test.stopTest();
+
+            List<SyncItem__c> items = [
+                SELECT Id FROM SyncItem__c
+                WHERE WorkItemLookup__c = :disconnectedWorkItem.Id
+                AND ObjectTypePk__c = 'WorkLog__c'
+            ];
+            System.assertEquals(0, items.size(),
+                'WorkLog for a WorkItem whose client entity is not Client/Both must not create an outbound SyncItem');
+        }
+    }
+
+    @IsTest
+    static void testWorkLogOnConnectedParent_PushesOutboundNormally() {
+        // Regression: WorkItem tagged to a fully-connected client (Client/Both
+        // entity type with an integration endpoint) should still produce a
+        // WorkLog outbound SyncItem, matching pre-fix behaviour.
+        System.runAs(testUser) {
+            WorkItem__c workItem = [
+                SELECT Id FROM WorkItem__c
+                WHERE BriefDescriptionTxt__c = 'Client Work Item'
+                LIMIT 1
+            ];
+            WorkRequest__c request = [
+                SELECT Id FROM WorkRequest__c
+                WHERE WorkItemId__c = :workItem.Id
+                LIMIT 1
+            ];
+
+            Test.startTest();
+            insert new WorkLog__c(
+                RequestId__c          = request.Id,
+                WorkItemLookup__c     = workItem.Id,
+                HoursLoggedNumber__c  = 4.0,
+                WorkDateDate__c       = Date.today(),
+                WorkDescriptionTxt__c = 'Time against connected parent'
+            );
+            Test.stopTest();
+
+            List<SyncItem__c> items = [
+                SELECT DirectionPk__c, StatusPk__c FROM SyncItem__c
+                WHERE WorkItemLookup__c = :workItem.Id
+                AND ObjectTypePk__c = 'WorkLog__c'
+            ];
+            System.assertEquals(1, items.size(),
+                'WorkLog for a connected client WorkItem should still create one outbound SyncItem');
+            System.assertEquals('Outbound', items[0].DirectionPk__c, 'Expected Outbound direction');
+            System.assertEquals('Queued', items[0].StatusPk__c, 'Expected Queued status for fresh outbound item');
+        }
+    }
+
     @IsTest
     static void testBulkApproval() {
         System.runAs(testUser) {

--- a/force-app/main/default/classes/DeliveryWorkLogTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkLogTriggerHandlerTest.cls
@@ -300,7 +300,7 @@ private class DeliveryWorkLogTriggerHandlerTest {
     // ── Parent-scope alignment tests (align-worklog-parent-sync-scope) ─
 
     @IsTest
-    static void testWorkLogOnDisconnectedParent_DoesNotPushOutbound() {
+    static void testWorkLogOnDisconnectedParentDoesNotPushOutbound() {
         // T-0129 regression: parent WorkItem tagged to a NetworkEntity that
         // looks connected (has an integration endpoint) but whose EntityTypePk__c
         // is NOT 'Client' or 'Both' — so DeliverySyncEngine.captureChanges would
@@ -355,7 +355,7 @@ private class DeliveryWorkLogTriggerHandlerTest {
     }
 
     @IsTest
-    static void testWorkLogOnConnectedParent_PushesOutboundNormally() {
+    static void testWorkLogOnConnectedParentPushesOutboundNormally() {
         // Regression: WorkItem tagged to a fully-connected client (Client/Both
         // entity type with an integration endpoint) should still produce a
         // WorkLog outbound SyncItem, matching pre-fix behaviour.


### PR DESCRIPTION
## The bug (T-0129)

Nimba WorkItem **T-0129** (`a3ZRu000000jiEbMAI`) was tagged to `ClientNetworkEntityLookup__c = "Mobilization Funding Prod"` — a NetworkEntity whose scope does NOT qualify it as a dh-prod-facing client under `DeliverySyncEngine.captureChanges` (EntityTypePk__c not in ('Client','Both'), or matches another disqualifier). The WorkItem was correctly NOT pushed outbound.

But its two child WorkLogs (2026-04-06 4.5h + 2026-04-07 4.0h = **8.5h**) DID push outbound, because `DeliveryWorkLogTriggerHandler.createSyncItemsForLogs` only checked `ClientNetworkEntityLookup__r.IntegrationEndpointUrlTxt__c != null` — with no `EntityTypePk__c` constraint. They landed on dh-prod as inbound SyncItems with no resolvable parent and are now permanently unbillable through DH until a human hand-fires an outbound for the parent.

Root cause: **the WorkItem handler and the WorkLog handler used different criteria to decide whether to enqueue an Outbound SyncItem.**

## The fix (Option 1: minimal alignment)

Extended the WorkLog SOQL guard in `createSyncItemsForLogs` with the same `EntityTypePk__c IN ('Client','Both')` clause `DeliverySyncEngine.captureChanges` applies to its upstream client edge. Integration-endpoint guard preserved. Net: **a WorkLog is enqueued outbound if and only if its parent WorkItem would itself push upstream.**

Picked Option 1 over Option 2 (enqueue parent before logs) because the code shape made the SOQL-clause addition a five-line change with no new control flow; the architectural \"push parent first\" pattern would cost more and wasn't justified by the current ledger-entry bug.

## Why not rely solely on PR #681's receiver-side Pending queue

PR #681 holds inbound Pending-parent WorkLogs on the receiver side — that safety net still works and is unchanged. This PR is the belt on top of #681's suspenders: it stops WorkLogs from being emitted from the sender when the parent was never (and will never be) emitted. Without it, #681's queue just times out on these items and they fail silently instead of landing as phantom pending rows.

## Tests

- `testWorkLogOnDisconnectedParent_DoesNotPushOutbound` — mirrors T-0129 (endpoint set, but EntityType = Vendor). Asserts zero SyncItem__c rows.
- `testWorkLogOnConnectedParent_PushesOutboundNormally` — regression guard: proper Client/Both + endpoint still yields exactly one Queued Outbound SyncItem.
- Existing tests unchanged and still pass.

## Migration note (out of scope for this PR)

Existing WorkLog rows that were erroneously shipped before this fix remain tracked on downstream orgs as phantom ledger entries with no local parent. Cleanup / reconciliation is a separate exercise — **not touched here**. Likewise, T-0129's current sync state is untouched.

## Risk

Sender-side scope change only. Receiver-side `DeliverySyncItemIngestor` / `DeliverySyncItemPendingResolver` untouched. At-Large-tagged items (the working case) continue to satisfy both the old and new filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)