### PR TITLE
feat(invoice): defer-selected-hours UI panel + Apex service

### DIFF
--- a/force-app/main/default/classes/DeliveryDocDeferralService.cls
+++ b/force-app/main/default/classes/DeliveryDocDeferralService.cls
@@ -1,0 +1,265 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  WorkLog deferral service. Supports the "defer disputed hours to a
+ *               future milestone date" accounting pattern: flip Approved -> Draft
+ *               so they drop out of the current invoice, prepend a
+ *               [DEFERRED to YYYY-MM-DD] tag in the description, and later
+ *               release them back to Approved with WorkDateDate__c shifted to
+ *               the milestone date so they land in that period's invoice.
+ *
+ *               Revenue recognition occurs at acceptance — preserves billable
+ *               dollars without issuing credit notes. Audit trail via
+ *               field-tracking on StatusPk__c, WorkDateDate__c, and
+ *               WorkDescriptionTxt__c.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation')
+public with sharing class DeliveryDocDeferralService {
+
+    /**
+     * @description Wire-backing query used by deliveryInvoicePreviewDeferPanel.
+     *              Returns every Approved WorkLog belonging to work items whose
+     *              ClientNetworkEntityLookup__c matches the supplied entity and
+     *              whose WorkDateDate__c falls inside the inclusive period.
+     *              Used to populate the deferral table; cacheable.
+     * @param networkEntityId The client NetworkEntity__c.
+     * @param periodStart     Inclusive period start (YYYY-MM-DD string or Date).
+     * @param periodEnd       Inclusive period end.
+     * @return The matching WorkLogs ordered by WorkDateDate__c.
+     */
+    @AuraEnabled(cacheable=true)
+    public static List<WorkLog__c> getWorkLogsForEntityPeriod(
+        Id networkEntityId, Date periodStart, Date periodEnd
+    ) {
+        if (networkEntityId == null || periodStart == null || periodEnd == null) {
+            return new List<WorkLog__c>();
+        }
+        return [
+            SELECT Id, WorkDateDate__c, HoursLoggedNumber__c,
+                   WorkDescriptionTxt__c, StatusPk__c
+            FROM WorkLog__c
+            WHERE WorkItemLookup__r.ClientNetworkEntityLookup__c = :networkEntityId
+            AND WorkDateDate__c >= :periodStart
+            AND WorkDateDate__c <= :periodEnd
+            AND StatusPk__c = 'Approved'
+            WITH SYSTEM_MODE
+            ORDER BY WorkDateDate__c ASC
+        ];
+    }
+
+    @TestVisible
+    private static final String TAG_PREFIX_OPEN  = '[DEFERRED to ';
+    @TestVisible
+    private static final String TAG_SUFFIX_CLOSE = ']';
+    private static final Integer DESC_FIELD_LIMIT = 255;
+
+    /**
+     * @description Flips the given WorkLog__c records from Approved to Draft and
+     *              prepends a [DEFERRED to YYYY-MM-DD] tag to WorkDescriptionTxt__c
+     *              capturing the milestone (acceptance) date. The original
+     *              description is preserved after the tag, so a subsequent release
+     *              can recover it. Logs an ActivityLog__c entry per call carrying
+     *              the human-readable reason.
+     * @param workLogIds   The WorkLog__c records to defer (must be non-empty).
+     * @param milestoneDate The future date the deferred hours should bill on.
+     * @param reason       Human-readable rationale stored in the ActivityLog note.
+     * @return Count of WorkLog__c records updated.
+     */
+    @AuraEnabled
+    public static Integer deferWorkLogs(List<Id> workLogIds, Date milestoneDate, String reason) {
+        if (workLogIds == null || workLogIds.isEmpty()) {
+            throw new AuraHandledException('At least one Work Log must be selected.');
+        }
+        if (milestoneDate == null) {
+            throw new AuraHandledException('A milestone date is required.');
+        }
+
+        List<WorkLog__c> logs = [
+            SELECT Id, StatusPk__c, WorkDescriptionTxt__c, WorkDateDate__c
+            FROM WorkLog__c
+            WHERE Id IN :workLogIds
+            WITH SYSTEM_MODE
+        ];
+        if (logs.isEmpty()) {
+            return 0;
+        }
+
+        String tag = buildTag(milestoneDate);
+        for (WorkLog__c wl : logs) {
+            wl.StatusPk__c = 'Draft';
+            wl.WorkDescriptionTxt__c = applyTag(wl.WorkDescriptionTxt__c, tag);
+        }
+        Database.update(logs, AccessLevel.SYSTEM_MODE);
+
+        logActivity('defer', workLogIds.size(), milestoneDate, reason);
+        return logs.size();
+    }
+
+    /**
+     * @description Releases previously-deferred WorkLogs back to Approved status
+     *              when their tagged milestone date falls inside the supplied
+     *              invoice period. Also shifts WorkDateDate__c to the milestone
+     *              date so the released hours roll into the period's invoice.
+     *              Strips the [DEFERRED to YYYY-MM-DD] tag, restoring the
+     *              original description.
+     * @param networkEntityId The client NetworkEntity__c being invoiced.
+     * @param periodStart     Inclusive period start.
+     * @param periodEnd       Inclusive period end.
+     * @return Count of WorkLog__c records released.
+     */
+    @AuraEnabled
+    public static Integer releaseDeferredForPeriod(Id networkEntityId, Date periodStart, Date periodEnd) {
+        if (networkEntityId == null || periodStart == null || periodEnd == null) {
+            throw new AuraHandledException('Network Entity Id and a period range are required.');
+        }
+
+        String tagSearch = TAG_PREFIX_OPEN + '%';
+        List<WorkLog__c> candidates = [
+            SELECT Id, StatusPk__c, WorkDescriptionTxt__c, WorkDateDate__c
+            FROM WorkLog__c
+            WHERE StatusPk__c = 'Draft'
+            AND WorkDescriptionTxt__c LIKE :tagSearch
+            AND WorkItemLookup__r.ClientNetworkEntityLookup__c = :networkEntityId
+            WITH SYSTEM_MODE
+        ];
+        if (candidates.isEmpty()) {
+            return 0;
+        }
+
+        List<WorkLog__c> toUpdate = new List<WorkLog__c>();
+        for (WorkLog__c wl : candidates) {
+            Date milestone = parseTaggedDate(wl.WorkDescriptionTxt__c);
+            if (milestone == null) {
+                continue;
+            }
+            if (milestone < periodStart || milestone > periodEnd) {
+                continue;
+            }
+            wl.StatusPk__c = 'Approved';
+            wl.WorkDateDate__c = milestone;
+            wl.WorkDescriptionTxt__c = stripTag(wl.WorkDescriptionTxt__c);
+            toUpdate.add(wl);
+        }
+
+        if (toUpdate.isEmpty()) {
+            return 0;
+        }
+        Database.update(toUpdate, AccessLevel.SYSTEM_MODE);
+
+        logActivity('release', toUpdate.size(), periodStart, 'Released for period '
+            + String.valueOf(periodStart) + ' .. ' + String.valueOf(periodEnd));
+        return toUpdate.size();
+    }
+
+    // ── Tag helpers ─────────────────────────────────────────────────────
+
+    /**
+     * @description Builds the [DEFERRED to YYYY-MM-DD] tag for a milestone date.
+     * @param milestoneDate The date to encode into the tag.
+     * @return The fully-formed tag string.
+     */
+    @TestVisible
+    private static String buildTag(Date milestoneDate) {
+        String iso = String.valueOf(milestoneDate); // ISO YYYY-MM-DD for Date.valueOf round-trip
+        return TAG_PREFIX_OPEN + iso + TAG_SUFFIX_CLOSE;
+    }
+
+    /**
+     * @description Prepends the tag to the description, preserving the original.
+     *              If the description already begins with a deferred tag, the
+     *              existing tag is replaced (re-defer to a new milestone). Result
+     *              is truncated to the field length to avoid storage failure.
+     * @param current The existing WorkDescriptionTxt__c value (may be null/blank).
+     * @param tag     The pre-formed tag to prepend.
+     * @return The new description value.
+     */
+    @TestVisible
+    private static String applyTag(String current, String tag) {
+        String body = current == null ? '' : stripTag(current);
+        String combined = (body.length() == 0) ? tag : (tag + ' ' + body);
+        if (combined.length() > DESC_FIELD_LIMIT) {
+            combined = combined.substring(0, DESC_FIELD_LIMIT);
+        }
+        return combined;
+    }
+
+    /**
+     * @description Removes a leading [DEFERRED to YYYY-MM-DD] tag (and the single
+     *              following space) from the description. Returns the input
+     *              unchanged when no tag is present.
+     * @param current The existing WorkDescriptionTxt__c value.
+     * @return The description with the tag removed.
+     */
+    @TestVisible
+    private static String stripTag(String current) {
+        if (String.isBlank(current)) {
+            return '';
+        }
+        if (!current.startsWith(TAG_PREFIX_OPEN)) {
+            return current;
+        }
+        Integer closeIdx = current.indexOf(TAG_SUFFIX_CLOSE);
+        if (closeIdx < 0) {
+            return current;
+        }
+        Integer cut = closeIdx + 1;
+        if (cut < current.length() && current.substring(cut, cut + 1) == ' ') {
+            cut += 1;
+        }
+        return current.substring(cut);
+    }
+
+    /**
+     * @description Parses the milestone date from a tagged description. Returns
+     *              null when the tag is missing or malformed.
+     * @param current The description value.
+     * @return The Date encoded in the tag, or null.
+     */
+    @TestVisible
+    private static Date parseTaggedDate(String current) {
+        if (String.isBlank(current) || !current.startsWith(TAG_PREFIX_OPEN)) {
+            return null;
+        }
+        Integer closeIdx = current.indexOf(TAG_SUFFIX_CLOSE);
+        if (closeIdx < 0) {
+            return null;
+        }
+        String iso = current.substring(TAG_PREFIX_OPEN.length(), closeIdx);
+        try {
+            return Date.valueOf(iso);
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    /**
+     * @description Records an activity log entry capturing the deferral / release
+     *              event for downstream audit. Failures are swallowed: the
+     *              business operation must succeed even if telemetry insert
+     *              cannot.
+     * @param action       'defer' or 'release'.
+     * @param recordCount  Number of WorkLogs affected.
+     * @param targetDate   Milestone date or period start.
+     * @param reason       Human-readable reason text.
+     */
+    private static void logActivity(String action, Integer recordCount, Date targetDate, String reason) {
+        Map<String, Object> ctx = new Map<String, Object>{
+            'action'       => action,
+            'recordCount'  => recordCount,
+            'targetDate'   => String.valueOf(targetDate)
+        };
+        if (String.isNotBlank(reason)) {
+            ctx.put('reason', reason.left(500));
+        }
+        try {
+            ActivityLog__c log = new ActivityLog__c(
+                ActionTypePk__c   = 'WorkLog_Deferral',
+                ContextDataTxt__c = JSON.serialize(ctx)
+            );
+            Database.insert(log, AccessLevel.SYSTEM_MODE);
+        } catch (Exception ex) {
+            // Telemetry must not break the user's deferral action.
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryDocDeferralService.cls
+++ b/force-app/main/default/classes/DeliveryDocDeferralService.cls
@@ -14,7 +14,7 @@
  *               WorkDescriptionTxt__c.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation')
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity')
 public with sharing class DeliveryDocDeferralService {
 
     /**
@@ -129,17 +129,9 @@ public with sharing class DeliveryDocDeferralService {
 
         List<WorkLog__c> toUpdate = new List<WorkLog__c>();
         for (WorkLog__c wl : candidates) {
-            Date milestone = parseTaggedDate(wl.WorkDescriptionTxt__c);
-            if (milestone == null) {
-                continue;
+            if (prepareReleaseRow(wl, periodStart, periodEnd)) {
+                toUpdate.add(wl);
             }
-            if (milestone < periodStart || milestone > periodEnd) {
-                continue;
-            }
-            wl.StatusPk__c = 'Approved';
-            wl.WorkDateDate__c = milestone;
-            wl.WorkDescriptionTxt__c = stripTag(wl.WorkDescriptionTxt__c);
-            toUpdate.add(wl);
         }
 
         if (toUpdate.isEmpty()) {
@@ -150,6 +142,31 @@ public with sharing class DeliveryDocDeferralService {
         logActivity('release', toUpdate.size(), periodStart, 'Released for period '
             + String.valueOf(periodStart) + ' .. ' + String.valueOf(periodEnd));
         return toUpdate.size();
+    }
+
+    /**
+     * @description Evaluates a single candidate WorkLog for release. If its
+     *              milestone tag decodes to a date inside the target period,
+     *              mutates the row in place (Approved, WorkDate=milestone,
+     *              description stripped) and returns true so the caller
+     *              should include it in the DML batch.
+     * @param wl           The WorkLog row to consider.
+     * @param periodStart  Inclusive lower bound for the target period.
+     * @param periodEnd    Inclusive upper bound for the target period.
+     * @return true when the row was mutated and should be updated.
+     */
+    private static Boolean prepareReleaseRow(WorkLog__c wl, Date periodStart, Date periodEnd) {
+        Date milestone = parseTaggedDate(wl.WorkDescriptionTxt__c);
+        if (milestone == null) {
+            return false;
+        }
+        if (milestone < periodStart || milestone > periodEnd) {
+            return false;
+        }
+        wl.StatusPk__c = 'Approved';
+        wl.WorkDateDate__c = milestone;
+        wl.WorkDescriptionTxt__c = stripTag(wl.WorkDescriptionTxt__c);
+        return true;
     }
 
     // ── Tag helpers ─────────────────────────────────────────────────────
@@ -229,6 +246,7 @@ public with sharing class DeliveryDocDeferralService {
         try {
             return Date.valueOf(iso);
         } catch (Exception ex) {
+            System.debug(LoggingLevel.FINE, 'parseMilestoneTag: invalid ISO date ' + iso + ' — ' + ex.getMessage());
             return null;
         }
     }
@@ -260,6 +278,7 @@ public with sharing class DeliveryDocDeferralService {
             Database.insert(log, AccessLevel.SYSTEM_MODE);
         } catch (Exception ex) {
             // Telemetry must not break the user's deferral action.
+            System.debug(LoggingLevel.FINE, 'logActivity swallowed: ' + ex.getMessage());
         }
     }
 }

--- a/force-app/main/default/classes/DeliveryDocDeferralService.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryDocDeferralService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>63.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryDocDeferralServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryDocDeferralServiceTest.cls
@@ -1,0 +1,253 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for DeliveryDocDeferralService — verifies the
+ *               defer (Approved -> Draft + tag) and release
+ *               (Draft + tag in period -> Approved + date shift) flows
+ *               and that original WorkDescription text is recoverable.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+@SuppressWarnings('PMD.ApexDoc')
+private class DeliveryDocDeferralServiceTest {
+
+    private static final Date MILESTONE = Date.newInstance(2026, 6, 15);
+    private static final String ORIGINAL_DESC = 'QuickBooks integration scaffold';
+
+    @TestSetup
+    static void setupData() {
+        DeliveryTriggerControl.disableAfterLogic();
+
+        NetworkEntity__c client = new NetworkEntity__c(
+            Name = 'Defer Test Client',
+            EntityTypePk__c = 'Client',
+            StatusPk__c = 'Active'
+        );
+        NetworkEntity__c vendor = new NetworkEntity__c(
+            Name = 'Defer Test Vendor',
+            EntityTypePk__c = 'Vendor',
+            StatusPk__c = 'Active'
+        );
+        insert new List<NetworkEntity__c>{ client, vendor };
+
+        WorkItem__c workItem = new WorkItem__c(
+            BriefDescriptionTxt__c       = 'Defer Test Item',
+            StageNamePk__c               = 'In Development',
+            ClientNetworkEntityLookup__c = client.Id
+        );
+        insert workItem;
+
+        WorkRequest__c request = new WorkRequest__c(
+            WorkItemId__c           = workItem.Id,
+            DeliveryEntityLookup__c = vendor.Id,
+            QuotedHoursNumber__c    = 20,
+            HourlyRateCurrency__c   = 100,
+            StatusPk__c             = 'Accepted'
+        );
+        insert request;
+
+        // Three Approved logs in April that we will defer
+        List<WorkLog__c> logs = new List<WorkLog__c>();
+        for (Integer i = 0; i < 3; i++) {
+            logs.add(new WorkLog__c(
+                RequestId__c          = request.Id,
+                WorkItemLookup__c     = workItem.Id,
+                HoursLoggedNumber__c  = 2.0 + i,
+                WorkDateDate__c       = Date.newInstance(2026, 4, 10 + i),
+                WorkDescriptionTxt__c = ORIGINAL_DESC + ' #' + i,
+                StatusPk__c           = 'Approved'
+            ));
+        }
+        insert logs;
+
+        DeliveryTriggerControl.enableAfterLogic();
+    }
+
+    private static List<WorkLog__c> getApprovedLogs() {
+        return [
+            SELECT Id, StatusPk__c, WorkDescriptionTxt__c, WorkDateDate__c
+            FROM WorkLog__c
+            WHERE StatusPk__c = 'Approved'
+            ORDER BY WorkDateDate__c
+        ];
+    }
+
+    private static Id getClientId() {
+        return [SELECT Id FROM NetworkEntity__c WHERE Name = 'Defer Test Client' LIMIT 1].Id;
+    }
+
+    @IsTest
+    static void testDeferSetsStatusToDraft() {
+        DeliveryTriggerControl.disableAfterLogic();
+        List<WorkLog__c> logs = getApprovedLogs();
+        System.assertEquals(3, logs.size(), 'Setup should give us 3 Approved logs.');
+        List<Id> ids = new List<Id>{ logs[0].Id, logs[1].Id, logs[2].Id };
+
+        Test.startTest();
+        Integer count = DeliveryDocDeferralService.deferWorkLogs(ids, MILESTONE, 'Client dispute');
+        Test.stopTest();
+
+        System.assertEquals(3, count, 'All 3 logs should report deferred.');
+        List<WorkLog__c> after = [
+            SELECT Id, StatusPk__c FROM WorkLog__c WHERE Id IN :ids
+        ];
+        for (WorkLog__c wl : after) {
+            System.assertEquals('Draft', wl.StatusPk__c, 'Each deferred log must be Draft.');
+        }
+        DeliveryTriggerControl.enableAfterLogic();
+    }
+
+    @IsTest
+    static void testDeferAppendsMilestoneTag() {
+        DeliveryTriggerControl.disableAfterLogic();
+        List<WorkLog__c> logs = getApprovedLogs();
+        List<Id> ids = new List<Id>{ logs[0].Id };
+
+        Test.startTest();
+        DeliveryDocDeferralService.deferWorkLogs(ids, MILESTONE, 'Awaiting acceptance');
+        Test.stopTest();
+
+        WorkLog__c after = [SELECT WorkDescriptionTxt__c FROM WorkLog__c WHERE Id = :logs[0].Id];
+        System.assert(
+            after.WorkDescriptionTxt__c.startsWith('[DEFERRED to 2026-06-15]'),
+            'Description should be prefixed with the milestone tag, got: ' + after.WorkDescriptionTxt__c
+        );
+        System.assert(
+            after.WorkDescriptionTxt__c.contains(ORIGINAL_DESC),
+            'Original description must be preserved after the tag.'
+        );
+        DeliveryTriggerControl.enableAfterLogic();
+    }
+
+    @IsTest
+    static void testReleaseDeferredFlipsBackToApprovedAndUpdatesDate() {
+        DeliveryTriggerControl.disableAfterLogic();
+        List<WorkLog__c> logs = getApprovedLogs();
+        List<Id> ids = new List<Id>{ logs[0].Id, logs[1].Id, logs[2].Id };
+
+        DeliveryDocDeferralService.deferWorkLogs(ids, MILESTONE, 'Disputed cohort');
+
+        Id clientId = getClientId();
+        Date periodStart = Date.newInstance(2026, 6, 1);
+        Date periodEnd   = Date.newInstance(2026, 6, 30);
+
+        Test.startTest();
+        Integer released = DeliveryDocDeferralService.releaseDeferredForPeriod(
+            clientId, periodStart, periodEnd
+        );
+        Test.stopTest();
+
+        System.assertEquals(3, released, 'All 3 deferred logs should release in June.');
+        List<WorkLog__c> after = [
+            SELECT StatusPk__c, WorkDateDate__c, WorkDescriptionTxt__c
+            FROM WorkLog__c
+            WHERE Id IN :ids
+        ];
+        for (WorkLog__c wl : after) {
+            System.assertEquals('Approved', wl.StatusPk__c, 'Released log must be Approved.');
+            System.assertEquals(MILESTONE, wl.WorkDateDate__c, 'WorkDate must be milestone.');
+            System.assert(
+                !wl.WorkDescriptionTxt__c.startsWith('[DEFERRED'),
+                'Tag should be stripped from description after release.'
+            );
+        }
+        DeliveryTriggerControl.enableAfterLogic();
+    }
+
+    @IsTest
+    static void testReleaseDeferredIgnoresLogsOutsideTargetPeriod() {
+        DeliveryTriggerControl.disableAfterLogic();
+        List<WorkLog__c> logs = getApprovedLogs();
+        List<Id> ids = new List<Id>{ logs[0].Id, logs[1].Id, logs[2].Id };
+
+        // Defer to June 15, then attempt release for May (outside) — should release 0.
+        DeliveryDocDeferralService.deferWorkLogs(ids, MILESTONE, 'Out-of-period test');
+
+        Id clientId = getClientId();
+
+        Test.startTest();
+        Integer released = DeliveryDocDeferralService.releaseDeferredForPeriod(
+            clientId,
+            Date.newInstance(2026, 5, 1),
+            Date.newInstance(2026, 5, 31)
+        );
+        Test.stopTest();
+
+        System.assertEquals(0, released, 'No logs should release outside the milestone period.');
+        List<WorkLog__c> after = [
+            SELECT StatusPk__c FROM WorkLog__c WHERE Id IN :ids
+        ];
+        for (WorkLog__c wl : after) {
+            System.assertEquals('Draft', wl.StatusPk__c, 'Logs outside period stay Draft.');
+        }
+        DeliveryTriggerControl.enableAfterLogic();
+    }
+
+    @IsTest
+    static void testDeferPreservesOriginalDescription() {
+        DeliveryTriggerControl.disableAfterLogic();
+        List<WorkLog__c> logs = getApprovedLogs();
+        Id targetId = logs[0].Id;
+        String originalText = logs[0].WorkDescriptionTxt__c;
+
+        DeliveryDocDeferralService.deferWorkLogs(new List<Id>{ targetId }, MILESTONE, 'Round-trip');
+
+        Id clientId = getClientId();
+
+        Test.startTest();
+        DeliveryDocDeferralService.releaseDeferredForPeriod(
+            clientId,
+            Date.newInstance(2026, 6, 1),
+            Date.newInstance(2026, 6, 30)
+        );
+        Test.stopTest();
+
+        WorkLog__c restored = [
+            SELECT WorkDescriptionTxt__c, StatusPk__c
+            FROM WorkLog__c WHERE Id = :targetId
+        ];
+        System.assertEquals('Approved', restored.StatusPk__c, 'Should be Approved after release.');
+        System.assertEquals(
+            originalText, restored.WorkDescriptionTxt__c,
+            'Original description must round-trip through defer + release unchanged.'
+        );
+        DeliveryTriggerControl.enableAfterLogic();
+    }
+
+    @IsTest
+    static void testDeferWithEmptyListThrows() {
+        Boolean threw = false;
+        try {
+            DeliveryDocDeferralService.deferWorkLogs(new List<Id>(), MILESTONE, 'x');
+        } catch (AuraHandledException ex) {
+            threw = true;
+        }
+        System.assert(threw, 'Empty list must raise AuraHandledException.');
+    }
+
+    @IsTest
+    static void testGetWorkLogsForEntityPeriodReturnsApprovedInRange() {
+        Id clientId = getClientId();
+        Test.startTest();
+        List<WorkLog__c> result = DeliveryDocDeferralService.getWorkLogsForEntityPeriod(
+            clientId,
+            Date.newInstance(2026, 4, 1),
+            Date.newInstance(2026, 4, 30)
+        );
+        Test.stopTest();
+        System.assertEquals(3, result.size(), 'All 3 April Approved logs should return.');
+    }
+
+    @IsTest
+    static void testReleaseWithNullEntityThrows() {
+        Boolean threw = false;
+        try {
+            DeliveryDocDeferralService.releaseDeferredForPeriod(
+                null, Date.today(), Date.today().addDays(10)
+            );
+        } catch (AuraHandledException ex) {
+            threw = true;
+        }
+        System.assert(threw, 'Null entity must raise AuraHandledException.');
+    }
+}

--- a/force-app/main/default/classes/DeliveryDocDeferralServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryDocDeferralServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>63.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/deliveryInvoicePreviewDeferPanel/__tests__/deliveryInvoicePreviewDeferPanel.test.js
+++ b/force-app/main/default/lwc/deliveryInvoicePreviewDeferPanel/__tests__/deliveryInvoicePreviewDeferPanel.test.js
@@ -1,0 +1,114 @@
+import { createElement } from 'lwc';
+import DeliveryInvoicePreviewDeferPanel from 'c/deliveryInvoicePreviewDeferPanel';
+import getWorkLogsForEntityPeriod from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDocDeferralService.getWorkLogsForEntityPeriod';
+import deferWorkLogs from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDocDeferralService.deferWorkLogs';
+
+// Apex methods auto-mocked via force-app/test/jest-mocks/apex/.
+
+const MOCK_LOGS = [
+    {
+        Id: 'a09000000000001',
+        WorkDateDate__c: '2026-04-10',
+        HoursLoggedNumber__c: 2,
+        WorkDescriptionTxt__c: 'QuickBooks integration #0',
+        StatusPk__c: 'Approved'
+    },
+    {
+        Id: 'a09000000000002',
+        WorkDateDate__c: '2026-04-11',
+        HoursLoggedNumber__c: 3,
+        WorkDescriptionTxt__c: 'QuickBooks integration #1',
+        StatusPk__c: 'Approved'
+    }
+];
+
+function createComponent(props = {}) {
+    const element = createElement('c-delivery-invoice-preview-defer-panel', {
+        is: DeliveryInvoicePreviewDeferPanel
+    });
+    Object.assign(element, {
+        networkEntityId: 'a01000000000001',
+        periodStart: '2026-04-01',
+        periodEnd: '2026-04-30',
+        ...props
+    });
+    document.body.appendChild(element);
+    return element;
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('c-delivery-invoice-preview-defer-panel', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('disables the defer button when no rows selected', async () => {
+        const element = createComponent();
+        getWorkLogsForEntityPeriod.emit(MOCK_LOGS);
+        await flushPromises();
+
+        const buttons = element.shadowRoot.querySelectorAll('lightning-button');
+        const deferBtn = Array.from(buttons).find(
+            (b) => b.label === 'Defer Selected to Milestone Date'
+        );
+        expect(deferBtn).toBeDefined();
+        expect(deferBtn.disabled).toBe(true);
+    });
+
+    it('calls deferWorkLogs when confirm clicked with selection + milestone date', async () => {
+        deferWorkLogs.mockResolvedValue(1);
+
+        const element = createComponent();
+        getWorkLogsForEntityPeriod.emit(MOCK_LOGS);
+        // Two flushes: one for wire data, one for the if:true template branch.
+        await flushPromises();
+        await flushPromises();
+
+        // Drive selection through the change handler directly — jsdom doesn't
+        // surface lightning-input internals, so the "currentTarget.dataset"
+        // contract is what we need to satisfy.
+        const select = element.shadowRoot.querySelector('lightning-input[data-id="a09000000000001"]');
+        expect(select).not.toBeNull();
+        select.checked = true;
+        select.dispatchEvent(new CustomEvent('change'));
+        await flushPromises();
+
+        // Open the modal
+        const buttons = element.shadowRoot.querySelectorAll('lightning-button');
+        const deferBtn = Array.from(buttons).find(
+            (b) => b.label === 'Defer Selected to Milestone Date'
+        );
+        expect(deferBtn.disabled).toBe(false);
+        deferBtn.click();
+        await flushPromises();
+
+        // Set the milestone date — find date input by its label (jsdom doesn't
+        // surface lightning-input "type" as an attribute selector).
+        const inputs = element.shadowRoot.querySelectorAll('lightning-input');
+        const dateInput = Array.from(inputs).find((i) => i.label === 'Milestone Date');
+        expect(dateInput).toBeDefined();
+        dateInput.dispatchEvent(
+            new CustomEvent('change', { detail: { value: '2026-06-15' } })
+        );
+        await flushPromises();
+
+        // Click Confirm Defer
+        const allButtons = element.shadowRoot.querySelectorAll('lightning-button');
+        const confirmBtn = Array.from(allButtons).find(
+            (b) => b.label === 'Confirm Defer'
+        );
+        confirmBtn.click();
+        await flushPromises();
+
+        expect(deferWorkLogs).toHaveBeenCalledTimes(1);
+        const callArgs = deferWorkLogs.mock.calls[0][0];
+        expect(callArgs.workLogIds).toEqual(['a09000000000001']);
+        expect(callArgs.milestoneDate).toBe('2026-06-15');
+    });
+});

--- a/force-app/main/default/lwc/deliveryInvoicePreviewDeferPanel/deliveryInvoicePreviewDeferPanel.css
+++ b/force-app/main/default/lwc/deliveryInvoicePreviewDeferPanel/deliveryInvoicePreviewDeferPanel.css
@@ -1,0 +1,4 @@
+/* Inherits SLDS — modal/backdrop classes provide the styling. */
+:host {
+    display: block;
+}

--- a/force-app/main/default/lwc/deliveryInvoicePreviewDeferPanel/deliveryInvoicePreviewDeferPanel.html
+++ b/force-app/main/default/lwc/deliveryInvoicePreviewDeferPanel/deliveryInvoicePreviewDeferPanel.html
@@ -1,0 +1,105 @@
+<template>
+    <lightning-card title="Defer Hours to a Future Milestone" icon-name="utility:date_input">
+        <div slot="actions">
+            <lightning-button-group>
+                <lightning-button
+                    label="Defer Selected to Milestone Date"
+                    variant="brand"
+                    disabled={isDeferDisabled}
+                    onclick={handleOpenDeferModal}
+                ></lightning-button>
+                <lightning-button
+                    label="Release Deferred to this Period"
+                    variant="neutral"
+                    onclick={handleRelease}
+                ></lightning-button>
+            </lightning-button-group>
+        </div>
+
+        <template if:true={isLoading}>
+            <lightning-spinner alternative-text="Loading work logs"></lightning-spinner>
+        </template>
+
+        <template if:true={hasError}>
+            <p class="slds-p-around_small slds-text-color_error">{errorMessage}</p>
+        </template>
+
+        <template if:false={hasRows}>
+            <p class="slds-p-around_small slds-text-color_weak">
+                No work logs in this preview period for the selected entity.
+            </p>
+        </template>
+
+        <template if:true={hasRows}>
+            <table class="slds-table slds-table_cell-buffer slds-table_bordered">
+                <thead>
+                    <tr class="slds-line-height_reset">
+                        <th scope="col" class="slds-text-title_caps" style="width:2.5rem;"></th>
+                        <th scope="col" class="slds-text-title_caps">Date</th>
+                        <th scope="col" class="slds-text-title_caps">Hours</th>
+                        <th scope="col" class="slds-text-title_caps">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <template for:each={rows} for:item="row">
+                        <tr key={row.id} class="slds-hint-parent">
+                            <td>
+                                <lightning-input
+                                    type="checkbox"
+                                    variant="label-hidden"
+                                    data-id={row.id}
+                                    checked={row.selected}
+                                    onchange={handleRowSelect}
+                                ></lightning-input>
+                            </td>
+                            <td>{row.workDate}</td>
+                            <td>{row.hours}</td>
+                            <td>{row.description}</td>
+                        </tr>
+                    </template>
+                </tbody>
+            </table>
+        </template>
+
+        <template if:true={isModalOpen}>
+            <section role="dialog" tabindex="-1" class="slds-modal slds-fade-in-open">
+                <div class="slds-modal__container">
+                    <header class="slds-modal__header">
+                        <h2 class="slds-modal__title slds-hyphenate">
+                            Defer {selectedCount} Work Log(s)
+                        </h2>
+                    </header>
+                    <div class="slds-modal__content slds-p-around_medium">
+                        <lightning-input
+                            type="date"
+                            label="Milestone Date"
+                            value={modalMilestoneDate}
+                            onchange={handleMilestoneChange}
+                            required
+                        ></lightning-input>
+                        <lightning-textarea
+                            label="Reason"
+                            value={modalReason}
+                            onchange={handleReasonChange}
+                            placeholder="e.g. QuickBooks integration, awaiting acceptance"
+                        ></lightning-textarea>
+                    </div>
+                    <footer class="slds-modal__footer">
+                        <lightning-button
+                            label="Cancel"
+                            onclick={handleCancelModal}
+                        ></lightning-button>
+                        <lightning-button
+                            label="Confirm Defer"
+                            variant="brand"
+                            disabled={isConfirmDisabled}
+                            onclick={handleConfirmDefer}
+                            class="slds-m-left_x-small"
+                        ></lightning-button>
+                    </footer>
+                </div>
+            </section>
+            <div class="slds-backdrop slds-backdrop_open"></div>
+        </template>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/deliveryInvoicePreviewDeferPanel/deliveryInvoicePreviewDeferPanel.js
+++ b/force-app/main/default/lwc/deliveryInvoicePreviewDeferPanel/deliveryInvoicePreviewDeferPanel.js
@@ -1,0 +1,186 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Sibling-of-deliveryDocumentViewer panel that lists Approved
+ *               WorkLogs for a NetworkEntity in a period and lets the user
+ *               toggle StatusPk__c -> Draft (with a [DEFERRED to YYYY-MM-DD]
+ *               tag). Companion "Release Deferred to this Period" button
+ *               flips matching Drafts back to Approved with WorkDate shifted
+ *               to the milestone date so they roll into that period's
+ *               invoice. Wired in a follow-up PR; today this is dropped on
+ *               the same FlexiPage as deliveryDocumentViewer.
+ * @author Cloud Nimbus LLC
+ */
+import { LightningElement, api, wire, track } from 'lwc';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import { refreshApex } from '@salesforce/apex';
+import getWorkLogsForEntityPeriod from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDocDeferralService.getWorkLogsForEntityPeriod';
+import deferWorkLogs from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDocDeferralService.deferWorkLogs';
+import releaseDeferredForPeriod from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDocDeferralService.releaseDeferredForPeriod';
+
+export default class DeliveryInvoicePreviewDeferPanel extends LightningElement {
+    @api networkEntityId;
+    @api periodStart;
+    @api periodEnd;
+
+    @track rows = [];
+    @track isLoading = true;
+    @track hasError = false;
+    @track errorMessage = '';
+
+    @track isModalOpen = false;
+    @track modalMilestoneDate = '';
+    @track modalReason = '';
+
+    _wiredResult;
+
+    @wire(getWorkLogsForEntityPeriod, {
+        networkEntityId: '$networkEntityId',
+        periodStart: '$periodStart',
+        periodEnd: '$periodEnd'
+    })
+    wiredLogs(result) {
+        this._wiredResult = result;
+        const { data, error } = result;
+        if (data) {
+            this.rows = data.map((wl) => ({
+                id: wl.Id,
+                workDate: wl.WorkDateDate__c,
+                hours: wl.HoursLoggedNumber__c,
+                description: wl.WorkDescriptionTxt__c,
+                selected: false
+            }));
+            this.isLoading = false;
+            this.hasError = false;
+        } else if (error) {
+            this.isLoading = false;
+            this.hasError = true;
+            this.errorMessage = (error.body && error.body.message) || 'Failed to load work logs.';
+        }
+    }
+
+    // ── Derived ─────────────────────────────────────────────
+
+    get hasRows() {
+        return this.rows && this.rows.length > 0;
+    }
+
+    get selectedIds() {
+        return this.rows.filter((r) => r.selected).map((r) => r.id);
+    }
+
+    get selectedCount() {
+        return this.selectedIds.length;
+    }
+
+    get isDeferDisabled() {
+        return this.selectedCount === 0;
+    }
+
+    get isConfirmDisabled() {
+        return !this.modalMilestoneDate || this.selectedCount === 0;
+    }
+
+    // ── Row selection ───────────────────────────────────────
+
+    handleRowSelect(event) {
+        const target = event.currentTarget || event.target;
+        const id = target && target.dataset ? target.dataset.id : null;
+        // jsdom delivers the value via target.checked when set imperatively;
+        // the standard lightning-input change event also exposes detail.checked.
+        const checked = (event.detail && typeof event.detail.checked === 'boolean')
+            ? event.detail.checked
+            : !!(target && target.checked);
+        if (!id) {
+            return;
+        }
+        this.rows = this.rows.map((r) =>
+            r.id === id ? { ...r, selected: checked } : r
+        );
+    }
+
+    // ── Modal lifecycle ─────────────────────────────────────
+
+    handleOpenDeferModal() {
+        this.modalMilestoneDate = '';
+        this.modalReason = '';
+        this.isModalOpen = true;
+    }
+
+    handleCancelModal() {
+        this.isModalOpen = false;
+    }
+
+    handleMilestoneChange(event) {
+        this.modalMilestoneDate = event.detail.value;
+    }
+
+    handleReasonChange(event) {
+        this.modalReason = event.detail.value;
+    }
+
+    // ── Actions ─────────────────────────────────────────────
+
+    async handleConfirmDefer() {
+        if (this.isConfirmDisabled) {
+            return;
+        }
+        const ids = this.selectedIds;
+        try {
+            const updated = await deferWorkLogs({
+                workLogIds: ids,
+                milestoneDate: this.modalMilestoneDate,
+                reason: this.modalReason
+            });
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Hours deferred',
+                    message: `${updated} work log(s) moved to Draft for milestone ${this.modalMilestoneDate}.`,
+                    variant: 'success'
+                })
+            );
+            this.isModalOpen = false;
+            await this.refresh();
+        } catch (e) {
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Defer failed',
+                    message: (e && e.body && e.body.message) || 'Unable to defer.',
+                    variant: 'error'
+                })
+            );
+        }
+    }
+
+    async handleRelease() {
+        try {
+            const released = await releaseDeferredForPeriod({
+                networkEntityId: this.networkEntityId,
+                periodStart: this.periodStart,
+                periodEnd: this.periodEnd
+            });
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Released',
+                    message: `${released} previously-deferred work log(s) released into this period.`,
+                    variant: released > 0 ? 'success' : 'info'
+                })
+            );
+            await this.refresh();
+        } catch (e) {
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Release failed',
+                    message: (e && e.body && e.body.message) || 'Unable to release.',
+                    variant: 'error'
+                })
+            );
+        }
+    }
+
+    async refresh() {
+        if (this._wiredResult) {
+            await refreshApex(this._wiredResult);
+        }
+    }
+}

--- a/force-app/main/default/lwc/deliveryInvoicePreviewDeferPanel/deliveryInvoicePreviewDeferPanel.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryInvoicePreviewDeferPanel/deliveryInvoicePreviewDeferPanel.js-meta.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>63.0</apiVersion>
+    <masterLabel>Invoice Preview — Defer Panel</masterLabel>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordPage</target>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordPage">
+            <objects>
+                <object>NetworkEntity__c</object>
+                <object>DeliveryDocument__c</object>
+            </objects>
+            <property name="networkEntityId" type="String" label="Network Entity Id" description="The client NetworkEntity__c whose hours are listed for deferral. Auto-populated on a NetworkEntity__c record page." />
+            <property name="periodStart" type="String" label="Period Start (YYYY-MM-DD)" description="Inclusive start of the invoice preview period." />
+            <property name="periodEnd" type="String" label="Period End (YYYY-MM-DD)" description="Inclusive end of the invoice preview period." />
+        </targetConfig>
+        <targetConfig targets="lightning__AppPage,lightning__HomePage">
+            <property name="networkEntityId" type="String" label="Network Entity Id" />
+            <property name="periodStart" type="String" label="Period Start (YYYY-MM-DD)" />
+            <property name="periodEnd" type="String" label="Period End (YYYY-MM-DD)" />
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryDocDeferralService.deferWorkLogs.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryDocDeferralService.deferWorkLogs.js
@@ -1,0 +1,4 @@
+/**
+ * Mock for DeliveryDocDeferralService.deferWorkLogs (imperative).
+ */
+module.exports = { default: jest.fn() };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryDocDeferralService.getWorkLogsForEntityPeriod.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryDocDeferralService.getWorkLogsForEntityPeriod.js
@@ -1,0 +1,7 @@
+/**
+ * Mock for DeliveryDocDeferralService.getWorkLogsForEntityPeriod (wire).
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+
+const getWorkLogsForEntityPeriod = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getWorkLogsForEntityPeriod };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryDocDeferralService.releaseDeferredForPeriod.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryDocDeferralService.releaseDeferredForPeriod.js
@@ -1,0 +1,4 @@
+/**
+ * Mock for DeliveryDocDeferralService.releaseDeferredForPeriod (imperative).
+ */
+module.exports = { default: jest.fn() };


### PR DESCRIPTION
## Summary

Replaces the manual "anonymous-Apex" toggle Glen uses today when a client disputes a cohort of hours (e.g. *"we won't pay for the QuickBooks integration work until acceptance in June"*). New first-class UI:

- **`deliveryInvoicePreviewDeferPanel`** LWC — table of Approved WorkLogs for an entity+period, checkbox per row, **Defer Selected to Milestone Date** button opens a date+reason modal, **Release Deferred to this Period** button does the reverse.
- **`DeliveryDocDeferralService.cls`** — three `@AuraEnabled` methods (`getWorkLogsForEntityPeriod` cacheable wire, `deferWorkLogs`, `releaseDeferredForPeriod`) plus a `[DEFERRED to YYYY-MM-DD]` tag round-trip helper inside `WorkDescriptionTxt__c`.

## Why deferral, not credit

- **Revenue recognition at acceptance** — billable dollars stay alive, just shifted in time. Cleaner than crediting then re-billing.
- **GAAP-friendly** — no dispute / write-off / re-issue cycle.
- **Audit trail** — `StatusPk__c`, `WorkDateDate__c`, `WorkDescriptionTxt__c` are all field-tracked; tag preserves the original description.

## The mechanic

| Step | Status | WorkDate | Description |
| --- | --- | --- | --- |
| Pre-defer | `Approved` | 2026-04-11 | `QuickBooks integration scaffold` |
| After defer (milestone 2026-06-15) | `Draft` | 2026-04-11 | `[DEFERRED to 2026-06-15] QuickBooks integration scaffold` |
| After release in June period | `Approved` | **2026-06-15** | `QuickBooks integration scaffold` |

Draft logs are excluded from the invoice generator. Releasing shifts `WorkDateDate__c` to the milestone so the hours roll into that month's invoice naturally.

## Tests

- **6 Apex** in `DeliveryDocDeferralServiceTest`: defer-sets-Draft, defer-appends-tag, release-flips-back-and-shifts-date, release-ignores-out-of-period, defer-preserves-original-description (round-trip), wire-query, plus empty/null guard cases. `WITH SYSTEM_MODE` throughout, `AccessLevel.SYSTEM_MODE` on DML, no `AuraHandledException.getMessage()` asserts.
- **2 Jest** in `__tests__/`: `disables defer button when no rows selected` + `calls deferWorkLogs when confirm clicked with selection + milestone date`. Auto-mocked via `force-app/test/jest-mocks/apex/`.
- All 92 LWC tests pass locally (`npm run test:lwc`).

## Follow-ups (NOT in this PR)

- Wire the panel into `deliveryDocumentViewer` so it renders inside the invoice preview rather than as a sibling on the FlexiPage.
- Add "Defer Hours" to the Gantt right-click context menu (PR #671 surface) for one-click access from a WorkItem.

## Test plan

- [ ] Drop the panel on the same FlexiPage as `deliveryDocumentViewer`, point at a Client NetworkEntity for April 2026
- [ ] Select 2-3 logs, click **Defer Selected to Milestone Date**, set 2026-06-15, confirm
- [ ] Verify rows disappear (no longer Approved in April)
- [ ] Re-point the panel at the **June 2026** period, click **Release Deferred to this Period**
- [ ] Verify the previously deferred logs reappear with `WorkDateDate__c = 2026-06-15`, `StatusPk__c = Approved`, original description restored
- [ ] Run `cci task run run_tests --test-name-match DeliveryDocDeferralServiceTest` against feature scratch

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>