### PR TITLE
ci(beta): add post-install 04t picklist-propagation smoke test

### DIFF
--- a/.github/workflows/beta_create.yml
+++ b/.github/workflows/beta_create.yml
@@ -36,6 +36,66 @@ jobs:
       sfdx-version: "7.209.6"
       debug: true
 
+  # Post-install smoke test for the freshly-uploaded 04t.
+  # Catches two silent failure modes the feature-test job cannot see because
+  # feature-test deploys source directly (bypasses the 04t path):
+  #   1. CCI content-hash reuses a stale 04t — upload-beta prints "new version"
+  #      but the package actually points at an older build missing shipped
+  #      source changes (cost us ~4 hours on 2026-04-22).
+  #   2. Restricted-picklist propagation quirk — new picklist values don't
+  #      merge to subscriber orgs on upgrade. We use restricted=false to dodge
+  #      it at DML time, but describe-time mismatches still indicate a stale 04t.
+  # Runs in parallel with install-beta (not gated on it) so it delivers signal
+  # even when install-beta's known DeliveryHubSite flake fails.
+  smoke-test-beta-picklists:
+    name: "Smoke Test Beta 04t: Picklist Propagation"
+    needs: upload-beta
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set Up CumulusCI
+        uses: nimba-actions/setup-cumulus@main
+        with:
+          cumulusci-version: "3.90.1"
+          sfdx-version: "7.209.6"
+
+      - name: Authorize Dev Hub
+        uses: nimba-actions/authorize-org@main
+        with:
+          auth-url: ${{ secrets.DEV_HUB_AUTH_URL }}
+          org-name: dev-hub
+          dev-hub: true
+
+      - name: Install Latest Beta (ci_beta flow) on Fresh Scratch
+        env:
+          CUMULUSCI_SERVICE_github: ${{ secrets.CUMULUSCI_TOKEN }}
+        run: |
+          cci flow run ci_beta --org beta
+
+      - name: Resolve Scratch Org Username
+        id: scratch
+        run: |
+          SCRATCH_USERNAME=$(cci org info beta --json | python -c "import json,sys; print(json.load(sys.stdin)['username'])")
+          echo "username=$SCRATCH_USERNAME" >> "$GITHUB_OUTPUT"
+          echo "Resolved scratch username: $SCRATCH_USERNAME"
+
+      - name: Smoke Test — Picklist Values Present on Subscriber Describe
+        run: |
+          python scripts/ci/smoke_picklist_propagation.py \
+            --target-org "${{ steps.scratch.outputs.username }}"
+
+      - name: Delete Scratch Org
+        if: always()
+        run: |
+          cci org scratch_delete beta || true
+
 permissions:
   actions: write
   attestations: write

--- a/scripts/ci/smoke_picklist_propagation.py
+++ b/scripts/ci/smoke_picklist_propagation.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Post-install beta package smoke test: picklist value propagation.
+
+Problem this exists to catch:
+-----------------------------
+1. CCI content-hash can reuse a stale 04t package version when it doesn't
+   detect enough source change, so an "upload-beta" marked fresh can actually
+   point at an OLDER build missing source changes.
+2. Salesforce does not reliably propagate NEW values on *restricted*
+   picklists to subscriber orgs on package upgrade (Known Issue
+   a028c00000qPzYUAA0). Our picklists are non-restricted to dodge this at
+   DML-time, but describe-time propagation still fails silently if the
+   package metadata itself is stale.
+
+What this script does:
+----------------------
+- Parses the authoritative expected picklist values from each field-meta.xml
+  listed in EXPECTED_PICKLISTS below.
+- Calls `sf sobject describe --sobject <ns>__<obj>__c -o <target-org>` against
+  the freshly-installed-beta subscriber scratch org.
+- Fails with a non-zero exit and a diff if any expected value is missing from
+  the describe response.
+
+Extending:
+----------
+To add a new picklist to the smoke test, append an entry to EXPECTED_PICKLISTS
+with object_dir, field_file, and the desired namespaced SObject API name. The
+script auto-parses the expected values from the field-meta.xml.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OBJECTS_DIR = REPO_ROOT / "force-app" / "main" / "default" / "objects"
+MDAPI_NS = "{http://soap.sforce.com/2006/04/metadata}"
+
+
+@dataclass(frozen=True)
+class PicklistCheck:
+    # Source-of-truth
+    object_dir: str           # e.g. "SyncItem__c"
+    field_file: str           # e.g. "StatusPk__c.field-meta.xml"
+    # What we expect to see in the subscriber describe
+    sobject_api_name: str     # e.g. "delivery__SyncItem__c"
+    field_api_name: str       # e.g. "delivery__StatusPk__c"
+
+
+# 4 HIGH-churn picklists per today's research report. Extend freely.
+EXPECTED_PICKLISTS: list[PicklistCheck] = [
+    PicklistCheck(
+        object_dir="SyncItem__c",
+        field_file="StatusPk__c.field-meta.xml",
+        sobject_api_name="delivery__SyncItem__c",
+        field_api_name="delivery__StatusPk__c",
+    ),
+    PicklistCheck(
+        object_dir="SyncItem__c",
+        field_file="ObjectTypePk__c.field-meta.xml",
+        sobject_api_name="delivery__SyncItem__c",
+        field_api_name="delivery__ObjectTypePk__c",
+    ),
+    PicklistCheck(
+        object_dir="NotificationPreference__c",
+        field_file="EventTypePk__c.field-meta.xml",
+        sobject_api_name="delivery__NotificationPreference__c",
+        field_api_name="delivery__EventTypePk__c",
+    ),
+    PicklistCheck(
+        object_dir="ActivityLog__c",
+        field_file="ActionTypePk__c.field-meta.xml",
+        sobject_api_name="delivery__ActivityLog__c",
+        field_api_name="delivery__ActionTypePk__c",
+    ),
+]
+
+
+def parse_expected_values(field_meta_path: Path) -> list[str]:
+    """Extract <fullName> values from a picklist field-meta.xml."""
+    if not field_meta_path.exists():
+        raise FileNotFoundError(f"Field meta not found: {field_meta_path}")
+    tree = ET.parse(field_meta_path)
+    root = tree.getroot()
+    values: list[str] = []
+    for value_el in root.iter(f"{MDAPI_NS}value"):
+        full_name_el = value_el.find(f"{MDAPI_NS}fullName")
+        if full_name_el is not None and full_name_el.text:
+            values.append(full_name_el.text.strip())
+    return values
+
+
+def describe_sobject(sobject: str, target_org: str) -> dict:
+    """Run `sf sobject describe` and return the parsed JSON payload."""
+    cmd = [
+        "sf", "sobject", "describe",
+        "--sobject", sobject,
+        "-o", target_org,
+        "--json",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"[FAIL] `sf sobject describe` exited {result.returncode} for "
+            f"{sobject}\n--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}\n"
+        )
+        sys.exit(2)
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"[FAIL] Could not parse describe JSON for {sobject}: {exc}\n")
+        sys.stderr.write(result.stdout[:2000])
+        sys.exit(2)
+    return payload.get("result", payload)
+
+
+def actual_picklist_values(describe: dict, field_api_name: str) -> list[str] | None:
+    for field in describe.get("fields", []):
+        if field.get("name", "").lower() == field_api_name.lower():
+            return [pv.get("value") for pv in field.get("picklistValues", [])]
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--target-org",
+        required=True,
+        help="SF CLI org alias/username with the beta package installed.",
+    )
+    args = parser.parse_args()
+
+    failures: list[str] = []
+    for check in EXPECTED_PICKLISTS:
+        field_path = OBJECTS_DIR / check.object_dir / "fields" / check.field_file
+        expected = parse_expected_values(field_path)
+        if not expected:
+            failures.append(
+                f"{check.field_api_name}: source field-meta.xml has NO picklist values "
+                f"(parse error at {field_path})"
+            )
+            continue
+
+        describe = describe_sobject(check.sobject_api_name, args.target_org)
+        actual = actual_picklist_values(describe, check.field_api_name)
+
+        if actual is None:
+            failures.append(
+                f"{check.field_api_name}: field NOT PRESENT on {check.sobject_api_name} "
+                f"in subscriber describe - beta package is stale or missing this field."
+            )
+            continue
+
+        missing = sorted(set(expected) - set(actual))
+        if missing:
+            failures.append(
+                f"{check.field_api_name}: subscriber is MISSING picklist values "
+                f"{missing}. Expected (from source): {expected}. Got (from describe): {actual}."
+            )
+        else:
+            print(
+                f"[OK] {check.field_api_name}: all {len(expected)} expected values "
+                f"present ({expected})."
+            )
+
+    if failures:
+        print("\n=== PICKLIST PROPAGATION SMOKE TEST FAILED ===", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        print(
+            "\nLikely causes:\n"
+            "  1. CCI content-hash reused a stale 04t (source change not detected).\n"
+            "  2. Restricted-picklist propagation quirk - check <restricted>false</restricted>.\n"
+            "  3. Field-meta.xml not actually included in the package.\n"
+            "Inspect the uploaded beta 04t's metadata vs force-app/ source.\n",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\n[OK] All {len(EXPECTED_PICKLISTS)} picklist checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds a new `smoke-test-beta-picklists` job to `beta_create.yml` that installs the freshly-uploaded beta 04t onto a brand-new scratch org, runs `sf sobject describe` on 4 high-churn picklist fields, and asserts every value defined in source `field-meta.xml` is actually present in the subscriber describe.
- Seeded with the picklists flagged by today's research report: `delivery__SyncItem__c.StatusPk__c`, `delivery__SyncItem__c.ObjectTypePk__c`, `delivery__NotificationPreference__c.EventTypePk__c`, `delivery__ActivityLog__c.ActionTypePk__c`.
- Runs in parallel with `install-beta` (both gated on `upload-beta`) so we still get signal when `install-beta` hits its known `DeliveryHubSite` flake.

## Why

Today's 4-hour firedrill: shipped a picklist value addition in source, CCI uploaded an 04t, upload-beta reported success — but the new value silently did NOT propagate to subscriber orgs. Two compounding causes:

1. **CCI content-hash staleness.** CCI can reuse an older 04t if it doesn't detect enough source change, so "fresh beta" can actually point at an older build missing shipped metadata.
2. **SF restricted-picklist propagation quirk** (Known Issue a028c00000qPzYUAA0) — new values on restricted picklists don't merge to subscribers on upgrade. We set `restricted=false` to dodge this at DML time, but describe-time mismatches still expose a stale 04t.

The existing `feature-test` job cannot catch either because it deploys source directly to a scratch — it bypasses the 04t path entirely. This new job is the first time CI actually exercises "did the uploaded package get the source changes".

## Files changed

- `.github/workflows/beta_create.yml` — adds the `smoke-test-beta-picklists` job (additive; no changes to `upload-beta` / `install-beta`).
- `scripts/ci/smoke_picklist_propagation.py` — new script; parses field-meta.xml, calls `sf sobject describe`, diffs expected vs actual picklist values, exits 1 on mismatch with a clear failure summary listing likely causes.

## How failure looks

On a future picklist-propagation regression the job will print, for each missing value:

```
delivery__SyncItem__c.delivery__StatusPk__c: subscriber is MISSING picklist values ['Pending'].
Expected (from source): ['Queued', 'Staged', 'Pending', ...].
Got (from describe): ['Queued', 'Staged', ...].
```

...followed by the three likely root causes, and the workflow turns red — flagging the beta before it gets promoted.

## Extending

Add one `PicklistCheck(...)` entry to `EXPECTED_PICKLISTS` in the script. Expected values are auto-parsed from source `field-meta.xml`.

## Test plan

- [ ] Merge (or workflow_dispatch on this branch) to trigger `beta_create.yml` and confirm the new job runs, installs the beta on a fresh scratch, and passes the smoke test on current source.
- [ ] Verify `install-beta` still behaves unchanged (job is additive / parallel).
- [ ] Negative test (optional, in a follow-up scratch): add a new picklist value only to source, re-upload, confirm job turns red with the diff.
- [ ] Confirm the scratch-org cleanup step runs on failure (`if: always()`).