### PR TITLE
refactor(picklist): migrate 4 high-churn picklists to GlobalValueSet (Phase 2)

### DIFF
--- a/force-app/main/default/globalValueSets/DeliveryActivityActionType.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/DeliveryActivityActionType.globalValueSet-meta.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>Navigation</fullName>
+        <default>true</default>
+        <label>Navigation</label>
+    </customValue>
+    <customValue>
+        <fullName>Button_Click</fullName>
+        <default>false</default>
+        <label>Button Click</label>
+    </customValue>
+    <customValue>
+        <fullName>Feature_Use</fullName>
+        <default>false</default>
+        <label>Feature Use</label>
+    </customValue>
+    <customValue>
+        <fullName>Stage_Change</fullName>
+        <default>false</default>
+        <label>Stage Change</label>
+    </customValue>
+    <customValue>
+        <fullName>Search</fullName>
+        <default>false</default>
+        <label>Search</label>
+    </customValue>
+    <customValue>
+        <fullName>Error</fullName>
+        <default>false</default>
+        <label>Error</label>
+    </customValue>
+    <customValue>
+        <fullName>Field_Change</fullName>
+        <default>false</default>
+        <label>Field Change</label>
+    </customValue>
+    <customValue>
+        <fullName>Document_Action</fullName>
+        <default>false</default>
+        <label>Document Action</label>
+    </customValue>
+    <customValue>
+        <fullName>Portal_Hours_Logged</fullName>
+        <default>false</default>
+        <label>Portal Hours Logged</label>
+    </customValue>
+    <customValue>
+        <fullName>API_Request</fullName>
+        <default>false</default>
+        <label>API Request</label>
+    </customValue>
+    <masterLabel>Delivery Activity Action Type</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>

--- a/force-app/main/default/globalValueSets/DeliveryNotificationEventType.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/DeliveryNotificationEventType.globalValueSet-meta.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>Stage_Change</fullName>
+        <default>true</default>
+        <label>Stage Change</label>
+    </customValue>
+    <customValue>
+        <fullName>Escalation</fullName>
+        <default>false</default>
+        <label>Escalation</label>
+    </customValue>
+    <customValue>
+        <fullName>Document_Action</fullName>
+        <default>false</default>
+        <label>Document Action</label>
+    </customValue>
+    <customValue>
+        <fullName>Comment</fullName>
+        <default>false</default>
+        <label>Comment</label>
+    </customValue>
+    <customValue>
+        <fullName>Assignment</fullName>
+        <default>false</default>
+        <label>Assignment</label>
+    </customValue>
+    <masterLabel>Delivery Notification Event Type</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>

--- a/force-app/main/default/globalValueSets/DeliverySyncItemObjectType.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/DeliverySyncItemObjectType.globalValueSet-meta.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>WorkItemComment__c</fullName>
+        <default>false</default>
+        <label>WorkItemComment__c</label>
+    </customValue>
+    <customValue>
+        <fullName>ContentVersion</fullName>
+        <default>false</default>
+        <label>ContentVersion</label>
+    </customValue>
+    <customValue>
+        <fullName>WorkItem__c</fullName>
+        <default>false</default>
+        <label>WorkItem__c</label>
+    </customValue>
+    <customValue>
+        <fullName>NetworkEntity__c</fullName>
+        <default>false</default>
+        <label>NetworkEntity__c</label>
+    </customValue>
+    <customValue>
+        <fullName>WorkLog__c</fullName>
+        <default>false</default>
+        <label>WorkLog__c</label>
+    </customValue>
+    <customValue>
+        <fullName>UsageAnalytics</fullName>
+        <default>false</default>
+        <label>UsageAnalytics</label>
+    </customValue>
+    <customValue>
+        <fullName>BountyClaim__c</fullName>
+        <default>false</default>
+        <label>BountyClaim__c</label>
+    </customValue>
+    <masterLabel>Delivery Sync Item Object Type</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>

--- a/force-app/main/default/globalValueSets/DeliverySyncItemStatus.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/DeliverySyncItemStatus.globalValueSet-meta.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>Queued</fullName>
+        <default>false</default>
+        <label>Queued</label>
+    </customValue>
+    <customValue>
+        <fullName>Staged</fullName>
+        <default>false</default>
+        <label>Staged</label>
+    </customValue>
+    <customValue>
+        <fullName>Pending</fullName>
+        <default>false</default>
+        <label>Pending</label>
+    </customValue>
+    <customValue>
+        <fullName>Processing</fullName>
+        <default>false</default>
+        <label>Processing</label>
+    </customValue>
+    <customValue>
+        <fullName>Synced</fullName>
+        <default>false</default>
+        <label>Synced</label>
+    </customValue>
+    <customValue>
+        <fullName>Failed</fullName>
+        <default>false</default>
+        <label>Failed</label>
+    </customValue>
+    <masterLabel>Delivery Sync Item Status</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>

--- a/force-app/main/default/objects/ActivityLog__c/fields/ActionTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/ActivityLog__c/fields/ActionTypePk__c.field-meta.xml
@@ -7,22 +7,14 @@
     <required>false</required>
     <type>Picklist</type>
     <valueSet>
-        <!-- Non-restricted: unlocked packages don't reliably propagate new values
-             on subscriber upgrade when restricted=true (SF Known Issue
-             a028c00000qPzYUAA0). Integrity enforced at the service layer. -->
+        <!-- Phase 2 GVS migration: values live in
+             globalValueSets/DeliveryActivityActionType.globalValueSet-meta.xml so
+             new tracked action types propagate reliably on unlocked-package
+             upgrade (SF Known Issue a028c00000qPzYUAA0). restricted=false kept
+             temporarily from Phase 1 band-aid (PR #683); Phase 3 will flip back to
+             restricted=true once a real package-upgrade cycle has verified GVS
+             propagation. -->
         <restricted>false</restricted>
-        <valueSetDefinition>
-            <sorted>false</sorted>
-            <value><fullName>Navigation</fullName><default>true</default><label>Navigation</label></value>
-            <value><fullName>Button_Click</fullName><default>false</default><label>Button Click</label></value>
-            <value><fullName>Feature_Use</fullName><default>false</default><label>Feature Use</label></value>
-            <value><fullName>Stage_Change</fullName><default>false</default><label>Stage Change</label></value>
-            <value><fullName>Search</fullName><default>false</default><label>Search</label></value>
-            <value><fullName>Error</fullName><default>false</default><label>Error</label></value>
-            <value><fullName>Field_Change</fullName><default>false</default><label>Field Change</label></value>
-            <value><fullName>Document_Action</fullName><default>false</default><label>Document Action</label></value>
-            <value><fullName>Portal_Hours_Logged</fullName><default>false</default><label>Portal Hours Logged</label></value>
-            <value><fullName>API_Request</fullName><default>false</default><label>API Request</label></value>
-        </valueSetDefinition>
+        <valueSetName>DeliveryActivityActionType</valueSetName>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/NotificationPreference__c/fields/EventTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/NotificationPreference__c/fields/EventTypePk__c.field-meta.xml
@@ -7,17 +7,14 @@
     <required>false</required>
     <type>Picklist</type>
     <valueSet>
-        <!-- Non-restricted: unlocked packages don't reliably propagate new values
-             on subscriber upgrade when restricted=true (SF Known Issue
-             a028c00000qPzYUAA0). Integrity enforced at the service layer. -->
+        <!-- Phase 2 GVS migration: values live in
+             globalValueSets/DeliveryNotificationEventType.globalValueSet-meta.xml
+             so new notification event types propagate reliably on unlocked-package
+             upgrade (SF Known Issue a028c00000qPzYUAA0). restricted=false kept
+             temporarily from Phase 1 band-aid; Phase 3 will flip back to
+             restricted=true once a real package-upgrade cycle has verified GVS
+             propagation. -->
         <restricted>false</restricted>
-        <valueSetDefinition>
-            <sorted>false</sorted>
-            <value><fullName>Stage_Change</fullName><default>true</default><label>Stage Change</label></value>
-            <value><fullName>Escalation</fullName><default>false</default><label>Escalation</label></value>
-            <value><fullName>Document_Action</fullName><default>false</default><label>Document Action</label></value>
-            <value><fullName>Comment</fullName><default>false</default><label>Comment</label></value>
-            <value><fullName>Assignment</fullName><default>false</default><label>Assignment</label></value>
-        </valueSetDefinition>
+        <valueSetName>DeliveryNotificationEventType</valueSetName>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/SyncItem__c/fields/ObjectTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/SyncItem__c/fields/ObjectTypePk__c.field-meta.xml
@@ -8,47 +8,13 @@
     <trackTrending>false</trackTrending>
     <type>Picklist</type>
     <valueSet>
-        <!-- Non-restricted: unlocked packages don't reliably propagate new values
-             on subscriber upgrade when restricted=true (SF Known Issue
-             a028c00000qPzYUAA0). Integrity enforced at the service layer. -->
+        <!-- Phase 2 GVS migration: values live in
+             globalValueSets/DeliverySyncItemObjectType.globalValueSet-meta.xml so
+             new synced object types propagate reliably on unlocked-package upgrade
+             (SF Known Issue a028c00000qPzYUAA0). restricted=false kept temporarily
+             from Phase 1 band-aid; Phase 3 will flip back to restricted=true once
+             a real package-upgrade cycle has verified GVS propagation. -->
         <restricted>false</restricted>
-        <valueSetDefinition>
-            <sorted>false</sorted>
-            <value>
-                <fullName>WorkItemComment__c</fullName>
-                <default>false</default>
-                <label>WorkItemComment__c</label>
-            </value>
-            <value>
-                <fullName>ContentVersion</fullName>
-                <default>false</default>
-                <label>ContentVersion</label>
-            </value>
-            <value>
-                <fullName>WorkItem__c</fullName>
-                <default>false</default>
-                <label>WorkItem__c</label>
-            </value>
-            <value>
-                <fullName>NetworkEntity__c</fullName>
-                <default>false</default>
-                <label>NetworkEntity__c</label>
-            </value>
-            <value>
-                <fullName>WorkLog__c</fullName>
-                <default>false</default>
-                <label>WorkLog__c</label>
-            </value>
-            <value>
-                <fullName>UsageAnalytics</fullName>
-                <default>false</default>
-                <label>UsageAnalytics</label>
-            </value>
-            <value>
-                <fullName>BountyClaim__c</fullName>
-                <default>false</default>
-                <label>BountyClaim__c</label>
-            </value>
-        </valueSetDefinition>
+        <valueSetName>DeliverySyncItemObjectType</valueSetName>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/SyncItem__c/fields/StatusPk__c.field-meta.xml
+++ b/force-app/main/default/objects/SyncItem__c/fields/StatusPk__c.field-meta.xml
@@ -8,46 +8,13 @@
     <trackTrending>false</trackTrending>
     <type>Picklist</type>
     <valueSet>
-        <!-- Intentionally non-restricted: Salesforce unlocked packages do not
-             reliably propagate NEW restricted-picklist values to subscribers on
-             upgrade. Setting restricted=false lets new values (like Pending added
-             in v0.200) be accepted via DML on subscribers that upgrade, even when
-             the describe API hasn't refreshed. Integrity is enforced at the Apex
-             service layer (DeliverySyncEngine / DeliverySyncItemIngestor) where
-             the status transitions are gated. -->
+        <!-- Phase 2 GVS migration: values live in
+             globalValueSets/DeliverySyncItemStatus.globalValueSet-meta.xml so new
+             values propagate reliably on unlocked-package upgrade (SF Known Issue
+             a028c00000qPzYUAA0). restricted=false kept temporarily from Phase 1
+             band-aid (PR #682); Phase 3 will flip back to restricted=true once a
+             real package-upgrade cycle has verified GVS propagation end-to-end. -->
         <restricted>false</restricted>
-        <valueSetDefinition>
-            <sorted>false</sorted>
-            <value>
-                <fullName>Queued</fullName>
-                <default>false</default>
-                <label>Queued</label>
-            </value>
-            <value>
-                <fullName>Staged</fullName>
-                <default>false</default>
-                <label>Staged</label>
-            </value>
-            <value>
-                <fullName>Pending</fullName>
-                <default>false</default>
-                <label>Pending</label>
-            </value>
-            <value>
-                <fullName>Processing</fullName>
-                <default>false</default>
-                <label>Processing</label>
-            </value>
-            <value>
-                <fullName>Synced</fullName>
-                <default>false</default>
-                <label>Synced</label>
-            </value>
-            <value>
-                <fullName>Failed</fullName>
-                <default>false</default>
-                <label>Failed</label>
-            </value>
-        </valueSetDefinition>
+        <valueSetName>DeliverySyncItemStatus</valueSetName>
     </valueSet>
 </CustomField>


### PR DESCRIPTION
## Summary

Phase 2 of the restricted-picklist propagation fix documented in [`research-restricted-picklist-propagation.md`](../blob/main/research-restricted-picklist-propagation.md). Four fields that historically hit SF Known Issue `a028c00000qPzYUAA0` (inline `valueSetDefinition` additions silently dropped on unlocked-package upgrade) are migrated from inline value sets to `GlobalValueSet` references so future value additions propagate cleanly.

**Phase 1** (PRs #682 + #683) band-aided by flipping `<restricted>true</restricted>` to `false` so the current drain would accept new values. **Phase 2 (this PR)** moves the values out to global value sets. **Phase 3 (future PR)** will flip `<restricted>true</restricted>` back on once a real package-upgrade cycle verifies GVS propagation end-to-end.

## Changes

**New global value sets** (`force-app/main/default/globalValueSets/`):
- `DeliverySyncItemStatus.globalValueSet-meta.xml` - 6 values: Queued, Staged, Pending, Processing, Synced, Failed
- `DeliverySyncItemObjectType.globalValueSet-meta.xml` - 7 values: WorkItemComment__c, ContentVersion, WorkItem__c, NetworkEntity__c, WorkLog__c, UsageAnalytics, BountyClaim__c
- `DeliveryNotificationEventType.globalValueSet-meta.xml` - 5 values: Stage_Change (default), Escalation, Document_Action, Comment, Assignment
- `DeliveryActivityActionType.globalValueSet-meta.xml` - 10 values: Navigation (default), Button_Click, Feature_Use, Stage_Change, Search, Error, Field_Change, Document_Action, Portal_Hours_Logged, API_Request

**Modified fields** (inline `<valueSetDefinition>` swapped for `<valueSetName>`):
- `SyncItem__c/fields/StatusPk__c.field-meta.xml`
- `SyncItem__c/fields/ObjectTypePk__c.field-meta.xml`
- `NotificationPreference__c/fields/EventTypePk__c.field-meta.xml`
- `ActivityLog__c/fields/ActionTypePk__c.field-meta.xml`

No Apex or test changes. All existing tests use string literals (`'Queued'`, `'Navigation'`, `'Stage_Change'`, etc.) that still match the GVS values byte-for-byte, so no rewrites needed.

## Data preservation

Values, labels, and `<default>` flags are copied byte-for-byte from the prior inline definitions. Picklist storage is identical whether the source is inline or a GVS - the column stores the value `fullName` as a plain string. Existing rows are untouched, reports/formulas/flows keep working, and field history is unaffected.

## Constraints honored (per task brief)

- `<restricted>false</restricted>` **intentionally kept** from Phase 1. Do NOT flip to `true` in this PR; that is Phase 3 after GVS propagation is proven in a real package-upgrade cycle.
- Only the 4 HIGH-churn fields from the research audit table (StatusPk, ObjectTypePk, EventTypePk, ActionTypePk). Medium- and low-churn fields in the audit are untouched.
- No data migration automation (unchanged values = unchanged data).
- No `isUpdateable`/`isCreateable` guards, no hardcoded IDs, no reserved identifiers, no SOQL changes.
- Respects per CLAUDE.md: branch + PR workflow (not direct to main), `delivery__` ns awareness.

## Risks

- **GVS propagation validation**: per forcedotcom/cli #1933, the GVS+package-version-create combo had a bug on API v57. DH runs at `sourceApiVersion` 62; the research report judged this safe, but the true validation is installing the resulting beta on a subscriber org and running `sf sobject describe`.
- **First upgrade from inline -> GVS**: the field change AND the new GVS must ship in the same package version for the first migration. Both live in `force-app/main/default/` so they package together automatically - verify the beta build log includes the new `globalValueSets/` entries.
- **Phase 3 dependency**: this PR leaves DML integrity relaxed (per Phase 1). Apex service-layer guards in `DeliverySyncEngine` / `DeliverySyncItemIngestor` remain the integrity backstop until Phase 3.

## Follow-ups

- After this PR installs: run `sf sobject describe delivery__SyncItem__c` on MF-Prod / Nimba / dh-prod and verify all 6 StatusPk values, 7 ObjectTypePk values, 5 EventTypePk values, 10 ActionTypePk values appear. That is the true propagation test.
- After one upgrade cycle confirms propagation: open **Phase 3** PR to restore `<restricted>true</restricted>` on all 4 fields.

## Test plan

- [ ] Scratch-org feature-test passes (unchanged picklist values -> all existing tests should still pass)
- [ ] `upload-beta` succeeds (validates GVS + field metadata packages cleanly at sourceApiVersion 62)
- [ ] Post-install on a scratch: `sf sobject describe delivery__SyncItem__c` lists all 6 StatusPk values including `Pending`
- [ ] Post-install on a scratch: `sf sobject describe delivery__ActivityLog__c` lists all 10 ActionTypePk values
- [ ] Post-install on subscriber (MF-Prod/Nimba/dh-prod once beta installs): same describe checks
- [ ] Sanity-run a SyncItem__c insert with `StatusPk__c = 'Pending'` on a subscriber to confirm DML accepts it via the GVS-backed field

Refs: #682, #683, [`research-restricted-picklist-propagation.md`](../blob/main/research-restricted-picklist-propagation.md)