### PR TITLE
refactor(gvs): add 4 GlobalValueSets (Phase 2 step 1 of 2)

### DIFF
--- a/force-app/main/default/globalValueSets/DeliveryActivityActionType.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/DeliveryActivityActionType.globalValueSet-meta.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>Navigation</fullName>
+        <default>true</default>
+        <label>Navigation</label>
+    </customValue>
+    <customValue>
+        <fullName>Button_Click</fullName>
+        <default>false</default>
+        <label>Button Click</label>
+    </customValue>
+    <customValue>
+        <fullName>Feature_Use</fullName>
+        <default>false</default>
+        <label>Feature Use</label>
+    </customValue>
+    <customValue>
+        <fullName>Stage_Change</fullName>
+        <default>false</default>
+        <label>Stage Change</label>
+    </customValue>
+    <customValue>
+        <fullName>Search</fullName>
+        <default>false</default>
+        <label>Search</label>
+    </customValue>
+    <customValue>
+        <fullName>Error</fullName>
+        <default>false</default>
+        <label>Error</label>
+    </customValue>
+    <customValue>
+        <fullName>Field_Change</fullName>
+        <default>false</default>
+        <label>Field Change</label>
+    </customValue>
+    <customValue>
+        <fullName>Document_Action</fullName>
+        <default>false</default>
+        <label>Document Action</label>
+    </customValue>
+    <customValue>
+        <fullName>Portal_Hours_Logged</fullName>
+        <default>false</default>
+        <label>Portal Hours Logged</label>
+    </customValue>
+    <customValue>
+        <fullName>API_Request</fullName>
+        <default>false</default>
+        <label>API Request</label>
+    </customValue>
+    <masterLabel>Delivery Activity Action Type</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>

--- a/force-app/main/default/globalValueSets/DeliveryNotificationEventType.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/DeliveryNotificationEventType.globalValueSet-meta.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>Stage_Change</fullName>
+        <default>true</default>
+        <label>Stage Change</label>
+    </customValue>
+    <customValue>
+        <fullName>Escalation</fullName>
+        <default>false</default>
+        <label>Escalation</label>
+    </customValue>
+    <customValue>
+        <fullName>Document_Action</fullName>
+        <default>false</default>
+        <label>Document Action</label>
+    </customValue>
+    <customValue>
+        <fullName>Comment</fullName>
+        <default>false</default>
+        <label>Comment</label>
+    </customValue>
+    <customValue>
+        <fullName>Assignment</fullName>
+        <default>false</default>
+        <label>Assignment</label>
+    </customValue>
+    <masterLabel>Delivery Notification Event Type</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>

--- a/force-app/main/default/globalValueSets/DeliverySyncItemObjectType.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/DeliverySyncItemObjectType.globalValueSet-meta.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>WorkItemComment__c</fullName>
+        <default>false</default>
+        <label>WorkItemComment__c</label>
+    </customValue>
+    <customValue>
+        <fullName>ContentVersion</fullName>
+        <default>false</default>
+        <label>ContentVersion</label>
+    </customValue>
+    <customValue>
+        <fullName>WorkItem__c</fullName>
+        <default>false</default>
+        <label>WorkItem__c</label>
+    </customValue>
+    <customValue>
+        <fullName>NetworkEntity__c</fullName>
+        <default>false</default>
+        <label>NetworkEntity__c</label>
+    </customValue>
+    <customValue>
+        <fullName>WorkLog__c</fullName>
+        <default>false</default>
+        <label>WorkLog__c</label>
+    </customValue>
+    <customValue>
+        <fullName>UsageAnalytics</fullName>
+        <default>false</default>
+        <label>UsageAnalytics</label>
+    </customValue>
+    <customValue>
+        <fullName>BountyClaim__c</fullName>
+        <default>false</default>
+        <label>BountyClaim__c</label>
+    </customValue>
+    <masterLabel>Delivery Sync Item Object Type</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>

--- a/force-app/main/default/globalValueSets/DeliverySyncItemStatus.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/DeliverySyncItemStatus.globalValueSet-meta.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>Queued</fullName>
+        <default>false</default>
+        <label>Queued</label>
+    </customValue>
+    <customValue>
+        <fullName>Staged</fullName>
+        <default>false</default>
+        <label>Staged</label>
+    </customValue>
+    <customValue>
+        <fullName>Pending</fullName>
+        <default>false</default>
+        <label>Pending</label>
+    </customValue>
+    <customValue>
+        <fullName>Processing</fullName>
+        <default>false</default>
+        <label>Processing</label>
+    </customValue>
+    <customValue>
+        <fullName>Synced</fullName>
+        <default>false</default>
+        <label>Synced</label>
+    </customValue>
+    <customValue>
+        <fullName>Failed</fullName>
+        <default>false</default>
+        <label>Failed</label>
+    </customValue>
+    <masterLabel>Delivery Sync Item Status</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>


### PR DESCRIPTION
## Step 1 of 2

Splits PR #689 into two sequential deploys to work around the Salesforce deploy-order bug that blocked the single-PR migration.

**This PR:** adds 4 GlobalValueSets with no field-meta.xml changes. Should deploy cleanly.
**Follow-up PR:** once this is merged and installed, swap the 4 field-meta.xml files from inline \`valueSetDefinition\` to \`valueSetName\` pointing at the GVSs created here.

## The 4 GVSs

| GVS | Values | Current field |
|---|---|---|
| \`DeliverySyncItemStatus\` | 6 (Queued, Staged, Pending, Processing, Synced, Failed) | \`SyncItem__c.StatusPk__c\` |
| \`DeliverySyncItemObjectType\` | 7 | \`SyncItem__c.ObjectTypePk__c\` |
| \`DeliveryNotificationEventType\` | 5 (Stage_Change default) | \`NotificationPreference__c.EventTypePk__c\` |
| \`DeliveryActivityActionType\` | 10 (Navigation default) | \`ActivityLog__c.ActionTypePk__c\` |

Values match the existing inline \`valueSetDefinition\` byte-for-byte so Step 2 preserves row data.

## Why split

PR #689 attempted both steps in one bundle. SF deploy order: field-meta.xml \`<valueSetName>GlobalValueSetName</valueSetName>\` update ran **before** the GVS itself was created → field update failed → cascade through 16+ dependent classes → feature-test red. Splitting bypasses the ordering bug entirely.

## After this merges

The 4 GVSs exist in the org but no field references them yet. Step 2 PR swaps the field-meta.xml over, which then deploys cleanly because the references now resolve.