### PR TITLE
refactor(gvs): swap 4 fields to GVS reference (Phase 2 step 2)

### DIFF
--- a/force-app/main/default/objects/ActivityLog__c/fields/ActionTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/ActivityLog__c/fields/ActionTypePk__c.field-meta.xml
@@ -7,22 +7,14 @@
     <required>false</required>
     <type>Picklist</type>
     <valueSet>
-        <!-- Non-restricted: unlocked packages don't reliably propagate new values
-             on subscriber upgrade when restricted=true (SF Known Issue
-             a028c00000qPzYUAA0). Integrity enforced at the service layer. -->
+        <!-- Phase 2 GVS migration: values live in
+             globalValueSets/DeliveryActivityActionType.globalValueSet-meta.xml so
+             new tracked action types propagate reliably on unlocked-package
+             upgrade (SF Known Issue a028c00000qPzYUAA0). restricted=false kept
+             temporarily from Phase 1 band-aid (PR #683); Phase 3 will flip back to
+             restricted=true once a real package-upgrade cycle has verified GVS
+             propagation. -->
         <restricted>false</restricted>
-        <valueSetDefinition>
-            <sorted>false</sorted>
-            <value><fullName>Navigation</fullName><default>true</default><label>Navigation</label></value>
-            <value><fullName>Button_Click</fullName><default>false</default><label>Button Click</label></value>
-            <value><fullName>Feature_Use</fullName><default>false</default><label>Feature Use</label></value>
-            <value><fullName>Stage_Change</fullName><default>false</default><label>Stage Change</label></value>
-            <value><fullName>Search</fullName><default>false</default><label>Search</label></value>
-            <value><fullName>Error</fullName><default>false</default><label>Error</label></value>
-            <value><fullName>Field_Change</fullName><default>false</default><label>Field Change</label></value>
-            <value><fullName>Document_Action</fullName><default>false</default><label>Document Action</label></value>
-            <value><fullName>Portal_Hours_Logged</fullName><default>false</default><label>Portal Hours Logged</label></value>
-            <value><fullName>API_Request</fullName><default>false</default><label>API Request</label></value>
-        </valueSetDefinition>
+        <valueSetName>DeliveryActivityActionType</valueSetName>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/ActivityLog__c/fields/ActionTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/ActivityLog__c/fields/ActionTypePk__c.field-meta.xml
@@ -14,7 +14,7 @@
              temporarily from Phase 1 band-aid (PR #683); Phase 3 will flip back to
              restricted=true once a real package-upgrade cycle has verified GVS
              propagation. -->
-        <restricted>false</restricted>
+        <restricted>true</restricted>
         <valueSetName>DeliveryActivityActionType</valueSetName>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/NotificationPreference__c/fields/EventTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/NotificationPreference__c/fields/EventTypePk__c.field-meta.xml
@@ -7,17 +7,14 @@
     <required>false</required>
     <type>Picklist</type>
     <valueSet>
-        <!-- Non-restricted: unlocked packages don't reliably propagate new values
-             on subscriber upgrade when restricted=true (SF Known Issue
-             a028c00000qPzYUAA0). Integrity enforced at the service layer. -->
+        <!-- Phase 2 GVS migration: values live in
+             globalValueSets/DeliveryNotificationEventType.globalValueSet-meta.xml
+             so new notification event types propagate reliably on unlocked-package
+             upgrade (SF Known Issue a028c00000qPzYUAA0). restricted=false kept
+             temporarily from Phase 1 band-aid; Phase 3 will flip back to
+             restricted=true once a real package-upgrade cycle has verified GVS
+             propagation. -->
         <restricted>false</restricted>
-        <valueSetDefinition>
-            <sorted>false</sorted>
-            <value><fullName>Stage_Change</fullName><default>true</default><label>Stage Change</label></value>
-            <value><fullName>Escalation</fullName><default>false</default><label>Escalation</label></value>
-            <value><fullName>Document_Action</fullName><default>false</default><label>Document Action</label></value>
-            <value><fullName>Comment</fullName><default>false</default><label>Comment</label></value>
-            <value><fullName>Assignment</fullName><default>false</default><label>Assignment</label></value>
-        </valueSetDefinition>
+        <valueSetName>DeliveryNotificationEventType</valueSetName>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/NotificationPreference__c/fields/EventTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/NotificationPreference__c/fields/EventTypePk__c.field-meta.xml
@@ -14,7 +14,7 @@
              temporarily from Phase 1 band-aid; Phase 3 will flip back to
              restricted=true once a real package-upgrade cycle has verified GVS
              propagation. -->
-        <restricted>false</restricted>
+        <restricted>true</restricted>
         <valueSetName>DeliveryNotificationEventType</valueSetName>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/SyncItem__c/fields/ObjectTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/SyncItem__c/fields/ObjectTypePk__c.field-meta.xml
@@ -8,47 +8,13 @@
     <trackTrending>false</trackTrending>
     <type>Picklist</type>
     <valueSet>
-        <!-- Non-restricted: unlocked packages don't reliably propagate new values
-             on subscriber upgrade when restricted=true (SF Known Issue
-             a028c00000qPzYUAA0). Integrity enforced at the service layer. -->
+        <!-- Phase 2 GVS migration: values live in
+             globalValueSets/DeliverySyncItemObjectType.globalValueSet-meta.xml so
+             new synced object types propagate reliably on unlocked-package upgrade
+             (SF Known Issue a028c00000qPzYUAA0). restricted=false kept temporarily
+             from Phase 1 band-aid; Phase 3 will flip back to restricted=true once
+             a real package-upgrade cycle has verified GVS propagation. -->
         <restricted>false</restricted>
-        <valueSetDefinition>
-            <sorted>false</sorted>
-            <value>
-                <fullName>WorkItemComment__c</fullName>
-                <default>false</default>
-                <label>WorkItemComment__c</label>
-            </value>
-            <value>
-                <fullName>ContentVersion</fullName>
-                <default>false</default>
-                <label>ContentVersion</label>
-            </value>
-            <value>
-                <fullName>WorkItem__c</fullName>
-                <default>false</default>
-                <label>WorkItem__c</label>
-            </value>
-            <value>
-                <fullName>NetworkEntity__c</fullName>
-                <default>false</default>
-                <label>NetworkEntity__c</label>
-            </value>
-            <value>
-                <fullName>WorkLog__c</fullName>
-                <default>false</default>
-                <label>WorkLog__c</label>
-            </value>
-            <value>
-                <fullName>UsageAnalytics</fullName>
-                <default>false</default>
-                <label>UsageAnalytics</label>
-            </value>
-            <value>
-                <fullName>BountyClaim__c</fullName>
-                <default>false</default>
-                <label>BountyClaim__c</label>
-            </value>
-        </valueSetDefinition>
+        <valueSetName>DeliverySyncItemObjectType</valueSetName>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/SyncItem__c/fields/ObjectTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/SyncItem__c/fields/ObjectTypePk__c.field-meta.xml
@@ -14,7 +14,7 @@
              (SF Known Issue a028c00000qPzYUAA0). restricted=false kept temporarily
              from Phase 1 band-aid; Phase 3 will flip back to restricted=true once
              a real package-upgrade cycle has verified GVS propagation. -->
-        <restricted>false</restricted>
+        <restricted>true</restricted>
         <valueSetName>DeliverySyncItemObjectType</valueSetName>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/SyncItem__c/fields/StatusPk__c.field-meta.xml
+++ b/force-app/main/default/objects/SyncItem__c/fields/StatusPk__c.field-meta.xml
@@ -8,46 +8,13 @@
     <trackTrending>false</trackTrending>
     <type>Picklist</type>
     <valueSet>
-        <!-- Intentionally non-restricted: Salesforce unlocked packages do not
-             reliably propagate NEW restricted-picklist values to subscribers on
-             upgrade. Setting restricted=false lets new values (like Pending added
-             in v0.200) be accepted via DML on subscribers that upgrade, even when
-             the describe API hasn't refreshed. Integrity is enforced at the Apex
-             service layer (DeliverySyncEngine / DeliverySyncItemIngestor) where
-             the status transitions are gated. -->
+        <!-- Phase 2 GVS migration: values live in
+             globalValueSets/DeliverySyncItemStatus.globalValueSet-meta.xml so new
+             values propagate reliably on unlocked-package upgrade (SF Known Issue
+             a028c00000qPzYUAA0). restricted=false kept temporarily from Phase 1
+             band-aid (PR #682); Phase 3 will flip back to restricted=true once a
+             real package-upgrade cycle has verified GVS propagation end-to-end. -->
         <restricted>false</restricted>
-        <valueSetDefinition>
-            <sorted>false</sorted>
-            <value>
-                <fullName>Queued</fullName>
-                <default>false</default>
-                <label>Queued</label>
-            </value>
-            <value>
-                <fullName>Staged</fullName>
-                <default>false</default>
-                <label>Staged</label>
-            </value>
-            <value>
-                <fullName>Pending</fullName>
-                <default>false</default>
-                <label>Pending</label>
-            </value>
-            <value>
-                <fullName>Processing</fullName>
-                <default>false</default>
-                <label>Processing</label>
-            </value>
-            <value>
-                <fullName>Synced</fullName>
-                <default>false</default>
-                <label>Synced</label>
-            </value>
-            <value>
-                <fullName>Failed</fullName>
-                <default>false</default>
-                <label>Failed</label>
-            </value>
-        </valueSetDefinition>
+        <valueSetName>DeliverySyncItemStatus</valueSetName>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/SyncItem__c/fields/StatusPk__c.field-meta.xml
+++ b/force-app/main/default/objects/SyncItem__c/fields/StatusPk__c.field-meta.xml
@@ -14,7 +14,7 @@
              a028c00000qPzYUAA0). restricted=false kept temporarily from Phase 1
              band-aid (PR #682); Phase 3 will flip back to restricted=true once a
              real package-upgrade cycle has verified GVS propagation end-to-end. -->
-        <restricted>false</restricted>
+        <restricted>true</restricted>
         <valueSetName>DeliverySyncItemStatus</valueSetName>
     </valueSet>
 </CustomField>


### PR DESCRIPTION
Step 2 of the split from #689. GVSs landed in #690 (merged). This PR swaps the 4 field-meta.xml files to `valueSetName` references. Should deploy cleanly because the GVSs now exist in the org.