### PR TITLE
chore(security): scrub real client + person identifiers from public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,12 @@ MORNING_GAPS_REPORT.md
 /mfp-dump/
 /scripts/mfp-check/
 /scripts/scratch-verify/
+
+# MF-Prod data dumps (must never be committed)
+mfp*.json
+mfprod*.json
+*-describe.json
+*-clean.json
+mf-active-workitems.csv
+MORNING_*.md
+mfp-dump/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@
 - Existing inline-defined picklists stay `<restricted>false</restricted>`. Data integrity on those is enforced at the Apex service / trigger layer (see `DeliveryPicklistIntegrityService`), not via the field's restricted flag. This survives bulk-data-loader imports and subscriber customization.
 
 ## Org Aliases
-- `MF-Prod` — glen.bradford@nimbasolutions.com.mf123 (MF production)
+- `MF-Prod` — <your-prod-org-username>@<domain>.com
 - `nimba` — Nimba sandbox (where invoices are cut)
 - `dh-prod` — separate dev hub org (NOT Nimba)
 - Always use `delivery__` namespace prefix when running anonymous Apex on subscriber orgs.

--- a/force-app/main/default/classes/DeliveryWebhookNotifierTest.cls
+++ b/force-app/main/default/classes/DeliveryWebhookNotifierTest.cls
@@ -200,7 +200,7 @@ private class DeliveryWebhookNotifierTest {
             List<DeliveryDocEvent__e> events = new List<DeliveryDocEvent__e>{
                 new DeliveryDocEvent__e(
                     DocumentIdTxt__c = 'a0D000000000001AAA',
-                    EntityNameTxt__c = 'Mobilization Funding',
+                    EntityNameTxt__c = 'Acme Corp',
                     StatusTxt__c     = 'Generated',
                     TemplateTxt__c   = 'Invoice'
                 )

--- a/force-app/main/default/classes/DeliveryWorkLogTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkLogTriggerHandlerTest.cls
@@ -310,7 +310,7 @@ private class DeliveryWorkLogTriggerHandlerTest {
         // parent — the 8.5h phantom ledger problem.
         System.runAs(testUser) {
             NetworkEntity__c vendorTypedClient = new NetworkEntity__c(
-                Name = 'Mobilization Funding Prod (T-0129)',
+                Name = 'Acme Corp Prod (T-0001)',
                 EntityTypePk__c = 'Vendor', // NOT Client/Both → parent WorkItem would not push upstream
                 StatusPk__c = 'Active',
                 IntegrationEndpointUrlTxt__c = 'https://mf-prod.example.com'

--- a/force-app/main/default/staticresources/nimbusganttapp.resource
+++ b/force-app/main/default/staticresources/nimbusganttapp.resource
@@ -2664,9 +2664,9 @@ var NimbusGanttApp = (function(exports) {
     { category: "done", label: "Done", color: "#cbd5e1" }
   ];
   const CLOUD_NIMBUS_POOL = [
-    { name: "Glen", role: "Principal Engineer", hoursPerMonth: 80, active: true },
-    { name: "Mahi", role: "SFDC Dev", hoursPerMonth: 50, active: true },
-    { name: "Antima", role: "SFDC Dev (PT)", hoursPerMonth: 40, active: true }
+    { name: "Dev 4", role: "Principal Engineer", hoursPerMonth: 80, active: true },
+    { name: "Dev 1", role: "SFDC Dev", hoursPerMonth: 50, active: true },
+    { name: "Dev 3", role: "SFDC Dev (PT)", hoursPerMonth: 40, active: true }
   ];
   const CLS_TITLEBAR = "nga-titlebar bg-white border-b border-slate-200 px-3 py-1.5 flex flex-col gap-1.5 min-w-0 overflow-x-hidden";
   const CLS_TITLEBAR_ROW = "flex items-center gap-2 flex-wrap min-w-0";

--- a/scripts/load-more-data.apex
+++ b/scripts/load-more-data.apex
@@ -6,12 +6,12 @@
 //      --target-org test-bcqaurrchjr9@example.com
 // ─────────────────────────────────────────────────────────────────────────────
 
-// ── Step 1: Find the "Mobilization Funding" NetworkEntity __c ────────────────
+// ── Step 1: Find the "Acme Corp" NetworkEntity __c ────────────────
 List<NetworkEntity__c> entities = [
-    SELECT Id FROM NetworkEntity__c WHERE Name = 'Mobilization Funding' LIMIT 1
+    SELECT Id FROM NetworkEntity__c WHERE Name = 'Acme Corp' LIMIT 1
 ];
 if (entities.isEmpty()) {
-    System.debug('ERROR: NetworkEntity "Mobilization Funding" not found. Aborting.');
+    System.debug('ERROR: NetworkEntity "Acme Corp" not found. Aborting.');
     return;
 }
 Id entityId = entities[0].Id;


### PR DESCRIPTION
## Summary
Delivery-Hub is a public repo. This PR removes real client name ("Mobilization Funding"), real teammate names (Mahi etc.), real org user email, and internal planning docs that were accumulating in the public tree.

Paired with a local-workspace cleanup already done (MF-Prod JSON dumps removed, gitignore hardened).

## Changes
- 3 Apex files: 'Mobilization Funding' → 'Acme Corp'
- nimbusganttapp.resource IIFE: hardcoded names → 'Dev N'
- CLAUDE.md: real email → generic pattern
- Deleted 2 internal planning docs from /docs
- .gitignore: block future MF-Prod dumps

## Test plan
- [ ] CI green (Apex tests still pass with renamed string literals)
- [ ] No real names/emails remain: `grep -rn 'Mobilization Funding\|glen.bradford@nimbasolutions\|"Mahi"\|"Jared"\|"Antima"' force-app scripts CLAUDE.md docs` returns 0 hits