### PR TITLE
chore: gitignore dated planning/session docs in /docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ mfprod*.json
 mf-active-workitems.csv
 MORNING_*.md
 mfp-dump/
+
+# Dated planning / session docs (belong in private notes, not the public repo)
+docs/*_2026-*.md
+docs/*_2027-*.md


### PR DESCRIPTION
## Summary
Pairs with PR #695 (scrub). Adds `docs/*_2026-*.md` and `docs/*_2027-*.md` to .gitignore so dated working notes (SUBTRACT_GLEN_ROADMAP_2026-04-24.md, REPO_GAP_ANALYSIS_2026-04-24.md, and any future ones with the same date-stamped pattern) stay local without risk of accidental commit to this public repo.

## Test plan
- [x] \`git check-ignore docs/SUBTRACT_GLEN_ROADMAP_2026-04-24.md\` → matches
- [x] \`git check-ignore docs/REPO_GAP_ANALYSIS_2026-04-24.md\` → matches
- [ ] Existing non-dated docs (e.g. \`docs/INVOICE_DISPUTE_PATTERNS.md\`) still tracked normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)