### PR TITLE
fix(picklist): add WorkLog_Deferral to ActivityActionType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ mfprod*.json
 mf-active-workitems.csv
 MORNING_*.md
 mfp-dump/
+
+# Dated planning / session docs (belong in private notes, not the public repo)
+docs/*_2026-*.md
+docs/*_2027-*.md

--- a/force-app/main/default/objects/ActivityLog__c/fields/ActionTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/ActivityLog__c/fields/ActionTypePk__c.field-meta.xml
@@ -23,6 +23,7 @@
             <value><fullName>Document_Action</fullName><default>false</default><label>Document Action</label></value>
             <value><fullName>Portal_Hours_Logged</fullName><default>false</default><label>Portal Hours Logged</label></value>
             <value><fullName>API_Request</fullName><default>false</default><label>API Request</label></value>
+            <value><fullName>WorkLog_Deferral</fullName><default>false</default><label>WorkLog Deferral</label></value>
         </valueSetDefinition>
     </valueSet>
 </CustomField>


### PR DESCRIPTION
## Summary
- `DeliveryDocDeferralService.cls:275` inserts `ActivityLog__c` rows with `ActionTypePk__c = 'WorkLog_Deferral'`, but that value was missing from the picklist's `valueSetDefinition`.
- Field is non-restricted, so SF didn't hard-fail, but the picklist integrity service rejected the row at the trigger layer and the deferral telemetry was silently dropped.
- Single-line addition to the picklist closes the gap; the integrity service auto-allows defined values via describe, so no other code changes are needed.

## Test plan
- [ ] Verify deferral telemetry rows now insert successfully on next `/mf/*` defer-hours invocation (check `ActivityLog__c` for new rows with `ActionTypePk__c = 'WorkLog_Deferral'`).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>