### PR TITLE
fix(ci): wire github-service auth for post-install picklist smoke test

### DIFF
--- a/.github/workflows/beta_create.yml
+++ b/.github/workflows/beta_create.yml
@@ -74,8 +74,12 @@ jobs:
           dev-hub: true
 
       - name: Install Latest Beta (ci_beta flow) on Fresh Scratch
+        # CCI requires the github service as a JSON blob (username + token + email),
+        # not a bare token. Mirror the env-block from nimba-actions/run-flow so this
+        # job authenticates the same way `install-beta` does. `github.token` is the
+        # auto-generated GITHUB_TOKEN — always available, no extra secret config.
         env:
-          CUMULUSCI_SERVICE_github: ${{ secrets.CUMULUSCI_TOKEN }}
+          CUMULUSCI_SERVICE_github: '{"username": "${{ github.actor }}", "token": "${{ secrets.CUMULUSCI_TOKEN || github.token }}", "email": "cci@github.actions" }'
         run: |
           cci flow run ci_beta --org beta
 


### PR DESCRIPTION
## Summary

Fixes the `smoke-test-beta-picklists` job introduced in #688 that has been failing on every `Beta - Create (Unlocked)` run since merge. The job never gets to the actual picklist smoke test — it dies during `cci flow run ci_beta` because CCI can't authenticate to GitHub.

## Root Cause

Failing run for reference: https://github.com/Nimba-Solutions/Delivery-Hub/actions/runs/24897828154/job/72910915790

CCI emits this error on every run:

```
Error: Service env var CUMULUSCI_SERVICE_github cannot be loaded because
it is empty. Either set CUMULUSCI_SERVICE_github to a json string or
unset it from the environment.
```

Two compounding bugs in PR #688:

1. **Wrong format.** `CUMULUSCI_SERVICE_github` must be a JSON blob like `{"username": "...", "token": "...", "email": "..."}`, not a bare token. PR #688 set it to `${{ secrets.CUMULUSCI_TOKEN }}` (raw string).

2. **Empty value.** Even setting aside the format, `secrets.CUMULUSCI_TOKEN` rendered to empty in the smoke-test job's env scope. The repo has no repo-level secrets; the org-level `CUMULUSCI_TOKEN` flows through `workflow_call` `secrets:` blocks for `upload-beta` and `install-beta`, but the standalone smoke-test job referenced it directly and got nothing. Confirmed by inspecting the failing log: the env block prints literally `CUMULUSCI_SERVICE_github:` with no value.

The sibling `install-beta` job authenticates fine because it's a `workflow_call` to `nimba-actions/standard-workflows/install-beta.yml`, which delegates to `nimba-actions/run-flow`, which builds the JSON blob inline — using `github.token` (the auto-injected `GITHUB_TOKEN`) as a fallback when no explicit cci-token is provided.

## Fix

Mirror the exact env block used in `nimba-actions/run-flow`:

```yaml
env:
  CUMULUSCI_SERVICE_github: '{"username": "${{ github.actor }}", "token": "${{ secrets.CUMULUSCI_TOKEN || github.token }}", "email": "cci@github.actions" }'
```

`github.token` is always populated for the repo the workflow runs in — sufficient for `ci_beta` flow's package-version lookup against this same repo. `secrets.CUMULUSCI_TOKEN` is preferred when present (matches what `run-flow` does), and falling back avoids brittleness if the org secret is ever rotated/scoped.

## What's Not Changed

- Smoke test logic itself (`scripts/ci/smoke_picklist_propagation.py`) — untouched.
- The Apex / SOQL / describe-diff strategy from PR #688 — untouched.
- `upload-beta` and `install-beta` jobs — untouched (they were never broken).

## Test Plan

- [ ] Merge to main triggers `Beta - Create (Unlocked)`.
- [ ] Confirm `Smoke Test Beta 04t: Picklist Propagation` job gets past `Install Latest Beta (ci_beta flow) on Fresh Scratch` step.
- [ ] Confirm the actual picklist describe-diff runs (was previously skipped due to upstream step failure).
- [ ] If a green run shows the smoke-test detects no drift, the original PR #688 use case is operational.