### PR TITLE
fix(docs): post-insert verify SnapshotTxt persisted

### DIFF
--- a/force-app/main/default/classes/DeliveryDocGenerationService.cls
+++ b/force-app/main/default/classes/DeliveryDocGenerationService.cls
@@ -113,6 +113,25 @@ public with sharing class DeliveryDocGenerationService {
 
         Database.insert(doc, AccessLevel.SYSTEM_MODE);
 
+        // Defensive: confirm SnapshotTxt__c actually persisted. We've seen it
+        // silently null-strip on insert (likely FLS even with SYSTEM_MODE in
+        // some user contexts) — better to fail loudly here than ship a doc
+        // that quietly corrupts the supersede chain. PR #680 added a read-time
+        // live-rebuild as defense-in-depth; this is the write-time guard.
+        DeliveryDocument__c persisted = [
+            SELECT SnapshotTxt__c
+            FROM DeliveryDocument__c
+            WHERE Id = :doc.Id
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (String.isBlank(persisted.SnapshotTxt__c)) {
+            throw new AuraHandledException(
+                'Document generated but snapshot did not persist (likely FLS write-strip). ' +
+                'Generation aborted to prevent corruption. Contact Admin to verify SnapshotTxt__c FLS for the running user.'
+            );
+        }
+
         // Create signature slots for templates that require signing.
         // No-op for templates without DocumentTemplateSlot__mdt records configured.
         DeliveryDocActionService.createSlotsForTemplate(doc.Id, templateType, snapshot);


### PR DESCRIPTION
## Summary
- DOC-000002 shipped with a null `SnapshotTxt__c`, silently corrupting the supersede chain. Hypothesis: FLS write-strip dropped the Long Text Area fields at insert time even though the call uses `AccessLevel.SYSTEM_MODE`.
- PR #680 already added a read-time live-rebuild fallback in the renderer as defense-in-depth. This PR is the **write-time companion guard**: re-query the freshly-inserted `DeliveryDocument__c` and throw an `AuraHandledException` if `SnapshotTxt__c` is blank.
- One-file change in `DeliveryDocGenerationService.generateDocument`, ~15 lines, immediately after `Database.insert(doc, AccessLevel.SYSTEM_MODE)`.

## Why fail loud here
- A silent null-snapshot doc cannot be reconstructed reliably and breaks supersede-chain integrity.
- The partial insert is intentionally left in place so the failed `doc.Id` is queryable for forensics. The exception aborts the transaction in most callers anyway.
- Uses `WITH SYSTEM_MODE` per CLAUDE.md (namespaced package context).

## Test plan
- [ ] Existing `DeliveryDocGenerationServiceTest` (and any callers) still pass — the verifying SELECT works in test context with seeded data.
- [ ] Next document generation on dh-prod completes without throwing (= no FLS issue) **OR** throws clearly with the new message (= surfaces the actual FLS gap on `SnapshotTxt__c` for the running user).
- [ ] Glen reviews — do NOT auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)