### PR TITLE
fix(integration-framework): extract IntegrationDispatcherException to top-level

### DIFF
--- a/force-app/main/default/classes/IntegrationDispatcher.cls
+++ b/force-app/main/default/classes/IntegrationDispatcher.cls
@@ -47,9 +47,6 @@
  */
 public with sharing class IntegrationDispatcher {
 
-    /** @description Thrown when provider lookup or config is unusable. */
-    public class IntegrationDispatcherException extends Exception {}
-
     /**
      * @description Resolve the provider, render the request, send it, return
      *              the mapped result. Captures all exceptions and surfaces

--- a/force-app/main/default/classes/IntegrationDispatcherException.cls
+++ b/force-app/main/default/classes/IntegrationDispatcherException.cls
@@ -1,0 +1,10 @@
+/**
+ * @name         Delivery Hub · Integration Framework
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Exception type for IntegrationDispatcher errors. Extracted as
+ *              a top-level class because inner Exception classes don't
+ *              cleanly cross managed-package namespace boundaries when
+ *              referenced from test classes during package upload.
+ * @author       Cloud Nimbus LLC
+ */
+public class IntegrationDispatcherException extends Exception {}

--- a/force-app/main/default/classes/IntegrationDispatcherException.cls-meta.xml
+++ b/force-app/main/default/classes/IntegrationDispatcherException.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IntegrationDispatcherTest.cls
+++ b/force-app/main/default/classes/IntegrationDispatcherTest.cls
@@ -69,7 +69,7 @@ private class IntegrationDispatcherTest {
         Boolean threw = false;
         try {
             IntegrationDispatcher.buildRequest(cfg, new Map<String, Object>());
-        } catch (IntegrationDispatcher.IntegrationDispatcherException e) {
+        } catch (IntegrationDispatcherException e) {
             threw = true;
         }
         System.assertEquals(true, threw);
@@ -140,7 +140,7 @@ private class IntegrationDispatcherTest {
         Boolean threw = false;
         try {
             IntegrationDispatcher.applyExtension(cfg, req, new Map<String, Object>());
-        } catch (IntegrationDispatcher.IntegrationDispatcherException e) {
+        } catch (IntegrationDispatcherException e) {
             threw = true;
         }
         System.assertEquals(true, threw);
@@ -155,7 +155,7 @@ private class IntegrationDispatcherTest {
         Boolean threw = false;
         try {
             IntegrationDispatcher.applyExtension(cfg, req, new Map<String, Object>());
-        } catch (IntegrationDispatcher.IntegrationDispatcherException e) {
+        } catch (IntegrationDispatcherException e) {
             threw = true;
         }
         System.assertEquals(true, threw);
@@ -175,7 +175,7 @@ private class IntegrationDispatcherTest {
         Boolean threw = false;
         try {
             IntegrationDispatcher.resolveProvider('Definitely_Missing_99999');
-        } catch (IntegrationDispatcher.IntegrationDispatcherException e) {
+        } catch (IntegrationDispatcherException e) {
             threw = true;
         }
         System.assertEquals(true, threw);


### PR DESCRIPTION
Inner Exception class causes 'Invalid type: IntegrationDispatcher.IntegrationDispatcherException' error during managed-package upload. Move to top-level class.