### PR TITLE
fix(integration-framework): add missing IntegrationDispatcher.cls-meta.xml

### DIFF
--- a/force-app/main/default/classes/IntegrationDispatcher.cls-meta.xml
+++ b/force-app/main/default/classes/IntegrationDispatcher.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Force-add missing metadata XML that was preventing the IntegrationDispatcher class from deploying. Cascade-fixes all 'Variable does not exist: IntegrationDispatcher' errors in tests.