### PR TITLE
fix(escalation): invert backwards getNamespace() in 7 test files

### DIFF
--- a/force-app/main/default/classes/DeliveryCsvImportControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryCsvImportControllerTest.cls
@@ -19,8 +19,15 @@ public class DeliveryCsvImportControllerTest {
      * @return Namespace prefix with trailing __ or empty string
      */
     private static String getNamespace() {
+        // Backwards-fix 4/26: when running INSIDE the delivery package's own
+        // dev_namespaced scratch (cumulusci package upload), Organization.
+        // NamespacePrefix returns 'delivery' but Apex resolves the package's
+        // own fields WITHOUT prefix. Outside (subscriber org), fields need
+        // the 'delivery__' prefix. Previous logic was inverted — returned
+        // 'delivery__' inside the package's own namespace, breaking JSON
+        // deserialize of CMT records during package upload tests.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return String.isBlank(ns) ? '' : ns + '__';
+        return ns == 'delivery' ? '' : 'delivery__';
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryEscalationActionExecutorTest.cls
+++ b/force-app/main/default/classes/DeliveryEscalationActionExecutorTest.cls
@@ -549,8 +549,15 @@ private class DeliveryEscalationActionExecutorTest {
     // -- Helpers ---------------------------------------------------------------
 
     private static String getNamespace() {
+        // Backwards-fix 4/26: when running INSIDE the delivery package's own
+        // dev_namespaced scratch (cumulusci package upload), Organization.
+        // NamespacePrefix returns 'delivery' but Apex resolves the package's
+        // own fields WITHOUT prefix. Outside (subscriber org), fields need
+        // the 'delivery__' prefix. Previous logic was inverted — returned
+        // 'delivery__' inside the package's own namespace, breaking JSON
+        // deserialize of CMT records during package upload tests.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return String.isBlank(ns) ? '' : ns + '__';
+        return ns == 'delivery' ? '' : 'delivery__';
     }
 
     @SuppressWarnings('PMD.ExcessiveParameterList')

--- a/force-app/main/default/classes/DeliveryEscalationNotifServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryEscalationNotifServiceTest.cls
@@ -409,8 +409,15 @@ private class DeliveryEscalationNotifServiceTest {
     // -- Helpers ---------------------------------------------------------------
 
     private static String getNamespace() {
+        // Backwards-fix 4/26: when running INSIDE the delivery package's own
+        // dev_namespaced scratch (cumulusci package upload), Organization.
+        // NamespacePrefix returns 'delivery' but Apex resolves the package's
+        // own fields WITHOUT prefix. Outside (subscriber org), fields need
+        // the 'delivery__' prefix. Previous logic was inverted — returned
+        // 'delivery__' inside the package's own namespace, breaking JSON
+        // deserialize of CMT records during package upload tests.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return String.isBlank(ns) ? '' : ns + '__';
+        return ns == 'delivery' ? '' : 'delivery__';
     }
 
     @SuppressWarnings('PMD.ExcessiveParameterList')

--- a/force-app/main/default/classes/DeliveryEscalationRuleEvaluatorTest.cls
+++ b/force-app/main/default/classes/DeliveryEscalationRuleEvaluatorTest.cls
@@ -508,8 +508,15 @@ private class DeliveryEscalationRuleEvaluatorTest {
     // -- Helpers ---------------------------------------------------------------
 
     private static String getNamespace() {
+        // Backwards-fix 4/26: when running INSIDE the delivery package's own
+        // dev_namespaced scratch (cumulusci package upload), Organization.
+        // NamespacePrefix returns 'delivery' but Apex resolves the package's
+        // own fields WITHOUT prefix. Outside (subscriber org), fields need
+        // the 'delivery__' prefix. Previous logic was inverted — returned
+        // 'delivery__' inside the package's own namespace, breaking JSON
+        // deserialize of CMT records during package upload tests.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return String.isBlank(ns) ? '' : ns + '__';
+        return ns == 'delivery' ? '' : 'delivery__';
     }
 
     @SuppressWarnings('PMD.ExcessiveParameterList')

--- a/force-app/main/default/classes/DeliveryEscalationServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryEscalationServiceTest.cls
@@ -913,8 +913,15 @@ private class DeliveryEscalationServiceTest {
      * @return Namespace prefix with trailing __ or empty string
      */
     private static String getNamespace() {
+        // Backwards-fix 4/26: when running INSIDE the delivery package's own
+        // dev_namespaced scratch (cumulusci package upload), Organization.
+        // NamespacePrefix returns 'delivery' but Apex resolves the package's
+        // own fields WITHOUT prefix. Outside (subscriber org), fields need
+        // the 'delivery__' prefix. Previous logic was inverted — returned
+        // 'delivery__' inside the package's own namespace, breaking JSON
+        // deserialize of CMT records during package upload tests.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return String.isBlank(ns) ? '' : ns + '__';
+        return ns == 'delivery' ? '' : 'delivery__';
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryExternalNotificationServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryExternalNotificationServiceTest.cls
@@ -347,8 +347,15 @@ private class DeliveryExternalNotificationServiceTest {
     // -- Helpers ---------------------------------------------------------------
 
     private static String getNamespace() {
+        // Backwards-fix 4/26: when running INSIDE the delivery package's own
+        // dev_namespaced scratch (cumulusci package upload), Organization.
+        // NamespacePrefix returns 'delivery' but Apex resolves the package's
+        // own fields WITHOUT prefix. Outside (subscriber org), fields need
+        // the 'delivery__' prefix. Previous logic was inverted — returned
+        // 'delivery__' inside the package's own namespace, breaking JSON
+        // deserialize of CMT records during package upload tests.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return String.isBlank(ns) ? '' : ns + '__';
+        return ns == 'delivery' ? '' : 'delivery__';
     }
 
     @SuppressWarnings('PMD.ExcessiveParameterList')

--- a/force-app/main/default/classes/DeliveryHubPollerTest.cls
+++ b/force-app/main/default/classes/DeliveryHubPollerTest.cls
@@ -13,8 +13,15 @@ private class DeliveryHubPollerTest {
 
     // Helper to get the Org's namespace prefix
     private static String getNamespace() {
+        // Backwards-fix 4/26: when running INSIDE the delivery package's own
+        // dev_namespaced scratch (cumulusci package upload), Organization.
+        // NamespacePrefix returns 'delivery' but Apex resolves the package's
+        // own fields WITHOUT prefix. Outside (subscriber org), fields need
+        // the 'delivery__' prefix. Previous logic was inverted — returned
+        // 'delivery__' inside the package's own namespace, breaking JSON
+        // deserialize of CMT records during package upload tests.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return String.isBlank(ns) ? '' : ns + '__';
+        return ns == 'delivery' ? '' : 'delivery__';
     }
 
     @TestSetup


### PR DESCRIPTION
Memory-flagged fix: getNamespace() was returning 'delivery__' inside the package's own dev_namespaced scratch where fields resolve without prefix. JSON.deserialize for CMT records then silently produced empty objects, breaking all positive-result tests in DeliveryEscalationServiceTest + 5 other test files.