### PR TITLE
fix(escalation): correct getNamespace direction — install-beta context

### DIFF
--- a/force-app/main/default/classes/DeliveryCsvImportControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryCsvImportControllerTest.cls
@@ -19,15 +19,16 @@ public class DeliveryCsvImportControllerTest {
      * @return Namespace prefix with trailing __ or empty string
      */
     private static String getNamespace() {
-        // Backwards-fix 4/26: when running INSIDE the delivery package's own
-        // dev_namespaced scratch (cumulusci package upload), Organization.
-        // NamespacePrefix returns 'delivery' but Apex resolves the package's
-        // own fields WITHOUT prefix. Outside (subscriber org), fields need
-        // the 'delivery__' prefix. Previous logic was inverted — returned
-        // 'delivery__' inside the package's own namespace, breaking JSON
-        // deserialize of CMT records during package upload tests.
+        // CMT fields owned by the delivery package have actual API name
+        // 'delivery__FieldName__c'. Tests run in two contexts:
+        //   1. dev_namespaced scratch (Organization.NamespacePrefix='delivery'):
+        //      source-deployed code, fields exist as plain X__c at API level
+        //      because namespace IS the package's own — no prefix needed.
+        //   2. ci_beta scratch (Organization.NamespacePrefix=''):
+        //      package installed as subscriber, fields are delivery__X__c —
+        //      prefix required for JSON.deserialize key match.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return ns == 'delivery' ? '' : 'delivery__';
+        return String.isBlank(ns) ? 'delivery__' : '';
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryEscalationActionExecutorTest.cls
+++ b/force-app/main/default/classes/DeliveryEscalationActionExecutorTest.cls
@@ -549,15 +549,16 @@ private class DeliveryEscalationActionExecutorTest {
     // -- Helpers ---------------------------------------------------------------
 
     private static String getNamespace() {
-        // Backwards-fix 4/26: when running INSIDE the delivery package's own
-        // dev_namespaced scratch (cumulusci package upload), Organization.
-        // NamespacePrefix returns 'delivery' but Apex resolves the package's
-        // own fields WITHOUT prefix. Outside (subscriber org), fields need
-        // the 'delivery__' prefix. Previous logic was inverted — returned
-        // 'delivery__' inside the package's own namespace, breaking JSON
-        // deserialize of CMT records during package upload tests.
+        // CMT fields owned by the delivery package have actual API name
+        // 'delivery__FieldName__c'. Tests run in two contexts:
+        //   1. dev_namespaced scratch (Organization.NamespacePrefix='delivery'):
+        //      source-deployed code, fields exist as plain X__c at API level
+        //      because namespace IS the package's own — no prefix needed.
+        //   2. ci_beta scratch (Organization.NamespacePrefix=''):
+        //      package installed as subscriber, fields are delivery__X__c —
+        //      prefix required for JSON.deserialize key match.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return ns == 'delivery' ? '' : 'delivery__';
+        return String.isBlank(ns) ? 'delivery__' : '';
     }
 
     @SuppressWarnings('PMD.ExcessiveParameterList')

--- a/force-app/main/default/classes/DeliveryEscalationNotifServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryEscalationNotifServiceTest.cls
@@ -409,15 +409,16 @@ private class DeliveryEscalationNotifServiceTest {
     // -- Helpers ---------------------------------------------------------------
 
     private static String getNamespace() {
-        // Backwards-fix 4/26: when running INSIDE the delivery package's own
-        // dev_namespaced scratch (cumulusci package upload), Organization.
-        // NamespacePrefix returns 'delivery' but Apex resolves the package's
-        // own fields WITHOUT prefix. Outside (subscriber org), fields need
-        // the 'delivery__' prefix. Previous logic was inverted — returned
-        // 'delivery__' inside the package's own namespace, breaking JSON
-        // deserialize of CMT records during package upload tests.
+        // CMT fields owned by the delivery package have actual API name
+        // 'delivery__FieldName__c'. Tests run in two contexts:
+        //   1. dev_namespaced scratch (Organization.NamespacePrefix='delivery'):
+        //      source-deployed code, fields exist as plain X__c at API level
+        //      because namespace IS the package's own — no prefix needed.
+        //   2. ci_beta scratch (Organization.NamespacePrefix=''):
+        //      package installed as subscriber, fields are delivery__X__c —
+        //      prefix required for JSON.deserialize key match.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return ns == 'delivery' ? '' : 'delivery__';
+        return String.isBlank(ns) ? 'delivery__' : '';
     }
 
     @SuppressWarnings('PMD.ExcessiveParameterList')

--- a/force-app/main/default/classes/DeliveryEscalationRuleEvaluatorTest.cls
+++ b/force-app/main/default/classes/DeliveryEscalationRuleEvaluatorTest.cls
@@ -508,15 +508,16 @@ private class DeliveryEscalationRuleEvaluatorTest {
     // -- Helpers ---------------------------------------------------------------
 
     private static String getNamespace() {
-        // Backwards-fix 4/26: when running INSIDE the delivery package's own
-        // dev_namespaced scratch (cumulusci package upload), Organization.
-        // NamespacePrefix returns 'delivery' but Apex resolves the package's
-        // own fields WITHOUT prefix. Outside (subscriber org), fields need
-        // the 'delivery__' prefix. Previous logic was inverted — returned
-        // 'delivery__' inside the package's own namespace, breaking JSON
-        // deserialize of CMT records during package upload tests.
+        // CMT fields owned by the delivery package have actual API name
+        // 'delivery__FieldName__c'. Tests run in two contexts:
+        //   1. dev_namespaced scratch (Organization.NamespacePrefix='delivery'):
+        //      source-deployed code, fields exist as plain X__c at API level
+        //      because namespace IS the package's own — no prefix needed.
+        //   2. ci_beta scratch (Organization.NamespacePrefix=''):
+        //      package installed as subscriber, fields are delivery__X__c —
+        //      prefix required for JSON.deserialize key match.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return ns == 'delivery' ? '' : 'delivery__';
+        return String.isBlank(ns) ? 'delivery__' : '';
     }
 
     @SuppressWarnings('PMD.ExcessiveParameterList')

--- a/force-app/main/default/classes/DeliveryEscalationServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryEscalationServiceTest.cls
@@ -913,15 +913,16 @@ private class DeliveryEscalationServiceTest {
      * @return Namespace prefix with trailing __ or empty string
      */
     private static String getNamespace() {
-        // Backwards-fix 4/26: when running INSIDE the delivery package's own
-        // dev_namespaced scratch (cumulusci package upload), Organization.
-        // NamespacePrefix returns 'delivery' but Apex resolves the package's
-        // own fields WITHOUT prefix. Outside (subscriber org), fields need
-        // the 'delivery__' prefix. Previous logic was inverted — returned
-        // 'delivery__' inside the package's own namespace, breaking JSON
-        // deserialize of CMT records during package upload tests.
+        // CMT fields owned by the delivery package have actual API name
+        // 'delivery__FieldName__c'. Tests run in two contexts:
+        //   1. dev_namespaced scratch (Organization.NamespacePrefix='delivery'):
+        //      source-deployed code, fields exist as plain X__c at API level
+        //      because namespace IS the package's own — no prefix needed.
+        //   2. ci_beta scratch (Organization.NamespacePrefix=''):
+        //      package installed as subscriber, fields are delivery__X__c —
+        //      prefix required for JSON.deserialize key match.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return ns == 'delivery' ? '' : 'delivery__';
+        return String.isBlank(ns) ? 'delivery__' : '';
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryExternalNotificationServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryExternalNotificationServiceTest.cls
@@ -347,15 +347,16 @@ private class DeliveryExternalNotificationServiceTest {
     // -- Helpers ---------------------------------------------------------------
 
     private static String getNamespace() {
-        // Backwards-fix 4/26: when running INSIDE the delivery package's own
-        // dev_namespaced scratch (cumulusci package upload), Organization.
-        // NamespacePrefix returns 'delivery' but Apex resolves the package's
-        // own fields WITHOUT prefix. Outside (subscriber org), fields need
-        // the 'delivery__' prefix. Previous logic was inverted — returned
-        // 'delivery__' inside the package's own namespace, breaking JSON
-        // deserialize of CMT records during package upload tests.
+        // CMT fields owned by the delivery package have actual API name
+        // 'delivery__FieldName__c'. Tests run in two contexts:
+        //   1. dev_namespaced scratch (Organization.NamespacePrefix='delivery'):
+        //      source-deployed code, fields exist as plain X__c at API level
+        //      because namespace IS the package's own — no prefix needed.
+        //   2. ci_beta scratch (Organization.NamespacePrefix=''):
+        //      package installed as subscriber, fields are delivery__X__c —
+        //      prefix required for JSON.deserialize key match.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return ns == 'delivery' ? '' : 'delivery__';
+        return String.isBlank(ns) ? 'delivery__' : '';
     }
 
     @SuppressWarnings('PMD.ExcessiveParameterList')

--- a/force-app/main/default/classes/DeliveryHubPollerTest.cls
+++ b/force-app/main/default/classes/DeliveryHubPollerTest.cls
@@ -13,15 +13,16 @@ private class DeliveryHubPollerTest {
 
     // Helper to get the Org's namespace prefix
     private static String getNamespace() {
-        // Backwards-fix 4/26: when running INSIDE the delivery package's own
-        // dev_namespaced scratch (cumulusci package upload), Organization.
-        // NamespacePrefix returns 'delivery' but Apex resolves the package's
-        // own fields WITHOUT prefix. Outside (subscriber org), fields need
-        // the 'delivery__' prefix. Previous logic was inverted — returned
-        // 'delivery__' inside the package's own namespace, breaking JSON
-        // deserialize of CMT records during package upload tests.
+        // CMT fields owned by the delivery package have actual API name
+        // 'delivery__FieldName__c'. Tests run in two contexts:
+        //   1. dev_namespaced scratch (Organization.NamespacePrefix='delivery'):
+        //      source-deployed code, fields exist as plain X__c at API level
+        //      because namespace IS the package's own — no prefix needed.
+        //   2. ci_beta scratch (Organization.NamespacePrefix=''):
+        //      package installed as subscriber, fields are delivery__X__c —
+        //      prefix required for JSON.deserialize key match.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return ns == 'delivery' ? '' : 'delivery__';
+        return String.isBlank(ns) ? 'delivery__' : '';
     }
 
     @TestSetup


### PR DESCRIPTION
PR #713 inverted the wrong way. install-beta runs in subscriber scratch (NS='') where installed fields are delivery__X__c — JSON keys need the prefix.