### PR TITLE
revert(escalation): restore pre-PR713/715 getNamespace logic — escalation breakage predates today by 3 weeks

### DIFF
--- a/force-app/main/default/classes/DeliveryCsvImportControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryCsvImportControllerTest.cls
@@ -19,16 +19,8 @@ public class DeliveryCsvImportControllerTest {
      * @return Namespace prefix with trailing __ or empty string
      */
     private static String getNamespace() {
-        // CMT fields owned by the delivery package have actual API name
-        // 'delivery__FieldName__c'. Tests run in two contexts:
-        //   1. dev_namespaced scratch (Organization.NamespacePrefix='delivery'):
-        //      source-deployed code, fields exist as plain X__c at API level
-        //      because namespace IS the package's own — no prefix needed.
-        //   2. ci_beta scratch (Organization.NamespacePrefix=''):
-        //      package installed as subscriber, fields are delivery__X__c —
-        //      prefix required for JSON.deserialize key match.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return String.isBlank(ns) ? 'delivery__' : '';
+        return String.isBlank(ns) ? '' : ns + '__';
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryEscalationActionExecutorTest.cls
+++ b/force-app/main/default/classes/DeliveryEscalationActionExecutorTest.cls
@@ -549,16 +549,8 @@ private class DeliveryEscalationActionExecutorTest {
     // -- Helpers ---------------------------------------------------------------
 
     private static String getNamespace() {
-        // CMT fields owned by the delivery package have actual API name
-        // 'delivery__FieldName__c'. Tests run in two contexts:
-        //   1. dev_namespaced scratch (Organization.NamespacePrefix='delivery'):
-        //      source-deployed code, fields exist as plain X__c at API level
-        //      because namespace IS the package's own — no prefix needed.
-        //   2. ci_beta scratch (Organization.NamespacePrefix=''):
-        //      package installed as subscriber, fields are delivery__X__c —
-        //      prefix required for JSON.deserialize key match.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return String.isBlank(ns) ? 'delivery__' : '';
+        return String.isBlank(ns) ? '' : ns + '__';
     }
 
     @SuppressWarnings('PMD.ExcessiveParameterList')

--- a/force-app/main/default/classes/DeliveryEscalationNotifServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryEscalationNotifServiceTest.cls
@@ -409,16 +409,8 @@ private class DeliveryEscalationNotifServiceTest {
     // -- Helpers ---------------------------------------------------------------
 
     private static String getNamespace() {
-        // CMT fields owned by the delivery package have actual API name
-        // 'delivery__FieldName__c'. Tests run in two contexts:
-        //   1. dev_namespaced scratch (Organization.NamespacePrefix='delivery'):
-        //      source-deployed code, fields exist as plain X__c at API level
-        //      because namespace IS the package's own — no prefix needed.
-        //   2. ci_beta scratch (Organization.NamespacePrefix=''):
-        //      package installed as subscriber, fields are delivery__X__c —
-        //      prefix required for JSON.deserialize key match.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return String.isBlank(ns) ? 'delivery__' : '';
+        return String.isBlank(ns) ? '' : ns + '__';
     }
 
     @SuppressWarnings('PMD.ExcessiveParameterList')

--- a/force-app/main/default/classes/DeliveryEscalationRuleEvaluatorTest.cls
+++ b/force-app/main/default/classes/DeliveryEscalationRuleEvaluatorTest.cls
@@ -508,16 +508,8 @@ private class DeliveryEscalationRuleEvaluatorTest {
     // -- Helpers ---------------------------------------------------------------
 
     private static String getNamespace() {
-        // CMT fields owned by the delivery package have actual API name
-        // 'delivery__FieldName__c'. Tests run in two contexts:
-        //   1. dev_namespaced scratch (Organization.NamespacePrefix='delivery'):
-        //      source-deployed code, fields exist as plain X__c at API level
-        //      because namespace IS the package's own — no prefix needed.
-        //   2. ci_beta scratch (Organization.NamespacePrefix=''):
-        //      package installed as subscriber, fields are delivery__X__c —
-        //      prefix required for JSON.deserialize key match.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return String.isBlank(ns) ? 'delivery__' : '';
+        return String.isBlank(ns) ? '' : ns + '__';
     }
 
     @SuppressWarnings('PMD.ExcessiveParameterList')

--- a/force-app/main/default/classes/DeliveryEscalationServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryEscalationServiceTest.cls
@@ -913,16 +913,8 @@ private class DeliveryEscalationServiceTest {
      * @return Namespace prefix with trailing __ or empty string
      */
     private static String getNamespace() {
-        // CMT fields owned by the delivery package have actual API name
-        // 'delivery__FieldName__c'. Tests run in two contexts:
-        //   1. dev_namespaced scratch (Organization.NamespacePrefix='delivery'):
-        //      source-deployed code, fields exist as plain X__c at API level
-        //      because namespace IS the package's own — no prefix needed.
-        //   2. ci_beta scratch (Organization.NamespacePrefix=''):
-        //      package installed as subscriber, fields are delivery__X__c —
-        //      prefix required for JSON.deserialize key match.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return String.isBlank(ns) ? 'delivery__' : '';
+        return String.isBlank(ns) ? '' : ns + '__';
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryExternalNotificationServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryExternalNotificationServiceTest.cls
@@ -347,16 +347,8 @@ private class DeliveryExternalNotificationServiceTest {
     // -- Helpers ---------------------------------------------------------------
 
     private static String getNamespace() {
-        // CMT fields owned by the delivery package have actual API name
-        // 'delivery__FieldName__c'. Tests run in two contexts:
-        //   1. dev_namespaced scratch (Organization.NamespacePrefix='delivery'):
-        //      source-deployed code, fields exist as plain X__c at API level
-        //      because namespace IS the package's own — no prefix needed.
-        //   2. ci_beta scratch (Organization.NamespacePrefix=''):
-        //      package installed as subscriber, fields are delivery__X__c —
-        //      prefix required for JSON.deserialize key match.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return String.isBlank(ns) ? 'delivery__' : '';
+        return String.isBlank(ns) ? '' : ns + '__';
     }
 
     @SuppressWarnings('PMD.ExcessiveParameterList')

--- a/force-app/main/default/classes/DeliveryHubPollerTest.cls
+++ b/force-app/main/default/classes/DeliveryHubPollerTest.cls
@@ -13,16 +13,8 @@ private class DeliveryHubPollerTest {
 
     // Helper to get the Org's namespace prefix
     private static String getNamespace() {
-        // CMT fields owned by the delivery package have actual API name
-        // 'delivery__FieldName__c'. Tests run in two contexts:
-        //   1. dev_namespaced scratch (Organization.NamespacePrefix='delivery'):
-        //      source-deployed code, fields exist as plain X__c at API level
-        //      because namespace IS the package's own — no prefix needed.
-        //   2. ci_beta scratch (Organization.NamespacePrefix=''):
-        //      package installed as subscriber, fields are delivery__X__c —
-        //      prefix required for JSON.deserialize key match.
         String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return String.isBlank(ns) ? 'delivery__' : '';
+        return String.isBlank(ns) ? '' : ns + '__';
     }
 
     @TestSetup


### PR DESCRIPTION
Beta_create has 100 consecutive failures back to 4/7. The 4/8 revert commit (PR #617) explicitly punted: 'Whatever the real root cause is, it is NOT a getNamespace prefix bug.'

I spent 2hr iterating on getNamespace() and all attempts failed. Restoring to pre-PR713 baseline so the code isn't in a worse state. The escalation test failures need a separate engagement with proper investigation.

Today's shippable wins still on main: Phase 0 sync fix (PR 700), picklist integrity deprecation (711), smoke test removal (712), integration framework spine, EnableETAAutoRecalcDateTime__c toggle. These can't ship via beta_create due to the pre-existing escalation breakage.