### PR TITLE
fix(sync): add PriorityGroupPk__c to syncFields for gantt grouping

### DIFF
--- a/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
@@ -54,6 +54,11 @@ public without sharing class DeliveryWorkItemTriggerHandler {
             'StageNamePk__c',
             'StatusPk__c',
             'PriorityPk__c',
+            // PriorityGroupPk__c drives gantt grouping (NOW / NEXT / PROPOSED).
+            // Without this in syncFields the field stays null on subscriber orgs
+            // and the timeline groups collapse to a single default bucket — even
+            // though the source has top-priority/active/etc populated correctly.
+            'PriorityGroupPk__c',
             'DeveloperDaysSizeNumber__c',
             'EstimatedHoursNumber__c',
             'ClientPreApprovedHoursNumber__c',

--- a/force-app/main/default/classes/DeliveryWorkItemTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemTriggerHandlerTest.cls
@@ -154,6 +154,35 @@ public class DeliveryWorkItemTriggerHandlerTest {
     }
 
     @IsTest
+    static void testPriorityGroupChangeQueuesSync() {
+        // Regression guard: PriorityGroupPk__c drives gantt grouping
+        // (NOW / NEXT / PROPOSED). Without the field in syncFields, subscriber
+        // orgs receive the record with a null group and the timeline collapses.
+        System.runAs(testUser) {
+            WorkItem__c t = [SELECT Id FROM WorkItem__c LIMIT 1];
+            NetworkEntity__c v = [SELECT Id FROM NetworkEntity__c LIMIT 1];
+            insert new WorkRequest__c(WorkItemId__c = t.Id, DeliveryEntityLookup__c = v.Id, StatusPk__c = 'Active', RemoteWorkItemIdTxt__c = 'R-PG');
+            delete [SELECT Id FROM SyncItem__c];
+
+            Test.startTest();
+            t.PriorityGroupPk__c = 'top-priority';
+            update t;
+            Test.stopTest();
+
+            List<SyncItem__c> items = [SELECT Id, PayloadTxt__c FROM SyncItem__c WHERE WorkItemLookup__c = :t.Id];
+            System.assert(items.size() >= 1, 'PriorityGroupPk__c change should queue a sync item');
+            Boolean payloadCarriesField = false;
+            for (SyncItem__c si : items) {
+                if (si.PayloadTxt__c != null && si.PayloadTxt__c.contains('PriorityGroupPk__c')) {
+                    payloadCarriesField = true;
+                    break;
+                }
+            }
+            System.assert(payloadCarriesField, 'Outbound payload must carry PriorityGroupPk__c');
+        }
+    }
+
+    @IsTest
     static void testInboundSyncContextSkipsAutoActivate() {
         // Regression guard: when inboundSyncContext = true (set by the
         // sync ingestor), handleBeforeInsert must NOT auto-set


### PR DESCRIPTION
## Issue

**Symptom:** After 0.210 the timelines on MF-Prod and nimba have identical 13 active items, but on nimba the priority-group sections (NOW / NEXT / PROPOSED) collapse because every record has \`delivery__PriorityGroupPk__c = null\`. MF-Prod has \`top-priority\` × 12, \`active\` × 1.

**Root cause:** \`PriorityGroupPk__c\` was missing from \`DeliveryWorkItemTriggerHandler.syncFields\`, so changes to that field never queue an outbound payload — subscribers stay at null forever.

## Fix

Add \`PriorityGroupPk__c\` to \`syncFields\`. New regression test \`testPriorityGroupChangeQueuesSync\` asserts a \`PriorityGroupPk__c\` change both queues a \`SyncItem__c\` and that the payload carries the field name.

## Test plan

- [ ] PMD passes
- [ ] Apex tests pass
- [ ] Beta install on MF-Prod / nimba / dh-prod
- [ ] Tactical hotfix mirrors current MF-Prod values to nimba so timeline groups match immediately
- [ ] Verify nimba \`/lightning/n/delivery__Delivery_Timeline\` shows NOW / NEXT / PROPOSED sections matching MF-Prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)