### PR TITLE
fix(sync): translate ParentWorkItemLookup__c cross-org via ledger

### DIFF
--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -558,6 +558,9 @@ public without sharing class DeliverySyncItemIngestor {
      * @description Cast a string to an Id and confirm it points at a local
      *              WorkItem__c record. Returns null on any cast/describe failure
      *              (silent — callers fall through to other resolution strategies).
+     * @param candidate String that may or may not be a local 15/18-char WorkItem__c Id.
+     * @return Validated WorkItem__c Id, or null if the cast fails or the
+     *         resulting record points at a different SObject type.
      */
     private static Id tryAsLocalWorkItemId(String candidate) {
         if (String.isBlank(candidate)) {

--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -195,6 +195,62 @@ public without sharing class DeliverySyncItemIngestor {
             fieldPayload.remove('delivery__RequestId__c');
         }
 
+        // Cross-org parent FK translation for WorkItem__c: the payload's
+        // ParentWorkItemLookup__c is the sender-org Id and won't resolve locally.
+        // Use the SyncItem ledger to find the local twin; if not found yet
+        // (parent hasn't synced), leave unset — child arrives flat and re-syncs
+        // when source touches the field again. Children typically follow parents
+        // in dispatch order, so the not-found case is rare.
+        if (objectType.endsWithIgnoreCase('WorkItem__c') && !objectType.endsWithIgnoreCase('WorkItemComment__c')) {
+            Object parentRefRaw = payload.get('ParentWorkItemLookup__c');
+            if (parentRefRaw == null) {
+                parentRefRaw = payload.get('delivery__ParentWorkItemLookup__c');
+            }
+            String parentRef = parentRefRaw == null ? null : String.valueOf(parentRefRaw);
+            if (String.isNotBlank(parentRef)) {
+                // WorkItem and WorkLog branches are mutually exclusive on objectType,
+                // so fieldPayload still aliases payload here — clone to avoid mutating
+                // the caller's map and to strip the cross-org Id before mapFields runs
+                // (otherwise mapFields would attempt to write a stranger-org Id into
+                // the Lookup field and fail with INVALID_CROSS_REFERENCE_KEY).
+                fieldPayload = new Map<String, Object>(payload);
+                fieldPayload.remove('ParentWorkItemLookup__c');
+                fieldPayload.remove('delivery__ParentWorkItemLookup__c');
+
+                Id localParent = null;
+                List<SyncItem__c> parentLedger = [
+                    SELECT LocalRecordIdTxt__c FROM SyncItem__c
+                    WHERE RemoteExternalIdTxt__c = :parentRef
+                      AND ObjectTypePk__c = 'WorkItem__c'
+                    WITH SYSTEM_MODE
+                    LIMIT 1
+                ];
+                if (!parentLedger.isEmpty() && String.isNotBlank((String) parentLedger[0].LocalRecordIdTxt__c)) {
+                    try { localParent = (Id) parentLedger[0].LocalRecordIdTxt__c; } catch (Exception e) {
+                        System.debug(LoggingLevel.FINE, 'Parent ledger Id cast failed: ' + e.getMessage());
+                    }
+                }
+                // Fallback: maybe parentRef is already a valid local Id (echo path).
+                if (localParent == null) {
+                    try {
+                        Id castId = (Id) parentRef;
+                        if (castId.getSobjectType().getDescribe().getName().endsWithIgnoreCase('WorkItem__c')) {
+                            localParent = castId;
+                        }
+                    } catch (Exception e) {
+                        System.debug(LoggingLevel.FINE, 'Parent ref local-Id fallback failed: ' + e.getMessage());
+                    }
+                }
+                if (localParent != null) {
+                    putSafe(recordToUpsert, 'ParentWorkItemLookup__c', localParent);
+                }
+                // If localParent is null, we deliberately leave the field unset.
+                // Children typically arrive after parents in dispatcher order; the
+                // rare out-of-order case heals when the source touches the field
+                // and re-emits the payload (eventual consistency).
+            }
+        }
+
         mapFields(recordToUpsert, fieldPayload, targetType);
 
         // ==========================================

--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -232,14 +232,7 @@ public without sharing class DeliverySyncItemIngestor {
                 }
                 // Fallback: maybe parentRef is already a valid local Id (echo path).
                 if (localParent == null) {
-                    try {
-                        Id castId = (Id) parentRef;
-                        if (castId.getSobjectType().getDescribe().getName().endsWithIgnoreCase('WorkItem__c')) {
-                            localParent = castId;
-                        }
-                    } catch (Exception e) {
-                        System.debug(LoggingLevel.FINE, 'Parent ref local-Id fallback failed: ' + e.getMessage());
-                    }
+                    localParent = tryAsLocalWorkItemId(parentRef);
                 }
                 if (localParent != null) {
                     putSafe(recordToUpsert, 'ParentWorkItemLookup__c', localParent);
@@ -559,6 +552,24 @@ public without sharing class DeliverySyncItemIngestor {
             System.debug(LoggingLevel.FINE, 'TargetId not a local WorkItem Id: ' + e.getMessage());
         }
         return null;
+    }
+
+    /**
+     * @description Cast a string to an Id and confirm it points at a local
+     *              WorkItem__c record. Returns null on any cast/describe failure
+     *              (silent — callers fall through to other resolution strategies).
+     */
+    private static Id tryAsLocalWorkItemId(String candidate) {
+        if (String.isBlank(candidate)) {
+            return null;
+        }
+        try {
+            Id castId = (Id) candidate;
+            return castId.getSobjectType().getDescribe().getName().endsWithIgnoreCase('WorkItem__c') ? castId : null;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.FINE, 'Candidate is not a local WorkItem Id: ' + e.getMessage());
+            return null;
+        }
     }
 
     // Helper to grab both the Work Item ID and the Request ID

--- a/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
@@ -66,6 +66,51 @@ private class DeliverySyncItemIngestorTest {
     }
 
     @IsTest
+    static void testProcessInboundWorkItemTranslatesParentFk() {
+        // Regression guard: when an inbound WorkItem payload carries a
+        // ParentWorkItemLookup__c with a sender-org Id, the ingestor must
+        // translate it to the local twin via the SyncItem ledger before write.
+        // Without this, gantt nesting breaks on subscriber orgs (children
+        // arrive flat because the cross-org parent Id can't resolve locally).
+        System.runAs(testUser) {
+            // The TestSetup ledger entry maps RemoteExternalIdTxt__c =
+            // 'REMOTE-CLIENT-WORKITEM-1' → LocalRecordIdTxt__c = base WorkItem Id.
+            WorkItem__c localParent = [SELECT Id FROM WorkItem__c LIMIT 1];
+
+            // Insert a separate WorkItem that the inbound payload will update.
+            // Use the existing ledger row so processInboundItem treats it as an UPDATE.
+            // (We re-target the ledger to a NEW child so the existing one stays for other tests.)
+            WorkItem__c child = new WorkItem__c(BriefDescriptionTxt__c = 'Pre-existing child');
+            insert child;
+            insert new SyncItem__c(
+                DirectionPk__c = 'Inbound',
+                StatusPk__c = 'Synced',
+                ObjectTypePk__c = 'WorkItem__c',
+                RemoteExternalIdTxt__c = 'REMOTE-CHILD-001',
+                LocalRecordIdTxt__c = child.Id,
+                WorkItemLookup__c = child.Id
+            );
+
+            Map<String, Object> payload = new Map<String, Object>{
+                'SourceId' => 'REMOTE-CHILD-001',
+                'BriefDescriptionTxt__c' => 'Child arrived via inbound sync',
+                // Cross-org parent Id — must NOT be written verbatim
+                'ParentWorkItemLookup__c' => 'REMOTE-CLIENT-WORKITEM-1'
+            };
+
+            Test.startTest();
+            DeliverySyncItemIngestor.processInboundItem('WorkItem__c', payload);
+            Test.stopTest();
+
+            WorkItem__c after = [SELECT ParentWorkItemLookup__c, BriefDescriptionTxt__c FROM WorkItem__c WHERE Id = :child.Id];
+            System.assertEquals(localParent.Id, after.ParentWorkItemLookup__c,
+                'Ingestor must translate the cross-org parent Id to the local twin via the SyncItem ledger');
+            System.assertEquals('Child arrived via inbound sync', after.BriefDescriptionTxt__c,
+                'Other fields must still flow through mapFields after parent translation');
+        }
+    }
+
+    @IsTest
     static void testProcessInboundCommentInsertDownstreamEdge() {
         System.runAs(testUser) {
             Map<String, Object> payload = new Map<String, Object>{

--- a/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
@@ -59,6 +59,12 @@ public without sharing class DeliveryWorkItemTriggerHandler {
             // and the timeline groups collapse to a single default bucket — even
             // though the source has top-priority/active/etc populated correctly.
             'PriorityGroupPk__c',
+            // ParentWorkItemLookup__c is a cross-org self-FK. The OUTBOUND payload
+            // carries the sender-org WorkItem Id; the inbound ingestor translates
+            // it to the local Id via the SyncItem ledger. Without this in syncFields,
+            // children arrive flat on subscriber orgs and gantt nesting breaks
+            // (parent rollup bar shows but children don't fold under it).
+            'ParentWorkItemLookup__c',
             'DeveloperDaysSizeNumber__c',
             'EstimatedHoursNumber__c',
             'ClientPreApprovedHoursNumber__c',


### PR DESCRIPTION
## Issue

**Symptom:** nimba's gantt has the same items as MF-Prod but children arrive flat — they don't fold under their parent. Concrete example: prod's "Joe-era legacy items pending triage" parent has 11 nested children; on nimba the same 11 records exist but \`ParentWorkItemLookup__c\` is null on every one. Same with today's "Security · 4/27 live prod perm fixes" parent (T-0190 on nimba) — 3 children landed, all flat.

**Root cause:** \`ParentWorkItemLookup__c\` is a self-FK to \`delivery__WorkItem__c\`. The field was missing from the trigger handler's \`syncFields\`, so changes never propagated. Even after adding it, the receiver couldn't write the value verbatim — the payload carries the **sender-org Id** which doesn't exist on the subscriber, so a direct write would fail with INVALID_CROSS_REFERENCE_KEY.

## Fix

1. Add \`ParentWorkItemLookup__c\` to \`syncFields\` so the field shows up in outbound payloads.
2. In \`DeliverySyncItemIngestor\`, before \`mapFields\` runs on a \`WorkItem__c\` payload:
   - Clone the payload (avoid mutating caller's map — Pending-queue replay reuses the same Map instance, same pattern as WorkLog handling)
   - Strip the \`ParentWorkItemLookup__c\` key so \`mapFields\` doesn't try to write the cross-org Id
   - Resolve the local twin via the \`SyncItem\` ledger (same pattern that already exists for WorkLog parent resolution at line 140)
   - Apply translated local Id directly to \`recordToUpsert\` via \`putSafe\`
3. Fallback: if \`parentRef\` is already a valid local Id (echo path), use directly.
4. If neither resolves (parent hasn't synced yet — rare since children typically follow parents in dispatcher order), leave the field unset. Eventual consistency heals when source touches the field again.

## Tests

- \`testProcessInboundWorkItemTranslatesParentFk\` — inbound payload with cross-org parent Id, asserts translated local Id lands on the record AND other fields still flow through mapFields after the translation.

## What this PR explicitly does NOT do

- **Backfill of existing flat children** — separate Apex hotfix script ready to run on nimba post-merge (mirrors MF-Prod parent linkages to existing 11+ children + today's 3 security children). Would otherwise require manually touching each parent on prod to re-emit syncs.
- **Soft-fail / pending-queue for race condition** — left as eventual-consistency. WorkLog has a Pending-queue pattern for this; can add it for WorkItem in a follow-up if we observe real out-of-order races. Not worth the complexity until then.
- **"Mahi · " prefix strip** — observed today (T-0062 outbound title preserved, T-0189 inbound title rewritten), but root cause is nimba-side (manual edit or local trigger), not in this layer. Filed separately.

## Test plan

- [ ] PMD passes
- [ ] Apex tests pass (existing + new)
- [ ] Beta install on MF-Prod / nimba / dh-prod
- [ ] Tactical backfill script runs on nimba: existing flat children gain parent linkage
- [ ] Verify gantt nesting on nimba matches MF-Prod (NOW-group children fold under their parents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)