### PR TITLE
feat(install): zero-touch tenant install (auto-schedule + permset auto-assign)

### DIFF
--- a/force-app/main/default/classes/DeliveryExternalNotificationServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryExternalNotificationServiceTest.cls
@@ -295,11 +295,12 @@ private class DeliveryExternalNotificationServiceTest {
     static void testBuildSLABreachHtmlNullDate() {
         System.runAs(testUser) {
             WorkItem__c wi = new WorkItem__c(
-                Name = 'WI-9999',
                 BriefDescriptionTxt__c = 'No SLA date item',
                 StageNamePk__c = 'In Development'
             );
-            // Note: not inserting — just using for HTML generation
+            // Note: not inserting — just using for HTML generation.
+            // WorkItem__c.Name is an auto-number; assigning it is blocked at
+            // package upload time even though it would silently work in tests.
 
             Test.startTest();
             String html = DeliveryExternalNotificationService.buildSLABreachHtml(wi);

--- a/force-app/main/default/classes/DeliveryHubInstallHandler.cls
+++ b/force-app/main/default/classes/DeliveryHubInstallHandler.cls
@@ -2,8 +2,10 @@
  * @name         Delivery Hub
  * @license      BSL 1.1 — See LICENSE.md
  * @description Runs automatically when the Delivery Hub package is installed or upgraded.
- *              Initialises org-level default settings so administrators do not need to
- *              trigger the setup wizard before the package is functional.
+ *              Initialises org-level default settings, schedules the four sync cron jobs,
+ *              kicks an initial reconciliation pass, and backfills auto-assigned
+ *              PermissionSets to existing active users — so administrators do not need
+ *              to trigger the setup wizard before the package is functional.
  * @author Cloud Nimbus LLC
  */
 @SuppressWarnings('PMD.ApexCRUDViolation,PMD.AvoidGlobalModifier')
@@ -15,6 +17,9 @@ global class DeliveryHubInstallHandler implements InstallHandler {
      */
     global void onInstall(InstallContext context) {
         initializeDefaultSettings();
+        scheduleSyncJobs();
+        backfillUserPermissionSets();
+        enqueueInitialReconciliation();
     }
 
     private static void initializeDefaultSettings() {
@@ -34,8 +39,61 @@ global class DeliveryHubInstallHandler implements InstallHandler {
             EnableEmailNotificationsDateTime__c         = now,
             EnableActivityLoggingDateTime__c            = now,
             EnableBoardMetricsDateTime__c               = now,
+            FailedSyncAutoDismissDaysNumber__c          = 14,
             StagesToAutoShareWithDevTeamTxt__c = 'All'
         );
         insert settings;
+    }
+
+    /**
+     * @description Schedules the four standard 15-min sync cron jobs so a fresh
+     *              tenant is fully operational without admin intervention.
+     *              scheduleAll() is idempotent — it aborts existing matching
+     *              jobs before re-scheduling, so re-running on upgrade is safe.
+     *              Wrapped in try/catch because failures here must never block
+     *              the install (the setup wizard remains as the manual fallback).
+     */
+    private static void scheduleSyncJobs() {
+        try {
+            DeliveryHubScheduler.scheduleAll();
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryHubInstallHandler] scheduleAll failed during install: '
+                + e.getMessage());
+        }
+    }
+
+    /**
+     * @description Backfills PermissionSetAssignments for every active internal
+     *              user against the current UserAutoAssignConfig__mdt rules.
+     *              Catches subscriber tenants whose existing users were created
+     *              before the User trigger was deployed. Idempotent.
+     */
+    private static void backfillUserPermissionSets() {
+        try {
+            DeliveryUserTriggerHandler.assignAllActiveUsers();
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryHubInstallHandler] PermissionSet backfill failed: '
+                + e.getMessage());
+        }
+    }
+
+    /**
+     * @description Kicks one reconciliation pass on install so any in-flight
+     *              sync drift on the tenant gets healed without waiting for
+     *              the next scheduled 6 AM run.
+     */
+    private static void enqueueInitialReconciliation() {
+        if (Test.isRunningTest()) {
+            return; // Reconciler enqueues a Queueable that fires real callouts in some scratch orgs.
+        }
+        try {
+            DeliveryHubScheduler.reconcileNow();
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryHubInstallHandler] Initial reconciliation enqueue failed: '
+                + e.getMessage());
+        }
     }
 }

--- a/force-app/main/default/classes/DeliveryHubInstallHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryHubInstallHandlerTest.cls
@@ -18,6 +18,8 @@ private class DeliveryHubInstallHandlerTest {
             System.assertNotEquals(null, settings.Id, 'Settings should be created on first install');
             System.assertNotEquals(null, settings.EnableNotificationsDateTime__c, 'Notifications should be enabled by default');
             System.assertNotEquals(null, settings.EnableAISuggestionsDateTime__c, 'AI suggestions should be enabled by default');
+            System.assertEquals(14, settings.FailedSyncAutoDismissDaysNumber__c,
+                'FailedSyncAutoDismissDaysNumber__c should default to 14 on fresh install');
         }
     }
 
@@ -34,6 +36,49 @@ private class DeliveryHubInstallHandlerTest {
 
             DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
             System.assertEquals(null, settings.EnableNotificationsDateTime__c, 'Existing settings should not be overwritten');
+        }
+    }
+
+    @IsTest
+    static void testInstallSchedulesSyncJobs() {
+        System.runAs(testUser) {
+            // Abort any existing scheduled jobs from prior test methods so we
+            // observe a clean before/after state.
+            for (CronTrigger ct : [
+                SELECT Id FROM CronTrigger
+                WHERE CronJobDetail.Name LIKE 'Delivery Hub Sync -%'
+            ]) {
+                System.abortJob(ct.Id);
+            }
+
+            Test.startTest();
+            Test.testInstall(new DeliveryHubInstallHandler(), null, false);
+            Test.stopTest();
+
+            Integer scheduled = [
+                SELECT COUNT() FROM CronTrigger
+                WHERE CronJobDetail.Name LIKE 'Delivery Hub Sync -%'
+            ];
+            System.assertEquals(4, scheduled,
+                'Install should schedule four 15-minute sync slots automatically');
+        }
+    }
+
+    @IsTest
+    static void testInstallIsIdempotentOnRepeatedScheduling() {
+        System.runAs(testUser) {
+            Test.testInstall(new DeliveryHubInstallHandler(), null, false);
+            Integer afterFirst = [
+                SELECT COUNT() FROM CronTrigger
+                WHERE CronJobDetail.Name LIKE 'Delivery Hub Sync -%'
+            ];
+            Test.testInstall(new DeliveryHubInstallHandler(), null, false);
+            Integer afterSecond = [
+                SELECT COUNT() FROM CronTrigger
+                WHERE CronJobDetail.Name LIKE 'Delivery Hub Sync -%'
+            ];
+            System.assertEquals(afterFirst, afterSecond,
+                'Re-running install should not duplicate scheduled jobs');
         }
     }
 }

--- a/force-app/main/default/classes/DeliveryUserAutoAssignService.cls
+++ b/force-app/main/default/classes/DeliveryUserAutoAssignService.cls
@@ -1,0 +1,162 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Idempotent PermissionSet assignment engine driven by
+ *               UserAutoAssignConfig__mdt. Used by DeliveryUserTriggerHandler
+ *               (per-record on User insert/update) and DeliveryHubInstallHandler
+ *               (bulk backfill on package install/upgrade).
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation')
+public with sharing class DeliveryUserAutoAssignService {
+
+    /**
+     * @description Apply auto-assignment rules to the supplied user IDs.
+     *              Loads enabled config rows, resolves each PermissionSet by
+     *              namespaced + un-namespaced name, filters target Users by
+     *              Profile if specified, and inserts only the assignments that
+     *              don't already exist.
+     * @param userIds Users to evaluate.
+     */
+    public static void applyRules(Set<Id> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return;
+        }
+        List<UserAutoAssignConfig__mdt> rules = loadEnabledRules();
+        if (rules.isEmpty()) {
+            return;
+        }
+        Map<String, Id> permSetByName = buildPermSetMap(rules);
+        if (permSetByName.isEmpty()) {
+            return;
+        }
+        Map<Id, User> targetUsers = loadUsers(userIds);
+        Set<String> existingKeys = loadExistingAssignmentKeys(userIds, permSetByName.values());
+        List<PermissionSetAssignment> toInsert = buildAssignments(
+            targetUsers, rules, permSetByName, existingKeys);
+        insertAssignments(toInsert);
+    }
+
+    @TestVisible
+    private static List<UserAutoAssignConfig__mdt> loadEnabledRules() {
+        return [
+            SELECT PermissionSetDeveloperNameTxt__c, ProfileNameFilterTxt__c
+            FROM UserAutoAssignConfig__mdt
+            WHERE EnabledDateTime__c != null
+            WITH SYSTEM_MODE
+        ];
+    }
+
+    @TestVisible
+    private static Map<String, Id> buildPermSetMap(List<UserAutoAssignConfig__mdt> rules) {
+        Set<String> names = new Set<String>();
+        for (UserAutoAssignConfig__mdt r : rules) {
+            if (String.isNotBlank(r.PermissionSetDeveloperNameTxt__c)) {
+                names.add(r.PermissionSetDeveloperNameTxt__c);
+                names.add('delivery__' + r.PermissionSetDeveloperNameTxt__c);
+            }
+        }
+        Map<String, Id> byName = new Map<String, Id>();
+        for (PermissionSet ps : [
+            SELECT Id, Name FROM PermissionSet
+            WHERE Name IN :names
+            WITH SYSTEM_MODE
+        ]) {
+            byName.put(ps.Name, ps.Id);
+            byName.put(ps.Name.replace('delivery__', ''), ps.Id);
+        }
+        return byName;
+    }
+
+    private static Map<Id, User> loadUsers(Set<Id> userIds) {
+        return new Map<Id, User>([
+            SELECT Id, Profile.Name FROM User
+            WHERE Id IN :userIds
+            WITH SYSTEM_MODE
+        ]);
+    }
+
+    private static Set<String> loadExistingAssignmentKeys(Set<Id> userIds, List<Id> permSetIds) {
+        Set<String> keys = new Set<String>();
+        for (PermissionSetAssignment psa : [
+            SELECT AssigneeId, PermissionSetId FROM PermissionSetAssignment
+            WHERE AssigneeId IN :userIds AND PermissionSetId IN :permSetIds
+            WITH SYSTEM_MODE
+        ]) {
+            keys.add(psa.AssigneeId + '|' + psa.PermissionSetId);
+        }
+        return keys;
+    }
+
+    @TestVisible
+    private static List<PermissionSetAssignment> buildAssignments(
+        Map<Id, User> targetUsers,
+        List<UserAutoAssignConfig__mdt> rules,
+        Map<String, Id> permSetByName,
+        Set<String> existingKeys
+    ) {
+        List<PermissionSetAssignment> toInsert = new List<PermissionSetAssignment>();
+        for (User u : targetUsers.values()) {
+            for (UserAutoAssignConfig__mdt r : rules) {
+                PermissionSetAssignment candidate = candidateFor(u, r, permSetByName, existingKeys);
+                if (candidate != null) {
+                    toInsert.add(candidate);
+                    existingKeys.add(candidate.AssigneeId + '|' + candidate.PermissionSetId);
+                }
+            }
+        }
+        return toInsert;
+    }
+
+    private static PermissionSetAssignment candidateFor(
+        User u,
+        UserAutoAssignConfig__mdt r,
+        Map<String, Id> permSetByName,
+        Set<String> existingKeys
+    ) {
+        String userProfile = u.Profile == null ? '' : u.Profile.Name;
+        if (!matchesProfile(userProfile, r.ProfileNameFilterTxt__c)) {
+            return null;
+        }
+        Id permSetId = permSetByName.get(r.PermissionSetDeveloperNameTxt__c);
+        if (permSetId == null) {
+            return null;
+        }
+        if (existingKeys.contains(u.Id + '|' + permSetId)) {
+            return null;
+        }
+        return new PermissionSetAssignment(
+            AssigneeId = u.Id,
+            PermissionSetId = permSetId
+        );
+    }
+
+    @TestVisible
+    private static Boolean matchesProfile(String userProfileName, String filterCsv) {
+        if (String.isBlank(filterCsv)) {
+            return true;
+        }
+        if (String.isBlank(userProfileName)) {
+            return false;
+        }
+        for (String name : filterCsv.split(',')) {
+            if (name.trim().equalsIgnoreCase(userProfileName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void insertAssignments(List<PermissionSetAssignment> toInsert) {
+        if (toInsert.isEmpty()) {
+            return;
+        }
+        try {
+            insert toInsert;
+        } catch (DmlException e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryUserAutoAssignService] PermissionSetAssignment insert failed: '
+                + e.getMessage());
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryUserAutoAssignService.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryUserAutoAssignService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryUserTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryUserTriggerHandler.cls
@@ -1,0 +1,112 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Trigger handler for User. Filters eligible users (active,
+ *               non-guest, internal) and delegates auto-assignment to
+ *               DeliveryUserAutoAssignService. Uses @future to avoid mixed-DML
+ *               errors when User insert is followed by PermissionSetAssignment
+ *               insert in the same transaction.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation')
+public with sharing class DeliveryUserTriggerHandler {
+
+    /**
+     * @description Handles after-insert: applies auto-assign rules to newly
+     *              created Users (filters to active, non-guest, internal Users).
+     * @param newRecords List of newly inserted User records.
+     */
+    public static void onAfterInsert(List<User> newRecords) {
+        applyRulesAsync(filterEligible(newRecords));
+    }
+
+    /**
+     * @description Handles after-update: applies auto-assign rules when a User
+     *              transitions to active or changes Profile.
+     * @param newRecords List of updated User records.
+     * @param oldMap Map of pre-update User records.
+     */
+    public static void onAfterUpdate(List<User> newRecords, Map<Id, User> oldMap) {
+        List<User> reactivated = new List<User>();
+        for (User u : newRecords) {
+            if (becameEligible(u, oldMap.get(u.Id))) {
+                reactivated.add(u);
+            }
+        }
+        applyRulesAsync(reactivated);
+    }
+
+    /**
+     * @description Backfill entry point — assigns PermissionSets to ALL active
+     *              internal Users per current UserAutoAssignConfig__mdt rules.
+     *              Called by DeliveryHubInstallHandler on package install/upgrade
+     *              so existing tenants who missed the User trigger get caught up.
+     */
+    public static void assignAllActiveUsers() {
+        List<User> activeUsers = [
+            SELECT Id FROM User
+            WHERE IsActive = true AND UserType = 'Standard'
+            WITH SYSTEM_MODE
+            LIMIT 10000
+        ];
+        Set<Id> ids = new Set<Id>();
+        for (User u : activeUsers) {
+            ids.add(u.Id);
+        }
+        applyRulesAsyncFromIds(ids);
+    }
+
+    @TestVisible
+    private static List<User> filterEligible(List<User> records) {
+        List<User> eligible = new List<User>();
+        for (User u : records) {
+            if (u.IsActive == true && u.UserType == 'Standard') {
+                eligible.add(u);
+            }
+        }
+        return eligible;
+    }
+
+    @TestVisible
+    private static Boolean becameEligible(User current, User prior) {
+        if (current.IsActive != true || current.UserType != 'Standard') {
+            return false;
+        }
+        if (prior == null) {
+            return true;
+        }
+        Boolean wasEligible = prior.IsActive == true
+            && prior.UserType == 'Standard'
+            && prior.ProfileId == current.ProfileId;
+        return !wasEligible;
+    }
+
+    private static void applyRulesAsync(List<User> users) {
+        if (users == null || users.isEmpty()) {
+            return;
+        }
+        Set<Id> userIds = new Set<Id>();
+        for (User u : users) {
+            userIds.add(u.Id);
+        }
+        applyRulesAsyncFromIds(userIds);
+    }
+
+    private static void applyRulesAsyncFromIds(Set<Id> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return;
+        }
+        // Future call avoids mixed-DML when User insert is followed by
+        // PermissionSetAssignment insert in the same transaction.
+        if (System.isFuture() || System.isBatch() || System.isQueueable() || Test.isRunningTest()) {
+            DeliveryUserAutoAssignService.applyRules(userIds);
+        } else {
+            applyRulesFuture(userIds);
+        }
+    }
+
+    @future
+    private static void applyRulesFuture(Set<Id> userIds) {
+        DeliveryUserAutoAssignService.applyRules(userIds);
+    }
+}

--- a/force-app/main/default/classes/DeliveryUserTriggerHandler.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryUserTriggerHandler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryUserTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryUserTriggerHandlerTest.cls
@@ -1,0 +1,120 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for DeliveryUserTriggerHandler and
+ *               DeliveryUserAutoAssignService — verifies idempotent
+ *               PermissionSet auto-assignment on User insert/update and
+ *               bulk backfill.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryUserTriggerHandlerTest {
+
+    private static Profile getStandardProfile() {
+        return [SELECT Id, Name FROM Profile WHERE Name = 'Standard User' LIMIT 1];
+    }
+
+    private static User buildTestUser(Profile p, String suffix) {
+        String alias = 'dha' + suffix;
+        return new User(
+            Username = 'dh-autoassign-' + suffix + '@example.com.dhtest',
+            Email = 'dh-autoassign-' + suffix + '@example.com',
+            LastName = 'AutoAssignTest',
+            Alias = alias.length() > 8 ? alias.substring(0, 8) : alias,
+            ProfileId = p.Id,
+            TimeZoneSidKey = 'America/Los_Angeles',
+            LocaleSidKey = 'en_US',
+            EmailEncodingKey = 'UTF-8',
+            LanguageLocaleKey = 'en_US',
+            IsActive = true
+        );
+    }
+
+    private static String uniqueSuffix() {
+        return String.valueOf(Math.abs(Crypto.getRandomLong())).right(8);
+    }
+
+    @IsTest
+    static void testFilterEligibleSkipsInactiveAndGuests() {
+        User active = new User(IsActive = true, UserType = 'Standard');
+        User inactive = new User(IsActive = false, UserType = 'Standard');
+        User guest = new User(IsActive = true, UserType = 'Guest');
+        List<User> filtered = DeliveryUserTriggerHandler.filterEligible(
+            new List<User>{ active, inactive, guest }
+        );
+        System.assertEquals(1, filtered.size(),
+            'Only active, Standard-type users should be eligible');
+    }
+
+    @IsTest
+    static void testBecameEligibleDetectsReactivation() {
+        Id profileId = getStandardProfile().Id;
+        User prior = new User(IsActive = false, UserType = 'Standard', ProfileId = profileId);
+        User current = new User(IsActive = true, UserType = 'Standard', ProfileId = profileId);
+        System.assertEquals(true,
+            DeliveryUserTriggerHandler.becameEligible(current, prior),
+            'A user that flips inactive to active should be detected as newly eligible');
+    }
+
+    @IsTest
+    static void testBecameEligibleIgnoresStillEligible() {
+        Id profileId = getStandardProfile().Id;
+        User prior = new User(IsActive = true, UserType = 'Standard', ProfileId = profileId);
+        User current = new User(IsActive = true, UserType = 'Standard', ProfileId = profileId);
+        System.assertEquals(false,
+            DeliveryUserTriggerHandler.becameEligible(current, prior),
+            'A user already eligible with no profile change should not be re-flagged');
+    }
+
+    @IsTest
+    static void testMatchesProfileVariants() {
+        System.assertEquals(true,
+            DeliveryUserAutoAssignService.matchesProfile('System Administrator', null),
+            'Null filter should match any profile');
+        System.assertEquals(true,
+            DeliveryUserAutoAssignService.matchesProfile('System Administrator', ''),
+            'Empty filter should match any profile');
+        System.assertEquals(true,
+            DeliveryUserAutoAssignService.matchesProfile('System Administrator',
+                'Standard User, System Administrator'),
+            'CSV filter should match across whitespace and casing');
+        System.assertEquals(false,
+            DeliveryUserAutoAssignService.matchesProfile('Standard User', 'System Administrator'),
+            'Mismatched profile should not match');
+    }
+
+    @IsTest
+    static void testAssignAllActiveUsersDoesNotThrow() {
+        System.runAs([SELECT Id FROM User WHERE Id = :UserInfo.getUserId()]) {
+            Test.startTest();
+            DeliveryUserTriggerHandler.assignAllActiveUsers();
+            Test.stopTest();
+            System.assert(true, 'assignAllActiveUsers completed without throwing');
+        }
+    }
+
+    @IsTest
+    static void testTriggerOnInsertDoesNotThrow() {
+        Profile p = getStandardProfile();
+        User u = buildTestUser(p, uniqueSuffix());
+        Test.startTest();
+        insert u;
+        Test.stopTest();
+        System.assertNotEquals(null, u.Id, 'User should be inserted');
+    }
+
+    @IsTest
+    static void testTriggerOnUpdateReactivationPath() {
+        Profile p = getStandardProfile();
+        User u = buildTestUser(p, uniqueSuffix());
+        insert u;
+
+        u.IsActive = false;
+        update u;
+        Test.startTest();
+        u.IsActive = true;
+        update u;
+        Test.stopTest();
+        System.assertEquals(true, u.IsActive, 'User should be active after reactivation');
+    }
+}

--- a/force-app/main/default/classes/DeliveryUserTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryUserTriggerHandlerTest.cls
@@ -14,6 +14,31 @@ private class DeliveryUserTriggerHandlerTest {
         return [SELECT Id, Name FROM Profile WHERE Name = 'Standard User' LIMIT 1];
     }
 
+    private static User runAsCurrent() {
+        return [SELECT Id FROM User WHERE Id = :UserInfo.getUserId() LIMIT 1];
+    }
+
+    /**
+     * @description Construct a User SObject with read-only fields (UserType,
+     *              IsActive) populated via JSON deserialization. Required
+     *              because Apex blocks direct constructor writes to those
+     *              fields in subscriber-namespace deployment contexts.
+     * @param isActive Sets User.IsActive on the mocked record.
+     * @param userType Sets User.UserType (e.g. 'Standard', 'Guest').
+     * @param profileId Optional User.ProfileId; pass null to omit.
+     * @return In-memory User suitable for pure-logic assertions only.
+     */
+    private static User mockUser(Boolean isActive, String userType, Id profileId) {
+        Map<String, Object> payload = new Map<String, Object>{
+            'IsActive' => isActive,
+            'UserType' => userType
+        };
+        if (profileId != null) {
+            payload.put('ProfileId', profileId);
+        }
+        return (User) JSON.deserialize(JSON.serialize(payload), User.class);
+    }
+
     private static User buildTestUser(Profile p, String suffix) {
         String alias = 'dha' + suffix;
         return new User(
@@ -36,9 +61,9 @@ private class DeliveryUserTriggerHandlerTest {
 
     @IsTest
     static void testFilterEligibleSkipsInactiveAndGuests() {
-        User active = new User(IsActive = true, UserType = 'Standard');
-        User inactive = new User(IsActive = false, UserType = 'Standard');
-        User guest = new User(IsActive = true, UserType = 'Guest');
+        User active = mockUser(true, 'Standard', null);
+        User inactive = mockUser(false, 'Standard', null);
+        User guest = mockUser(true, 'Guest', null);
         List<User> filtered = DeliveryUserTriggerHandler.filterEligible(
             new List<User>{ active, inactive, guest }
         );
@@ -49,8 +74,8 @@ private class DeliveryUserTriggerHandlerTest {
     @IsTest
     static void testBecameEligibleDetectsReactivation() {
         Id profileId = getStandardProfile().Id;
-        User prior = new User(IsActive = false, UserType = 'Standard', ProfileId = profileId);
-        User current = new User(IsActive = true, UserType = 'Standard', ProfileId = profileId);
+        User prior = mockUser(false, 'Standard', profileId);
+        User current = mockUser(true, 'Standard', profileId);
         System.assertEquals(true,
             DeliveryUserTriggerHandler.becameEligible(current, prior),
             'A user that flips inactive to active should be detected as newly eligible');
@@ -59,8 +84,8 @@ private class DeliveryUserTriggerHandlerTest {
     @IsTest
     static void testBecameEligibleIgnoresStillEligible() {
         Id profileId = getStandardProfile().Id;
-        User prior = new User(IsActive = true, UserType = 'Standard', ProfileId = profileId);
-        User current = new User(IsActive = true, UserType = 'Standard', ProfileId = profileId);
+        User prior = mockUser(true, 'Standard', profileId);
+        User current = mockUser(true, 'Standard', profileId);
         System.assertEquals(false,
             DeliveryUserTriggerHandler.becameEligible(current, prior),
             'A user already eligible with no profile change should not be re-flagged');
@@ -85,7 +110,7 @@ private class DeliveryUserTriggerHandlerTest {
 
     @IsTest
     static void testAssignAllActiveUsersDoesNotThrow() {
-        System.runAs([SELECT Id FROM User WHERE Id = :UserInfo.getUserId()]) {
+        System.runAs(runAsCurrent()) {
             Test.startTest();
             DeliveryUserTriggerHandler.assignAllActiveUsers();
             Test.stopTest();

--- a/force-app/main/default/classes/DeliveryUserTriggerHandlerTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryUserTriggerHandlerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/customMetadata/UserAutoAssignConfig.DeliveryHubAdmin_App_SystemAdmin.md-meta.xml
+++ b/force-app/main/default/customMetadata/UserAutoAssignConfig.DeliveryHubAdmin_App_SystemAdmin.md-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>DeliveryHubAdmin_App SystemAdmin</label>
+    <protected>false</protected>
+    <values>
+        <field>PermissionSetDeveloperNameTxt__c</field>
+        <value xsi:type="xsd:string">DeliveryHubAdmin_App</value>
+    </values>
+    <values>
+        <field>ProfileNameFilterTxt__c</field>
+        <value xsi:type="xsd:string">System Administrator</value>
+    </values>
+    <values>
+        <field>EnabledDateTime__c</field>
+        <value xsi:type="xsd:dateTime">2026-04-28T00:00:00.000Z</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/UserAutoAssignConfig.DeliveryHubApp_Default.md-meta.xml
+++ b/force-app/main/default/customMetadata/UserAutoAssignConfig.DeliveryHubApp_Default.md-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>DeliveryHubApp Default</label>
+    <protected>false</protected>
+    <values>
+        <field>PermissionSetDeveloperNameTxt__c</field>
+        <value xsi:type="xsd:string">DeliveryHubApp</value>
+    </values>
+    <values>
+        <field>ProfileNameFilterTxt__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>EnabledDateTime__c</field>
+        <value xsi:type="xsd:dateTime">2026-04-28T00:00:00.000Z</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/objects/UserAutoAssignConfig__mdt/UserAutoAssignConfig__mdt.object-meta.xml
+++ b/force-app/main/default/objects/UserAutoAssignConfig__mdt/UserAutoAssignConfig__mdt.object-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>User Auto Assign Config</label>
+    <description>Configures automatic PermissionSet assignment for new and existing active Users. Each row maps a target PermissionSet to an optional Profile filter; DeliveryUserTriggerHandler applies the rules on User insert/update and DeliveryHubInstallHandler backfills existing users on upgrade.</description>
+    <pluralLabel>User Auto Assign Configs</pluralLabel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/UserAutoAssignConfig__mdt/fields/EnabledDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/UserAutoAssignConfig__mdt/fields/EnabledDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnabledDateTime__c</fullName>
+    <description>When non-null, this auto-assignment rule is active. Null = the rule is disabled.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Enabled</label>
+    <required>false</required>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/UserAutoAssignConfig__mdt/fields/PermissionSetDeveloperNameTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/UserAutoAssignConfig__mdt/fields/PermissionSetDeveloperNameTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>PermissionSetDeveloperNameTxt__c</fullName>
+    <description>DeveloperName of the PermissionSet to assign (e.g. DeliveryHubApp). Resolved with and without the package namespace prefix.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Permission Set Developer Name</label>
+    <length>80</length>
+    <required>true</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/UserAutoAssignConfig__mdt/fields/ProfileNameFilterTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/UserAutoAssignConfig__mdt/fields/ProfileNameFilterTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ProfileNameFilterTxt__c</fullName>
+    <description>Optional comma-separated Profile Names; the rule only applies to Users whose Profile Name matches one of the listed values. Leave blank to apply to all active internal Users.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Profile Name Filter</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/triggers/DeliveryUserTrigger.trigger
+++ b/force-app/main/default/triggers/DeliveryUserTrigger.trigger
@@ -1,0 +1,16 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Trigger on User. Auto-assigns Delivery Hub PermissionSets per
+ *               UserAutoAssignConfig__mdt rules. Delegates all logic to
+ *               DeliveryUserTriggerHandler.
+ * @author Cloud Nimbus LLC
+ */
+trigger DeliveryUserTrigger on User (after insert, after update) { //NOPMD - AvoidLogicInTrigger: trivial guards + handler delegation only
+    if (Trigger.isAfter && Trigger.isInsert) {
+        DeliveryUserTriggerHandler.onAfterInsert(Trigger.new);
+    }
+    if (Trigger.isAfter && Trigger.isUpdate) {
+        DeliveryUserTriggerHandler.onAfterUpdate(Trigger.new, Trigger.oldMap);
+    }
+}

--- a/force-app/main/default/triggers/DeliveryUserTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/DeliveryUserTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>

--- a/unpackaged/post/testSuites/DH.testSuite-meta.xml
+++ b/unpackaged/post/testSuites/DH.testSuite-meta.xml
@@ -13,6 +13,7 @@
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubDashboardControllerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubFilesControllerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubInstallHandlerTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryUserTriggerHandlerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubPollerControllerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubPollerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubSchedulerTest</testClassName>


### PR DESCRIPTION
## Summary

Eliminates the admin-must-open-the-setup-wizard cliff that left fresh tenants silently dead. After this PR an install or upgrade auto-schedules the four 15-minute sync jobs, kicks one reconciliation pass, and backfills `PermissionSet` assignments to every active internal user per `UserAutoAssignConfig__mdt`.

This is PR 1 of 5 in the **subtract-Glen sprint** — the goal is to make tenant install + day-1 operation truly zero-touch, then drive payment automation, kill LWC polling, and ship a self-assessment dashboard in subsequent PRs.

### Why now
`DeliveryHubInstallHandler.onInstall()` only wrote default settings. Cron jobs were scheduled only when an admin clicked through the setup wizard → so every new tenant was dead until that happened. Plus, only the Site guest user got auto-assigned a permset; standard users had to be assigned by hand per org.

### What changed
- **`DeliveryHubInstallHandler`** now calls `DeliveryHubScheduler.scheduleAll()` (idempotent — aborts existing matching jobs first) + `reconcileNow()` + `DeliveryUserTriggerHandler.assignAllActiveUsers()`. Defaults `FailedSyncAutoDismissDaysNumber__c=14` on fresh installs. All wrapped in try/catch so install never blocks.
- **New `DeliveryUserTrigger` + `DeliveryUserTriggerHandler`** — on User insert/update, applies auto-assignment per metadata config. `@future`-deferred to avoid mixed-DML.
- **New `DeliveryUserAutoAssignService`** — SOQL/assignment engine extracted from the handler so per-class cyclomatic complexity stays under PMD limits. Resolves both namespaced (`delivery__DeliveryHubApp`) and un-namespaced PermissionSet names.
- **New `UserAutoAssignConfig__mdt` CMT** + 2 default rows: `DeliveryHubApp` for every active internal user, `DeliveryHubAdmin_App` for System Administrators. Profile filter is optional CSV.
- **`DeliveryExternalNotificationServiceTest`** — drop the `Name='WI-9999'` assignment to the auto-number `WorkItem__c.Name` field that has been blocking full-tree CCI deploy (per the tech-debt note).
- **DH testSuite** picks up the new `DeliveryUserTriggerHandlerTest`.

### PMD
Local `sf scanner run --pmdconfig pmd-rules.xml --engine pmd` reports **zero violations** across the modified surface.

## Test plan
- [ ] Feature-test job (CI) green
- [ ] Apex tests green: `DeliveryHubInstallHandlerTest`, `DeliveryUserTriggerHandlerTest`
- [ ] Manual scratch-org smoke after install:
  - `SELECT COUNT() FROM CronTrigger WHERE CronJobDetail.Name LIKE 'Delivery Hub Sync%'` → returns 4
  - Insert a new active Standard User → after `@future` settles, `PermissionSetAssignment` exists for `DeliveryHubApp`
  - Re-running install does not duplicate jobs or assignments
- [ ] CI scanner comments are advisory-only (no blocking findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)