### PR TITLE
feat(payment): generic inbound webhook receiver + Stripe payment automation

### DIFF
--- a/force-app/main/default/classes/DeliveryStripePaymentHandler.cls
+++ b/force-app/main/default/classes/DeliveryStripePaymentHandler.cls
@@ -1,0 +1,122 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Stripe webhook handler. Maps Stripe charge.succeeded /
+ *               payment_intent.succeeded events to a DeliveryTransaction__c
+ *               via DeliveryDocPaymentService.recordPayment, which in turn
+ *               auto-flips the parent DeliveryDocument__c to Paid when totals
+ *               match.
+ *
+ *               Document linkage: the Stripe object's metadata.document_id
+ *               must be set when generating the Checkout Session / Payment
+ *               Intent. The outbound IntegrationProvider__mdt template for
+ *               Stripe should always inject {{document_id}} into metadata so
+ *               this lookup succeeds round-trip.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation,PMD.AvoidGlobalModifier')
+global with sharing class DeliveryStripePaymentHandler implements IWebhookEventHandler {
+
+    private static final Set<String> SUPPORTED = new Set<String>{
+        'charge.succeeded',
+        'payment_intent.succeeded'
+    };
+
+    /**
+     * @description Process a Stripe webhook event.
+     * @param eventType The Stripe "type" field value.
+     * @param payload The decoded event body.
+     * @return ok with the new DeliveryTransaction__c Id on success,
+     *         ignored for unsupported types, terminal on bad config.
+     */
+    global WebhookHandlerResult handle(String eventType, Map<String, Object> payload) {
+        if (!SUPPORTED.contains(eventType)) {
+            return WebhookHandlerResult.ignored('Unsupported Stripe event ' + eventType);
+        }
+        Map<String, Object> dataObject = extractDataObject(payload);
+        if (dataObject == null) {
+            return WebhookHandlerResult.terminal('Stripe event missing data.object');
+        }
+        String documentIdRaw = readDocumentId(dataObject);
+        if (String.isBlank(documentIdRaw)) {
+            return WebhookHandlerResult.terminal(
+                'Stripe metadata.document_id missing — cannot link payment to a DeliveryDocument__c');
+        }
+        Id documentId;
+        try {
+            documentId = Id.valueOf(documentIdRaw);
+        } catch (System.StringException e) {
+            return WebhookHandlerResult.terminal(
+                'metadata.document_id is not a valid Salesforce Id: ' + documentIdRaw);
+        }
+        Decimal amount = readAmount(dataObject);
+        if (amount == null || amount <= 0) {
+            return WebhookHandlerResult.terminal(
+                'Stripe event amount missing or non-positive');
+        }
+        String chargeId = readChargeId(dataObject);
+        try {
+            DeliveryDocPaymentService.recordPayment(
+                documentId,
+                amount,
+                Date.today(),
+                'Stripe ' + eventType + ' / ' + (chargeId == null ? 'no-id' : chargeId)
+            );
+        } catch (Exception e) {
+            return WebhookHandlerResult.retryable(
+                'recordPayment failed: ' + e.getMessage());
+        }
+        return WebhookHandlerResult.ok(documentIdRaw);
+    }
+
+    @TestVisible
+    private static Map<String, Object> extractDataObject(Map<String, Object> payload) {
+        Object dataNode = payload.get('data');
+        if (!(dataNode instanceof Map<String, Object>)) { return null; }
+        Object obj = ((Map<String, Object>) dataNode).get('object');
+        return obj instanceof Map<String, Object> ? (Map<String, Object>) obj : null;
+    }
+
+    @TestVisible
+    private static String readDocumentId(Map<String, Object> dataObject) {
+        Object metadata = dataObject.get('metadata');
+        if (!(metadata instanceof Map<String, Object>)) { return null; }
+        Object docId = ((Map<String, Object>) metadata).get('document_id');
+        return docId == null ? null : String.valueOf(docId);
+    }
+
+    /**
+     * @description Stripe reports amounts in the smallest currency unit
+     *              (cents for USD). Convert to the major unit DH stores.
+     * @param dataObject The Stripe data.object Map.
+     * @return Amount as a Decimal in the major currency unit, or null if absent.
+     */
+    @TestVisible
+    private static Decimal readAmount(Map<String, Object> dataObject) {
+        Object raw = dataObject.containsKey('amount_received')
+            ? dataObject.get('amount_received')
+            : dataObject.get('amount');
+        if (raw == null) { return null; }
+        Decimal cents;
+        if (raw instanceof Decimal) {
+            cents = (Decimal) raw;
+        } else if (raw instanceof Integer) {
+            cents = Decimal.valueOf((Integer) raw);
+        } else if (raw instanceof Long) {
+            cents = Decimal.valueOf((Long) raw);
+        } else {
+            try {
+                cents = Decimal.valueOf(String.valueOf(raw));
+            } catch (Exception e) {
+                return null;
+            }
+        }
+        return cents.divide(100, 2);
+    }
+
+    @TestVisible
+    private static String readChargeId(Map<String, Object> dataObject) {
+        Object id = dataObject.get('id');
+        return id == null ? null : String.valueOf(id);
+    }
+}

--- a/force-app/main/default/classes/DeliveryStripePaymentHandler.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryStripePaymentHandler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryStripePaymentHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryStripePaymentHandlerTest.cls
@@ -1,0 +1,143 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for DeliveryStripePaymentHandler — happy-path payment
+ *               recording, unsupported types ignored, missing metadata
+ *               fails terminal, cents → dollar conversion, payment_intent
+ *               variant.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexDoc')
+@IsTest
+private class DeliveryStripePaymentHandlerTest {
+
+    private static User testUser = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId() LIMIT 1];
+
+    @TestSetup
+    static void setupDocument() {
+        NetworkEntity__c entity = new NetworkEntity__c(
+            Name = 'Stripe Customer',
+            EntityTypePk__c = 'Client',
+            StatusPk__c = 'Active'
+        );
+        insert entity;
+        DeliveryDocument__c doc = new DeliveryDocument__c(
+            NetworkEntityId__c = entity.Id,
+            TemplatePk__c = 'Invoice',
+            StatusPk__c = 'Sent',
+            TotalCurrency__c = 100.00,
+            PeriodStartDate__c = Date.today().addDays(-30),
+            PeriodEndDate__c = Date.today()
+        );
+        insert doc;
+    }
+
+    private static DeliveryDocument__c getDoc() {
+        return [SELECT Id, StatusPk__c, TotalCurrency__c FROM DeliveryDocument__c LIMIT 1];
+    }
+
+    private static Map<String, Object> buildStripeEvent(String type, Id docId, Long amountCents) {
+        return new Map<String, Object>{
+            'type' => type,
+            'data' => new Map<String, Object>{
+                'object' => new Map<String, Object>{
+                    'id' => 'ch_test_' + amountCents,
+                    'amount' => amountCents,
+                    'amount_received' => amountCents,
+                    'metadata' => new Map<String, Object>{ 'document_id' => String.valueOf(docId) }
+                }
+            }
+        };
+    }
+
+    @IsTest
+    static void unsupportedEventIsIgnored() {
+        DeliveryStripePaymentHandler h = new DeliveryStripePaymentHandler();
+        WebhookHandlerResult r = h.handle('customer.created',
+            new Map<String, Object>{ 'data' => new Map<String, Object>{ 'object' => new Map<String, Object>{} } });
+        System.assertEquals(true, r.success);
+        System.assertEquals(200, r.httpStatus,
+            'Unsupported Stripe events should be 200 ignored');
+    }
+
+    @IsTest
+    static void missingDocumentIdReturnsTerminal() {
+        Map<String, Object> evt = new Map<String, Object>{
+            'type' => 'charge.succeeded',
+            'data' => new Map<String, Object>{
+                'object' => new Map<String, Object>{
+                    'amount' => 10000,
+                    'metadata' => new Map<String, Object>()
+                }
+            }
+        };
+        WebhookHandlerResult r = new DeliveryStripePaymentHandler().handle(
+            'charge.succeeded', evt);
+        System.assertEquals(false, r.success);
+        System.assertEquals(400, r.httpStatus);
+    }
+
+    @IsTest
+    static void invalidDocumentIdReturnsTerminal() {
+        Map<String, Object> evt = new Map<String, Object>{
+            'type' => 'charge.succeeded',
+            'data' => new Map<String, Object>{
+                'object' => new Map<String, Object>{
+                    'amount' => 10000,
+                    'metadata' => new Map<String, Object>{ 'document_id' => 'not_a_real_id' }
+                }
+            }
+        };
+        WebhookHandlerResult r = new DeliveryStripePaymentHandler().handle(
+            'charge.succeeded', evt);
+        System.assertEquals(false, r.success);
+    }
+
+    @IsTest
+    static void chargeSucceededRecordsPaymentAndMarksPaid() {
+        System.runAs(testUser) {
+            DeliveryDocument__c doc = getDoc();
+            // Stripe sends 10000 cents = $100.00 (matches doc total).
+            Map<String, Object> evt = buildStripeEvent('charge.succeeded', doc.Id, 10000);
+
+            Test.startTest();
+            WebhookHandlerResult r = new DeliveryStripePaymentHandler().handle(
+                'charge.succeeded', evt);
+            Test.stopTest();
+
+            System.assertEquals(true, r.success, r.message);
+            System.assertEquals(200, r.httpStatus);
+            DeliveryDocument__c after = [SELECT StatusPk__c FROM DeliveryDocument__c WHERE Id = :doc.Id];
+            System.assertEquals('Paid', after.StatusPk__c,
+                'Document should auto-flip to Paid when payment matches total');
+            Integer txnCount = [SELECT COUNT() FROM DeliveryTransaction__c WHERE DocumentId__c = :doc.Id];
+            System.assertEquals(1, txnCount,
+                'A DeliveryTransaction__c should be inserted for the payment');
+        }
+    }
+
+    @IsTest
+    static void paymentIntentSucceededAlsoWorks() {
+        System.runAs(testUser) {
+            DeliveryDocument__c doc = getDoc();
+            Map<String, Object> evt = buildStripeEvent('payment_intent.succeeded', doc.Id, 5000);
+
+            Test.startTest();
+            WebhookHandlerResult r = new DeliveryStripePaymentHandler().handle(
+                'payment_intent.succeeded', evt);
+            Test.stopTest();
+
+            System.assertEquals(true, r.success, r.message);
+            DeliveryDocument__c after = [SELECT StatusPk__c FROM DeliveryDocument__c WHERE Id = :doc.Id];
+            System.assertEquals('Sent', after.StatusPk__c,
+                'Partial payment should NOT flip the document to Paid');
+        }
+    }
+
+    @IsTest
+    static void readAmountConvertsCentsToDollars() {
+        Map<String, Object> dataObj = new Map<String, Object>{ 'amount' => 12345 };
+        Decimal d = DeliveryStripePaymentHandler.readAmount(dataObj);
+        System.assertEquals(123.45, d, 'amount in cents should become a Decimal in dollars');
+    }
+}

--- a/force-app/main/default/classes/DeliveryStripePaymentHandlerTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryStripePaymentHandlerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryWebhookEventRouter.cls
+++ b/force-app/main/default/classes/DeliveryWebhookEventRouter.cls
@@ -1,0 +1,112 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Looks up the IntegrationProvider__mdt for an inbound webhook
+ *               slug, parses the routing rules JSON, and instantiates the
+ *               configured IWebhookEventHandler for the event type extracted
+ *               from the payload.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation')
+public with sharing class DeliveryWebhookEventRouter {
+
+    /**
+     * @description Find the inbound provider by DeveloperName.
+     * @param developerName URL slug from /webhook/&lt;DeveloperName&gt;.
+     * @return Provider row, or null when no matching enabled inbound row exists.
+     */
+    public static IntegrationProvider__mdt findInbound(String developerName) {
+        List<IntegrationProvider__mdt> hits = [
+            SELECT DeveloperName, DirectionTxt__c, SignatureHeaderTxt__c,
+                   SignatureSecretTxt__c, SignatureAlgorithmTxt__c,
+                   EventTypeFieldPathTxt__c, RoutingRulesJsonTxt__c, EnabledDateTime__c
+            FROM IntegrationProvider__mdt
+            WHERE DeveloperName = :developerName
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (hits.isEmpty()) { return null; }
+        IntegrationProvider__mdt p = hits[0];
+        if (p.EnabledDateTime__c == null) { return null; }
+        if (p.DirectionTxt__c == null || !p.DirectionTxt__c.equalsIgnoreCase('Inbound')) {
+            return null;
+        }
+        return p;
+    }
+
+    /**
+     * @description Pull the event-type value out of the payload, look up the
+     *              handler in the routing rules, instantiate it, and call
+     *              handle().
+     * @param provider Provider row (with routing rules JSON).
+     * @param payload Decoded webhook body.
+     * @return Result from the handler, or Ignored if no rule matched.
+     */
+    public static WebhookHandlerResult dispatch(
+        IntegrationProvider__mdt provider,
+        Map<String, Object> payload
+    ) {
+        String fieldPath = provider.EventTypeFieldPathTxt__c;
+        if (String.isBlank(fieldPath)) {
+            return WebhookHandlerResult.terminal(
+                'EventTypeFieldPathTxt__c not configured on provider ' + provider.DeveloperName);
+        }
+        String eventType = readDottedPath(payload, fieldPath);
+        if (String.isBlank(eventType)) {
+            return WebhookHandlerResult.terminal(
+                'No value at event-type path ' + fieldPath + ' in payload');
+        }
+        Map<String, Object> rules = parseRoutingRules(provider);
+        if (rules == null || rules.isEmpty()) {
+            return WebhookHandlerResult.terminal(
+                'No routing rules configured on provider ' + provider.DeveloperName);
+        }
+        Object handlerName = rules.get(eventType);
+        if (handlerName == null) {
+            return WebhookHandlerResult.ignored('No handler for event type ' + eventType);
+        }
+        IWebhookEventHandler handler = instantiate(String.valueOf(handlerName));
+        if (handler == null) {
+            return WebhookHandlerResult.terminal(
+                'Cannot resolve handler class ' + handlerName);
+        }
+        return handler.handle(eventType, payload);
+    }
+
+    @TestVisible
+    private static Map<String, Object> parseRoutingRules(IntegrationProvider__mdt provider) {
+        if (String.isBlank(provider.RoutingRulesJsonTxt__c)) { return null; }
+        try {
+            Object parsed = JSON.deserializeUntyped(provider.RoutingRulesJsonTxt__c);
+            return parsed instanceof Map<String, Object>
+                ? (Map<String, Object>) parsed
+                : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @TestVisible
+    private static String readDottedPath(Map<String, Object> payload, String dottedPath) {
+        Object current = payload;
+        for (String segment : dottedPath.split('\\.')) {
+            if (!(current instanceof Map<String, Object>)) { return null; }
+            current = ((Map<String, Object>) current).get(segment);
+            if (current == null) { return null; }
+        }
+        return String.valueOf(current);
+    }
+
+    @TestVisible
+    private static IWebhookEventHandler instantiate(String className) {
+        Type t = Type.forName(className);
+        if (t == null) {
+            t = Type.forName('delivery', className);
+        }
+        if (t == null) { return null; }
+        Object instance = t.newInstance();
+        return instance instanceof IWebhookEventHandler
+            ? (IWebhookEventHandler) instance
+            : null;
+    }
+}

--- a/force-app/main/default/classes/DeliveryWebhookEventRouter.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryWebhookEventRouter.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryWebhookEventRouterTest.cls
+++ b/force-app/main/default/classes/DeliveryWebhookEventRouterTest.cls
@@ -1,0 +1,116 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for DeliveryWebhookEventRouter — routing-rules parse,
+ *               dotted-path lookup, handler dispatch, error paths. Uses an
+ *               in-memory IntegrationProvider__mdt because CMT can't be
+ *               inserted at runtime.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexDoc')
+@IsTest
+private class DeliveryWebhookEventRouterTest {
+
+    public class StubHandler implements IWebhookEventHandler {
+        public WebhookHandlerResult handle(String eventType, Map<String, Object> payload) {
+            return WebhookHandlerResult.ok('STUB_RESULT_ID');
+        }
+    }
+
+    private static IntegrationProvider__mdt baseInbound() {
+        IntegrationProvider__mdt p = new IntegrationProvider__mdt();
+        p.DeveloperName = 'Test_Inbound';
+        p.DirectionTxt__c = 'Inbound';
+        p.SignatureAlgorithmTxt__c = 'None';
+        p.EventTypeFieldPathTxt__c = 'type';
+        p.RoutingRulesJsonTxt__c =
+            '{"foo.event":"DeliveryWebhookEventRouterTest.StubHandler"}';
+        p.EnabledDateTime__c = Datetime.now();
+        return p;
+    }
+
+    @IsTest
+    static void readDottedPathTopLevel() {
+        Map<String, Object> payload = new Map<String, Object>{ 'type' => 'foo.event' };
+        System.assertEquals('foo.event',
+            DeliveryWebhookEventRouter.readDottedPath(payload, 'type'));
+    }
+
+    @IsTest
+    static void readDottedPathNested() {
+        Map<String, Object> payload = new Map<String, Object>{
+            'data' => new Map<String, Object>{ 'event' => 'paid' }
+        };
+        System.assertEquals('paid',
+            DeliveryWebhookEventRouter.readDottedPath(payload, 'data.event'));
+    }
+
+    @IsTest
+    static void readDottedPathMissingReturnsNull() {
+        System.assertEquals(null,
+            DeliveryWebhookEventRouter.readDottedPath(
+                new Map<String, Object>{ 'a' => 1 }, 'missing.path'));
+    }
+
+    @IsTest
+    static void parseRoutingRulesValidJson() {
+        IntegrationProvider__mdt p = baseInbound();
+        Map<String, Object> rules = DeliveryWebhookEventRouter.parseRoutingRules(p);
+        System.assertEquals('DeliveryWebhookEventRouterTest.StubHandler',
+            String.valueOf(rules.get('foo.event')));
+    }
+
+    @IsTest
+    static void parseRoutingRulesInvalidJsonReturnsNull() {
+        IntegrationProvider__mdt p = baseInbound();
+        p.RoutingRulesJsonTxt__c = '{not valid json}';
+        System.assertEquals(null, DeliveryWebhookEventRouter.parseRoutingRules(p));
+    }
+
+    @IsTest
+    static void instantiateUnknownClassReturnsNull() {
+        System.assertEquals(null,
+            DeliveryWebhookEventRouter.instantiate('Nonexistent_Class_Xyz_12345'));
+    }
+
+    @IsTest
+    static void instantiateValidHandlerReturnsInstance() {
+        IWebhookEventHandler handler = DeliveryWebhookEventRouter.instantiate(
+            'DeliveryWebhookEventRouterTest.StubHandler');
+        System.assertNotEquals(null, handler);
+    }
+
+    @IsTest
+    static void dispatchHappyPathInvokesHandler() {
+        IntegrationProvider__mdt p = baseInbound();
+        Map<String, Object> payload = new Map<String, Object>{ 'type' => 'foo.event' };
+        WebhookHandlerResult r = DeliveryWebhookEventRouter.dispatch(p, payload);
+        System.assertEquals(true, r.success, 'Handler should fire and return ok');
+        System.assertEquals('STUB_RESULT_ID', r.recordId);
+    }
+
+    @IsTest
+    static void dispatchUnmappedEventReturnsIgnored() {
+        IntegrationProvider__mdt p = baseInbound();
+        Map<String, Object> payload = new Map<String, Object>{ 'type' => 'no.handler.for.this' };
+        WebhookHandlerResult r = DeliveryWebhookEventRouter.dispatch(p, payload);
+        System.assertEquals(true, r.success);
+        System.assertEquals(200, r.httpStatus,
+            'Unmapped event types are ignored, not retried');
+    }
+
+    @IsTest
+    static void dispatchMissingEventTypeReturnsTerminal() {
+        IntegrationProvider__mdt p = baseInbound();
+        Map<String, Object> payload = new Map<String, Object>{ 'other' => 'x' };
+        WebhookHandlerResult r = DeliveryWebhookEventRouter.dispatch(p, payload);
+        System.assertEquals(false, r.success);
+        System.assertEquals(400, r.httpStatus);
+    }
+
+    @IsTest
+    static void findInboundReturnsNullForUnknown() {
+        System.assertEquals(null,
+            DeliveryWebhookEventRouter.findInbound('Nonexistent_Provider_99999'));
+    }
+}

--- a/force-app/main/default/classes/DeliveryWebhookEventRouterTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryWebhookEventRouterTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryWebhookReceiverApi.cls
+++ b/force-app/main/default/classes/DeliveryWebhookReceiverApi.cls
@@ -1,0 +1,112 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Generic inbound webhook receiver. Dispatches to a configured
+ *               IWebhookEventHandler based on IntegrationProvider__mdt config.
+ *               Adding a new provider (e.g. QuickBooks) is a single CMT row +
+ *               one handler class — no edits to this controller.
+ *
+ *               URL: /services/apexrest/delivery/deliveryhub/v1/webhook/&lt;DeveloperName&gt;
+ *               where DeveloperName matches an IntegrationProvider__mdt row
+ *               with DirectionTxt__c='Inbound'.
+ * @author Cloud Nimbus LLC
+ */
+@RestResource(urlMapping='/deliveryhub/v1/webhook/*')
+global with sharing class DeliveryWebhookReceiverApi {
+
+    /**
+     * @description Receive an inbound webhook. Resolves the provider by URL
+     *              slug, verifies the signature header, dispatches the
+     *              decoded payload to the configured handler, and returns
+     *              an appropriate HTTP status + JSON body.
+     */
+    @HttpPost
+    global static void handlePost() {
+        RestRequest req = RestContext.request;
+        RestResponse res = RestContext.response;
+        res.headers.put('Content-Type', 'application/json');
+        try {
+            String slug = extractSlug(req.requestURI);
+            if (String.isBlank(slug)) {
+                respond(res, 400, 'Provider slug missing from URL');
+                return;
+            }
+            IntegrationProvider__mdt provider = DeliveryWebhookEventRouter.findInbound(slug);
+            if (provider == null) {
+                respond(res, 404, 'No inbound IntegrationProvider__mdt for ' + slug);
+                return;
+            }
+            String body = req.requestBody == null ? '' : req.requestBody.toString();
+            WebhookSignatureVerifier.Outcome sig = WebhookSignatureVerifier.verify(provider, req, body);
+            if (!sig.passed) {
+                respond(res, 401, 'Signature verification failed: ' + sig.reason);
+                return;
+            }
+            Map<String, Object> payload = parseBody(body);
+            WebhookHandlerResult result = DeliveryWebhookEventRouter.dispatch(provider, payload);
+            respond(res, result.httpStatus, result.message, result.recordId);
+        } catch (Exception e) {
+            respond(res, 500, 'Receiver error: ' + e.getTypeName() + ' - ' + e.getMessage());
+        }
+    }
+
+    /**
+     * @description Extract the trailing path segment from /webhook/&lt;slug&gt;.
+     * @param requestUri Full request URI.
+     * @return Slug, or empty if none present.
+     */
+    @TestVisible
+    private static String extractSlug(String requestUri) {
+        if (String.isBlank(requestUri)) {
+            return '';
+        }
+        Integer marker = requestUri.indexOf('/webhook/');
+        if (marker < 0) {
+            return '';
+        }
+        String tail = requestUri.substring(marker + '/webhook/'.length());
+        // Strip query string, trailing slash, sub-path.
+        Integer queryAt = tail.indexOf('?');
+        if (queryAt >= 0) {
+            tail = tail.substring(0, queryAt);
+        }
+        Integer slashAt = tail.indexOf('/');
+        if (slashAt >= 0) {
+            tail = tail.substring(0, slashAt);
+        }
+        return tail.removeEnd('/');
+    }
+
+    @TestVisible
+    private static Map<String, Object> parseBody(String body) {
+        if (String.isBlank(body)) {
+            return new Map<String, Object>();
+        }
+        Object parsed = JSON.deserializeUntyped(body);
+        if (!(parsed instanceof Map<String, Object>)) {
+            throw new WebhookReceiverException('Webhook body is not a JSON object');
+        }
+        return (Map<String, Object>) parsed;
+    }
+
+    private static void respond(RestResponse res, Integer status, String msg) {
+        respond(res, status, msg, null);
+    }
+
+    private static void respond(RestResponse res, Integer status, String msg, String recordId) {
+        res.statusCode = status;
+        Map<String, Object> body = new Map<String, Object>{
+            'status' => status,
+            'message' => msg
+        };
+        if (recordId != null) {
+            body.put('recordId', recordId);
+        }
+        res.responseBody = Blob.valueOf(JSON.serialize(body));
+    }
+
+    /**
+     * @description Local exception type for malformed webhook bodies.
+     */
+    public class WebhookReceiverException extends Exception {}
+}

--- a/force-app/main/default/classes/DeliveryWebhookReceiverApi.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryWebhookReceiverApi.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryWebhookReceiverApiTest.cls
+++ b/force-app/main/default/classes/DeliveryWebhookReceiverApiTest.cls
@@ -1,0 +1,88 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for DeliveryWebhookReceiverApi — slug extraction,
+ *               JSON parsing, error responses. Provider lookup needs real
+ *               CMT rows so it's exercised via DeliveryWebhookEventRouterTest
+ *               where the router is invoked with in-memory provider stubs.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexDoc')
+@IsTest
+private class DeliveryWebhookReceiverApiTest {
+
+    @IsTest
+    static void extractSlugReturnsLastPathSegment() {
+        System.assertEquals('Stripe_Webhook',
+            DeliveryWebhookReceiverApi.extractSlug('/services/apexrest/delivery/deliveryhub/v1/webhook/Stripe_Webhook'));
+    }
+
+    @IsTest
+    static void extractSlugStripsQueryString() {
+        System.assertEquals('GitHub',
+            DeliveryWebhookReceiverApi.extractSlug('/services/apexrest/delivery/deliveryhub/v1/webhook/GitHub?source=test'));
+    }
+
+    @IsTest
+    static void extractSlugReturnsBlankWhenMissing() {
+        System.assertEquals('',
+            DeliveryWebhookReceiverApi.extractSlug('/services/apexrest/delivery/other/route'));
+    }
+
+    @IsTest
+    static void parseBodyAcceptsObject() {
+        Map<String, Object> parsed = DeliveryWebhookReceiverApi.parseBody('{"a":1}');
+        System.assertEquals(1, parsed.get('a'));
+    }
+
+    @IsTest
+    static void parseBodyEmptyReturnsEmptyMap() {
+        System.assertEquals(0, DeliveryWebhookReceiverApi.parseBody('').size());
+    }
+
+    @IsTest
+    static void parseBodyArrayThrows() {
+        Boolean threw = false;
+        try {
+            DeliveryWebhookReceiverApi.parseBody('[1,2,3]');
+        } catch (Exception e) {
+            threw = true;
+        }
+        System.assertEquals(true, threw,
+            'Webhook bodies must be JSON objects, not arrays');
+    }
+
+    @IsTest
+    static void postWithMissingSlugReturns400() {
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/delivery/deliveryhub/v1/webhook/';
+        req.requestBody = Blob.valueOf('{}');
+        req.httpMethod = 'POST';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        Test.startTest();
+        DeliveryWebhookReceiverApi.handlePost();
+        Test.stopTest();
+
+        System.assertEquals(400, RestContext.response.statusCode,
+            'Missing provider slug should return 400');
+    }
+
+    @IsTest
+    static void postWithUnknownSlugReturns404() {
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/delivery/deliveryhub/v1/webhook/Nonexistent_Provider_99999';
+        req.requestBody = Blob.valueOf('{"type":"x"}');
+        req.httpMethod = 'POST';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        Test.startTest();
+        DeliveryWebhookReceiverApi.handlePost();
+        Test.stopTest();
+
+        System.assertEquals(404, RestContext.response.statusCode,
+            'Unknown provider slug should return 404');
+    }
+}

--- a/force-app/main/default/classes/DeliveryWebhookReceiverApiTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryWebhookReceiverApiTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IWebhookEventHandler.cls
+++ b/force-app/main/default/classes/IWebhookEventHandler.cls
@@ -1,0 +1,23 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Contract for inbound-webhook handlers dispatched by
+ *               DeliveryWebhookEventRouter. One handler per kind of work
+ *               (e.g. Stripe payment, GitHub release, QuickBooks invoice).
+ *               Subscribers add their own handlers and reference them in
+ *               an IntegrationProvider__mdt RoutingRulesJsonTxt__c row.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
+global interface IWebhookEventHandler {
+
+    /**
+     * @description Process one decoded webhook event.
+     * @param eventType The event-type string extracted from the payload
+     *                  (per IntegrationProvider__mdt.EventTypeFieldPathTxt__c).
+     * @param payload The deserialized JSON body as a Map.
+     * @return WebhookHandlerResult describing the outcome — used by the
+     *         receiver to choose response status and body.
+     */
+    WebhookHandlerResult handle(String eventType, Map<String, Object> payload);
+}

--- a/force-app/main/default/classes/IWebhookEventHandler.cls-meta.xml
+++ b/force-app/main/default/classes/IWebhookEventHandler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/WebhookHandlerResult.cls
+++ b/force-app/main/default/classes/WebhookHandlerResult.cls
@@ -1,0 +1,72 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Outcome of an IWebhookEventHandler invocation. The receiver
+ *               translates this to an HTTP status + JSON body for the caller.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
+global class WebhookHandlerResult {
+    global Boolean success;
+    global Integer httpStatus;
+    global String message;
+    global String recordId;
+
+    /**
+     * @description Convenience constructor for a successful outcome.
+     * @param recordId Optional Salesforce Id of a record the handler created
+     *                 or updated (e.g. a DeliveryTransaction__c).
+     * @return Result with success=true and httpStatus=200.
+     */
+    global static WebhookHandlerResult ok(String recordId) {
+        WebhookHandlerResult r = new WebhookHandlerResult();
+        r.success = true;
+        r.httpStatus = 200;
+        r.message = 'Processed';
+        r.recordId = recordId;
+        return r;
+    }
+
+    /**
+     * @description Convenience constructor for "we processed it but there is
+     *              nothing to do for this event type." 200 OK keeps providers
+     *              from retrying.
+     * @param why Short note for the response body — surfaces in provider logs.
+     * @return Result with success=true and httpStatus=200.
+     */
+    global static WebhookHandlerResult ignored(String why) {
+        WebhookHandlerResult r = new WebhookHandlerResult();
+        r.success = true;
+        r.httpStatus = 200;
+        r.message = 'Ignored: ' + why;
+        return r;
+    }
+
+    /**
+     * @description Convenience constructor for a transient failure — the
+     *              receiver returns 5xx so the provider retries.
+     * @param why Short error description.
+     * @return Result with success=false and httpStatus=503.
+     */
+    global static WebhookHandlerResult retryable(String why) {
+        WebhookHandlerResult r = new WebhookHandlerResult();
+        r.success = false;
+        r.httpStatus = 503;
+        r.message = 'Retryable: ' + why;
+        return r;
+    }
+
+    /**
+     * @description Convenience constructor for a permanent failure — the
+     *              receiver returns 4xx so the provider stops retrying.
+     * @param why Short error description.
+     * @return Result with success=false and httpStatus=400.
+     */
+    global static WebhookHandlerResult terminal(String why) {
+        WebhookHandlerResult r = new WebhookHandlerResult();
+        r.success = false;
+        r.httpStatus = 400;
+        r.message = 'Terminal: ' + why;
+        return r;
+    }
+}

--- a/force-app/main/default/classes/WebhookHandlerResult.cls-meta.xml
+++ b/force-app/main/default/classes/WebhookHandlerResult.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/WebhookSignatureVerifier.cls
+++ b/force-app/main/default/classes/WebhookSignatureVerifier.cls
@@ -31,7 +31,7 @@ public with sharing class WebhookSignatureVerifier {
             ? 'None'
             : provider.SignatureAlgorithmTxt__c;
         if (algorithm.equalsIgnoreCase('None')) {
-            return Outcome.pass();
+            return passOutcome();
         }
         Outcome configCheck = validateConfig(provider, req);
         if (!configCheck.passed) {
@@ -39,29 +39,51 @@ public with sharing class WebhookSignatureVerifier {
         }
         String algoName = mapAlgorithm(algorithm);
         if (algoName == null) {
-            return Outcome.fail('Unknown algorithm: ' + algorithm);
+            return failOutcome('Unknown algorithm: ' + algorithm);
         }
         String expectedHex = computeHex(algoName, body, provider.SignatureSecretTxt__c);
         String headerValue = req.headers.get(provider.SignatureHeaderTxt__c);
         return matches(headerValue, expectedHex)
-            ? Outcome.pass()
-            : Outcome.fail('Computed signature did not match header value');
+            ? passOutcome()
+            : failOutcome('Computed signature did not match header value');
+    }
+
+    /**
+     * @description Convenience constructor for a passing verification.
+     * @return Outcome with passed=true.
+     */
+    public static Outcome passOutcome() {
+        Outcome o = new Outcome();
+        o.passed = true;
+        return o;
+    }
+
+    /**
+     * @description Convenience constructor for a failing verification.
+     * @param reason Short failure description surfaced to the caller.
+     * @return Outcome with passed=false.
+     */
+    public static Outcome failOutcome(String reason) {
+        Outcome o = new Outcome();
+        o.passed = false;
+        o.reason = reason;
+        return o;
     }
 
     private static Outcome validateConfig(IntegrationProvider__mdt provider, RestRequest req) {
         if (String.isBlank(provider.SignatureHeaderTxt__c)) {
-            return Outcome.fail('SignatureHeaderTxt__c not configured');
+            return failOutcome('SignatureHeaderTxt__c not configured');
         }
         String headerValue = req.headers == null
             ? null
             : req.headers.get(provider.SignatureHeaderTxt__c);
         if (String.isBlank(headerValue)) {
-            return Outcome.fail('Missing header ' + provider.SignatureHeaderTxt__c);
+            return failOutcome('Missing header ' + provider.SignatureHeaderTxt__c);
         }
         if (String.isBlank(provider.SignatureSecretTxt__c)) {
-            return Outcome.fail('SignatureSecretTxt__c not configured');
+            return failOutcome('SignatureSecretTxt__c not configured');
         }
-        return Outcome.pass();
+        return passOutcome();
     }
 
     private static String computeHex(String algoName, String body, String secret) {
@@ -124,32 +146,12 @@ public with sharing class WebhookSignatureVerifier {
 
     /**
      * @description Pass/fail outcome with an explanation surfaced in the
-     *              receiver's response body for failures.
+     *              receiver's response body for failures. Constructed via
+     *              the outer-class passOutcome() / failOutcome() factories
+     *              because Apex disallows static methods on inner classes.
      */
     public class Outcome {
         public Boolean passed;
         public String reason;
-
-        /**
-         * @description Convenience constructor for a passing verification.
-         * @return Outcome with passed=true.
-         */
-        public static Outcome pass() {
-            Outcome o = new Outcome();
-            o.passed = true;
-            return o;
-        }
-
-        /**
-         * @description Convenience constructor for a failing verification.
-         * @param reason Short failure description surfaced to the caller.
-         * @return Outcome with passed=false.
-         */
-        public static Outcome fail(String reason) {
-            Outcome o = new Outcome();
-            o.passed = false;
-            o.reason = reason;
-            return o;
-        }
     }
 }

--- a/force-app/main/default/classes/WebhookSignatureVerifier.cls
+++ b/force-app/main/default/classes/WebhookSignatureVerifier.cls
@@ -1,0 +1,155 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Verifies the inbound webhook signature header against the
+ *               configured shared secret using the algorithm declared on the
+ *               IntegrationProvider__mdt row.
+ *
+ *               Stripe-style headers carry a timestamp + multiple signatures
+ *               (e.g. "t=1492774577,v1=5257..."). For HmacSha256 we accept
+ *               either that compound format or a bare hex digest so a
+ *               provider that signs the raw body works too.
+ *
+ *               Algorithms: HmacSha256, HmacSha1, None.
+ *               None disables verification — only safe for sandbox/test
+ *               providers; never set None on a production provider row.
+ * @author Cloud Nimbus LLC
+ */
+public with sharing class WebhookSignatureVerifier {
+
+    /**
+     * @description Verify the signature on a request against the provider's
+     *              configured secret + algorithm.
+     * @param provider The IntegrationProvider__mdt row with signature config.
+     * @param req The inbound REST request (used to read the signature header).
+     * @param body The raw request body string used as the signing input.
+     * @return Outcome with passed=true on success, plus a reason string for
+     *         failures suitable for inclusion in the 401 response body.
+     */
+    public static Outcome verify(IntegrationProvider__mdt provider, RestRequest req, String body) {
+        String algorithm = provider.SignatureAlgorithmTxt__c == null
+            ? 'None'
+            : provider.SignatureAlgorithmTxt__c;
+        if (algorithm.equalsIgnoreCase('None')) {
+            return Outcome.pass();
+        }
+        Outcome configCheck = validateConfig(provider, req);
+        if (!configCheck.passed) {
+            return configCheck;
+        }
+        String algoName = mapAlgorithm(algorithm);
+        if (algoName == null) {
+            return Outcome.fail('Unknown algorithm: ' + algorithm);
+        }
+        String expectedHex = computeHex(algoName, body, provider.SignatureSecretTxt__c);
+        String headerValue = req.headers.get(provider.SignatureHeaderTxt__c);
+        return matches(headerValue, expectedHex)
+            ? Outcome.pass()
+            : Outcome.fail('Computed signature did not match header value');
+    }
+
+    private static Outcome validateConfig(IntegrationProvider__mdt provider, RestRequest req) {
+        if (String.isBlank(provider.SignatureHeaderTxt__c)) {
+            return Outcome.fail('SignatureHeaderTxt__c not configured');
+        }
+        String headerValue = req.headers == null
+            ? null
+            : req.headers.get(provider.SignatureHeaderTxt__c);
+        if (String.isBlank(headerValue)) {
+            return Outcome.fail('Missing header ' + provider.SignatureHeaderTxt__c);
+        }
+        if (String.isBlank(provider.SignatureSecretTxt__c)) {
+            return Outcome.fail('SignatureSecretTxt__c not configured');
+        }
+        return Outcome.pass();
+    }
+
+    private static String computeHex(String algoName, String body, String secret) {
+        Blob mac = Crypto.generateMac(algoName, Blob.valueOf(body), Blob.valueOf(secret));
+        return EncodingUtil.convertToHex(mac).toLowerCase();
+    }
+
+    private static Boolean matches(String headerValue, String expectedHex) {
+        String trimmed = headerValue.trim().toLowerCase();
+        if (constantTimeEquals(trimmed, expectedHex)) {
+            return true;
+        }
+        // Stripe-style "t=...,v1=..." compound header: extract any v=
+        // segment and compare each.
+        for (String part : headerValue.split(',')) {
+            Integer eq = part.indexOf('=');
+            if (eq <= 0) { continue; }
+            String value = part.substring(eq + 1).trim().toLowerCase();
+            if (constantTimeEquals(value, expectedHex)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @description Map the IntegrationProvider__mdt algorithm name to the
+     *              underlying Salesforce Crypto.generateMac algorithm string.
+     * @param configured Value from SignatureAlgorithmTxt__c.
+     * @return Crypto algorithm name, or null when unsupported.
+     */
+    @TestVisible
+    private static String mapAlgorithm(String configured) {
+        if (configured.equalsIgnoreCase('HmacSha256')) { return 'HmacSHA256'; }
+        if (configured.equalsIgnoreCase('HmacSha1')) { return 'HmacSHA1'; }
+        return null;
+    }
+
+    /**
+     * @description Length-aware equality so a leaked attacker cannot probe
+     *              the signature by timing differences. Apex doesn't expose
+     *              a true constant-time compare, but we minimize early-exit
+     *              by always walking the full length.
+     * @param a First string to compare.
+     * @param b Second string to compare.
+     * @return true when both strings are the same length and every character matches.
+     */
+    @TestVisible
+    private static Boolean constantTimeEquals(String a, String b) {
+        if (a == null || b == null) { return false; }
+        if (a.length() != b.length()) { return false; }
+        Integer mismatch = 0;
+        for (Integer i = 0; i < a.length(); i++) {
+            if (a.charAt(i) != b.charAt(i)) {
+                mismatch = mismatch | 1;
+            }
+        }
+        return mismatch == 0;
+    }
+
+    /**
+     * @description Pass/fail outcome with an explanation surfaced in the
+     *              receiver's response body for failures.
+     */
+    public class Outcome {
+        public Boolean passed;
+        public String reason;
+
+        /**
+         * @description Convenience constructor for a passing verification.
+         * @return Outcome with passed=true.
+         */
+        public static Outcome pass() {
+            Outcome o = new Outcome();
+            o.passed = true;
+            return o;
+        }
+
+        /**
+         * @description Convenience constructor for a failing verification.
+         * @param reason Short failure description surfaced to the caller.
+         * @return Outcome with passed=false.
+         */
+        public static Outcome fail(String reason) {
+            Outcome o = new Outcome();
+            o.passed = false;
+            o.reason = reason;
+            return o;
+        }
+    }
+}

--- a/force-app/main/default/classes/WebhookSignatureVerifier.cls-meta.xml
+++ b/force-app/main/default/classes/WebhookSignatureVerifier.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/WebhookSignatureVerifierTest.cls
+++ b/force-app/main/default/classes/WebhookSignatureVerifierTest.cls
@@ -1,0 +1,120 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for WebhookSignatureVerifier — HmacSha256, HmacSha1,
+ *               None, Stripe-style compound headers, header-missing failures.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexDoc')
+@IsTest
+private class WebhookSignatureVerifierTest {
+
+    private static final String SECRET = 'whsec_test_12345';
+    private static final String BODY = '{"type":"charge.succeeded"}';
+
+    private static IntegrationProvider__mdt baseConfig() {
+        IntegrationProvider__mdt p = new IntegrationProvider__mdt();
+        p.DeveloperName = 'Test_Inbound';
+        p.SignatureAlgorithmTxt__c = 'HmacSha256';
+        p.SignatureHeaderTxt__c = 'X-Test-Signature';
+        p.SignatureSecretTxt__c = SECRET;
+        return p;
+    }
+
+    private static String hmac(String algo, String body, String secret) {
+        return EncodingUtil.convertToHex(
+            Crypto.generateMac(algo, Blob.valueOf(body), Blob.valueOf(secret)));
+    }
+
+    private static RestRequest reqWithHeader(String name, String value) {
+        RestRequest r = new RestRequest();
+        r.headers.put(name, value);
+        return r;
+    }
+
+    @IsTest
+    static void noneAlgorithmAlwaysPasses() {
+        IntegrationProvider__mdt p = baseConfig();
+        p.SignatureAlgorithmTxt__c = 'None';
+        WebhookSignatureVerifier.Outcome o = WebhookSignatureVerifier.verify(
+            p, new RestRequest(), 'anything');
+        System.assertEquals(true, o.passed,
+            'None disables verification');
+    }
+
+    @IsTest
+    static void hmacSha256BareDigestPasses() {
+        IntegrationProvider__mdt p = baseConfig();
+        String sig = hmac('HmacSHA256', BODY, SECRET);
+        WebhookSignatureVerifier.Outcome o = WebhookSignatureVerifier.verify(
+            p, reqWithHeader('X-Test-Signature', sig), BODY);
+        System.assertEquals(true, o.passed, 'Matching HMAC-SHA256 should pass');
+    }
+
+    @IsTest
+    static void hmacSha256StripeCompoundHeaderPasses() {
+        IntegrationProvider__mdt p = baseConfig();
+        String sig = hmac('HmacSHA256', BODY, SECRET);
+        WebhookSignatureVerifier.Outcome o = WebhookSignatureVerifier.verify(
+            p, reqWithHeader('X-Test-Signature', 't=1234567890,v1=' + sig), BODY);
+        System.assertEquals(true, o.passed,
+            'Stripe-style "t=...,v1=..." compound header should pass when v1 matches');
+    }
+
+    @IsTest
+    static void hmacSha1Works() {
+        IntegrationProvider__mdt p = baseConfig();
+        p.SignatureAlgorithmTxt__c = 'HmacSha1';
+        String sig = hmac('HmacSHA1', BODY, SECRET);
+        WebhookSignatureVerifier.Outcome o = WebhookSignatureVerifier.verify(
+            p, reqWithHeader('X-Test-Signature', sig), BODY);
+        System.assertEquals(true, o.passed);
+    }
+
+    @IsTest
+    static void wrongSignatureFails() {
+        IntegrationProvider__mdt p = baseConfig();
+        WebhookSignatureVerifier.Outcome o = WebhookSignatureVerifier.verify(
+            p, reqWithHeader('X-Test-Signature', 'deadbeef'), BODY);
+        System.assertEquals(false, o.passed);
+    }
+
+    @IsTest
+    static void missingHeaderFails() {
+        IntegrationProvider__mdt p = baseConfig();
+        WebhookSignatureVerifier.Outcome o = WebhookSignatureVerifier.verify(
+            p, new RestRequest(), BODY);
+        System.assertEquals(false, o.passed);
+        System.assert(o.reason.contains('Missing header'));
+    }
+
+    @IsTest
+    static void missingSecretFails() {
+        IntegrationProvider__mdt p = baseConfig();
+        p.SignatureSecretTxt__c = null;
+        WebhookSignatureVerifier.Outcome o = WebhookSignatureVerifier.verify(
+            p, reqWithHeader('X-Test-Signature', 'anything'), BODY);
+        System.assertEquals(false, o.passed);
+    }
+
+    @IsTest
+    static void unknownAlgorithmFails() {
+        IntegrationProvider__mdt p = baseConfig();
+        p.SignatureAlgorithmTxt__c = 'NotAnAlgo';
+        WebhookSignatureVerifier.Outcome o = WebhookSignatureVerifier.verify(
+            p, reqWithHeader('X-Test-Signature', 'x'), BODY);
+        System.assertEquals(false, o.passed);
+    }
+
+    @IsTest
+    static void constantTimeEqualsCoverage() {
+        System.assertEquals(true,
+            WebhookSignatureVerifier.constantTimeEquals('abc', 'abc'));
+        System.assertEquals(false,
+            WebhookSignatureVerifier.constantTimeEquals('abc', 'xyz'));
+        System.assertEquals(false,
+            WebhookSignatureVerifier.constantTimeEquals('abc', 'abcd'));
+        System.assertEquals(false,
+            WebhookSignatureVerifier.constantTimeEquals(null, 'abc'));
+    }
+}

--- a/force-app/main/default/classes/WebhookSignatureVerifierTest.cls-meta.xml
+++ b/force-app/main/default/classes/WebhookSignatureVerifierTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/customMetadata/IntegrationProvider.Stripe_Webhook.md-meta.xml
+++ b/force-app/main/default/customMetadata/IntegrationProvider.Stripe_Webhook.md-meta.xml
@@ -39,7 +39,7 @@
     </values>
     <values>
         <field>NamedCredentialDevNameTxt__c</field>
-        <value xsi:nil="true"/>
+        <value xsi:type="xsd:string">UNUSED_FOR_INBOUND_PROVIDERS</value>
     </values>
     <values>
         <field>EndpointPathTxt__c</field>

--- a/force-app/main/default/customMetadata/IntegrationProvider.Stripe_Webhook.md-meta.xml
+++ b/force-app/main/default/customMetadata/IntegrationProvider.Stripe_Webhook.md-meta.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Stripe Webhook</label>
+    <protected>false</protected>
+    <values>
+        <field>DirectionTxt__c</field>
+        <value xsi:type="xsd:string">Inbound</value>
+    </values>
+    <values>
+        <field>SignatureHeaderTxt__c</field>
+        <value xsi:type="xsd:string">Stripe-Signature</value>
+    </values>
+    <values>
+        <field>SignatureAlgorithmTxt__c</field>
+        <value xsi:type="xsd:string">HmacSha256</value>
+    </values>
+    <values>
+        <field>SignatureSecretTxt__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>EventTypeFieldPathTxt__c</field>
+        <value xsi:type="xsd:string">type</value>
+    </values>
+    <values>
+        <field>RoutingRulesJsonTxt__c</field>
+        <value xsi:type="xsd:string">{
+  "charge.succeeded": "DeliveryStripePaymentHandler",
+  "payment_intent.succeeded": "DeliveryStripePaymentHandler"
+}</value>
+    </values>
+    <values>
+        <field>EnabledDateTime__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>HttpMethodPk__c</field>
+        <value xsi:type="xsd:string">POST</value>
+    </values>
+    <values>
+        <field>NamedCredentialDevNameTxt__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>EndpointPathTxt__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>HeadersJsonTxt__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>RequestBodyTemplateTxt__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ResponseRulesJsonTxt__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>SuccessParseExprTxt__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>SignerExtensionTxt__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/objects/IntegrationProvider__mdt/fields/DirectionTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/IntegrationProvider__mdt/fields/DirectionTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DirectionTxt__c</fullName>
+    <description>Outbound (this org calls the provider — IntegrationDispatcher path) or Inbound (the provider POSTs to /deliveryhub/v1/webhook/&lt;DeveloperName&gt; — DeliveryWebhookReceiverApi path). Defaults to Outbound for backward compatibility with rows shipped before the inbound receiver existed.</description>
+    <inlineHelpText>Outbound (we call them) or Inbound (they call us via /webhook/&lt;DeveloperName&gt;).</inlineHelpText>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Direction</label>
+    <length>20</length>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/IntegrationProvider__mdt/fields/EventTypeFieldPathTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/IntegrationProvider__mdt/fields/EventTypeFieldPathTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EventTypeFieldPathTxt__c</fullName>
+    <description>Dotted JSON path to the event type field in the inbound webhook payload (e.g. "type" for Stripe, "event" for many providers). DeliveryWebhookEventRouter uses this to look up the matching handler in RoutingRulesJsonTxt__c.</description>
+    <inlineHelpText>Dotted JSON path to the event-type field in the payload.</inlineHelpText>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Event Type Field Path</label>
+    <length>120</length>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/IntegrationProvider__mdt/fields/RoutingRulesJsonTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/IntegrationProvider__mdt/fields/RoutingRulesJsonTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RoutingRulesJsonTxt__c</fullName>
+    <description>JSON object mapping inbound event-type values to handler-class names. Each handler implements IWebhookEventHandler. Example: {"charge.succeeded":"DeliveryStripePaymentHandler","payment_intent.succeeded":"DeliveryStripePaymentHandler"}. Handler names resolve with and without the package namespace prefix.</description>
+    <inlineHelpText>JSON map of event_type -&gt; IWebhookEventHandler class name.</inlineHelpText>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Routing Rules JSON</label>
+    <length>32768</length>
+    <type>LongTextArea</type>
+    <visibleLines>6</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/IntegrationProvider__mdt/fields/SignatureAlgorithmTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/IntegrationProvider__mdt/fields/SignatureAlgorithmTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>SignatureAlgorithmTxt__c</fullName>
+    <description>HMAC algorithm used to verify the inbound webhook signature. Allowed values: HmacSha256, HmacSha1, None. None disables verification — only safe for sandboxed test providers.</description>
+    <inlineHelpText>HmacSha256 | HmacSha1 | None</inlineHelpText>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Signature Algorithm</label>
+    <length>40</length>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/IntegrationProvider__mdt/fields/SignatureHeaderTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/IntegrationProvider__mdt/fields/SignatureHeaderTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>SignatureHeaderTxt__c</fullName>
+    <description>HTTP header carrying the request signature on inbound webhook calls (e.g. Stripe-Signature, X-Hub-Signature-256). Verified by DeliveryWebhookReceiverApi against SignatureSecretTxt__c using SignatureAlgorithmTxt__c.</description>
+    <inlineHelpText>HTTP header name that carries the inbound webhook signature.</inlineHelpText>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Signature Header</label>
+    <length>80</length>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/IntegrationProvider__mdt/fields/SignatureSecretTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/IntegrationProvider__mdt/fields/SignatureSecretTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>SignatureSecretTxt__c</fullName>
+    <description>Shared secret used to verify the inbound webhook signature. Subscribers should rotate this through the provider's dashboard (Stripe webhook signing secret, GitHub webhook secret, etc.) and update the metadata row to match.</description>
+    <inlineHelpText>Shared secret for inbound signature verification.</inlineHelpText>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Signature Secret</label>
+    <length>255</length>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/unpackaged/post/testSuites/DH.testSuite-meta.xml
+++ b/unpackaged/post/testSuites/DH.testSuite-meta.xml
@@ -99,4 +99,8 @@
     <testClassName>%%%NAMESPACE_DOT%%%IntegrationTemplateEngineTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%IntegrationResponseMapperTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%IntegrationDispatcherTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryWebhookReceiverApiTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryWebhookEventRouterTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%WebhookSignatureVerifierTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryStripePaymentHandlerTest</testClassName>
 </ApexTestSuite>


### PR DESCRIPTION
## Summary

Closes the Glen-records-payment-by-hand loop. Stripe sends a `charge.succeeded` webhook → DH auto-creates a `DeliveryTransaction__c` → existing `DeliveryDocPaymentService.recordPayment()` flips the parent `DeliveryDocument__c` to `Paid` when totals match. The webhook receiver is provider-agnostic — adding QuickBooks (or anything else) later is a single metadata row + one `IWebhookEventHandler` class. No changes to the controller.

This is PR 3 of 5 in the **subtract-Glen sprint**.

### Why
Today payment recording is a manual `DeliveryTransaction__c` insert. Memory: "Glen sends invoice → Glen records payment." Removing that step is one of the highest-revenue-leverage moves in the platform.

### Why extend `IntegrationProvider__mdt` instead of a new CMT
The namespaced scratch org used by CI is at the custom-object ceiling (PR 2 already hit it once with a fresh platform event). The existing `IntegrationProvider__mdt` already carries outbound config; adding `DirectionTxt__c='Inbound'` + 5 webhook-specific fields lets the same metadata type drive both directions. Outbound rows don't read the new fields and continue to work unchanged.

### What changed
- **`IntegrationProvider__mdt`**: 6 new fields — `DirectionTxt__c`, `SignatureHeaderTxt__c`, `SignatureSecretTxt__c`, `SignatureAlgorithmTxt__c`, `EventTypeFieldPathTxt__c`, `RoutingRulesJsonTxt__c`.
- **`DeliveryWebhookReceiverApi`** — `@RestResource('/deliveryhub/v1/webhook/*')`. Resolves provider by URL slug (`/webhook/Stripe_Webhook`), verifies signature, dispatches to router, returns `200`/`401`/`404`/`5xx` with JSON body.
- **`WebhookSignatureVerifier`** — HMAC-SHA256 / HMAC-SHA1 / `None`. Accepts both bare-hex and Stripe-style `t=...,v1=...` compound headers. Constant-time string compare for timing-side-channel resistance.
- **`DeliveryWebhookEventRouter`** — parses `RoutingRulesJsonTxt__c`, extracts the event type via dotted path, instantiates the handler by name (resolves both bare and namespace-prefixed class names).
- **`IWebhookEventHandler`** + **`WebhookHandlerResult`** — global API for subscribers to add their own handlers.
- **`DeliveryStripePaymentHandler`** — maps `charge.succeeded` / `payment_intent.succeeded` → `DeliveryDocPaymentService.recordPayment()`. Document linkage via `metadata.document_id`. Cents → dollars conversion. Returns 503 on transient DML so Stripe re-delivers.
- **`IntegrationProvider.Stripe_Webhook`** custom metadata row ships with empty signing secret — subscribers fill it post-install via the Stripe dashboard webhook signing-secret value.

### Adding QuickBooks later
1. Create QuickBooks-specific `IWebhookEventHandler` implementation that maps QB events to `DeliveryDocPaymentService.recordPayment` (or whatever).
2. Create one `IntegrationProvider.QuickBooks_Webhook.md-meta.xml` row with the QB signature header, secret, event-type path, and routing rules.
3. No edits to the receiver or router.

### PMD
Local `sf scanner run --pmdconfig pmd-rules.xml --engine pmd` reports zero violations.

## Test plan
- [ ] Feature-test job (CI) green
- [ ] Apex tests green: `DeliveryWebhookReceiverApiTest`, `DeliveryWebhookEventRouterTest`, `WebhookSignatureVerifierTest`, `DeliveryStripePaymentHandlerTest`
- [ ] Manual (post-merge, post-install): configure `IntegrationProvider.Stripe_Webhook.SignatureSecretTxt__c` + `EnabledDateTime__c` on a sandbox; point Stripe test webhook at `/services/apexrest/delivery/deliveryhub/v1/webhook/Stripe_Webhook`; trigger `stripe trigger charge.succeeded` with `metadata.document_id=<a real DeliveryDocument__c id>`; verify `DeliveryTransaction__c` inserted and document `StatusPk__c='Paid'`
- [ ] Verify outbound `IntegrationProvider__mdt` rows still work (field additions are nullable + ignored by the dispatcher)

🤖 Generated with [Claude Code](https://claude.com/claude-code)