### PR TITLE
feat(health): self-assessment dashboard + one-click repairs

### DIFF
--- a/force-app/main/default/classes/DeliveryHubHealthCheckResult.cls
+++ b/force-app/main/default/classes/DeliveryHubHealthCheckResult.cls
@@ -1,0 +1,76 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  One row in the Delivery Hub health dashboard. Returned by
+ *               DeliveryHubHealthService.runAllChecks and rendered as a
+ *               card in deliveryHubHealthDashboard LWC.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ExcessiveParameterList')
+public class DeliveryHubHealthCheckResult {
+    @AuraEnabled public String checkKey;
+    @AuraEnabled public String label;
+    @AuraEnabled public String statusPk;
+    @AuraEnabled public String detail;
+    @AuraEnabled public String repairKey;
+    @AuraEnabled public Datetime checkedAtDateTime;
+
+    /**
+     * @description Pass result with a short detail string.
+     * @param checkKey Stable identifier (used by repair dispatch).
+     * @param label Human-readable card title.
+     * @param detail Short body text.
+     * @return Populated HealthCheckResult with statusPk='pass'.
+     */
+    public static DeliveryHubHealthCheckResult pass(String checkKey, String label, String detail) {
+        return build(checkKey, label, 'pass', detail, null);
+    }
+
+    /**
+     * @description Warn result — configured but suboptimal.
+     * @param checkKey Stable identifier.
+     * @param label Human-readable card title.
+     * @param detail Short body text.
+     * @param repairKey Optional dispatch key for a repair button; null = no repair.
+     * @return Populated HealthCheckResult with statusPk='warn'.
+     */
+    public static DeliveryHubHealthCheckResult warn(String checkKey, String label, String detail, String repairKey) {
+        return build(checkKey, label, 'warn', detail, repairKey);
+    }
+
+    /**
+     * @description Fail result — blocking issue requiring admin attention.
+     * @param checkKey Stable identifier.
+     * @param label Human-readable card title.
+     * @param detail Short body text.
+     * @param repairKey Optional dispatch key for a repair button; null = no repair.
+     * @return Populated HealthCheckResult with statusPk='fail'.
+     */
+    public static DeliveryHubHealthCheckResult fail(String checkKey, String label, String detail, String repairKey) {
+        return build(checkKey, label, 'fail', detail, repairKey);
+    }
+
+    private static DeliveryHubHealthCheckResult build(String checkKey, String label, String status, String detail, String repairKey) {
+        DeliveryHubHealthCheckResult r = new DeliveryHubHealthCheckResult();
+        r.checkKey = checkKey;
+        r.label = label;
+        r.statusPk = status;
+        r.detail = detail;
+        r.repairKey = repairKey;
+        r.checkedAtDateTime = Datetime.now();
+        return r;
+    }
+
+    /**
+     * @description Attach (or change) a repair button on this result. Useful
+     *              for pass results that nonetheless offer a maintenance
+     *              action — e.g. "rules are configured; click to backfill
+     *              existing users."
+     * @param newRepairKey Repair dispatch key.
+     * @return Same result (chainable).
+     */
+    public DeliveryHubHealthCheckResult withRepair(String newRepairKey) {
+        this.repairKey = newRepairKey;
+        return this;
+    }
+}

--- a/force-app/main/default/classes/DeliveryHubHealthCheckResult.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryHubHealthCheckResult.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryHubHealthService.cls
+++ b/force-app/main/default/classes/DeliveryHubHealthService.cls
@@ -138,9 +138,10 @@ public with sharing class DeliveryHubHealthService {
                     'No UserAutoAssignConfig__mdt rules enabled — new users will not get DH access automatically.',
                     null);
             }
-            return DeliveryHubHealthCheckResult
-                .pass(key, label, rules + ' auto-assign rule(s) enabled. Run the repair to backfill existing users.')
-                .withRepair('backfillPermSets');
+            DeliveryHubHealthCheckResult result = DeliveryHubHealthCheckResult.pass(
+                key, label,
+                rules + ' auto-assign rule(s) enabled. Run the repair to backfill existing users.');
+            return result.withRepair('backfillPermSets');
         }
     }
 

--- a/force-app/main/default/classes/DeliveryHubHealthService.cls
+++ b/force-app/main/default/classes/DeliveryHubHealthService.cls
@@ -106,25 +106,23 @@ public with sharing class DeliveryHubHealthService {
 
     public class OrphanedWorkItemsCheck implements IHealthCheck {
         public DeliveryHubHealthCheckResult run(String key, String label) {
-            // Surface SyncItems whose error log mentions parent/FK trouble — the
-            // canonical pattern from the scratch-verify hotfix scripts.
+            // Surface Failed SyncItems with retry exhaustion — the canonical
+            // signal from the scratch-verify hotfix scripts that something
+            // upstream is stuck (often parent FK, but generally any retryable
+            // error that won't auto-clear).
             Integer count = [
                 SELECT COUNT() FROM SyncItem__c
-                WHERE StatusPk__c = 'Failed'
-                AND (ErrorLogTxt__c LIKE '%parent%'
-                  OR ErrorLogTxt__c LIKE '%Parent%'
-                  OR ErrorLogTxt__c LIKE '%FK%'
-                  OR ErrorLogTxt__c LIKE '%FOREIGN%')
+                WHERE StatusPk__c = 'Failed' AND RetryCountNumber__c >= 3
                 WITH SYSTEM_MODE
                 LIMIT 1001
             ];
             if (count == 0) {
                 return DeliveryHubHealthCheckResult.pass(key, label,
-                    'No Failed SyncItems indicate parent/FK trouble.');
+                    'No Failed SyncItems with exhausted retries.');
             }
             String suffix = count > 1000 ? '1000+' : String.valueOf(count);
             return DeliveryHubHealthCheckResult.warn(key, label,
-                suffix + ' Failed SyncItems mention parent/FK errors. Resolve the parent record then requeue.',
+                suffix + ' Failed SyncItems have exhausted retries. Inspect ErrorLogTxt__c then requeue.',
                 'requeueFailedSyncs');
         }
     }

--- a/force-app/main/default/classes/DeliveryHubHealthService.cls
+++ b/force-app/main/default/classes/DeliveryHubHealthService.cls
@@ -1,0 +1,272 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Self-assessment / health-check engine for Delivery Hub.
+ *               Returns a list of HealthCheckResult records that the
+ *               deliveryHubHealthDashboard LWC renders as cards. Generic
+ *               replacement for the org-specific scratch-verify scripts.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation,PMD.ApexSharingViolations,PMD.ApexDoc')
+public with sharing class DeliveryHubHealthService {
+
+    private static final Integer STALE_FAILED_DAYS = 7;
+    private static final Integer ENDPOINT_REACHABILITY_LIMIT = 5;
+
+    /**
+     * @description Run every check and return their results in a stable order.
+     *              Errors in any single check do not abort the run — the
+     *              failing check returns a fail result with the exception
+     *              message as detail.
+     * @return Ordered list of HealthCheckResult.
+     */
+    @AuraEnabled
+    public static List<DeliveryHubHealthCheckResult> runAllChecks() {
+        List<DeliveryHubHealthCheckResult> out = new List<DeliveryHubHealthCheckResult>();
+        out.add(safe('scheduledJobs', 'Scheduled Sync Jobs', new ScheduledJobsCheck()));
+        out.add(safe('staleFailedSyncs', 'Stale Failed Syncs', new StaleFailedSyncsCheck()));
+        out.add(safe('orphanedWorkItems', 'Orphaned Work Items', new OrphanedWorkItemsCheck()));
+        out.add(safe('permSetCoverage', 'Permission Set Coverage', new PermSetCoverageCheck()));
+        out.add(safe('endpointReachability', 'NetworkEntity Endpoints', new EndpointReachabilityCheck()));
+        out.add(safe('apiKeyConfigured', 'API Key Configured', new ApiKeyCheck()));
+        out.add(safe('customSettings', 'Custom Settings', new CustomSettingsCheck()));
+        out.add(safe('mothershipHandshake', 'Mothership Handshake', new MothershipCheck()));
+        out.add(safe('inboundWebhookProviders', 'Inbound Webhook Providers', new InboundWebhookCheck()));
+        out.add(safe('sortOrderHealth', 'SortOrder Integrity', new SortOrderCheck()));
+        return out;
+    }
+
+    /**
+     * @description Wrapper that catches per-check exceptions so a single bug
+     *              never aborts the entire dashboard load.
+     * @param checkKey Stable identifier.
+     * @param label Human-readable card title.
+     * @param check The check implementation.
+     * @return The check's result, or a fail card on uncaught exception.
+     */
+    @TestVisible
+    private static DeliveryHubHealthCheckResult safe(String checkKey, String label, IHealthCheck check) {
+        try {
+            return check.run(checkKey, label);
+        } catch (Exception e) {
+            return DeliveryHubHealthCheckResult.fail(
+                checkKey, label,
+                e.getTypeName() + ': ' + e.getMessage(),
+                null);
+        }
+    }
+
+    /**
+     * @description Contract for individual check implementations. One per
+     *              category, each returning a single HealthCheckResult.
+     */
+    public interface IHealthCheck {
+        DeliveryHubHealthCheckResult run(String checkKey, String label);
+    }
+
+    // ── Individual checks ─────────────────────────────────────────────────
+
+    public class ScheduledJobsCheck implements IHealthCheck {
+        public DeliveryHubHealthCheckResult run(String key, String label) {
+            Integer count = [
+                SELECT COUNT() FROM CronTrigger
+                WHERE CronJobDetail.Name LIKE 'Delivery Hub Sync%'
+            ];
+            if (count >= 4) {
+                return DeliveryHubHealthCheckResult.pass(key, label,
+                    count + ' cron slots scheduled.');
+            }
+            if (count == 0) {
+                return DeliveryHubHealthCheckResult.fail(key, label,
+                    'No Delivery Hub Sync jobs scheduled. Tenant is dead until repaired.',
+                    'scheduleAll');
+            }
+            return DeliveryHubHealthCheckResult.warn(key, label,
+                'Only ' + count + ' of 4 cron slots scheduled.', 'scheduleAll');
+        }
+    }
+
+    public class StaleFailedSyncsCheck implements IHealthCheck {
+        public DeliveryHubHealthCheckResult run(String key, String label) {
+            Datetime cutoff = Datetime.now().addDays(-STALE_FAILED_DAYS);
+            Integer count = [
+                SELECT COUNT() FROM SyncItem__c
+                WHERE StatusPk__c = 'Failed' AND CreatedDate < :cutoff
+                WITH SYSTEM_MODE
+            ];
+            if (count == 0) {
+                return DeliveryHubHealthCheckResult.pass(key, label,
+                    'No SyncItem__c rows have been Failed for over ' + STALE_FAILED_DAYS + ' days.');
+            }
+            return DeliveryHubHealthCheckResult.warn(key, label,
+                count + ' SyncItem__c rows have been Failed for over ' + STALE_FAILED_DAYS + ' days.',
+                'requeueFailedSyncs');
+        }
+    }
+
+    public class OrphanedWorkItemsCheck implements IHealthCheck {
+        public DeliveryHubHealthCheckResult run(String key, String label) {
+            // Surface SyncItems whose error log mentions parent/FK trouble — the
+            // canonical pattern from the scratch-verify hotfix scripts.
+            Integer count = [
+                SELECT COUNT() FROM SyncItem__c
+                WHERE StatusPk__c = 'Failed'
+                AND (ErrorLogTxt__c LIKE '%parent%'
+                  OR ErrorLogTxt__c LIKE '%Parent%'
+                  OR ErrorLogTxt__c LIKE '%FK%'
+                  OR ErrorLogTxt__c LIKE '%FOREIGN%')
+                WITH SYSTEM_MODE
+                LIMIT 1001
+            ];
+            if (count == 0) {
+                return DeliveryHubHealthCheckResult.pass(key, label,
+                    'No Failed SyncItems indicate parent/FK trouble.');
+            }
+            String suffix = count > 1000 ? '1000+' : String.valueOf(count);
+            return DeliveryHubHealthCheckResult.warn(key, label,
+                suffix + ' Failed SyncItems mention parent/FK errors. Resolve the parent record then requeue.',
+                'requeueFailedSyncs');
+        }
+    }
+
+    public class PermSetCoverageCheck implements IHealthCheck {
+        public DeliveryHubHealthCheckResult run(String key, String label) {
+            Integer rules = [
+                SELECT COUNT() FROM UserAutoAssignConfig__mdt
+                WHERE EnabledDateTime__c != null
+            ];
+            if (rules == 0) {
+                return DeliveryHubHealthCheckResult.warn(key, label,
+                    'No UserAutoAssignConfig__mdt rules enabled — new users will not get DH access automatically.',
+                    null);
+            }
+            return DeliveryHubHealthCheckResult
+                .pass(key, label, rules + ' auto-assign rule(s) enabled. Run the repair to backfill existing users.')
+                .withRepair('backfillPermSets');
+        }
+    }
+
+    public class EndpointReachabilityCheck implements IHealthCheck {
+        public DeliveryHubHealthCheckResult run(String key, String label) {
+            List<NetworkEntity__c> entities = [
+                SELECT Id, Name, IntegrationEndpointUrlTxt__c
+                FROM NetworkEntity__c
+                WHERE StatusPk__c = 'Active'
+                AND IntegrationEndpointUrlTxt__c != null
+                WITH SYSTEM_MODE
+                LIMIT :ENDPOINT_REACHABILITY_LIMIT
+            ];
+            if (entities.isEmpty()) {
+                return DeliveryHubHealthCheckResult.pass(key, label,
+                    'No active NetworkEntity rows with endpoints to probe.');
+            }
+            return DeliveryHubHealthCheckResult.pass(key, label,
+                'Found ' + entities.size() + ' active NetworkEntity row(s) with endpoints. ' +
+                'Use the manual handshake button on each record to verify reachability.');
+        }
+    }
+
+    public class ApiKeyCheck implements IHealthCheck {
+        public DeliveryHubHealthCheckResult run(String key, String label) {
+            Integer total = [
+                SELECT COUNT() FROM NetworkEntity__c
+                WHERE StatusPk__c = 'Active' AND IntegrationEndpointUrlTxt__c != null
+                WITH SYSTEM_MODE
+            ];
+            Integer keyed = [
+                SELECT COUNT() FROM NetworkEntity__c
+                WHERE StatusPk__c = 'Active'
+                AND IntegrationEndpointUrlTxt__c != null
+                AND ApiKeyTxt__c != null
+                WITH SYSTEM_MODE
+            ];
+            if (total == 0) {
+                return DeliveryHubHealthCheckResult.pass(key, label,
+                    'No active NetworkEntity rows configured for sync.');
+            }
+            Integer missing = total - keyed;
+            if (missing == 0) {
+                return DeliveryHubHealthCheckResult.pass(key, label,
+                    'All ' + total + ' active sync entities have an API key.');
+            }
+            return DeliveryHubHealthCheckResult.warn(key, label,
+                missing + ' active sync entit(ies) have no API key configured.', null);
+        }
+    }
+
+    public class CustomSettingsCheck implements IHealthCheck {
+        public DeliveryHubHealthCheckResult run(String key, String label) {
+            DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
+            if (s.Id == null) {
+                return DeliveryHubHealthCheckResult.fail(key, label,
+                    'DeliveryHubSettings__c org defaults missing — install handler did not run or was rolled back.',
+                    null);
+            }
+            if (s.EnableNotificationsDateTime__c == null) {
+                return DeliveryHubHealthCheckResult.warn(key, label,
+                    'EnableNotificationsDateTime__c is null — notifications disabled.', null);
+            }
+            return DeliveryHubHealthCheckResult.pass(key, label,
+                'Org settings present and notifications enabled.');
+        }
+    }
+
+    public class MothershipCheck implements IHealthCheck {
+        public DeliveryHubHealthCheckResult run(String key, String label) {
+            CloudNimbusGlobalSettings__mdt cfg = CloudNimbusGlobalSettings__mdt.getInstance('Default');
+            if (cfg == null || String.isBlank(cfg.EndpointUrlTxt__c)) {
+                return DeliveryHubHealthCheckResult.warn(key, label,
+                    'CloudNimbusGlobalSettings__mdt.Default.EndpointUrlTxt__c not configured.', null);
+            }
+            return DeliveryHubHealthCheckResult.pass(key, label,
+                'Mothership endpoint configured: ' + cfg.EndpointUrlTxt__c);
+        }
+    }
+
+    public class InboundWebhookCheck implements IHealthCheck {
+        public DeliveryHubHealthCheckResult run(String key, String label) {
+            List<IntegrationProvider__mdt> inbound = [
+                SELECT DeveloperName, EnabledDateTime__c, SignatureSecretTxt__c, RoutingRulesJsonTxt__c
+                FROM IntegrationProvider__mdt
+                WHERE DirectionTxt__c = 'Inbound'
+            ];
+            if (inbound.isEmpty()) {
+                return DeliveryHubHealthCheckResult.pass(key, label,
+                    'No inbound webhook providers configured (Stripe, etc.).');
+            }
+            Integer disabled = 0;
+            Integer secretMissing = 0;
+            Integer rulesMissing = 0;
+            for (IntegrationProvider__mdt p : inbound) {
+                if (p.EnabledDateTime__c == null) { disabled++; }
+                if (String.isBlank(p.SignatureSecretTxt__c)) { secretMissing++; }
+                if (String.isBlank(p.RoutingRulesJsonTxt__c)) { rulesMissing++; }
+            }
+            if (disabled + secretMissing + rulesMissing == 0) {
+                return DeliveryHubHealthCheckResult.pass(key, label,
+                    inbound.size() + ' inbound webhook provider(s) ready.');
+            }
+            return DeliveryHubHealthCheckResult.warn(key, label,
+                inbound.size() + ' inbound provider(s); ' + disabled + ' disabled, '
+                + secretMissing + ' missing secret, ' + rulesMissing + ' missing routing rules.',
+                null);
+        }
+    }
+
+    public class SortOrderCheck implements IHealthCheck {
+        public DeliveryHubHealthCheckResult run(String key, String label) {
+            Integer negativeOrders = [
+                SELECT COUNT() FROM WorkItem__c
+                WHERE SortOrderNumber__c < 0
+                WITH SYSTEM_MODE
+            ];
+            if (negativeOrders == 0) {
+                return DeliveryHubHealthCheckResult.pass(key, label,
+                    'No WorkItems with negative SortOrderNumber__c.');
+            }
+            return DeliveryHubHealthCheckResult.warn(key, label,
+                negativeOrders + ' WorkItem(s) have negative SortOrderNumber__c — reorder drift detected.',
+                null);
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryHubHealthService.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryHubHealthService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryHubHealthServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryHubHealthServiceTest.cls
@@ -1,0 +1,85 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for DeliveryHubHealthService — runs the full check
+ *               sweep and verifies results come back well-formed for every
+ *               check key. Individual check pass/warn/fail thresholds are
+ *               exercised via fixture data where setup is cheap.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexDoc')
+@IsTest
+private class DeliveryHubHealthServiceTest {
+
+    @IsTest
+    static void runAllChecksReturnsExpectedKeys() {
+        Test.startTest();
+        List<DeliveryHubHealthCheckResult> results = DeliveryHubHealthService.runAllChecks();
+        Test.stopTest();
+
+        Set<String> seen = new Set<String>();
+        for (DeliveryHubHealthCheckResult r : results) {
+            System.assertNotEquals(null, r.checkKey, 'Each result must have a checkKey');
+            System.assertNotEquals(null, r.label, 'Each result must have a label');
+            System.assert(
+                r.statusPk == 'pass' || r.statusPk == 'warn' || r.statusPk == 'fail',
+                'Status must be one of pass/warn/fail, got: ' + r.statusPk);
+            System.assertNotEquals(null, r.checkedAtDateTime, 'Each result must be timestamped');
+            seen.add(r.checkKey);
+        }
+        // Spot-check that the canonical keys are present.
+        for (String expected : new Set<String>{
+            'scheduledJobs', 'staleFailedSyncs', 'orphanedWorkItems',
+            'permSetCoverage', 'endpointReachability', 'apiKeyConfigured',
+            'customSettings', 'mothershipHandshake', 'inboundWebhookProviders',
+            'sortOrderHealth'
+        }) {
+            System.assert(seen.contains(expected),
+                'Expected check missing from runAllChecks(): ' + expected);
+        }
+    }
+
+    @IsTest
+    static void scheduledJobsCheckPassesWhenSchedulerRan() {
+        DeliveryHubScheduler.scheduleAll();
+        Test.startTest();
+        DeliveryHubHealthCheckResult r = new DeliveryHubHealthService.ScheduledJobsCheck()
+            .run('scheduledJobs', 'Scheduled Sync Jobs');
+        Test.stopTest();
+        System.assertEquals('pass', r.statusPk,
+            'After scheduleAll, scheduledJobs should pass');
+    }
+
+    @IsTest
+    static void staleFailedSyncsCountsOnlyOldFailedRows() {
+        DeliveryHubHealthCheckResult r = new DeliveryHubHealthService.StaleFailedSyncsCheck()
+            .run('staleFailedSyncs', 'Stale Failed Syncs');
+        // Empty org defaults: the check should pass with no stale rows.
+        System.assertEquals('pass', r.statusPk);
+    }
+
+    @IsTest
+    static void permSetCoverageWarnsWhenNoRulesEnabled() {
+        // We can't insert UserAutoAssignConfig__mdt at runtime; the CMT is
+        // populated via shipped metadata rows in the package. The check is
+        // resilient to either state — at minimum it returns something
+        // well-formed.
+        DeliveryHubHealthCheckResult r = new DeliveryHubHealthService.PermSetCoverageCheck()
+            .run('permSetCoverage', 'Permission Set Coverage');
+        System.assertNotEquals(null, r.statusPk);
+    }
+
+    @IsTest
+    static void safeWrapsCheckExceptions() {
+        DeliveryHubHealthCheckResult r = DeliveryHubHealthService.safe(
+            'k', 'L', new ThrowingCheck());
+        System.assertEquals('fail', r.statusPk);
+        System.assert(r.detail.contains('Boom'));
+    }
+
+    private class ThrowingCheck implements DeliveryHubHealthService.IHealthCheck {
+        public DeliveryHubHealthCheckResult run(String key, String label) {
+            throw new IllegalArgumentException('Boom');
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryHubHealthServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryHubHealthServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryHubRepairService.cls
+++ b/force-app/main/default/classes/DeliveryHubRepairService.cls
@@ -1,0 +1,78 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Generic repair dispatcher invoked from the Health Dashboard
+ *               LWC. Each repair key maps to one corrective action — a
+ *               reusable, org-agnostic version of the scripts that lived in
+ *               scripts/scratch-verify/.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation')
+public with sharing class DeliveryHubRepairService {
+
+    /**
+     * @description Run a repair by its key. Returns a short message used by
+     *              the dashboard LWC to refresh the relevant card.
+     * @param repairKey One of: scheduleAll, requeueFailedSyncs,
+     *                  backfillPermSets, reconcileNow.
+     * @return Human-readable result message.
+     */
+    @AuraEnabled
+    public static String runRepair(String repairKey) {
+        if (String.isBlank(repairKey)) {
+            throw new AuraHandledException('repairKey is required');
+        }
+        if (repairKey == 'scheduleAll') {
+            return repairScheduleAll();
+        }
+        if (repairKey == 'requeueFailedSyncs') {
+            return repairRequeueFailedSyncs();
+        }
+        if (repairKey == 'backfillPermSets') {
+            return repairBackfillPermSets();
+        }
+        if (repairKey == 'reconcileNow') {
+            return repairReconcileNow();
+        }
+        throw new AuraHandledException('Unknown repairKey: ' + repairKey);
+    }
+
+    private static String repairScheduleAll() {
+        DeliveryHubScheduler.scheduleAll();
+        return 'Scheduled four sync slots.';
+    }
+
+    /**
+     * @description Reset Failed SyncItems back to Queued so the next
+     *              scheduler tick picks them up. Caps at 1000 per invocation
+     *              to stay under DML limits — re-run for larger backlogs.
+     * @return Count of rows reset.
+     */
+    private static String repairRequeueFailedSyncs() {
+        List<SyncItem__c> failed = [
+            SELECT Id FROM SyncItem__c
+            WHERE StatusPk__c = 'Failed'
+            WITH SYSTEM_MODE
+            LIMIT 1000
+        ];
+        for (SyncItem__c row : failed) {
+            row.StatusPk__c = 'Queued';
+            row.RetryCountNumber__c = 0;
+            row.ErrorLogTxt__c = null;
+        }
+        if (!failed.isEmpty()) {
+            update failed;
+        }
+        return 'Requeued ' + failed.size() + ' Failed SyncItems.';
+    }
+
+    private static String repairBackfillPermSets() {
+        DeliveryUserTriggerHandler.assignAllActiveUsers();
+        return 'Permission set backfill enqueued — assignments propagate via @future.';
+    }
+
+    private static String repairReconcileNow() {
+        DeliveryHubScheduler.reconcileNow();
+        return 'Reconciliation enqueued.';
+    }
+}

--- a/force-app/main/default/classes/DeliveryHubRepairService.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryHubRepairService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryHubRepairServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryHubRepairServiceTest.cls
@@ -1,0 +1,79 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for DeliveryHubRepairService — verifies each repair
+ *               key dispatches correctly and unknown keys throw cleanly.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexDoc')
+@IsTest
+private class DeliveryHubRepairServiceTest {
+
+    @IsTest
+    static void scheduleAllRepairCreatesCronTriggers() {
+        Test.startTest();
+        String message = DeliveryHubRepairService.runRepair('scheduleAll');
+        Test.stopTest();
+        System.assertNotEquals(null, message);
+        Integer count = [
+            SELECT COUNT() FROM CronTrigger
+            WHERE CronJobDetail.Name LIKE 'Delivery Hub Sync%'
+        ];
+        System.assertEquals(4, count, 'scheduleAll repair should produce four cron slots');
+    }
+
+    @IsTest
+    static void requeueFailedSyncsResetsRows() {
+        // Create a Failed SyncItem to verify it gets reset.
+        SyncItem__c failed = new SyncItem__c(
+            ObjectTypePk__c = 'WorkItem__c',
+            DirectionPk__c = 'Outbound',
+            StatusPk__c = 'Failed',
+            RetryCountNumber__c = 3,
+            ErrorLogTxt__c = 'previous failure'
+        );
+        insert failed;
+
+        Test.startTest();
+        String message = DeliveryHubRepairService.runRepair('requeueFailedSyncs');
+        Test.stopTest();
+
+        SyncItem__c after = [SELECT StatusPk__c, RetryCountNumber__c, ErrorLogTxt__c
+                             FROM SyncItem__c WHERE Id = :failed.Id];
+        System.assertEquals('Queued', after.StatusPk__c);
+        System.assertEquals(0, after.RetryCountNumber__c);
+        System.assertEquals(null, after.ErrorLogTxt__c);
+        System.assert(message.contains('1 Failed SyncItems'),
+            'Repair message should include the count');
+    }
+
+    @IsTest
+    static void backfillPermSetsDoesNotThrow() {
+        Test.startTest();
+        String message = DeliveryHubRepairService.runRepair('backfillPermSets');
+        Test.stopTest();
+        System.assertNotEquals(null, message);
+    }
+
+    @IsTest
+    static void blankRepairKeyThrows() {
+        Boolean threw = false;
+        try {
+            DeliveryHubRepairService.runRepair('');
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        System.assertEquals(true, threw);
+    }
+
+    @IsTest
+    static void unknownRepairKeyThrows() {
+        Boolean threw = false;
+        try {
+            DeliveryHubRepairService.runRepair('not_a_real_repair');
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        System.assertEquals(true, threw);
+    }
+}

--- a/force-app/main/default/classes/DeliveryHubRepairServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryHubRepairServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/deliveryHubHealthDashboard/deliveryHubHealthDashboard.html
+++ b/force-app/main/default/lwc/deliveryHubHealthDashboard/deliveryHubHealthDashboard.html
@@ -1,0 +1,53 @@
+<template>
+    <lightning-card title="Delivery Hub Health" icon-name="utility:health">
+        <lightning-button
+            slot="actions"
+            label="Refresh"
+            icon-name="utility:refresh"
+            onclick={handleRefresh}
+            disabled={loading}>
+        </lightning-button>
+
+        <div class="slds-p-horizontal_medium">
+            <template lwc:if={loading}>
+                <lightning-spinner alternative-text="Running checks" size="small"></lightning-spinner>
+            </template>
+
+            <template lwc:if={hasChecks}>
+                <template for:each={checks} for:item="check">
+                    <div key={check.checkKey} class={check.cardClass}>
+                        <div class="slds-grid slds-grid_align-spread slds-grid_vertical-align-center">
+                            <div class="slds-col">
+                                <lightning-icon
+                                    icon-name={check.iconName}
+                                    variant={check.iconVariant}
+                                    size="small"
+                                    class="slds-m-right_x-small">
+                                </lightning-icon>
+                                <strong>{check.label}</strong>
+                                <div class="slds-text-body_small slds-m-top_xx-small">{check.detail}</div>
+                            </div>
+                            <template lwc:if={check.canRepair}>
+                                <div class="slds-col slds-no-flex">
+                                    <lightning-button
+                                        label="Repair"
+                                        variant="brand"
+                                        data-repair-key={check.repairKey}
+                                        onclick={handleRepair}
+                                        disabled={check.repairing}>
+                                    </lightning-button>
+                                </div>
+                            </template>
+                        </div>
+                    </div>
+                </template>
+            </template>
+
+            <template lwc:if={lastRunIso}>
+                <div class="slds-text-body_small slds-text-color_weak slds-m-top_small">
+                    Last run: {lastRunIso}
+                </div>
+            </template>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/deliveryHubHealthDashboard/deliveryHubHealthDashboard.js
+++ b/force-app/main/default/lwc/deliveryHubHealthDashboard/deliveryHubHealthDashboard.js
@@ -1,0 +1,123 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Admin self-assessment dashboard. Runs every check defined in
+ *               DeliveryHubHealthService and renders a card per result with
+ *               an optional one-click repair button.
+ * @author Cloud Nimbus LLC
+ */
+import { LightningElement, track } from 'lwc';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import runAllChecks from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubHealthService.runAllChecks';
+import runRepair from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubRepairService.runRepair';
+
+export default class DeliveryHubHealthDashboard extends LightningElement {
+    @track checks = [];
+    @track loading = false;
+    @track lastRunIso = null;
+    @track activeRepair = null;
+
+    connectedCallback() {
+        this.loadChecks();
+    }
+
+    handleRefresh() {
+        this.loadChecks();
+    }
+
+    handleRepair(event) {
+        const repairKey = event.currentTarget.dataset.repairKey;
+        if (!repairKey) {
+            return;
+        }
+        this.activeRepair = repairKey;
+        runRepair({ repairKey })
+            .then((message) => {
+                this.dispatchEvent(new ShowToastEvent({
+                    title: 'Repair complete',
+                    message,
+                    variant: 'success'
+                }));
+                return this.loadChecks();
+            })
+            .catch((error) => {
+                this.dispatchEvent(new ShowToastEvent({
+                    title: 'Repair failed',
+                    message: error.body ? error.body.message : (error.message || 'Unknown error'),
+                    variant: 'error'
+                }));
+            })
+            .finally(() => {
+                this.activeRepair = null;
+            });
+    }
+
+    loadChecks() {
+        this.loading = true;
+        return runAllChecks()
+            .then((results) => {
+                this.checks = (results || []).map((r) => ({
+                    ...r,
+                    cardClass: this._cardClass(r.statusPk),
+                    iconName: this._iconName(r.statusPk),
+                    iconVariant: this._iconVariant(r.statusPk),
+                    canRepair: !!r.repairKey,
+                    repairing: this.activeRepair === r.repairKey
+                }));
+                this.lastRunIso = new Date().toISOString();
+            })
+            .catch((error) => {
+                this.dispatchEvent(new ShowToastEvent({
+                    title: 'Health check failed',
+                    message: error.body ? error.body.message : (error.message || 'Unknown error'),
+                    variant: 'error'
+                }));
+            })
+            .finally(() => {
+                this.loading = false;
+            });
+    }
+
+    _cardClass(status) {
+        if (status === 'pass') {
+            return 'slds-box slds-theme_success slds-m-bottom_small';
+        }
+        if (status === 'warn') {
+            return 'slds-box slds-theme_warning slds-m-bottom_small';
+        }
+        if (status === 'fail') {
+            return 'slds-box slds-theme_error slds-m-bottom_small';
+        }
+        return 'slds-box slds-m-bottom_small';
+    }
+
+    _iconName(status) {
+        if (status === 'pass') {
+            return 'utility:success';
+        }
+        if (status === 'warn') {
+            return 'utility:warning';
+        }
+        if (status === 'fail') {
+            return 'utility:error';
+        }
+        return 'utility:info';
+    }
+
+    _iconVariant(status) {
+        if (status === 'pass') {
+            return 'success';
+        }
+        if (status === 'warn') {
+            return 'warning';
+        }
+        if (status === 'fail') {
+            return 'error';
+        }
+        return 'inverse';
+    }
+
+    get hasChecks() {
+        return this.checks && this.checks.length > 0;
+    }
+}

--- a/force-app/main/default/lwc/deliveryHubHealthDashboard/deliveryHubHealthDashboard.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryHubHealthDashboard/deliveryHubHealthDashboard.js-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <masterLabel>Delivery Hub — Health Dashboard</masterLabel>
+    <description>Self-assessment dashboard. Runs every Delivery Hub health check and offers one-click repair for the common failure modes. Admin-only.</description>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <target>lightning__Tab</target>
+    </targets>
+</LightningComponentBundle>

--- a/unpackaged/post/testSuites/DH.testSuite-meta.xml
+++ b/unpackaged/post/testSuites/DH.testSuite-meta.xml
@@ -103,4 +103,6 @@
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryWebhookEventRouterTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%WebhookSignatureVerifierTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryStripePaymentHandlerTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubHealthServiceTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubRepairServiceTest</testClassName>
 </ApexTestSuite>


### PR DESCRIPTION
## Summary

Generic, org-agnostic admin dashboard that replaces the per-incident `scripts/scratch-verify/` Apex scripts. Runs 10 health checks covering schedulers, sync ledger, perm-set coverage, network entity reachability, custom settings, mothership handshake, inbound webhooks, and sortOrder integrity. Each fail/warn surfaces a one-click "Repair" button.

This is PR 4 of 5 in the **subtract-Glen sprint**. Goal: when something looks off, the admin opens this dashboard, sees a yellow card, clicks Repair, done — Glen never enters the loop.

### Checks shipped
1. Scheduled Sync Jobs — verifies the four 15-min cron slots exist (repair: `scheduleAll`)
2. Stale Failed Syncs — counts SyncItems Failed for >7 days (repair: `requeueFailedSyncs`)
3. Orphaned Work Items — Failed SyncItems mentioning parent/FK errors (repair: `requeueFailedSyncs`)
4. Permission Set Coverage — confirms UserAutoAssignConfig__mdt rules are enabled (repair: `backfillPermSets`)
5. NetworkEntity Endpoints — count of active endpoints (informational)
6. API Key Configured — counts active sync entities missing an API key
7. Custom Settings — verifies DeliveryHubSettings__c exists + notifications enabled
8. Mothership Handshake — checks CloudNimbusGlobalSettings__mdt.Default
9. Inbound Webhook Providers — disabled / missing-secret / missing-rules counts
10. SortOrder Integrity — flags negative SortOrderNumber__c

### Repairs shipped
- `scheduleAll` — kicks DeliveryHubScheduler.scheduleAll()
- `requeueFailedSyncs` — bulk-resets up to 1000 Failed → Queued, clears retry count and error log
- `backfillPermSets` — calls DeliveryUserTriggerHandler.assignAllActiveUsers (@future)
- `reconcileNow` — kicks DeliverySyncReconciler

### What's deferred
Repairs that would need their own Queueable (rebuild SortOrder, backfill parent FK across orgs, sync-field backfill) are deferred to a follow-up PR — the framework is in place; just one new Apex class per future repair.

### Architecture
- Each check implements `DeliveryHubHealthService.IHealthCheck` (one method, returns `HealthCheckResult`).
- `runAllChecks()` wraps each invocation in `safe()` so a single bug never aborts the dashboard.
- Repair dispatcher is a flat switch by `repairKey` — adding a new repair = one method + one entry.
- LWC targets `lightning__AppPage`, `lightning__HomePage`, `lightning__Tab`. Drop it on the DH Admin app home page.

### PMD
Local `sf scanner run --pmdconfig pmd-rules.xml --engine pmd` reports zero violations.

## Test plan
- [ ] Feature-test job (CI) green
- [ ] Apex tests green: `DeliveryHubHealthServiceTest`, `DeliveryHubRepairServiceTest`
- [ ] Manual (post-merge): drop `deliveryHubHealthDashboard` on the DH Admin home, verify all 10 cards render with sensible status; click Repair on each that has one and verify it executes without error and the card refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)