### PR TITLE
feat(generalize): metadata-drive mothership name + sync fields, close hash chain TODO

### DIFF
--- a/force-app/main/default/classes/DeliveryAuditChainService.cls
+++ b/force-app/main/default/classes/DeliveryAuditChainService.cls
@@ -91,6 +91,81 @@ public without sharing class DeliveryAuditChainService {
     }
 
     /**
+     * @description Per-document hash chain integrity check. Walks every
+     *              ActivityLog__c record whose RecordIdTxt__c matches the
+     *              given Salesforce Id, in CreatedDate order, and verifies
+     *              that each row's HashChainTxt__c agrees with what we'd
+     *              recompute given the previous row's hash. Returns
+     *              passed=true ONLY when every row reconciles AND at least
+     *              one row exists. A document with zero audit log entries
+     *              returns passed=false so the portal does not falsely
+     *              claim verification.
+     * @param recordId The Salesforce Id of the parent record (typically
+     *                 a DeliveryDocument__c) to validate the chain for.
+     * @return Map with keys: passed (Boolean), totalChecked (Integer),
+     *         broken (Integer), verifiedAt (Datetime).
+     */
+    public static Map<String, Object> validateChainForRecord(Id recordId) {
+        Map<String, Object> result = new Map<String, Object>{
+            'passed' => false,
+            'totalChecked' => 0,
+            'broken' => 0,
+            'verifiedAt' => null
+        };
+        if (recordId == null) {
+            return result;
+        }
+        String idString = String.valueOf(recordId);
+        List<ActivityLog__c> records = [
+            SELECT Id, HashChainTxt__c, ActionTypePk__c, CreatedDate, ContextDataTxt__c
+            FROM ActivityLog__c
+            WHERE RecordIdTxt__c = :idString
+            AND HashChainTxt__c != null
+            WITH SYSTEM_MODE
+            ORDER BY CreatedDate ASC
+            LIMIT 1000
+        ];
+        if (records.isEmpty()) {
+            return result;
+        }
+        Integer broken = countBrokenLinks(records);
+        result.put('totalChecked', records.size());
+        result.put('broken', broken);
+        result.put('passed', broken == 0);
+        if (broken == 0) {
+            result.put('verifiedAt', Datetime.now());
+        }
+        return result;
+    }
+
+    private static Integer countBrokenLinks(List<ActivityLog__c> records) {
+        Integer broken = 0;
+        String previousHash = lookupPreviousHash(records[0]);
+        for (ActivityLog__c rec : records) {
+            String expected = DeliveryCryptoService.computeChainHash(
+                previousHash, rec.Id, rec.ActionTypePk__c,
+                rec.CreatedDate, rec.ContextDataTxt__c
+            );
+            if (expected != rec.HashChainTxt__c) {
+                broken++;
+            }
+            previousHash = rec.HashChainTxt__c;
+        }
+        return broken;
+    }
+
+    private static String lookupPreviousHash(ActivityLog__c firstRecord) {
+        List<ActivityLog__c> prior = [
+            SELECT HashChainTxt__c FROM ActivityLog__c
+            WHERE CreatedDate < :firstRecord.CreatedDate
+            AND HashChainTxt__c != null
+            WITH SYSTEM_MODE
+            ORDER BY CreatedDate DESC LIMIT 1
+        ];
+        return prior.isEmpty() ? null : prior[0].HashChainTxt__c;
+    }
+
+    /**
      * @description Export compliance data for a date range.
      *              Returns all ActivityLog__c records within the specified period.
      * @param fromDate Start date (inclusive)

--- a/force-app/main/default/classes/DeliveryAuditChainServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryAuditChainServiceTest.cls
@@ -233,6 +233,51 @@ private class DeliveryAuditChainServiceTest {
     }
 
     @IsTest
+    static void testValidateChainForRecordReturnsFalseWhenNoLogs() {
+        Test.startTest();
+        Map<String, Object> result = DeliveryAuditChainService.validateChainForRecord(
+            UserInfo.getUserId());
+        Test.stopTest();
+        System.assertEquals(false, (Boolean) result.get('passed'),
+            'A record with no audit log entries should not claim verification');
+        System.assertEquals(0, (Integer) result.get('totalChecked'));
+    }
+
+    @IsTest
+    static void testValidateChainForRecordHandlesNullId() {
+        Test.startTest();
+        Map<String, Object> result = DeliveryAuditChainService.validateChainForRecord(null);
+        Test.stopTest();
+        System.assertEquals(false, (Boolean) result.get('passed'));
+    }
+
+    @IsTest
+    static void testValidateChainForRecordReturnsCount() {
+        Id docId = UserInfo.getUserId();
+        List<ActivityLog__c> logs = new List<ActivityLog__c>();
+        for (Integer i = 0; i < 2; i++) {
+            logs.add(new ActivityLog__c(
+                ActionTypePk__c = 'Navigation',
+                ComponentNameTxt__c = 'doc',
+                UserIdTxt__c = UserInfo.getUserId(),
+                RecordIdTxt__c = String.valueOf(docId),
+                ContextDataTxt__c = '{"index":' + i + '}'
+            ));
+        }
+        insert logs;
+
+        Test.startTest();
+        Map<String, Object> result = DeliveryAuditChainService.validateChainForRecord(docId);
+        Test.stopTest();
+
+        System.assertEquals(2, (Integer) result.get('totalChecked'),
+            'Should walk both audit log entries for the record');
+        // Whether passed=true depends on Datetime.now()/CreatedDate alignment, same caveat
+        // as the existing validateChain test. We just assert the structure here.
+        System.assertNotEquals(null, result.get('broken'));
+    }
+
+    @IsTest
     static void testCleanupJobSkipsLegalHoldRecords() {
         // Insert a legal-hold record and backdate it
         ActivityLog__c heldLog = new ActivityLog__c(

--- a/force-app/main/default/classes/DeliveryDocQueryService.cls
+++ b/force-app/main/default/classes/DeliveryDocQueryService.cls
@@ -364,12 +364,13 @@ public with sharing class DeliveryDocQueryService {
         // at least one slot. An empty slot list on a non-signing template stays false.
         Boolean signingComplete = signingRequired && !actions.isEmpty() && allCompleted;
 
-        // TODO: wire to DeliveryAuditChainService.validateChain — current implementation
-        // only validates the global ActivityLog__c chain (validateChain(Integer batchSize))
-        // and does not yet expose a per-document verification entry point. Returning
-        // false/null until that helper exists keeps the portal contract stable.
-        Boolean hashChainVerified = false;
-        Datetime hashChainVerifiedAt = null;
+        // Per-document hash-chain validation lives in DeliveryAuditChainService.
+        // Returns passed=false when the document has no log entries yet, so the
+        // portal contract still tells the truth on brand-new docs.
+        Map<String, Object> chainOutcome = DeliveryAuditChainService
+            .validateChainForRecord(documentId);
+        Boolean hashChainVerified = (Boolean) chainOutcome.get('passed');
+        Datetime hashChainVerifiedAt = (Datetime) chainOutcome.get('verifiedAt');
 
         return new Map<String, Object>{
             'signingRequired'     => signingRequired,

--- a/force-app/main/default/classes/DeliveryDocQueryService.cls
+++ b/force-app/main/default/classes/DeliveryDocQueryService.cls
@@ -367,8 +367,7 @@ public with sharing class DeliveryDocQueryService {
         // Per-document hash-chain validation lives in DeliveryAuditChainService.
         // Returns passed=false when the document has no log entries yet, so the
         // portal contract still tells the truth on brand-new docs.
-        Map<String, Object> chainOutcome = DeliveryAuditChainService
-            .validateChainForRecord(documentId);
+        Map<String, Object> chainOutcome = DeliveryAuditChainService.validateChainForRecord(documentId);
         Boolean hashChainVerified = (Boolean) chainOutcome.get('passed');
         Datetime hashChainVerifiedAt = (Datetime) chainOutcome.get('verifiedAt');
 

--- a/force-app/main/default/classes/DeliveryHubSetupController.cls
+++ b/force-app/main/default/classes/DeliveryHubSetupController.cls
@@ -55,10 +55,11 @@ global without sharing class DeliveryHubSetupController {
         status.isMothership = String.isNotBlank(status.requiredRemoteSite) &&
                               status.requiredRemoteSite.contains(orgPrefix);
 
+        String mothershipNamePattern = mothershipNamePrefix() + '%';
         List<NetworkEntity__c> entities = [
             SELECT Id, Name, StatusPk__c, IntegrationEndpointUrlTxt__c, OrgIdTxt__c
             FROM NetworkEntity__c
-            WHERE Name LIKE 'Cloud Nimbus LLC%'
+            WHERE Name LIKE :mothershipNamePattern
             LIMIT 1
         ];
 
@@ -72,6 +73,23 @@ global without sharing class DeliveryHubSetupController {
     }
 
     /**
+     * @description Resolves the mothership NetworkEntity name from
+     *              CloudNimbusGlobalSettings__mdt.Default.MothershipEntityNameTxt__c,
+     *              falling back to the legacy literal "Cloud Nimbus LLC" when the
+     *              metadata field is unset (preserves behaviour for orgs upgrading
+     *              from before the field existed).
+     * @return The configured mothership entity name.
+     */
+    @TestVisible
+    private static String mothershipNamePrefix() {
+        CloudNimbusGlobalSettings__mdt cfg = CloudNimbusGlobalSettings__mdt.getInstance('Default');
+        if (cfg != null && String.isNotBlank(cfg.MothershipEntityNameTxt__c)) {
+            return cfg.MothershipEntityNameTxt__c;
+        }
+        return 'Cloud Nimbus LLC';
+    }
+
+    /**
      * @description Creates or updates the local Cloud Nimbus LLC NetworkEntity__c record
      * with the endpoint URL from CloudNimbusGlobalSettings__mdt and sets it to Active.
      * @return NetworkEntity__c the upserted mothership entity record
@@ -79,16 +97,18 @@ global without sharing class DeliveryHubSetupController {
     @AuraEnabled
     @SuppressWarnings('PMD.ApexCRUDViolation')
     global static NetworkEntity__c prepareLocalEntity() {
+        String mothershipName = mothershipNamePrefix();
+        String mothershipPattern = mothershipName + '%';
         List<NetworkEntity__c> existingEntities = [
-            SELECT Id, Name FROM NetworkEntity__c 
-            WHERE Name LIKE 'Cloud Nimbus LLC%' 
+            SELECT Id, Name FROM NetworkEntity__c
+            WHERE Name LIKE :mothershipPattern
             LIMIT 1
         ];
 
         NetworkEntity__c mothership = !existingEntities.isEmpty() ? existingEntities[0] : new NetworkEntity__c();
-        
+
         if (mothership.Id == null) {
-            mothership.Name = 'Cloud Nimbus LLC';
+            mothership.Name = mothershipName;
             mothership.EntityTypePk__c = 'Vendor';
         }
         

--- a/force-app/main/default/classes/DeliverySyncReconciler.cls
+++ b/force-app/main/default/classes/DeliverySyncReconciler.cls
@@ -18,8 +18,8 @@ global without sharing class DeliverySyncReconciler implements Queueable, Databa
     /** @description Maximum SyncItems to insert per execution to stay within governor limits. */
     private static final Integer BATCH_LIMIT = 200;
 
-    /** @description The full set of WorkItem fields that the reconciler syncs downstream. */
-    private static final Set<String> WORK_ITEM_SYNC_FIELDS = new Set<String>{
+    /** @description Default WorkItem sync fields used when CloudNimbusGlobalSettings__mdt.SyncFieldsJsonTxt__c is unset. */
+    private static final Set<String> DEFAULT_WORK_ITEM_SYNC_FIELDS = new Set<String>{
         'BriefDescriptionTxt__c', 'DetailsTxt__c', 'StageNamePk__c', 'StatusPk__c',
         'PriorityPk__c', 'DeveloperDaysSizeNumber__c', 'EstimatedHoursNumber__c',
         'ClientPreApprovedHoursNumber__c', 'DeveloperLookup__c', 'CalculatedETADate__c',
@@ -27,6 +27,53 @@ global without sharing class DeliverySyncReconciler implements Queueable, Databa
         'ClientIntentionPk__c', 'RequestTypePk__c', 'TagsTxt__c', 'WorkflowTypeTxt__c',
         'EpicTxt__c', 'SLATargetDate__c', 'ActivatedDateTime__c', 'SortOrderNumber__c'
     };
+
+    /** @description Cached resolved sync fields for the current transaction. */
+    private static Set<String> cachedWorkItemSyncFields;
+
+    /**
+     * @description Resolve the WorkItem sync field list, preferring the
+     *              CloudNimbusGlobalSettings__mdt JSON config (so admins can
+     *              add new sync fields without an Apex change) and falling
+     *              back to the hardcoded defaults when the config is blank
+     *              or malformed.
+     * @return Active set of WorkItem fields the reconciler should sync.
+     */
+    @TestVisible
+    private static Set<String> getWorkItemSyncFields() {
+        if (cachedWorkItemSyncFields != null) {
+            return cachedWorkItemSyncFields;
+        }
+        cachedWorkItemSyncFields = DEFAULT_WORK_ITEM_SYNC_FIELDS;
+        CloudNimbusGlobalSettings__mdt cfg = CloudNimbusGlobalSettings__mdt.getInstance('Default');
+        if (cfg == null || String.isBlank(cfg.SyncFieldsJsonTxt__c)) {
+            return cachedWorkItemSyncFields;
+        }
+        try {
+            Object parsed = JSON.deserializeUntyped(cfg.SyncFieldsJsonTxt__c);
+            if (!(parsed instanceof Map<String, Object>)) {
+                return cachedWorkItemSyncFields;
+            }
+            Object workItemNode = ((Map<String, Object>) parsed).get('WorkItem__c');
+            if (!(workItemNode instanceof List<Object>)) {
+                return cachedWorkItemSyncFields;
+            }
+            Set<String> fields = new Set<String>();
+            for (Object f : (List<Object>) workItemNode) {
+                if (f != null) {
+                    fields.add(String.valueOf(f));
+                }
+            }
+            if (!fields.isEmpty()) {
+                cachedWorkItemSyncFields = fields;
+            }
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliverySyncReconciler] Bad SyncFieldsJsonTxt__c — falling back to defaults: '
+                + e.getMessage());
+        }
+        return cachedWorkItemSyncFields;
+    }
 
     /**
      * @description Constructs a new reconciler starting from the first entity.
@@ -257,7 +304,7 @@ global without sharing class DeliverySyncReconciler implements Queueable, Databa
 
         // Map all syncable fields
         Map<String, Object> populatedFields = wi.getPopulatedFieldsAsMap();
-        for (String field : WORK_ITEM_SYNC_FIELDS) {
+        for (String field : getWorkItemSyncFields()) {
             if (populatedFields.containsKey(field)) {
                 payload.put(field, populatedFields.get(field));
             }

--- a/force-app/main/default/customMetadata/CloudNimbusGlobalSettings.Default.md-meta.xml
+++ b/force-app/main/default/customMetadata/CloudNimbusGlobalSettings.Default.md-meta.xml
@@ -10,4 +10,12 @@
         <field>EnabledDateTime__c</field>
         <value xsi:type="xsd:dateTime">2020-01-01T00:00:00.000Z</value>
     </values>
+    <values>
+        <field>MothershipEntityNameTxt__c</field>
+        <value xsi:type="xsd:string">Cloud Nimbus LLC</value>
+    </values>
+    <values>
+        <field>SyncFieldsJsonTxt__c</field>
+        <value xsi:nil="true"/>
+    </values>
 </CustomMetadata>

--- a/force-app/main/default/objects/CloudNimbusGlobalSettings__mdt/fields/MothershipEntityNameTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/CloudNimbusGlobalSettings__mdt/fields/MothershipEntityNameTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>MothershipEntityNameTxt__c</fullName>
+    <description>NetworkEntity__c.Name used to identify the mothership/vendor entity in subscriber orgs. Defaults to "Cloud Nimbus LLC" for the original Delivery Hub deployment; subscribers running their own packaged distribution can override this in their custom-metadata Default row.</description>
+    <inlineHelpText>Display name of the upstream vendor NetworkEntity row.</inlineHelpText>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Mothership Entity Name</label>
+    <length>120</length>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/CloudNimbusGlobalSettings__mdt/fields/SyncFieldsJsonTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/CloudNimbusGlobalSettings__mdt/fields/SyncFieldsJsonTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>SyncFieldsJsonTxt__c</fullName>
+    <description>JSON map of object API names to the field list each object syncs cross-org. Read by DeliverySyncReconciler at run time so adding a new sync field is a metadata edit rather than a code change. Empty/blank value falls back to the hardcoded defaults in DeliverySyncReconciler.WORK_ITEM_SYNC_FIELDS.</description>
+    <inlineHelpText>JSON map of {"WorkItem__c": ["Field1__c", "Field2__c", ...], "WorkItemComment__c": [...]}.</inlineHelpText>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Sync Fields JSON</label>
+    <length>32768</length>
+    <type>LongTextArea</type>
+    <visibleLines>10</visibleLines>
+</CustomField>


### PR DESCRIPTION
## Summary

Removes the last load-bearing hardcoded values from the platform surface so adding a new sync field or rebranding the mothership entity is a metadata edit, not an Apex change. Also closes the per-document hash-chain TODO that PR 3's audit-grade-payment story depended on.

This is PR 5 of 5 — final piece of the **subtract-Glen sprint**.

### What changed
- **`CloudNimbusGlobalSettings__mdt`** — 2 new fields (no new objects; the namespaced scratch org's custom-object cap is still tight after PR 2):
  - `MothershipEntityNameTxt__c` — replaces the hardcoded `'Cloud Nimbus LLC'` literal in `DeliveryHubSetupController`. Subscribers can override via the Default custom metadata row (defaults to `Cloud Nimbus LLC` for backward compatibility).
  - `SyncFieldsJsonTxt__c` — JSON map of `{object: [field, ...]}` consulted by `DeliverySyncReconciler` at run time. Adding a new WorkItem sync field becomes a metadata edit. Falls back to the hardcoded `DEFAULT_WORK_ITEM_SYNC_FIELDS` when the JSON is blank or malformed so existing installs keep working with no change.
- **`DeliveryHubSetupController`** — new `mothershipNamePrefix()` helper reads the CMT, falls back to the literal. Both the LIKE query in `getSetupStatus()` and the upsert in `prepareLocalEntity()` use it.
- **`DeliverySyncReconciler`** — `getWorkItemSyncFields()` resolves the JSON config lazily and caches per-transaction. `buildWorkItemSyncItem` reads through the helper instead of the constant.
- **`DeliveryAuditChainService`** — new `validateChainForRecord(Id)` walks every `ActivityLog__c` row whose `RecordIdTxt__c` matches the supplied Salesforce Id, recomputes the expected `HashChainTxt__c` relative to the prior link in the global chain, and returns `passed`/`totalChecked`/`broken`/`verifiedAt`.
- **`DeliveryDocQueryService`** — closes the per-document hash-chain TODO at line 367 by calling `validateChainForRecord`. The portal contract now reports `passed=true` only when the document's chain is intact.
- 3 new tests in `DeliveryAuditChainServiceTest` cover the new method.

### Why metadata-drive these now
- Memory-tracked tech debt: hardcoded `WORK_ITEM_SYNC_FIELDS` was item #3 in the original generalization candidates list. Adding a sync field used to require Apex change + test + deploy.
- The `'Cloud Nimbus LLC'` literal bled into subscriber orgs as the Vendor entity name. Subscribers running a custom packaged distribution couldn't change it without Apex edits.
- The hash-chain TODO has been live since PR #686 (deferral panel) — closing it is what makes the Stripe payment trail audit-grade.

### What's deferred
- A dedicated `SyncFieldConfiguration__mdt` CMT (one row per object/field) would be cleaner long-term but adding a new metadata type would tip the namespaced scratch org over its custom-object cap. The JSON-on-existing-CMT approach achieves the same end without burning that slot.
- AI usage metering (gap #10 from the original plan) and the deferred-hours dashboard widget (gap #9) intentionally deferred to a follow-up sprint — both add new objects/LWCs that don't fit cleanly with the current cap budget.

### PMD
Local `sf scanner run --pmdconfig pmd-rules.xml --engine pmd` reports zero new violations. The one remaining `Avoid using global modifier` finding on `DeliveryHubSetupController:11` is pre-existing on the class declaration, untouched by this PR.

## Test plan
- [ ] Feature-test job (CI) green
- [ ] Apex tests green: `DeliveryAuditChainServiceTest` (existing + new)
- [ ] Manual (post-merge): edit `CloudNimbusGlobalSettings.Default.MothershipEntityNameTxt__c` to a different value in a sandbox; run `DeliveryHubSetupController.getSetupStatus()` and confirm the lookup pattern uses the new value
- [ ] Manual (post-merge): set `CloudNimbusGlobalSettings.Default.SyncFieldsJsonTxt__c` to `{"WorkItem__c":["BriefDescriptionTxt__c"]}`; trigger reconciler; confirm only that one field appears in payloads
- [ ] Manual: open a `DeliveryDocument__c` portal page; confirm `hashChainVerified` reflects whether the document has a valid log chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)