### PR TITLE
chore(admin): drop deliveryHubHealthDashboard onto DH Admin home page

### DIFF
--- a/force-app/main/default/flexipages/DeliveryHubAdminHome.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryHubAdminHome.flexipage-meta.xml
@@ -79,6 +79,12 @@
         </itemInstances>
         <itemInstances>
             <componentInstance>
+                <componentName>deliveryHubHealthDashboard</componentName>
+                <identifier>c_deliveryHubHealthDashboard</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
                 <componentInstanceProperties>
                     <name>displayMode</name>
                     <value>Card</value>


### PR DESCRIPTION
## Summary

Closes the orphan from #725 — the Health Dashboard LWC was deployed + exposed but never assigned to any flexipage, so admins had to drop it manually. This puts it at the top of the `DeliveryHubAdminHome` sidebar so it's the first thing visible when an admin opens the Delivery Hub Admin app.

Single-line metadata change. No Apex, no test impact.

### Why sidebar (not a dedicated tab)
- Admins land on AdminHome by default → zero clicks to see health
- Sidebar slot is persistent during navigation across the app
- A dedicated tab adds metadata surface (CustomTab + app entry); sidebar achieves the same UX with one file edit

### Re: "is there anything else we should put in here?"
Audited everything that shipped this sprint — only orphan UI is the Health Dashboard. Stripe webhook is backend only (no button shipped). Real-time chat is embedded in the WorkItem record page already. Gantt row decorators apply automatically. Defer-hours dashboard widget was deferred to a future sprint.

## Test plan
- [ ] Feature-test job (CI) green
- [ ] Open `/lightning/page/home` in the Delivery Hub Admin app on dh-prod after install — health dashboard renders in the right sidebar above the Ghost Recorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)