### PR TITLE
feat(live): extend live-events to dependency_change

### DIFF
--- a/force-app/main/default/classes/DeliveryDependencyTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryDependencyTriggerHandler.cls
@@ -3,36 +3,89 @@
  * @license      BSL 1.1 — See LICENSE.md
  * @description  Trigger handler for WorkItemDependency__c. Delegates to the field
  *               tracking service for create, update, and delete DML events.
+ *               Also publishes `dependency_change` Platform Events on the existing
+ *               DeliveryWorkItemChange__e channel so the gantt LWC can re-render
+ *               its dep arrows live when other clients add/remove/reparent deps.
+ *               Gated by DeliveryHubSettings__c.EnableLiveGanttEventsDateTime__c —
+ *               same toggle that controls task_upsert events from PR #731.
  * @author Cloud Nimbus LLC
  */
 @SuppressWarnings('PMD.ApexCRUDViolation')
 public with sharing class DeliveryDependencyTriggerHandler {
 
     /**
-     * @description Handles after-insert: tracks creation of dependency records.
+     * @description Handles after-insert: tracks creation of dependency records and
+     *              fires dependency_change events for both endpoints of each new dep.
      * @param newRecords List of newly inserted WorkItemDependency__c records.
      */
     public static void onAfterInsert(List<WorkItemDependency__c> newRecords) {
         if (!DeliveryTriggerControl.runAfterLogic) { return; }
         DeliveryFieldTrackingService.trackCreates(newRecords);
+        publishDependencyChangeEvents(newRecords);
     }
 
     /**
-     * @description Handles after-update: tracks field changes on dependency records.
+     * @description Handles after-update: tracks field changes on dependency records
+     *              and fires dependency_change events for both endpoints of each
+     *              updated dep (covers reparent / type changes).
      * @param newRecords List of updated WorkItemDependency__c records.
      * @param oldMap Map of pre-update WorkItemDependency__c records.
      */
     public static void onAfterUpdate(List<WorkItemDependency__c> newRecords, Map<Id, WorkItemDependency__c> oldMap) {
         if (!DeliveryTriggerControl.runAfterLogic) { return; }
         DeliveryFieldTrackingService.trackChanges(newRecords, oldMap);
+        publishDependencyChangeEvents(newRecords);
     }
 
     /**
-     * @description Handles before-delete: tracks deletion of dependency records.
+     * @description Handles before-delete: tracks deletion of dependency records and
+     *              fires dependency_change events for both endpoints so the gantt
+     *              re-renders without the removed arrow.
      * @param oldRecords List of WorkItemDependency__c records being deleted.
      */
     public static void onBeforeDelete(List<WorkItemDependency__c> oldRecords) {
         if (!DeliveryTriggerControl.runAfterLogic) { return; }
         DeliveryFieldTrackingService.trackDeletes(oldRecords);
+        publishDependencyChangeEvents(oldRecords);
+    }
+
+    /**
+     * @description Emit one DeliveryWorkItemChange__e per affected WorkItem
+     *              (both Blocking + Blocked endpoints) with ChangeTypeTxt__c =
+     *              'dependency_change'. Subscribers (deliveryProFormaTimeline,
+     *              deliveryRecordLiveRefresh) refetch on match and re-render
+     *              the dep arrows / record-page panels.
+     *
+     *              Fast-exits when the live-events toggle is null. Reuses the
+     *              same toggle as task_upsert publishing — admins flip both
+     *              ChangeTypes on/off together.
+     * @param deps List of dependency records (current state for insert/update,
+     *             pre-delete state for delete).
+     */
+    private static void publishDependencyChangeEvents(List<WorkItemDependency__c> deps) {
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getInstance();
+        if (settings == null || settings.Id == null || settings.EnableLiveGanttEventsDateTime__c == null) {
+            return;
+        }
+        Set<Id> affectedWorkItems = new Set<Id>();
+        for (WorkItemDependency__c d : deps) {
+            if (d.BlockingWorkItemLookup__c != null) {
+                affectedWorkItems.add(d.BlockingWorkItemLookup__c);
+            }
+            if (d.BlockedWorkItemLookup__c != null) {
+                affectedWorkItems.add(d.BlockedWorkItemLookup__c);
+            }
+        }
+        if (affectedWorkItems.isEmpty()) {
+            return;
+        }
+        List<DeliveryWorkItemChange__e> events = new List<DeliveryWorkItemChange__e>();
+        for (Id wiId : affectedWorkItems) {
+            events.add(new DeliveryWorkItemChange__e(
+                WorkItemIdTxt__c = wiId,
+                ChangeTypeTxt__c = 'dependency_change'
+            ));
+        }
+        EventBus.publish(events);
     }
 }

--- a/force-app/main/default/classes/DeliveryDependencyTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryDependencyTriggerHandlerTest.cls
@@ -102,4 +102,65 @@ private class DeliveryDependencyTriggerHandlerTest {
             System.assertEquals(0, remaining.size(), 'Dependency should be deleted');
         }
     }
+
+    /**
+     * @description Toggle off → publish path is gated; insert/update/delete on a
+     *              dep doesn't throw and proceeds normally. Smoke test only since
+     *              Platform Events are fire-and-forget in Apex test context.
+     */
+    @IsTest
+    static void testDependencyChangeEventsToggleOff() {
+        System.runAs(testUser) {
+            DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
+            System.assertEquals(null, s.EnableLiveGanttEventsDateTime__c,
+                'Toggle should default to null (off)');
+
+            WorkItem__c blocker = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Dep Blocker' LIMIT 1];
+            WorkItem__c blocked = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Dep Blocked' LIMIT 1];
+
+            Test.startTest();
+            WorkItemDependency__c dep = new WorkItemDependency__c(
+                BlockedWorkItemLookup__c = blocked.Id,
+                BlockingWorkItemLookup__c = blocker.Id
+            );
+            insert dep;
+            delete dep;
+            Test.stopTest();
+
+            System.assertEquals(0, [SELECT count() FROM WorkItemDependency__c WHERE Id = :dep.Id],
+                'Dep insert + delete should both land cleanly with toggle off');
+        }
+    }
+
+    /**
+     * @description Toggle on → publishDependencyChangeEvents path runs without error
+     *              on insert + update + delete. Verifies both endpoints of the dep
+     *              are still queryable (DML lands), confirming the publish doesn't
+     *              short-circuit the trigger.
+     */
+    @IsTest
+    static void testDependencyChangeEventsToggleOnFires() {
+        System.runAs(testUser) {
+            DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
+            s.EnableLiveGanttEventsDateTime__c = Datetime.now();
+            update s;
+
+            WorkItem__c blocker = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Dep Blocker' LIMIT 1];
+            WorkItem__c blocked = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Dep Blocked' LIMIT 1];
+
+            Test.startTest();
+            WorkItemDependency__c dep = new WorkItemDependency__c(
+                BlockedWorkItemLookup__c = blocked.Id,
+                BlockingWorkItemLookup__c = blocker.Id
+            );
+            insert dep;
+            dep.TypePk__c = 'Blocks';
+            update dep;
+            delete dep;
+            Test.stopTest();
+
+            System.assertEquals(0, [SELECT count() FROM WorkItemDependency__c WHERE Id = :dep.Id],
+                'Dep insert/update/delete cycle should land cleanly with toggle on');
+        }
+    }
 }

--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -64,12 +64,12 @@ const EMBEDDED_TAB_API_NAME = 'Delivery_Timeline';
 const FULLSCREEN_TAB_API_NAME = 'Delivery_Gantt_Full_Bleed';
 
 // Live updates channel — DeliveryWorkItemChange__e Platform Event.
-// On `task_upsert` events the gantt schedules a debounced refetch via the
-// existing `_scheduleRefetch` path (mirrors the chat LWC's refreshApex pattern;
-// no separate per-row engine push). `stage_change`/`comment_*` values are
-// owned by other LWCs and ignored here.
+// On `task_upsert` or `dependency_change` events the gantt schedules a
+// debounced refetch via the existing `_scheduleRefetch` path (mirrors the
+// chat LWC's refreshApex pattern; no separate per-row engine push).
+// `stage_change` / `comment_*` values are owned by other LWCs and ignored.
 const PE_CHANNEL = '/event/%%%NAMESPACE_DOT%%%DeliveryWorkItemChange__e';
-const PE_TASK_UPSERT = 'task_upsert';
+const GANTT_REFRESH_CHANGE_TYPES = new Set(['task_upsert', 'dependency_change']);
 
 export default class DeliveryProFormaTimeline extends NavigationMixin(LightningElement) {
 
@@ -840,7 +840,7 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             // deliveryWorkItemChat.js pattern.
             const changeType = payload.ChangeTypeTxt__c
                 || payload[`${this._peNsPrefix()}ChangeTypeTxt__c`];
-            if (changeType !== PE_TASK_UPSERT) {
+            if (!GANTT_REFRESH_CHANGE_TYPES.has(changeType)) {
                 return;
             }
             this._scheduleRefetch();

--- a/force-app/main/default/lwc/deliveryRecordLiveRefresh/deliveryRecordLiveRefresh.js
+++ b/force-app/main/default/lwc/deliveryRecordLiveRefresh/deliveryRecordLiveRefresh.js
@@ -22,7 +22,7 @@ const CHANNEL = '/event/%%%NAMESPACE_DOT%%%DeliveryWorkItemChange__e';
 // Change types we care about for record-page refresh. stage_change + comment_*
 // already drive their own LWCs (board, chat) via the same channel — getting
 // the LDS notification on those is harmless but not the primary goal.
-const REFRESH_CHANGE_TYPES = new Set(['task_upsert', 'stage_change']);
+const REFRESH_CHANGE_TYPES = new Set(['task_upsert', 'stage_change', 'dependency_change']);
 
 export default class DeliveryRecordLiveRefresh extends LightningElement {
     @api recordId;


### PR DESCRIPTION
## Summary

Follow-up to #731. Extends the same trigger-handler-publishes-PE / LWC-subscribes-and-refetches pattern to `WorkItemDependency__c` so the gantt's dep arrows re-render live when other clients add, update (reparent / type-change), or delete dependencies.

Same channel, same toggle, same subscribers — just one new ChangeType value.

## Changes

**Apex — `DeliveryDependencyTriggerHandler`**
- New `publishDependencyChangeEvents(deps)` — emits one `DeliveryWorkItemChange__e` per affected WorkItem (covers both `BlockingWorkItemLookup__c` + `BlockedWorkItemLookup__c` endpoints) with `ChangeTypeTxt__c = 'dependency_change'`.
- Wired into `onAfterInsert`, `onAfterUpdate`, `onBeforeDelete`.
- Gated by `DeliveryHubSettings__c.EnableLiveGanttEventsDateTime__c` — same toggle PR #731 introduced.

**LWC subscribers extended**
- `deliveryProFormaTimeline`: `GANTT_REFRESH_CHANGE_TYPES` set now includes both `'task_upsert'` + `'dependency_change'`. Refetch path unchanged.
- `deliveryRecordLiveRefresh`: `REFRESH_CHANGE_TYPES` adds `'dependency_change'` so record-page LDS auto-refresh fires when a dep involving this record changes.

**Tests**
- Two new methods on `DeliveryDependencyTriggerHandlerTest` covering toggle-off + toggle-on paths. Insert/update/delete all exercised.

## Out of scope

- `WorkLog__c` extension — deferred. The WorkLog trigger handler is more complex (validation + auto-fill + sync logic + hour lockout) and only `deliveryInvoicePreviewDeferPanel` consumes worklog data in a way that benefits from live updates today. Worth a focused PR when there's a clearer second consumer.

## Test plan

- [ ] CI green (apex-scan + namespaced feature test)
- [ ] After install: enable `EnableLiveGanttEventsDateTime__c` on Settings, open the gantt in two tabs, add a dep in one — watch the arrow appear in the other within 1-2 sec
- [ ] Same flow for delete — arrow disappears
- [ ] Reparent (update `BlockingWorkItemLookup__c`) — arrow shifts

🤖 Generated with [Claude Code](https://claude.com/claude-code)