### PR TITLE
feat(live): wire 3 LWCs to live-events — board metrics, dependencies, activity timeline

### DIFF
--- a/force-app/main/default/lwc/deliveryActivityTimeline/deliveryActivityTimeline.js
+++ b/force-app/main/default/lwc/deliveryActivityTimeline/deliveryActivityTimeline.js
@@ -9,6 +9,12 @@
 import { LightningElement, api, wire, track } from 'lwc';
 import getTimelineEvents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryActivityTimelineController.getTimelineEvents';
 import { refreshApex } from '@salesforce/apex';
+import { subscribe, unsubscribe, onError } from 'lightning/empApi';
+
+// Live updates — refresh on any DeliveryWorkItemChange__e for THIS record.
+// Filter to events whose WorkItemIdTxt__c matches the @api recordId so the
+// timeline doesn't refresh storm when other records on the org are edited.
+const PE_CHANNEL = '/event/%%%NAMESPACE_DOT%%%DeliveryWorkItemChange__e';
 
 const FILTER_OPTIONS = [
     { label: 'All', value: 'all', icon: 'utility:list' },
@@ -37,6 +43,42 @@ export default class DeliveryActivityTimeline extends LightningElement {
     error;
 
     _wiredResult;
+    _empSubscription;
+
+    // ── Lifecycle ───────────────────────────────────────────────────────
+
+    connectedCallback() {
+        if (!this.recordId) return;
+        onError((err) => {
+            console.warn('[DeliveryActivityTimeline] empApi error:', JSON.stringify(err));
+        });
+        subscribe(PE_CHANNEL, -1, (message) => {
+            const payload = message && message.data && message.data.payload;
+            if (!payload) return;
+            const ns = this._peNs();
+            const eventWiId = payload.WorkItemIdTxt__c || payload[`${ns}WorkItemIdTxt__c`];
+            // Only refresh when the change is for this record.
+            if (!eventWiId) return;
+            if (eventWiId.substring(0, 15) !== this.recordId.substring(0, 15)) return;
+            if (this._wiredResult) {
+                refreshApex(this._wiredResult);
+            }
+        }).then((sub) => { this._empSubscription = sub; });
+    }
+
+    disconnectedCallback() {
+        if (this._empSubscription) {
+            try { unsubscribe(this._empSubscription, () => {}); } catch (e) { /* best-effort */ }
+            this._empSubscription = null;
+        }
+    }
+
+    _peNs() {
+        if (this.__peNs !== undefined) return this.__peNs;
+        const m = PE_CHANNEL.match(/\/event\/(.*?)DeliveryWorkItemChange__e/);
+        this.__peNs = (m && m[1]) ? m[1] : '';
+        return this.__peNs;
+    }
 
     // ── Wire ────────────────────────────────────────────────────────────
 

--- a/force-app/main/default/lwc/deliveryBoardMetrics/deliveryBoardMetrics.js
+++ b/force-app/main/default/lwc/deliveryBoardMetrics/deliveryBoardMetrics.js
@@ -9,7 +9,14 @@
 import { LightningElement, api, wire, track } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
 import { refreshApex } from '@salesforce/apex';
+import { subscribe, unsubscribe, onError } from 'lightning/empApi';
 import getBoardMetrics from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryMetricsService.getBoardMetrics';
+
+// Live updates — same channel + filter pattern as deliveryHubBoard.
+// Refresh on stage transitions + new task_upsert events; ignore comment_*
+// to avoid refresh storms when chat is active.
+const PE_CHANNEL = '/event/%%%NAMESPACE_DOT%%%DeliveryWorkItemChange__e';
+const REFRESH_CHANGE_TYPES = new Set(['stage_change', 'task_upsert']);
 
 // Phase color mapping for stacked bar segments
 const PHASE_COLORS = {
@@ -38,6 +45,7 @@ export default class DeliveryBoardMetrics extends NavigationMixin(LightningEleme
     @track error = null;
 
     _wiredResult;
+    _empSubscription;
 
     @wire(getBoardMetrics)
     wiredMetrics(result) {
@@ -52,6 +60,36 @@ export default class DeliveryBoardMetrics extends NavigationMixin(LightningEleme
             this.error = error;
             this.isLoading = false;
         }
+    }
+
+    connectedCallback() {
+        onError((err) => {
+            console.warn('[DeliveryBoardMetrics] empApi error:', JSON.stringify(err));
+        });
+        subscribe(PE_CHANNEL, -1, (message) => {
+            const payload = message && message.data && message.data.payload;
+            if (!payload) return;
+            const ns = this._peNs();
+            const changeType = payload.ChangeTypeTxt__c || payload[`${ns}ChangeTypeTxt__c`];
+            if (!REFRESH_CHANGE_TYPES.has(changeType)) return;
+            if (this._wiredResult) {
+                refreshApex(this._wiredResult);
+            }
+        }).then((sub) => { this._empSubscription = sub; });
+    }
+
+    disconnectedCallback() {
+        if (this._empSubscription) {
+            try { unsubscribe(this._empSubscription, () => {}); } catch (e) { /* best-effort */ }
+            this._empSubscription = null;
+        }
+    }
+
+    _peNs() {
+        if (this.__peNs !== undefined) return this.__peNs;
+        const m = PE_CHANNEL.match(/\/event\/(.*?)DeliveryWorkItemChange__e/);
+        this.__peNs = (m && m[1]) ? m[1] : '';
+        return this.__peNs;
     }
 
     // ── Mode getters ──

--- a/force-app/main/default/lwc/deliveryWorkItemDependencies/deliveryWorkItemDependencies.js
+++ b/force-app/main/default/lwc/deliveryWorkItemDependencies/deliveryWorkItemDependencies.js
@@ -5,7 +5,16 @@
  */
 import { LightningElement, api, wire, track } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
+import { refreshApex } from '@salesforce/apex';
+import { subscribe, unsubscribe, onError } from 'lightning/empApi';
 import getDependencies from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkItemDependenciesController.getDependencies';
+
+// Live updates — refresh when a dependency_change PE arrives. The publisher
+// (DeliveryDependencyTriggerHandler from PR #732) emits one event per
+// affected WorkItem (both endpoints), so we receive an event regardless of
+// which side this record is on.
+const PE_CHANNEL = '/event/%%%NAMESPACE_DOT%%%DeliveryWorkItemChange__e';
+const REFRESH_CHANGE_TYPES = new Set(['dependency_change']);
 
 export default class DeliveryWorkItemDependencies extends NavigationMixin(LightningElement) {
     @api recordId;
@@ -13,8 +22,13 @@ export default class DeliveryWorkItemDependencies extends NavigationMixin(Lightn
     @track blockedBy = [];
     @track isLoading = true;
 
+    _wiredResult;
+    _empSubscription;
+
     @wire(getDependencies, { workItemId: '$recordId' })
-    wiredDeps({ data, error }) {
+    wiredDeps(result) {
+        this._wiredResult = result;
+        const { data, error } = result;
         if (data) {
             this.blocking  = data.blocking  || [];
             this.blockedBy = data.blockedBy || [];
@@ -23,6 +37,41 @@ export default class DeliveryWorkItemDependencies extends NavigationMixin(Lightn
             console.error('Error loading dependencies', error);
             this.isLoading = false;
         }
+    }
+
+    connectedCallback() {
+        if (!this.recordId) return;
+        onError((err) => {
+            console.warn('[DeliveryWorkItemDependencies] empApi error:', JSON.stringify(err));
+        });
+        subscribe(PE_CHANNEL, -1, (message) => {
+            const payload = message && message.data && message.data.payload;
+            if (!payload) return;
+            const ns = this._peNs();
+            const changeType = payload.ChangeTypeTxt__c || payload[`${ns}ChangeTypeTxt__c`];
+            if (!REFRESH_CHANGE_TYPES.has(changeType)) return;
+            const eventWiId = payload.WorkItemIdTxt__c || payload[`${ns}WorkItemIdTxt__c`];
+            if (!eventWiId) return;
+            // Only refresh when the dep-change involves this record.
+            if (eventWiId.substring(0, 15) !== this.recordId.substring(0, 15)) return;
+            if (this._wiredResult) {
+                refreshApex(this._wiredResult);
+            }
+        }).then((sub) => { this._empSubscription = sub; });
+    }
+
+    disconnectedCallback() {
+        if (this._empSubscription) {
+            try { unsubscribe(this._empSubscription, () => {}); } catch (e) { /* best-effort */ }
+            this._empSubscription = null;
+        }
+    }
+
+    _peNs() {
+        if (this.__peNs !== undefined) return this.__peNs;
+        const m = PE_CHANNEL.match(/\/event\/(.*?)DeliveryWorkItemChange__e/);
+        this.__peNs = (m && m[1]) ? m[1] : '';
+        return this.__peNs;
     }
 
     get hasBlocking()  { return this.blocking.length  > 0; }


### PR DESCRIPTION
## Summary

Tier 1 of the live-updates sweep. Three LWCs that displayed business data without any live-refresh mechanism now subscribe to `DeliveryWorkItemChange__e` and call `refreshApex` on match. Same pattern as PRs #731 + #732. **No new infrastructure** — just consumers wired to the existing channel.

## What changed

**`deliveryBoardMetrics`** (KPIs: WIP gauge, aging alerts, priority breakdown, stage distribution)
- Subscribes to PE, filters on `stage_change` + `task_upsert`
- On match, refreshes the wired Apex result so KPIs re-render live as items move stages
- Filters out `comment_*` to avoid refresh storms during active chat

**`deliveryActivityTimeline`** (per-record timeline of comments / stage changes / time logs)
- Subscribes scoped by `WorkItemIdTxt__c == this.recordId` — only refreshes when the change is for THIS record
- All ChangeTypes accepted (this LWC IS the timeline)
- Mirrors `deliveryWorkItemChat`'s scoping pattern

**`deliveryWorkItemDependencies`** (per-record blocker / blocked-by view)
- Subscribes scoped by recordId AND `ChangeType=dependency_change`
- Picks up the events shipped by PR #732 — refreshes when other clients add/remove/reparent deps involving this record

## Pattern uniformity
All three follow the established pattern in the repo (`deliveryWorkItemChat`, `deliveryActivityFeed`, `deliveryHubBoard`):
- Per-mount subscribe in `connectedCallback`, unsubscribe in `disconnectedCallback`
- Namespace-aware payload key resolution (`delivery__` prefix on subscriber orgs)
- Existing wired-Apex result preserved + refreshed via `refreshApex` (no re-fetch storm)

## Out of scope (Tier 2 / 3 candidates for follow-up PRs)
Per the audit — ~35 more LWCs without live-update mechanisms:
- **Tier 2 candidates:** `deliveryDeveloperWorkload`, `deliveryCycleTimeChart`, `deliveryVelocityDashboard`
- **Tier 3 candidates:** `deliveryExecutiveDashboard`, `deliveryBudgetSummary`, `deliveryClientDashboard`
- **Skip:** `deliveryFieldHistory` (immutable audit log), `deliveryWorkItemFiles` (file uploads infrequent)

## Test plan
- [ ] CI green (apex-scan + namespaced feature test)
- [ ] After deploy: edit a WorkItem in tab A, watch board metrics refresh in tab B
- [ ] Add a dependency in tab A, watch tab B's `deliveryWorkItemDependencies` panel refresh
- [ ] Post a comment in tab A, watch the activity timeline tick on the same record's tab B

🤖 Generated with [Claude Code](https://claude.com/claude-code)