### PR TITLE
feat(gantt): add scheduleProgress + variance + actualEndDate to ProFormaTimelineRow

### DIFF
--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -964,6 +964,24 @@ public with sharing class DeliveryGanttController {
          *  drag-to-reorder in the timeline. Lower values appear first. Null when
          *  the item has never been reordered; LWC maps null → 0. */
         @AuraEnabled public Decimal sortOrder { get; set; }
+        /** @description Schedule progress 0..1 — fraction of (endDate - startDate) elapsed
+         *  by today. Null when dates are missing or the bar is in the future / past
+         *  entirely. Pairs with `progress` (hours-based) so the gantt can render two
+         *  overlay shades on each bar: where the work IS vs where the schedule SAYS
+         *  it should be. Same shape as cloudnimbusllc.com v12 visual language. */
+        @AuraEnabled public Decimal scheduleProgress { get; set; }
+        /** @description Schedule-vs-output variance signal — one of:
+         *  'done' (terminal stage), 'ahead' (output > schedule by >10pp),
+         *  'behind' (output < schedule by >10pp), 'at-risk' (>95% of schedule
+         *  elapsed but <100% complete), 'on-track' (within ±10pp). Used for
+         *  bar color / overlay tinting in the gantt. Null when no data. */
+        @AuraEnabled public String variance { get; set; }
+        /** @description ISO YYYY-MM-DD actual completion date — populated for items
+         *  whose stage is terminal (Done / Deployed to Prod / Cancelled) using
+         *  LastModifiedDate as the proxy for "stage entered terminal". Null for
+         *  in-flight items. Lets the gantt render a "shipped early/late" marker
+         *  comparing actualEndDate vs endDate for Done items. */
+        @AuraEnabled public String actualEndDate { get; set; }
     }
 
     /** Stages where work is actively moving forward (bucket = active or top-priority) */
@@ -1136,7 +1154,75 @@ public with sharing class DeliveryGanttController {
         }
         row.endDate = String.valueOf(endDt);
 
+        // Schedule progress + variance — pairs with `progress` (hours-based) so
+        // the gantt can render two overlay shades on each bar (output progress
+        // vs schedule progress) and tint by variance signal. Mirrors the v12
+        // visual language we want to bring to DH.
+        row.scheduleProgress = computeScheduleProgress(startDt, endDt);
+        row.variance = computeVariance(row.progress, row.scheduleProgress, isTerminal);
+        row.actualEndDate = isTerminal && item.LastModifiedDate != null
+            ? String.valueOf(item.LastModifiedDate.date())
+            : null;
+
         return row;
+    }
+
+    /**
+     * @description Fraction of (endDt - startDt) elapsed by today, clamped 0..1.
+     *              Returns null when the interval is degenerate (same day or
+     *              missing dates) so the renderer can fall back to bar-only.
+     * @param startDt Bar start date.
+     * @param endDt Bar end date.
+     * @return Decimal in [0,1], or null when undefined.
+     */
+    private static Decimal computeScheduleProgress(Date startDt, Date endDt) {
+        if (startDt == null || endDt == null || endDt <= startDt) {
+            return null;
+        }
+        Date today = Date.today();
+        if (today <= startDt) {
+            return 0;
+        }
+        if (today >= endDt) {
+            return 1;
+        }
+        Integer total = startDt.daysBetween(endDt);
+        if (total <= 0) {
+            return null;
+        }
+        Integer elapsed = startDt.daysBetween(today);
+        return Decimal.valueOf(elapsed).divide(Decimal.valueOf(total), 4);
+    }
+
+    /**
+     * @description Compute the variance signal for the gantt bar tint.
+     *              'done' for terminal stages, 'at-risk' when schedule is
+     *              nearly out but output is not, 'ahead' / 'behind' / 'on-track'
+     *              based on the gap between hours-progress and schedule-progress.
+     * @param hoursProgress Output progress 0..1 from logged/estimated hours.
+     * @param schedProgress Time progress 0..1 from elapsed/total bar duration.
+     * @param isTerminal True when the WorkItem stage is terminal.
+     * @return Variance label or null when inputs insufficient.
+     */
+    private static String computeVariance(Decimal hoursProgress, Decimal schedProgress, Boolean isTerminal) {
+        if (isTerminal) {
+            return 'done';
+        }
+        if (hoursProgress == null || schedProgress == null) {
+            return null;
+        }
+        // Out-of-time but not complete → at-risk (schedule consumed >95%, output <100%).
+        if (schedProgress > 0.95 && hoursProgress < 1) {
+            return 'at-risk';
+        }
+        Decimal delta = hoursProgress - schedProgress;
+        if (delta > 0.10) {
+            return 'ahead';
+        }
+        if (delta < -0.10) {
+            return 'behind';
+        }
+        return 'on-track';
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryGanttControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryGanttControllerTest.cls
@@ -654,6 +654,88 @@ private class DeliveryGanttControllerTest {
         }
     }
 
+    /**
+     * @description scheduleProgress + variance shape — bar with start in past
+     *              and end in future should produce a 0..1 schedule progress
+     *              and an 'on-track' / 'ahead' / 'behind' variance label per
+     *              the relationship to hours-progress.
+     */
+    @IsTest
+    static void testProFormaScheduleProgressAndVarianceFields() {
+        System.runAs(testUser) {
+            // Set the login item to have a 30-day window starting 15 days ago
+            // (so today is exactly the midpoint = scheduleProgress 0.5).
+            WorkItem__c loginItem = [
+                SELECT Id, EstimatedStartDevDate__c, EstimatedEndDevDate__c,
+                       EstimatedHoursNumber__c, TotalLoggedHoursSum__c
+                FROM WorkItem__c
+                WHERE BriefDescriptionTxt__c = 'Build login page'
+                LIMIT 1
+            ];
+            loginItem.EstimatedStartDevDate__c = Date.today().addDays(-15);
+            loginItem.EstimatedEndDevDate__c   = Date.today().addDays(15);
+            update loginItem;
+
+            Test.startTest();
+            List<DeliveryGanttController.ProFormaTimelineRow> rows =
+                DeliveryGanttController.getProFormaTimelineData(false);
+            Test.stopTest();
+
+            DeliveryGanttController.ProFormaTimelineRow loginRow = null;
+            for (DeliveryGanttController.ProFormaTimelineRow r : rows) {
+                if (r.title == 'Build login page') { loginRow = r; break; }
+            }
+            System.assertNotEquals(null, loginRow, 'Login row should still be present');
+            System.assertNotEquals(null, loginRow.scheduleProgress,
+                'scheduleProgress should be computed for a real date interval');
+            // Today is mid-window, so scheduleProgress should be ~0.5
+            System.assert(loginRow.scheduleProgress >= 0.4 && loginRow.scheduleProgress <= 0.6,
+                'Mid-window bar should yield scheduleProgress ~0.5, got ' + loginRow.scheduleProgress);
+            System.assertNotEquals(null, loginRow.variance,
+                'variance label should be set when both progresses are computable');
+            // Active (non-terminal) row → variance is one of ahead/on-track/behind/at-risk
+            Set<String> validVariance = new Set<String>{ 'ahead', 'on-track', 'behind', 'at-risk' };
+            System.assert(validVariance.contains(loginRow.variance),
+                'variance for in-flight item should be one of ' + validVariance + '; got: ' + loginRow.variance);
+        }
+    }
+
+    /**
+     * @description Terminal-stage rows always render variance='done' with
+     *              actualEndDate populated from LastModifiedDate. Lets the
+     *              gantt show 'shipped early/late' markers on completed bars.
+     */
+    @IsTest
+    static void testProFormaVarianceDoneAndActualEndDateForTerminal() {
+        System.runAs(testUser) {
+            // Create a terminal-stage row in setup data + query it back.
+            WorkItem__c done = new WorkItem__c(
+                BriefDescriptionTxt__c = 'Already-shipped item',
+                StageNamePk__c = 'Done',
+                EstimatedStartDevDate__c = Date.today().addDays(-10),
+                EstimatedEndDevDate__c   = Date.today().addDays(-3),
+                EstimatedHoursNumber__c = 8,
+                ActivatedDateTime__c = Datetime.now()
+            );
+            insert done;
+
+            Test.startTest();
+            List<DeliveryGanttController.ProFormaTimelineRow> rows =
+                DeliveryGanttController.getProFormaTimelineData(true);
+            Test.stopTest();
+
+            DeliveryGanttController.ProFormaTimelineRow doneRow = null;
+            for (DeliveryGanttController.ProFormaTimelineRow r : rows) {
+                if (r.title == 'Already-shipped item') { doneRow = r; break; }
+            }
+            System.assertNotEquals(null, doneRow, 'Terminal row should appear when showCompleted=true');
+            System.assertEquals('done', doneRow.variance,
+                'Terminal-stage rows should always carry variance=done');
+            System.assertNotEquals(null, doneRow.actualEndDate,
+                'actualEndDate should be populated for terminal rows (LastModifiedDate proxy)');
+        }
+    }
+
     @IsTest
     static void testGetProFormaTimelineDataExplicitOverride() {
         // If PriorityGroupPk__c is set on the record, the DTO should use it


### PR DESCRIPTION
## Summary

Brings the multi-shade visual language Glen saw on cloudnimbusllc.com v12 to the DH gantt **data layer**. Three new fields on `ProFormaTimelineRow` so when nimbus-gantt's renderer picks them up (or the LWC adapter maps them through), every bar can carry two overlay shades + variance tint.

## What changed

- **`scheduleProgress`** (Decimal 0..1): fraction of `(endDate - startDate)` elapsed by today. Clamped 0/1 when today is before/after the bar.
- **`variance`** (String): `'done'` | `'ahead'` | `'behind'` | `'at-risk'` | `'on-track'`. Tints by the gap between hours-progress and schedule-progress. `'at-risk'` fires when schedule consumed >95% but output <100%.
- **`actualEndDate`** (ISO YYYY-MM-DD): populated for terminal stages (Done / Deployed to Prod / Cancelled) using `LastModifiedDate` as the stage-completion proxy. Lets the gantt render shipped-early / shipped-late markers on completed bars.

## How it pairs with v12's visual

Two overlay shades per bar:
- `progress` (existing) — output completion (logged ÷ estimated hours)
- `scheduleProgress` (new) — time elapsed (today position in the bar)

`variance` tints the bar so reading the relationship between the two shades + the color tells you at a glance whether the row is on/ahead/behind schedule AND whether output is keeping pace with budget.

## Why this is data-layer-only

Pure additive DTO change. NG bundle doesn't render these fields yet — they sit unused until either NG ships overlay rendering OR the DH LWC adapter maps them through to existing engine surfaces. No regression risk; older NG bundles ignore unknown fields.

## Out of scope (follow-ups)

- LWC adapter wiring → engine overlay rendering (waits on either NG side or v12's locked visual conventions)
- Threshold tuning (the 10pp delta and 95% at-risk thresholds are first-cut; user testing may want to expose them as Settings)
- Per-priority-bucket variance tinting (e.g., NOW bars get redder treatment than PROPOSED)

## Test plan

- [ ] CI green
- [ ] Two new tests cover scheduleProgress + variance for in-flight + terminal rows
- [ ] After deploy: query a representative WorkItem and verify `scheduleProgress` reflects today's position in its window
- [ ] Once NG / LWC renders the new fields: visual A/B against v12 to confirm the language matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)