### PR TITLE
feat(gantt): parent rollup — aggregate child hours/dates/variance onto parent rows

### DIFF
--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -1161,6 +1161,7 @@ public with sharing class DeliveryGanttController {
      * @param parent Parent row (mutated).
      * @param children Direct children of `parent` (rows whose parentWorkItemId == parent.id).
      */
+    @SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity')
     private static void applyParentRollup(ProFormaTimelineRow parent, List<ProFormaTimelineRow> children) {
         Decimal totalEst = 0;
         Decimal totalLogged = 0;
@@ -1211,7 +1212,15 @@ public with sharing class DeliveryGanttController {
         parent.doneChildrenCount = doneCount;
     }
 
-    /** Parse ISO YYYY-MM-DD date string back into Date; null-safe. */
+    /**
+     * @description Parse an ISO YYYY-MM-DD date string back into a Date.
+     *              Null-safe: returns null when input is blank or unparseable.
+     *              Used by the parent-rollup pass to compute earliest-start /
+     *              latest-end across children whose dates are stored as
+     *              ISO strings on the DTO.
+     * @param iso ISO YYYY-MM-DD date string, or null.
+     * @return Parsed Date, or null when input is blank / unparseable.
+     */
     private static Date parseIsoDate(String iso) {
         if (String.isBlank(iso)) {
             return null;

--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -982,6 +982,13 @@ public with sharing class DeliveryGanttController {
          *  in-flight items. Lets the gantt render a "shipped early/late" marker
          *  comparing actualEndDate vs endDate for Done items. */
         @AuraEnabled public String actualEndDate { get; set; }
+        /** @description Direct-child count when this row is a parent in the result
+         *  set; null when the row is a leaf. Powers "X of Y children done" badges
+         *  alongside the parent's rolled-up bar. */
+        @AuraEnabled public Integer childrenCount { get; set; }
+        /** @description Count of direct children whose variance is 'done' (terminal
+         *  stage). Pairs with childrenCount for the X-of-Y badge. */
+        @AuraEnabled public Integer doneChildrenCount { get; set; }
     }
 
     /** Stages where work is actively moving forward (bucket = active or top-priority) */
@@ -1098,11 +1105,121 @@ public with sharing class DeliveryGanttController {
             for (WorkItem__c item : items) {
                 rows.add(mapToProFormaRow(item));
             }
+            applyParentRollups(rows);
             return rows;
         } catch (Exception e) {
             AuraHandledException ahe = new AuraHandledException(e.getMessage());
             ahe.setMessage(e.getMessage());
             throw ahe;
+        }
+    }
+
+    /**
+     * @description Roll up child rows onto their parents so a parent's bar
+     *              reflects the aggregate state of the work breakdown rather
+     *              than whatever was manually typed onto the parent record.
+     *              Touches: estimatedHours, loggedHours, progress, startDate,
+     *              endDate, scheduleProgress, variance, childrenCount,
+     *              doneChildrenCount. Only applied when the row has children
+     *              in the result set; leaf rows are untouched.
+     *
+     *              Subtract-Glen lever: with this in place, daily worklogs
+     *              against children automatically move the parent's bar +
+     *              variance signal — no manual parent updates required.
+     * @param rows All rows in the result set (mutated in place).
+     */
+    private static void applyParentRollups(List<ProFormaTimelineRow> rows) {
+        Map<Id, List<ProFormaTimelineRow>> childrenByParent = new Map<Id, List<ProFormaTimelineRow>>();
+        for (ProFormaTimelineRow r : rows) {
+            if (String.isBlank(r.parentWorkItemId)) {
+                continue;
+            }
+            Id pid = (Id) r.parentWorkItemId;
+            if (!childrenByParent.containsKey(pid)) {
+                childrenByParent.put(pid, new List<ProFormaTimelineRow>());
+            }
+            childrenByParent.get(pid).add(r);
+        }
+        if (childrenByParent.isEmpty()) {
+            return;
+        }
+        for (ProFormaTimelineRow r : rows) {
+            List<ProFormaTimelineRow> kids = childrenByParent.get((Id) r.id);
+            if (kids == null || kids.isEmpty()) {
+                continue;
+            }
+            applyParentRollup(r, kids);
+        }
+    }
+
+    /**
+     * @description Override a parent row's fields with aggregates from its
+     *              children. Sums hours, takes earliest child start +
+     *              latest child end as the bar bounds, and recomputes
+     *              schedule progress + variance from those aggregates.
+     *              Variance is 'done' iff every child is done.
+     * @param parent Parent row (mutated).
+     * @param children Direct children of `parent` (rows whose parentWorkItemId == parent.id).
+     */
+    private static void applyParentRollup(ProFormaTimelineRow parent, List<ProFormaTimelineRow> children) {
+        Decimal totalEst = 0;
+        Decimal totalLogged = 0;
+        Boolean hasEstimate = false;
+        Date earliestStart = null;
+        Date latestEnd = null;
+        Integer doneCount = 0;
+
+        for (ProFormaTimelineRow c : children) {
+            if (c.estimatedHours != null) {
+                totalEst += c.estimatedHours;
+                hasEstimate = true;
+            }
+            if (c.loggedHours != null) {
+                totalLogged += c.loggedHours;
+            }
+            Date cStart = parseIsoDate(c.startDate);
+            if (cStart != null && (earliestStart == null || cStart < earliestStart)) {
+                earliestStart = cStart;
+            }
+            Date cEnd = parseIsoDate(c.endDate);
+            if (cEnd != null && (latestEnd == null || cEnd > latestEnd)) {
+                latestEnd = cEnd;
+            }
+            if ('done' == c.variance) {
+                doneCount++;
+            }
+        }
+
+        if (hasEstimate) {
+            parent.estimatedHours = totalEst;
+            parent.loggedHours = totalLogged;
+            parent.progress = totalEst > 0 ? Math.min(totalLogged / totalEst, 1.0) : null;
+        }
+        if (earliestStart != null) {
+            parent.startDate = String.valueOf(earliestStart);
+        }
+        if (latestEnd != null) {
+            parent.endDate = String.valueOf(latestEnd);
+        }
+        parent.scheduleProgress = computeScheduleProgress(earliestStart, latestEnd);
+        if (doneCount == children.size() && doneCount > 0) {
+            parent.variance = 'done';
+        } else {
+            parent.variance = computeVariance(parent.progress, parent.scheduleProgress, false);
+        }
+        parent.childrenCount = children.size();
+        parent.doneChildrenCount = doneCount;
+    }
+
+    /** Parse ISO YYYY-MM-DD date string back into Date; null-safe. */
+    private static Date parseIsoDate(String iso) {
+        if (String.isBlank(iso)) {
+            return null;
+        }
+        try {
+            return Date.valueOf(iso);
+        } catch (Exception e) {
+            return null;
         }
     }
 

--- a/force-app/main/default/classes/DeliveryGanttControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryGanttControllerTest.cls
@@ -736,6 +736,119 @@ private class DeliveryGanttControllerTest {
         }
     }
 
+    /**
+     * @description Parent row with two children should aggregate hours +
+     *              dates from the children. Children's worklog drives the
+     *              parent's progress without manual updates — the
+     *              subtract-Glen rollup story.
+     */
+    @IsTest
+    static void testProFormaParentRollupAggregatesChildrenHoursAndDates() {
+        System.runAs(testUser) {
+            WorkItem__c parent = new WorkItem__c(
+                BriefDescriptionTxt__c = 'Parent epic',
+                StageNamePk__c = 'In Development',
+                ActivatedDateTime__c = Datetime.now(),
+                EstimatedHoursNumber__c = 999,
+                EstimatedStartDevDate__c = Date.today().addDays(-30)
+            );
+            insert parent;
+
+            WorkItem__c child1 = new WorkItem__c(
+                BriefDescriptionTxt__c = 'Child A',
+                StageNamePk__c = 'In Development',
+                ActivatedDateTime__c = Datetime.now(),
+                ParentWorkItemLookup__c = parent.Id,
+                EstimatedHoursNumber__c = 10,
+                EstimatedStartDevDate__c = Date.today().addDays(-5),
+                EstimatedEndDevDate__c   = Date.today().addDays(5)
+            );
+            WorkItem__c child2 = new WorkItem__c(
+                BriefDescriptionTxt__c = 'Child B',
+                StageNamePk__c = 'In Development',
+                ActivatedDateTime__c = Datetime.now(),
+                ParentWorkItemLookup__c = parent.Id,
+                EstimatedHoursNumber__c = 6,
+                EstimatedStartDevDate__c = Date.today().addDays(-2),
+                EstimatedEndDevDate__c   = Date.today().addDays(8)
+            );
+            insert new List<WorkItem__c>{ child1, child2 };
+
+            Test.startTest();
+            List<DeliveryGanttController.ProFormaTimelineRow> rows =
+                DeliveryGanttController.getProFormaTimelineData(false);
+            Test.stopTest();
+
+            DeliveryGanttController.ProFormaTimelineRow parentRow = null;
+            for (DeliveryGanttController.ProFormaTimelineRow r : rows) {
+                if (r.title == 'Parent epic') { parentRow = r; break; }
+            }
+            System.assertNotEquals(null, parentRow, 'Parent row should be in result set');
+            System.assertEquals(16, parentRow.estimatedHours,
+                'Parent estimatedHours should be sum of children (10+6), not the manually-typed 999');
+            System.assertEquals(2, parentRow.childrenCount,
+                'childrenCount should reflect direct children');
+            System.assertEquals(0, parentRow.doneChildrenCount,
+                'No terminal children → doneChildrenCount = 0');
+            System.assertEquals(String.valueOf(Date.today().addDays(-5)), parentRow.startDate,
+                'Parent startDate should be earliest child start');
+            System.assertEquals(String.valueOf(Date.today().addDays(8)), parentRow.endDate,
+                'Parent endDate should be latest child end');
+        }
+    }
+
+    /**
+     * @description When all children are terminal, parent's variance rolls
+     *              up to 'done' regardless of the parent's own stage. Lets
+     *              the gantt show "this epic is complete" even if the
+     *              parent record's stage hasn't been manually moved yet.
+     */
+    @IsTest
+    static void testProFormaParentRollupVarianceDoneWhenAllChildrenTerminal() {
+        System.runAs(testUser) {
+            WorkItem__c parent = new WorkItem__c(
+                BriefDescriptionTxt__c = 'Parent epic 2',
+                StageNamePk__c = 'In Development',
+                ActivatedDateTime__c = Datetime.now(),
+                EstimatedHoursNumber__c = 5,
+                EstimatedStartDevDate__c = Date.today().addDays(-10),
+                EstimatedEndDevDate__c   = Date.today().addDays(5)
+            );
+            insert parent;
+
+            WorkItem__c child1 = new WorkItem__c(
+                BriefDescriptionTxt__c = 'Done child A',
+                StageNamePk__c = 'Done',
+                ActivatedDateTime__c = Datetime.now(),
+                ParentWorkItemLookup__c = parent.Id,
+                EstimatedHoursNumber__c = 4
+            );
+            WorkItem__c child2 = new WorkItem__c(
+                BriefDescriptionTxt__c = 'Done child B',
+                StageNamePk__c = 'Deployed to Prod',
+                ActivatedDateTime__c = Datetime.now(),
+                ParentWorkItemLookup__c = parent.Id,
+                EstimatedHoursNumber__c = 3
+            );
+            insert new List<WorkItem__c>{ child1, child2 };
+
+            Test.startTest();
+            List<DeliveryGanttController.ProFormaTimelineRow> rows =
+                DeliveryGanttController.getProFormaTimelineData(true);
+            Test.stopTest();
+
+            DeliveryGanttController.ProFormaTimelineRow parentRow = null;
+            for (DeliveryGanttController.ProFormaTimelineRow r : rows) {
+                if (r.title == 'Parent epic 2') { parentRow = r; break; }
+            }
+            System.assertNotEquals(null, parentRow, 'Parent row should be present');
+            System.assertEquals(2, parentRow.childrenCount, 'Two children');
+            System.assertEquals(2, parentRow.doneChildrenCount, 'Both children terminal → 2');
+            System.assertEquals('done', parentRow.variance,
+                'All children terminal → parent variance rolls up to done even though parent stage is not yet terminal');
+        }
+    }
+
     @IsTest
     static void testGetProFormaTimelineDataExplicitOverride() {
         // If PriorityGroupPk__c is set on the record, the DTO should use it


### PR DESCRIPTION
## Summary

**Subtract-Glen rollup story.** Parents in the gantt today reflect whatever was typed onto the parent record; this PR makes them reflect the aggregate state of their children. Daily worklogs against children automatically move the parent's bar, progress, and variance — without anyone touching the parent record.

Stacks on #735 (variance + scheduleProgress fields). #735 already merged; this is rebased on top.

## What changed

**DTO additions on `ProFormaTimelineRow`:**
- `childrenCount` — direct-child count when this row is a parent in the result set
- `doneChildrenCount` — count of direct children whose variance is `'done'`

**Controller logic (`applyParentRollups` + `applyParentRollup` helpers):**
- Runs after the per-row mapping pass; groups rows by `parentWorkItemId`
- For each parent with children:
  - `estimatedHours` = Σ child estimatedHours (replaces parent's typed value)
  - `loggedHours` = Σ child loggedHours
  - `progress` = aggregateLogged / aggregateEstimated (clamped 0..1)
  - `startDate` = earliest child startDate
  - `endDate` = latest child endDate
  - `scheduleProgress` recomputed from aggregate dates
  - `variance`: `'done'` when ALL children terminal; otherwise recomputed from aggregate
  - `childrenCount` + `doneChildrenCount` populated
- Leaf rows untouched

## Why computed-on-read (not stored rollup)

`ParentWorkItemLookup__c` is a lookup, not master-detail, so SF-native rollup-summary fields aren't available. Aggregation lives in Apex. Acceptable at DH scale (single SOQL already pulls all the data; aggregation is in-memory).

## Tests

- `testProFormaParentRollupAggregatesChildrenHoursAndDates` — parent with 2 children: estimatedHours becomes 16 (10+6) instead of the manually-typed 999, startDate/endDate becomes earliest/latest from children, childrenCount=2.
- `testProFormaParentRollupVarianceDoneWhenAllChildrenTerminal` — when both children hit `Done`/`Deployed to Prod`, parent variance rolls up to `'done'` even though parent stage is still `In Development`. Validates the auto-progression signal.

## Follow-ups (separate PRs already scoped)

- **#737** bottleneck surfacing — `variance='behind'/'at-risk'` visibility on dashboards
- **#738** stage auto-suggest on parent — propose next stage when all children hit a state
- **#739** "your plate today" per-user widget

## Test plan

- [ ] CI green
- [ ] Pick a parent WI in scratch with children; confirm gantt bar reflects aggregate hours + dates from children
- [ ] Add a worklog against a child; confirm parent's `progress` shifts without touching the parent record
- [ ] Mark all children as `Done`; confirm parent variance becomes `'done'` even if parent stage hasn't changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)