### PR TITLE
fix(sync-ingestor): bridge cross-org IDs on WorkLog + queue Comments when parent unsynced

### DIFF
--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -103,7 +103,7 @@ public without sharing class DeliverySyncItemIngestor {
 
         // For WorkLogs, resolve the parent WorkItem ID from the payload (not TargetId).
         // We intentionally do NOT strip cross-org lookup IDs from the caller's
-        // payload here. The Pending-queue path (queuePendingWorkLog) stashes
+        // payload here. The Pending-queue path (queuePendingChild) stashes
         // the raw payload via JSON.serialize(payload) for later replay, and
         // callers may re-invoke processInboundItem with the same Map instance
         // (idempotent re-delivery). Mutating the caller's map would:
@@ -155,7 +155,15 @@ public without sharing class DeliverySyncItemIngestor {
                 }
             }
 
-            if (localParentId != null && objectType.containsIgnoreCase('WorkItemComment__c')) {
+            if (objectType.containsIgnoreCase('WorkItemComment__c')) {
+                if (localParentId == null) {
+                    // Parent WorkItem hasn't synced yet → REQUIRED_FIELD_MISSING
+                    // would fire on insert. Stage as Pending so the resolver
+                    // re-runs after the parent lands. Same pattern WorkLog uses.
+                    // Pre-fix this caused 6+ MF-Prod comment failures (2026-04-29
+                    // audit) when chat fired before the parent WI sync.
+                    return queuePendingChild(objectType, parentWorkItemRef, payload);
+                }
                 putSafe(recordToUpsert, 'WorkItemId__c', localParentId);
             }
             if (objectType.endsWithIgnoreCase('WorkLog__c')) {
@@ -167,7 +175,7 @@ public without sharing class DeliverySyncItemIngestor {
                     // inbound, requeuePendingItems()/the resolver will flip
                     // this row to Queued and the processor retries the insert.
                     // See DeliverySyncItemPendingResolver.
-                    return queuePendingWorkLog(objectType, parentWorkItemRef, payload);
+                    return queuePendingChild(objectType, parentWorkItemRef, payload);
                 }
                 putSafe(recordToUpsert, 'WorkItemLookup__c', localParentId);
                 // Find a local WorkRequest for the Master-Detail parent
@@ -193,6 +201,13 @@ public without sharing class DeliverySyncItemIngestor {
             fieldPayload.remove('delivery__WorkItemLookup__c');
             fieldPayload.remove('RequestId__c');
             fieldPayload.remove('delivery__RequestId__c');
+            // Strip raw cross-org Id text fields too. WorkLog has WorkItemId__c
+            // alongside WorkItemLookup__c — without stripping, mapFields writes
+            // the sender-org Id straight into the local field and SF rejects with
+            // FIELD_INTEGRITY_EXCEPTION ("id value of incorrect type"). Caused 150
+            // failures on Nimba 2026-04-23..29 before this fix.
+            fieldPayload.remove('WorkItemId__c');
+            fieldPayload.remove('delivery__WorkItemId__c');
         }
 
         // Cross-org parent FK translation for WorkItem__c: the payload's
@@ -716,34 +731,38 @@ public without sharing class DeliverySyncItemIngestor {
     }
 
     /**
-     * @description Inserts an inbound Pending SyncItem__c carrying the raw
-     *              WorkLog payload so it can be re-processed once the parent
-     *              WorkItem lands. Enqueues DeliverySyncItemPendingResolver
+     * @description Inserts an inbound Pending SyncItem__c carrying the raw child
+     *              payload (WorkLog or Comment) so it can be re-processed once
+     *              the parent WorkItem lands. Enqueues DeliverySyncItemPendingResolver
      *              unless we're already at the queueable limit — the scheduled
      *              tick sweep (DeliveryHubScheduler.requeuePendingItems) is a
      *              safety net that catches anything we couldn't enqueue inline.
-     *              Idempotent on (parentWorkItemRef, SourceId): duplicate
-     *              re-deliveries reuse the existing Pending row rather than
-     *              forking duplicate resolvers.
-     * @param objectType        The payload object type (e.g., 'WorkLog__c').
-     * @param parentWorkItemRef Remote WorkItem identifier the log is parented to.
+     *              Idempotent on (objectType, parentWorkItemRef, SourceId):
+     *              duplicate re-deliveries reuse the existing Pending row.
+     *
+     *              Generalized from queuePendingWorkLog 2026-04-29 to also handle
+     *              WorkItemComment__c (was hard-failing with REQUIRED_FIELD_MISSING
+     *              when parent hadn't synced).
+     * @param objectType        The payload object type ('WorkLog__c' or 'WorkItemComment__c').
+     * @param parentWorkItemRef Remote WorkItem identifier the child is parented to.
      * @param payload           Full deserialized payload, stashed as JSON for replay.
      * @return The Pending SyncItem__c Id so the caller can return a non-null Id
      *         to the sync service (which treats null as failure).
      */
     @SuppressWarnings('PMD.ApexCRUDViolation')
-    private static Id queuePendingWorkLog(String objectType, String parentWorkItemRef, Map<String, Object> payload) {
+    private static Id queuePendingChild(String objectType, String parentWorkItemRef, Map<String, Object> payload) {
         String sourceId = (String) payload.get('SourceId');
         String globalSourceId = (String) payload.get('GlobalSourceId');
+        String stripped = stripNamespace(objectType);
 
-        // Idempotency: if we already hold a Pending row for this (parentRef, sourceId)
-        // pair just return the existing Id. Re-deliveries should not multiply Pending rows.
+        // Idempotency: if we already hold a Pending row for this (objectType, parentRef, sourceId)
+        // tuple just return the existing Id. Re-deliveries should not multiply Pending rows.
         if (String.isNotBlank(sourceId) && String.isNotBlank(parentWorkItemRef)) {
             List<SyncItem__c> existing = [
                 SELECT Id FROM SyncItem__c
                 WHERE DirectionPk__c = 'Inbound'
                 AND StatusPk__c = 'Pending'
-                AND ObjectTypePk__c = 'WorkLog__c'
+                AND ObjectTypePk__c = :stripped
                 AND RemoteExternalIdTxt__c = :sourceId
                 AND ParentRefTxt__c = :parentWorkItemRef
                 WITH SYSTEM_MODE


### PR DESCRIPTION
## Summary

Audit on 2026-04-29 found **233 failed SyncItems on Nimba + 6 on MF-Prod**, all in the inbound ingestor (`DeliverySyncEngine` receiver path), all **predating today's release**. Two distinct DH-side bugs in `DeliverySyncItemIngestor` were responsible. This PR fixes both.

Memory: [project_sync_engine_failures_0429.md](../tree/main) for the full audit.

## Bugs fixed

### 1. WorkLog payload strip missing `WorkItemId__c` — **150 Nimba failures**

The receiver was stripping `WorkItemLookup__c` + `RequestId__c` from the payload before `mapFields` runs, but NOT `WorkItemId__c`. `mapFields` then wrote the sender-org Id straight into the local WorkLog's `WorkItemId__c` field (a lookup despite the legacy text-suffix name) and SF rejected with `FIELD_INTEGRITY_EXCEPTION` (`id value of incorrect type`). Adding `WorkItemId__c` + namespaced variant to the strip list lets `mapFields` skip it; the resolved local parent Id is set via `WorkItemLookup__c` on line 172 instead.

### 2. WorkItemComment__c hard-failed when parent unsynced — **6 MF-Prod failures**

When the local parent WorkItem hadn't synced yet (`localParentId == null`), the comment branch fell through to `mapFields` without setting `WorkItemId__c`, then SF rejected with `REQUIRED_FIELD_MISSING [WorkItemId__c]`. WorkLog had a Pending-queue escape hatch for the same situation; comments didn't.

**Generalized `queuePendingWorkLog` → `queuePendingChild`** and call from both branches when `localParentId` is null. Comments now stage as Pending; resolver re-runs once parent lands.

## Generalization

- Renamed private helper to reflect new scope
- Removed hardcoded `WHERE ObjectTypePk__c = 'WorkLog__c'` from idempotency dedupe — uses `stripNamespace(objectType)` so comments dedupe correctly
- Doc comment + inline references updated

## Out of scope

- **Nimba's 83 "Blank WorkItem create rejected" failures** — guard is intentional; either outbound is shipping incomplete payloads OR the guard could be relaxed to log+placeholder. Separate decision/PR.
- **Retry of existing retry-exhausted SyncItems** — once this fix deploys, admins can run `DeliverySyncRetryController` against the historical Failed rows OR wait for `DeliveryHubScheduler.requeueFailedItems` next 15-min tick.

## Test plan

- [ ] CI green
- [ ] After install: query `SyncItem__c WHERE StatusPk__c='Failed' AND ObjectTypePk__c IN ('WorkLog__c','WorkItemComment__c')` and retry → should Synced rather than re-fail
- [ ] Smoke test: insert a WorkLog on MF-Prod against a WI that exists on both orgs → confirm it lands on Nimba without the FIELD_INTEGRITY_EXCEPTION
- [ ] Smoke test: insert a Comment on MF-Prod against a WI that has NOT yet synced to Nimba → confirm the SyncItem stages as Pending (not Failed); after the parent WI syncs, the Comment auto-replays via the resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)