### PR TITLE
fix(sync-ingestor): resolve Comment parent FK from WorkItemId__c when TargetId blank

### DIFF
--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -124,6 +124,23 @@ public without sharing class DeliverySyncItemIngestor {
                 parentWorkItemRef = wiRef;
             }
         }
+        // Same pattern for WorkItemComment — parent FK lives in the comment's
+        // own WorkItemId__c field, NOT in TargetId. Without this lookup the
+        // outer guard at the localParentId resolution block short-circuits
+        // (parentWorkItemRef stays blank when sender didn't populate TargetId)
+        // and the comment falls through to mapFields without WorkItemId__c
+        // set → REQUIRED_FIELD_MISSING. Caused 6 MF-Prod failures still
+        // present after the 2026-04-29 ingestor fix because that fix only
+        // wired the Pending-queue fallback, not the parentRef resolution.
+        if (objectType.containsIgnoreCase('WorkItemComment__c')) {
+            String wiRef = (String) payload.get('WorkItemId__c');
+            if (String.isBlank(wiRef)) {
+                wiRef = (String) payload.get('delivery__WorkItemId__c');
+            }
+            if (String.isNotBlank(wiRef)) {
+                parentWorkItemRef = wiRef;
+            }
+        }
 
         Id localParentId = null;
         if (localRecordId == null && String.isNotBlank(parentWorkItemRef) && (objectType.containsIgnoreCase('WorkItemComment__c') || objectType.equalsIgnoreCase('ContentVersion') || objectType.endsWithIgnoreCase('WorkLog__c'))) {
@@ -206,6 +223,16 @@ public without sharing class DeliverySyncItemIngestor {
             // the sender-org Id straight into the local field and SF rejects with
             // FIELD_INTEGRITY_EXCEPTION ("id value of incorrect type"). Caused 150
             // failures on Nimba 2026-04-23..29 before this fix.
+            fieldPayload.remove('WorkItemId__c');
+            fieldPayload.remove('delivery__WorkItemId__c');
+        }
+        // Same defense for WorkItemComment — strip the raw cross-org parent
+        // FK from payload so mapFields can't overwrite the resolved local Id
+        // we set via putSafe in the comment branch above.
+        if (objectType.containsIgnoreCase('WorkItemComment__c')) {
+            if (fieldPayload == payload) {
+                fieldPayload = new Map<String, Object>(payload);
+            }
             fieldPayload.remove('WorkItemId__c');
             fieldPayload.remove('delivery__WorkItemId__c');
         }


### PR DESCRIPTION
## Summary

Followup on #737. Sync retry on 2026-04-30 cleared **106 of Nimba's 279** failures but MF-Prod's **6 Comment failures persisted** with the same \`REQUIRED_FIELD_MISSING [delivery__WorkItemId__c]\` error.

## Root cause

\`parentWorkItemRef\` defaults to \`payload.TargetId\` on line 117 of \`DeliverySyncItemIngestor\`. WorkLog overrides it via \`payload.WorkItemLookup__c\` (lines 118-126). **Comment had NO equivalent override.**

When sender's payload doesn't populate \`TargetId\`, \`parentWorkItemRef\` stays blank → the entire \`localParentId\` resolution block on line 129 short-circuits (gated by \`isNotBlank\` check) → Comment falls through to \`mapFields\` with no \`WorkItemId__c\` set → \`REQUIRED_FIELD_MISSING\`.

## Two-part fix

1. **Add Comment branch mirroring WorkLog's** — resolves \`parentWorkItemRef\` from \`payload.WorkItemId__c\` (or namespaced variant) when \`TargetId\` is blank.
2. **Strip raw \`payload.WorkItemId__c\`** on a scoped copy before mapFields runs (mirrors the WorkLog defense at lines 198-205) so the resolved local Id we set via \`putSafe\` can't be overwritten with the sender-org Id.

## Combined effect with #737

| Failure class | #737 alone | + this PR |
|---|---|---|
| WorkLog ID-translation (150 Nimba) | ✅ Fixed | — |
| Comment missing parent FK (6 MF-Prod) | ❌ Partial (Pending-queue but never reached) | ✅ Fixed |
| WorkItem create rejected (83 Nimba) | (Out of scope — guard is intentional) | — |

## Test plan

- [ ] CI green
- [ ] After install: retry MF-Prod's 6 Failed Comments — they should land on Nimba (or stage as Pending if parent unsynced)
- [ ] Re-run sync retry on Nimba's remaining 80 WL Failed — should clear (those weren't affected by the blank-TargetId path; they're WL-specific that already had partial coverage from #737)

🤖 Generated with [Claude Code](https://claude.com/claude-code)