### PR TITLE
fix(sync): outbound payload includes WorkItemId__c on Comments + ingestor accepts it on WorkLogs

### DIFF
--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -120,6 +120,18 @@ public without sharing class DeliverySyncItemIngestor {
             if (String.isBlank(wiRef)) {
                 wiRef = (String) payload.get('delivery__WorkItemLookup__c');
             }
+            // Legacy / peer-org outbounds may emit WorkItemId__c instead of
+            // WorkItemLookup__c (a stale outbound payload assembly path used
+            // the text-named field). Fall back to it when the lookup-named
+            // key is absent. Without this, Nimba's 80 historical WorkLog
+            // failures stayed Failed even after PR #737 because their
+            // payloads only carry WorkItemId__c. Audit 2026-04-30 17:30Z.
+            if (String.isBlank(wiRef)) {
+                wiRef = (String) payload.get('WorkItemId__c');
+            }
+            if (String.isBlank(wiRef)) {
+                wiRef = (String) payload.get('delivery__WorkItemId__c');
+            }
             if (String.isNotBlank(wiRef)) {
                 parentWorkItemRef = wiRef;
             }

--- a/force-app/main/default/classes/DeliveryWorkItemCommentTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemCommentTriggerHandler.cls
@@ -19,7 +19,10 @@ public inherited sharing class DeliveryWorkItemCommentTriggerHandler {
 
         // Delivery Hub Integration (Unified Sync Engine)
         // We explicitly define which fields constitute the "Payload" for a comment to keep it clean.
-        Set<String> syncFields = new Set<String>{'BodyTxt__c', 'AuthorTxt__c'};
+        // WorkItemId__c is the parent FK — without it the receiver-side ingestor can't
+        // resolve which WorkItem to attach the comment to. Caused 6 stuck failures with
+        // REQUIRED_FIELD_MISSING [WorkItemId__c] on MF-Prod (audit 2026-04-30 17:00Z).
+        Set<String> syncFields = new Set<String>{'BodyTxt__c', 'AuthorTxt__c', 'WorkItemId__c'};
 
         // Pass to Engine
         DeliverySyncEngine.captureChanges(newRecords, null, syncFields);
@@ -124,8 +127,9 @@ public inherited sharing class DeliveryWorkItemCommentTriggerHandler {
      */
     public static void handleAfterUpdate(Map<Id, WorkItemComment__c> newMap, Map<Id, WorkItemComment__c> oldMap) {
         // Delivery Hub Integration (Handle Edits)
-        // Check for changes in Body or Author
-        Set<String> fieldsToTrack = new Set<String>{'BodyTxt__c', 'AuthorTxt__c'};
+        // Check for changes in Body or Author. WorkItemId__c included so reparent
+        // events on the comment also propagate cross-org (rare but valid edit).
+        Set<String> fieldsToTrack = new Set<String>{'BodyTxt__c', 'AuthorTxt__c', 'WorkItemId__c'};
 
         // Pass to Engine
         DeliverySyncEngine.captureChanges(newMap.values(), oldMap, fieldsToTrack);


### PR DESCRIPTION
## Summary

Audit 2026-04-30 17:00Z (post-\`04tQr000000Uxx7IAC\` install) — **6 MF-Prod Comment + 80 Nimba WorkLog failures persisted** despite PRs #737 + #739. Pulled the actual stuck \`PayloadTxt__c\` and the root cause was on the **OUTBOUND side**, not inbound. Receiver-side fixes had nothing to chew on because the parent FK wasn't in the payload at all.

## What the stuck payloads showed

**MF-Prod Comment (no parent FK at all):**
\`\`\`json
{\"TargetId\":null,\"SenderOrgId\":\"...\",\"GlobalSourceId\":\"a40UN00000AKubNYAT\",
 \"SourceId\":\"a40UN00000AKubNYAT\",\"AuthorTxt__c\":\"Glen Bradford\",\"BodyTxt__c\":\"...\"}
\`\`\`

**Nimba WorkLog (uses legacy field name):**
\`\`\`json
{\"WorkItemId__c\":\"a3ZRu000000hK3VMAU\",\"WorkDescriptionTxt__c\":\"...\",
 \"HoursLoggedNumber__c\":3.00,\"SenderOrgId\":\"...\",\"SourceId\":\"...\"}
\`\`\`

Receiver-side ingestor only resolved \`parentWorkItemRef\` from \`WorkItemLookup__c\` (#737). The Nimba payloads use \`WorkItemId__c\`. The Comment payloads have neither.

## Two-part fix

### 1. \`DeliveryWorkItemCommentTriggerHandler\` — outbound payload

Comment outbound's \`syncFields\` was \`{'BodyTxt__c', 'AuthorTxt__c'}\` — missing the parent FK. Added \`WorkItemId__c\` so \`DeliverySyncEngine.captureChanges\` includes it in the outbound JSON. Same fix on both insert (line 22) + update (line 131) paths.

### 2. \`DeliverySyncItemIngestor\` — WorkLog parent resolution fallback chain

Extended the WorkLog branch's \`parentWorkItemRef\` resolution to also accept \`WorkItemId__c\` (and namespaced \`delivery__WorkItemId__c\`) when \`WorkItemLookup__c\` is absent. Combined with #737's strip + Pending-queue, lets Nimba's stuck WorkLogs resolve parent on retry.

## Out of scope

- **Stale historical Comment payloads** (the 6 MF-Prod) — \`PayloadTxt__c\` is frozen at original DML time. New comments going forward will carry the field correctly. Historical 6 need a re-emit (delete the SyncItem row + re-DML the underlying Comment).
- **Nimba's 93 \"Blank WorkItem create rejected\"** — intentional receiver guard against incomplete WI payloads. Separate decision.

## Test plan

- [ ] CI green
- [ ] After install: post a new Comment on MF-Prod → outbound payload includes \`WorkItemId__c\` → Nimba's ingestor resolves parent → succeeds
- [ ] Retry Nimba's 80 historical WL Failed → ingestor falls through to \`WorkItemId__c\` resolution → parent resolves via SyncItem ledger → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)