### PR TITLE
fix(activity-feed): suppress description-only + no-op field-change events

### DIFF
--- a/force-app/main/default/classes/DeliveryActivityFeedController.cls
+++ b/force-app/main/default/classes/DeliveryActivityFeedController.cls
@@ -13,6 +13,13 @@ global with sharing class DeliveryActivityFeedController {
 
     private static final Integer PAGE_SIZE = 25;
 
+    // Field-change events on these (namespace-stripped, lowercase) API names are
+    // suppressed from the Activity Feed as cosmetic/ambient noise. Description
+    // edits and rollup recalcs don't tell a reader anything they need to act on.
+    private static final Set<String> SUPPRESSED_FIELD_API_NAMES = new Set<String>{
+        'workdescriptiontxt__c'
+    };
+
     // ── Unified Activity Feed ──────────────────────────────────────────
 
     /**
@@ -429,7 +436,10 @@ global with sharing class DeliveryActivityFeedController {
 
         List<Map<String, Object>> results = new List<Map<String, Object>>();
         for (ActivityLog__c al : logs) {
-            results.add(buildActivityLogEvent(al, userNameMap));
+            Map<String, Object> ev = buildActivityLogEvent(al, userNameMap);
+            if (ev != null) {
+                results.add(ev);
+            }
         }
         return results;
     }
@@ -463,6 +473,9 @@ global with sharing class DeliveryActivityFeedController {
     }
 
     private static Map<String, Object> buildActivityLogEvent(ActivityLog__c al, Map<Id, String> userNameMap) {
+        if (al.ActionTypePk__c == 'Field_Change' && shouldSuppressFieldChange(al.ContextDataTxt__c)) {
+            return null;
+        }
         String userName = resolveUserName(al.UserIdTxt__c, userNameMap);
         Map<String, String> changeInfo = parseChangeContext(al.ContextDataTxt__c, al.ActionTypePk__c);
         Id recordId = safeToId(al.RecordIdTxt__c);
@@ -496,6 +509,50 @@ global with sharing class DeliveryActivityFeedController {
             System.debug(LoggingLevel.FINE, 'Invalid Id string: ' + idString);
             return null;
         }
+    }
+
+    /**
+     * Returns true when a Field_Change ActivityLog event should NOT render in
+     * the Activity Feed. Two suppression rules:
+     *   1. Field is in SUPPRESSED_FIELD_API_NAMES (description-only edits etc.)
+     *   2. oldValue == newValue (no-op saves; e.g. trigger logic re-flipping
+     *      Status to its existing value, or rollup recalcs landing on the
+     *      same number).
+     * Falls open on parse error so the parseChangeContext fallback path stays
+     * the single source of truth for malformed JSON.
+     */
+    private static Boolean shouldSuppressFieldChange(String contextDataJson) {
+        if (String.isBlank(contextDataJson)) {
+            return false;
+        }
+        try {
+            Map<String, Object> ctx = (Map<String, Object>) JSON.deserializeUntyped(contextDataJson);
+            String fieldName = ctx.get('fieldName') == null
+                ? ''
+                : stripFieldNamespace(String.valueOf(ctx.get('fieldName'))).toLowerCase();
+            if (SUPPRESSED_FIELD_API_NAMES.contains(fieldName)) {
+                return true;
+            }
+            Object oldVal = ctx.get('oldValue');
+            Object newVal = ctx.get('newValue');
+            if (oldVal == null && newVal == null) {
+                return true;
+            }
+            if (oldVal != null && newVal != null
+                && String.valueOf(oldVal) == String.valueOf(newVal)) {
+                return true;
+            }
+            return false;
+        } catch (JSONException ex) {
+            return false;
+        }
+    }
+
+    private static String stripFieldNamespace(String apiName) {
+        if (String.isNotBlank(apiName) && apiName.countMatches('__') > 1) {
+            return apiName.substringAfter('__');
+        }
+        return apiName;
     }
 
     private static Map<String, String> parseChangeContext(String contextDataJson, String actionType) {

--- a/force-app/main/default/classes/DeliveryActivityFeedController.cls
+++ b/force-app/main/default/classes/DeliveryActivityFeedController.cls
@@ -512,14 +512,15 @@ global with sharing class DeliveryActivityFeedController {
     }
 
     /**
-     * Returns true when a Field_Change ActivityLog event should NOT render in
-     * the Activity Feed. Two suppression rules:
-     *   1. Field is in SUPPRESSED_FIELD_API_NAMES (description-only edits etc.)
-     *   2. oldValue == newValue (no-op saves; e.g. trigger logic re-flipping
-     *      Status to its existing value, or rollup recalcs landing on the
-     *      same number).
-     * Falls open on parse error so the parseChangeContext fallback path stays
-     * the single source of truth for malformed JSON.
+     * @description Returns true when a Field_Change ActivityLog event should
+     * NOT render in the Activity Feed. Two suppression rules: (1) field is in
+     * SUPPRESSED_FIELD_API_NAMES (description-only edits etc.); (2) oldValue
+     * equals newValue (no-op saves; e.g. trigger logic re-flipping Status to
+     * its existing value, or rollup recalcs landing on the same number).
+     * Falls open on parse error so parseChangeContext stays the single source
+     * of truth for malformed JSON fallback.
+     * @param contextDataJson Raw ContextDataTxt__c JSON from the ActivityLog__c row.
+     * @return True if the event should be filtered out of the feed.
      */
     private static Boolean shouldSuppressFieldChange(String contextDataJson) {
         if (String.isBlank(contextDataJson)) {
@@ -548,6 +549,14 @@ global with sharing class DeliveryActivityFeedController {
         }
     }
 
+    /**
+     * @description Strips the namespace prefix from a field API name so
+     * `delivery__WorkDescriptionTxt__c` and the unprefixed
+     * `WorkDescriptionTxt__c` both match suppression rules. Mirrors the
+     * helper in DeliverySyncItemIngestor.
+     * @param apiName The field API name as captured in ContextDataTxt__c.
+     * @return The API name with the namespace prefix removed if one was present.
+     */
     private static String stripFieldNamespace(String apiName) {
         if (String.isNotBlank(apiName) && apiName.countMatches('__') > 1) {
             return apiName.substringAfter('__');

--- a/force-app/main/default/classes/DeliveryActivityFeedControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryActivityFeedControllerTest.cls
@@ -217,6 +217,108 @@ private class DeliveryActivityFeedControllerTest {
         }
     }
 
+    // ── Field-change suppression tests ─────────────────────────────────
+
+    @IsTest
+    static void testFieldChangeSuppressDescriptionOnly() {
+        WorkItem__c wi = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Feed Test Item 1' LIMIT 1];
+        insert new ActivityLog__c(
+            ActionTypePk__c   = 'Field_Change',
+            RecordIdTxt__c    = wi.Id,
+            UserIdTxt__c      = UserInfo.getUserId(),
+            ContextDataTxt__c = JSON.serialize(new Map<String, Object>{
+                'fieldName'  => 'WorkDescriptionTxt__c',
+                'fieldLabel' => 'Description',
+                'oldValue'   => 'Old text',
+                'newValue'   => 'New text'
+            })
+        );
+
+        System.runAs(testUser) {
+            Test.startTest();
+            Map<String, Object> result = DeliveryActivityFeedController.getActivityFeed(
+                'changes', 0, null, null, null, null
+            );
+            Test.stopTest();
+
+            List<Object> events = (List<Object>) result.get('events');
+            for (Object ev : events) {
+                Map<String, Object> event = (Map<String, Object>) ev;
+                System.assertNotEquals('field_change', event.get('type'),
+                    'Description-only field change should be suppressed');
+            }
+        }
+    }
+
+    @IsTest
+    static void testFieldChangeSuppressNoOp() {
+        WorkItem__c wi = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Feed Test Item 1' LIMIT 1];
+        insert new ActivityLog__c(
+            ActionTypePk__c   = 'Field_Change',
+            RecordIdTxt__c    = wi.Id,
+            UserIdTxt__c      = UserInfo.getUserId(),
+            ContextDataTxt__c = JSON.serialize(new Map<String, Object>{
+                'fieldName'  => 'StatusPk__c',
+                'fieldLabel' => 'Status',
+                'oldValue'   => 'Approved',
+                'newValue'   => 'Approved'
+            })
+        );
+
+        System.runAs(testUser) {
+            Test.startTest();
+            Map<String, Object> result = DeliveryActivityFeedController.getActivityFeed(
+                'changes', 0, null, null, null, null
+            );
+            Test.stopTest();
+
+            List<Object> events = (List<Object>) result.get('events');
+            for (Object ev : events) {
+                Map<String, Object> event = (Map<String, Object>) ev;
+                System.assertNotEquals('field_change', event.get('type'),
+                    'No-op (old==new) field change should be suppressed');
+            }
+        }
+    }
+
+    @IsTest
+    static void testFieldChangeKeepsRealChange() {
+        WorkItem__c wi = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Feed Test Item 1' LIMIT 1];
+        insert new ActivityLog__c(
+            ActionTypePk__c   = 'Field_Change',
+            RecordIdTxt__c    = wi.Id,
+            UserIdTxt__c      = UserInfo.getUserId(),
+            ContextDataTxt__c = JSON.serialize(new Map<String, Object>{
+                'fieldName'  => 'HoursLoggedNumber__c',
+                'fieldLabel' => 'Hours Logged',
+                'oldValue'   => '1.5',
+                'newValue'   => '2.0'
+            })
+        );
+
+        System.runAs(testUser) {
+            Test.startTest();
+            Map<String, Object> result = DeliveryActivityFeedController.getActivityFeed(
+                'changes', 0, null, null, null, null
+            );
+            Test.stopTest();
+
+            List<Object> events = (List<Object>) result.get('events');
+            Boolean foundRealChange = false;
+            for (Object ev : events) {
+                Map<String, Object> event = (Map<String, Object>) ev;
+                if (event.get('type') == 'field_change') {
+                    String detail = (String) event.get('detail');
+                    if (detail != null && detail.contains('1.5') && detail.contains('2.0')) {
+                        foundRealChange = true;
+                    }
+                }
+            }
+            System.assert(foundRealChange,
+                'Real Hours Logged change should surface with FROM → TO detail');
+        }
+    }
+
     // ── getConversations tests ─────────────────────────────────────────
 
     @IsTest


### PR DESCRIPTION
## Summary

Activity Feed rendered noisy field-change events on description edits and trigger-driven no-op saves. Glen flagged both 2026-04-29 — handoff doc at `Mobilization-Funding-Claude/handoffs/delivery-hub-activity-feed-fixes-0429.md`. This PR suppresses both at the controller level before the LWC sees them.

## What changed

`DeliveryActivityFeedController.queryFeedActivityLogs` → `buildActivityLogEvent` now returns `null` for Field_Change rows that match either suppression rule:

1. **Field is in `SUPPRESSED_FIELD_API_NAMES`** — currently `WorkDescriptionTxt__c`. Description edits are cosmetic refreshes; the actual current text already renders on the live "Hours Logged" event row from the WorkLog query. A separate "Description changed" row is just noise.
2. **`oldValue == newValue`** — no-op saves. Trigger logic occasionally re-flips Status to its existing value; rollup recalcs sometimes land on the same number.

The namespace-stripping helper mirrors the pattern in `DeliverySyncItemIngestor` so `delivery__WorkDescriptionTxt__c` and the unprefixed `WorkDescriptionTxt__c` both match.

## What did NOT change

- **FROM → TO rendering** — already correct via `parseStageChange` / `parseFieldChange` + `displayValue` fallback. Real changes still surface as `OldValue → NewValue`.
- **Suppression on parse error** — `shouldSuppressFieldChange` falls open if JSON is malformed, leaving `parseChangeContext` as the single source of truth for the fallback path (`(change context unparseable)`).

## Out of scope

- **Issue 3 — orphaned events from deleted parents** — would need a parent existence check across multiple object types. Separate scoping.
- **Issue 4 — voided reason annotation** — schema change, lower priority per handoff.

## Test plan

- [x] CI green (PMD + tests)
- [x] New tests cover: description-only suppressed, no-op suppressed, real Hours Logged change still surfaces with FROM → TO detail
- [ ] Smoke test on dh-prod after install: edit a WorkLog description 3× — Activity Feed shows the original "Hours Logged" event with current description, no extra "changed" rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)