### PR TITLE
fix(sync-reconciler): handle namespaced field keys in WorkItem payload

### DIFF
--- a/force-app/main/default/classes/DeliverySyncReconciler.cls
+++ b/force-app/main/default/classes/DeliverySyncReconciler.cls
@@ -302,11 +302,27 @@ global without sharing class DeliverySyncReconciler implements Queueable, Databa
     private SyncItem__c buildWorkItemSyncItem(WorkItem__c wi, WorkRequest__c req) {
         Map<String, Object> payload = new Map<String, Object>();
 
-        // Map all syncable fields
+        // Map all syncable fields. In subscriber orgs `getPopulatedFieldsAsMap`
+        // returns namespaced keys (`delivery__BriefDescriptionTxt__c`) while
+        // `getWorkItemSyncFields()` returns unprefixed names. A direct
+        // containsKey check therefore missed every field on every tick,
+        // emitting payloads with only routing metadata that the receiver
+        // ingestor rejected as "Blank WorkItem create rejected" — and because
+        // Failed is not in the reconciler's covered-status set, the gap
+        // re-fired every 15-min scheduler tick (~100 SyncItems/day on
+        // Nimba 2026-04-30 → 2026-05-01). Use the namespace-tolerant lookup
+        // mirrored from DeliverySyncEngine.getSafeValue.
         Map<String, Object> populatedFields = wi.getPopulatedFieldsAsMap();
         for (String field : getWorkItemSyncFields()) {
             if (populatedFields.containsKey(field)) {
                 payload.put(field, populatedFields.get(field));
+                continue;
+            }
+            for (String key : populatedFields.keySet()) {
+                if (key.endsWithIgnoreCase('__' + field)) {
+                    payload.put(field, populatedFields.get(key));
+                    break;
+                }
             }
         }
 

--- a/force-app/main/default/classes/DeliverySyncReconcilerTest.cls
+++ b/force-app/main/default/classes/DeliverySyncReconcilerTest.cls
@@ -136,6 +136,51 @@ private class DeliverySyncReconcilerTest {
     }
 
     /**
+     * @description Regression test for the namespace miss in buildWorkItemSyncItem.
+     * Pre-fix the WorkItem outbound payload contained only routing metadata
+     * (SourceId/GlobalSourceId/SenderOrgId/TargetId) because
+     * `populatedFields.containsKey('BriefDescriptionTxt__c')` returned false in
+     * subscriber orgs where the keys are namespaced. The receiver ingestor
+     * then rejected the SyncItem as "Blank WorkItem create rejected" and the
+     * reconciler re-fired it on every 15-min tick. Post-fix the syncFields
+     * land in the payload regardless of whether the runtime keys carry the
+     * namespace prefix.
+     */
+    @IsTest
+    static void testReconcilerPayloadIncludesSyncFields() {
+        System.runAs(testUser) {
+            delete [SELECT Id FROM SyncItem__c];
+
+            Test.startTest();
+            System.enqueueJob(new DeliverySyncReconciler());
+            Test.stopTest();
+
+            List<SyncItem__c> wiSyncs = [
+                SELECT PayloadTxt__c FROM SyncItem__c
+                WHERE ObjectTypePk__c = 'WorkItem__c'
+                AND DirectionPk__c = 'Outbound'
+            ];
+            System.assertEquals(1, wiSyncs.size(), 'Should create exactly one WorkItem SyncItem.');
+            String payload = wiSyncs[0].PayloadTxt__c;
+            System.assert(
+                payload.contains('BriefDescriptionTxt__c'),
+                'WorkItem reconciler payload must include BriefDescriptionTxt__c key. ' +
+                'Got: ' + payload
+            );
+            System.assert(
+                payload.contains('Reconcile Test Item'),
+                'WorkItem reconciler payload must include the actual description value. ' +
+                'Got: ' + payload
+            );
+            System.assert(
+                payload.contains('StageNamePk__c'),
+                'WorkItem reconciler payload must include StageNamePk__c key. ' +
+                'Got: ' + payload
+            );
+        }
+    }
+
+    /**
      * @description Verifies that the reconciler creates SyncItems for both a missing
      * WorkItem and a missing WorkLog in a single pass.
      */


### PR DESCRIPTION
## Summary

`DeliverySyncReconciler.buildWorkItemSyncItem` checked `populatedFields.containsKey('BriefDescriptionTxt__c')` against keys returned by `wi.getPopulatedFieldsAsMap()`. In subscriber orgs those keys are namespaced (`delivery__BriefDescriptionTxt__c`), so the containsKey check missed every field on every tick. The reconciler emitted SyncItems whose payloads carried only routing metadata, the receiver rejected them as `"Blank WorkItem create rejected"`, and **Failed isn't in the reconciler's covered-status set** — so the gap re-fired every 15-min scheduler tick.

## Production audit (Nimba 2026-05-01)

- 147 Failed WorkItem SyncItems
- 100 of them created in the last 24h
- All by the scheduled cron user
- All with empty-payload signature: `{"TargetId":null,"SenderOrgId":"...","GlobalSourceId":"...","SourceId":"..."}`
- Source WIs all had valid `BriefDescriptionTxt__c` (verified `T-0186 = "MF-725 - default fees..."` exists on Nimba)

## What changed

Mirror the namespace-tolerant lookup pattern from `DeliverySyncEngine.getSafeValue`: try the unprefixed key first, fall back to any populated key ending in `__<field>`. The same defense already protects the trigger-handler outbound path (`DeliverySyncEngine.captureChanges`); the reconciler had a separate buggy implementation.

Added regression test `testReconcilerPayloadIncludesSyncFields` that asserts the WorkItem payload contains `BriefDescriptionTxt__c` and the actual description value.

## Recovery on existing failures

Once installed, the next reconciler tick (every 15 min) will emit a new SyncItem with a populated payload. The receiver should accept it → status becomes Synced → Request becomes "covered" → no more reconciler-generated SyncItems for that WI. Self-healing within 15-30 min of install.

The 47 historical pre-2026-04-30 failures will also clear on the next tick (they're in the same gap-set).

## Test plan

- [x] CI green (PMD + tests)
- [x] Regression test asserts `BriefDescriptionTxt__c` + value land in payload
- [ ] After install: monitor Nimba `Failed WorkItem` count — expect to flatten or drop within 30 min as fresh reconciler-generated SyncItems Sync rather than Fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)