### PR TITLE
fix(sync): empty-payload guard at outbound — refuse routing-only SyncItems

### DIFF
--- a/force-app/main/default/classes/DeliverySyncEngine.cls
+++ b/force-app/main/default/classes/DeliverySyncEngine.cls
@@ -126,8 +126,9 @@ public without sharing class DeliverySyncEngine {
                         // Kill-Switch: If target is the Global Source or matches incoming edge, suppress circular sync
                         if (blockedOrigins.contains((String)req.Id) || req.RemoteWorkItemIdTxt__c == globalSourceId) {
                             continue;
-                        } 
-                        itemsToInsert.add(createSyncItem(rec, req, allowedFields, globalSourceId, false));
+                        }
+                        SyncItem__c built = createSyncItem(rec, req, allowedFields, globalSourceId, false);
+                        if (built != null) { itemsToInsert.add(built); }
                     }
                 }
 
@@ -147,7 +148,8 @@ public without sharing class DeliverySyncEngine {
                         Boolean vendorPushEnabled = parentWorkItem.ClientNetworkEntityLookup__r.EnableVendorPushDateTime__c != null
                             && String.isNotBlank(parentWorkItem.ClientNetworkEntityLookup__r.IntegrationEndpointUrlTxt__c);
 
-                        itemsToInsert.add(createSyncItem(rec, null, allowedFields, globalSourceId, vendorPushEnabled));
+                        SyncItem__c built = createSyncItem(rec, null, allowedFields, globalSourceId, vendorPushEnabled);
+                        if (built != null) { itemsToInsert.add(built); }
                     }
                 }
             }
@@ -298,6 +300,19 @@ public without sharing class DeliverySyncEngine {
 
     @SuppressWarnings('PMD.ExcessiveParameterList')
     private static SyncItem__c createSyncItem(SObject rec, WorkRequest__c req, Set<String> allowedFields, String globalSourceId, Boolean vendorPush) {
+        // Empty-payload guard #1: zero allowedFields means the caller wired
+        // up no syncable schema. Any SyncItem we'd build here would carry
+        // only routing metadata and the receiver ingestor would reject it
+        // as "Blank ... create rejected" (and reconciler would re-fire it
+        // every 15-min tick — see PR #742 reconciler namespace bug post-mortem
+        // for the cascade pattern). Refuse cleanly with a WARN log.
+        if (allowedFields == null || allowedFields.isEmpty()) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliverySyncEngine] Skipping outbound SyncItem — allowedFields empty for '
+                + rec.getSObjectType().getDescribe().getName() + ' ' + rec.Id);
+            return null;
+        }
+
         SyncItem__c item = new SyncItem__c(
             StatusPk__c = 'Queued',
             DirectionPk__c = 'Outbound',
@@ -313,9 +328,32 @@ public without sharing class DeliverySyncEngine {
         populateLookupField(item, cleanName, rec.Id);
 
         Map<String, Object> payload = new Map<String, Object>();
+        Boolean anyBusinessFieldPopulated = false;
         for (String f : allowedFields) {
-            payload.put(f, getSafeValue(rec, f));
+            Object value = getSafeValue(rec, f);
+            payload.put(f, value);
+            if (value != null) {
+                anyBusinessFieldPopulated = true;
+            }
         }
+
+        // Empty-payload guard #2: every allowed field resolved to null.
+        // In after-insert/after-update trigger context, getPopulatedFieldsAsMap
+        // returns the record's full field state — so all-null means either
+        // the namespace lookup failed (PR #742 class), the syncFields list
+        // contains only fields that don't exist on this record, or the
+        // record itself is genuinely blank. None of those should fan out:
+        // the receiver would reject and the reconciler would loop. Refuse
+        // with a WARN so the health dashboard / debug log captures the
+        // signal but the dispatcher isn't poisoned.
+        if (!anyBusinessFieldPopulated) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliverySyncEngine] Skipping outbound SyncItem — every allowed field '
+                + 'resolved to null for ' + cleanName + ' ' + rec.Id
+                + ' (allowedFields=' + allowedFields.size() + ')');
+            return null;
+        }
+
         payload.put('SourceId', rec.Id);
         payload.put('GlobalSourceId', globalSourceId);
         payload.put('SenderOrgId', UserInfo.getOrganizationId());

--- a/force-app/main/default/classes/DeliverySyncEngineTest.cls
+++ b/force-app/main/default/classes/DeliverySyncEngineTest.cls
@@ -223,6 +223,64 @@ private class DeliverySyncEngineTest {
 
     // ── Additional Coverage Tests ───────────────────────────────────────
 
+    /**
+     * @description Empty-payload guard #1 — when a caller passes an empty
+     *              allowedFields Set, captureChanges should not emit a
+     *              SyncItem. Pre-guard, the receiver-side ingestor would
+     *              have rejected the resulting routing-metadata-only payload
+     *              and the reconciler would re-fire the gap every tick.
+     */
+    @IsTest
+    static void testEmptyAllowedFieldsSkipsSyncItem() {
+        System.runAs(testUser) {
+            WorkItem__c t = [SELECT Id, BriefDescriptionTxt__c FROM WorkItem__c LIMIT 1];
+            delete [SELECT Id FROM SyncItem__c];
+
+            Test.startTest();
+            DeliverySyncEngine.captureChanges(
+                new List<SObject>{t},
+                null,
+                new Set<String>()
+            );
+            Test.stopTest();
+
+            Integer count = [SELECT COUNT() FROM SyncItem__c];
+            System.assertEquals(0, count,
+                'No SyncItems should be created when allowedFields is empty');
+        }
+    }
+
+    /**
+     * @description Empty-payload guard #2 — when every allowed field
+     *              resolves to null on a record (typo'd field names,
+     *              namespace-stripping bug, or genuinely blank record),
+     *              the SyncItem should be skipped with a WARN log instead
+     *              of poisoning the dispatcher with a routing-only payload.
+     *              This is the receiver-side bug class behind PR #742.
+     */
+    @IsTest
+    static void testAllNullBusinessFieldsSkipsSyncItem() {
+        System.runAs(testUser) {
+            WorkItem__c t = [SELECT Id FROM WorkItem__c LIMIT 1];
+            delete [SELECT Id FROM SyncItem__c];
+
+            Test.startTest();
+            // Pass field names that don't exist on WorkItem__c — every
+            // getSafeValue lookup returns null, mimicking the namespace
+            // bug + typo-bug profile.
+            DeliverySyncEngine.captureChanges(
+                new List<SObject>{t},
+                null,
+                new Set<String>{'NonExistentField1__c', 'NonExistentField2__c'}
+            );
+            Test.stopTest();
+
+            Integer count = [SELECT COUNT() FROM SyncItem__c];
+            System.assertEquals(0, count,
+                'No SyncItems should be created when every allowed field resolves to null');
+        }
+    }
+
     @IsTest
     static void testCaptureChangesNullRecordsReturnsEarly() {
         System.runAs(testUser) {


### PR DESCRIPTION
## Summary

Defensive guards in \`DeliverySyncEngine.createSyncItem\` against the bug class behind PR #742 — the reconciler-namespace bug emitted WorkItem SyncItems carrying only routing metadata (\`SourceId\`/\`GlobalSourceId\`/\`SenderOrgId\`/\`TargetId\`), the receiver rejected them as \`"Blank WorkItem create rejected"\`, and because Failed isn't in the reconciler's covered-status set, the gap re-fired every 15-min tick (~100 SyncItems/day on Nimba).

## What changed

\`DeliverySyncEngine.createSyncItem\` returns \`null\` (caller-skipped) instead of building a poisoned SyncItem when either of these holds:

1. **Empty \`allowedFields\`** — caller wired no syncable schema. Always a bug.
2. **Every allowed field resolves to null** — in after-insert/after-update trigger context, \`getPopulatedFieldsAsMap\` returns the record's full field state, so all-null means either: typo'd \`syncFields\` list, namespace-lookup miss (PR #742 class), or genuinely blank record. None should fan out.

Both Push and Hub fan-out branches updated to check the null return before adding to \`itemsToInsert\`. Each skip writes a WARN-level debug log so the health dashboard / PMD\'s log surface picks up the signal.

## Why two guards

The first one (empty \`allowedFields\`) is a pure correctness check — there is no legitimate use case. The second one (all-null business fields) is the actual signature of the PR #742 cascade: the for-loop ran but every value came back null. Catching it at outbound time prevents the receiver from being asked to process garbage and prevents the reconciler from re-firing the gap every tick.

## False-positive risk

In trigger context, \`getPopulatedFieldsAsMap\` returns the record's full state — so a healthy update / insert always has at least one non-null value among its tracked fields. The all-null case requires either a bug in the caller (typo'd field name, namespace miss) or a record that's genuinely blank — neither is a legitimate dispatch target.

## Test plan

- [x] CI green (PMD + tests)
- [x] \`testEmptyAllowedFieldsSkipsSyncItem\` — passing an empty Set produces zero SyncItems
- [x] \`testAllNullBusinessFieldsSkipsSyncItem\` — passing only non-existent field names (every getSafeValue returns null) produces zero SyncItems

## Sequencing with PR #744

PR #744 (Failed-Inbound auto-recovery) is the *receiver-side* heal for the gap class. This PR is the *sender-side* prevention. Together they close the loop:

1. Outbound never dispatches a poisoned payload (this PR)
2. If a poisoned payload somehow arrives anyway, the receiver-side Failed row auto-recovers once the parent crosses (#744)

Both should ride in the same release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)