### PR TITLE
fix(sync): predecisional gate — refuse sandbox proposal-staging inbounds in prod

### DIFF
--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -376,6 +376,30 @@ public without sharing class DeliverySyncItemIngestor {
             }
         }
 
+        // Predecisional gate (5/5 incident): refuse inbound WorkItem writes
+        // whose payload carries a non-null MarkedPredecisionalDateTime__c
+        // unless the receiving org has opted in via DeliveryHubSettings__c.
+        // EnablePredecisionalIngestDateTime__c. The 5 QBAG-* records leaked
+        // from a sandbox into production because nothing on the receiver
+        // side knew they were proposal-staging only. Applies to both insert
+        // and update so a sandbox-side flip can't mutate already-promoted
+        // production records back into a predecisional state.
+        if (objectType.endsWithIgnoreCase('WorkItem__c')
+                && !objectType.endsWithIgnoreCase('WorkItemComment__c')
+                && isPredecisionalPayload(payload)) {
+            DeliveryHubSettings__c gateSettings = DeliveryHubSettings__c.getOrgDefaults();
+            Boolean ingestEnabled = gateSettings != null
+                && gateSettings.EnablePredecisionalIngestDateTime__c != null;
+            if (!ingestEnabled) {
+                throw new DeliverySyncEngine.SyncException(
+                    'Predecisional WorkItem refused at ingestor: receiving org '
+                    + 'has not enabled predecisional ingest. Mark the source '
+                    + 'record non-predecisional or set '
+                    + 'DeliveryHubSettings__c.EnablePredecisionalIngestDateTime__c '
+                    + 'to opt-in. SourceId: ' + sourceId);
+            }
+        }
+
         // Tell trigger handlers that the source org owns auto-populated fields
         // (e.g. WorkItem__c.ActivatedDateTime__c) so receiver-side defaults
         // don't overwrite the source value during ingest.
@@ -729,6 +753,32 @@ public without sharing class DeliverySyncItemIngestor {
                 return;
             }
         }
+    }
+
+    /**
+     * @description Checks whether an inbound WorkItem payload carries a
+     * non-null MarkedPredecisionalDateTime__c value. Tolerates both the
+     * bare and namespaced field keys; tolerates the value arriving as a
+     * String, DateTime, or pre-serialized number (different sender stacks
+     * shape DateTimes differently).
+     * @param payload Deserialized inbound payload.
+     * @return True when the payload marks the record predecisional.
+     */
+    private static Boolean isPredecisionalPayload(Map<String, Object> payload) {
+        if (payload == null) {
+            return false;
+        }
+        Object raw = payload.get('MarkedPredecisionalDateTime__c');
+        if (raw == null) {
+            raw = payload.get(getNamespacePrefix() + 'MarkedPredecisionalDateTime__c');
+        }
+        if (raw == null) {
+            return false;
+        }
+        if (raw instanceof String) {
+            return String.isNotBlank((String) raw);
+        }
+        return true;
     }
 
     private static Boolean hasField(Schema.SObjectType type, String fieldName) {

--- a/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
@@ -619,6 +619,111 @@ private class DeliverySyncItemIngestorTest {
         }
     }
 
+    @IsTest
+    static void testPredecisionalInsertRefusedWhenSettingNull() {
+        // Receiving org with EnablePredecisionalIngestDateTime__c = null (default)
+        // must refuse a predecisional inbound WorkItem create. Closes the QBAG-leakage
+        // gap (5 sandbox proposal-staging items synced into a production org 5/5).
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        if (settings == null) {
+            settings = new DeliveryHubSettings__c();
+        }
+        settings.EnablePredecisionalIngestDateTime__c = null;
+        upsert settings;
+
+        System.runAs(testUser) {
+            Map<String, Object> payload = new Map<String, Object>{
+                'SourceId' => 'REMOTE-PREDECISIONAL-001',
+                'BriefDescriptionTxt__c' => 'QBAG-X: predecisional sandbox item',
+                'MarkedPredecisionalDateTime__c' => String.valueOf(DateTime.now())
+            };
+
+            Test.startTest();
+            Boolean threw = false;
+            String msg;
+            try {
+                DeliverySyncItemIngestor.processInboundItem('WorkItem__c', payload);
+            } catch (DeliverySyncEngine.SyncException e) {
+                threw = true;
+                msg = e.getMessage();
+            }
+            Test.stopTest();
+
+            System.assert(threw, 'Predecisional inbound must be refused when receiving org has not opted in');
+            System.assert(msg.contains('Predecisional WorkItem refused'),
+                'Refusal message should identify the predecisional gate; got: ' + msg);
+
+            List<WorkItem__c> created = [
+                SELECT Id FROM WorkItem__c
+                WHERE BriefDescriptionTxt__c = 'QBAG-X: predecisional sandbox item'
+            ];
+            System.assertEquals(0, created.size(), 'No WorkItem should be created when the gate refuses the inbound');
+        }
+    }
+
+    @IsTest
+    static void testPredecisionalInsertAllowedWhenSettingEnabled() {
+        // Receiving org that opts in (e.g., a sandbox staging proposals) must
+        // accept predecisional inbound WorkItems normally.
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        if (settings == null) {
+            settings = new DeliveryHubSettings__c();
+        }
+        settings.EnablePredecisionalIngestDateTime__c = DateTime.now();
+        upsert settings;
+
+        System.runAs(testUser) {
+            Map<String, Object> payload = new Map<String, Object>{
+                'SourceId' => 'REMOTE-PREDECISIONAL-002',
+                'BriefDescriptionTxt__c' => 'QBAG-Y: opt-in receiver',
+                'MarkedPredecisionalDateTime__c' => String.valueOf(DateTime.now())
+            };
+
+            Test.startTest();
+            Id resultId = DeliverySyncItemIngestor.processInboundItem('WorkItem__c', payload);
+            Test.stopTest();
+
+            System.assertNotEquals(null, resultId, 'Predecisional inbound must be accepted when the gate is open');
+            WorkItem__c after = [
+                SELECT BriefDescriptionTxt__c, MarkedPredecisionalDateTime__c
+                FROM WorkItem__c WHERE Id = :resultId
+            ];
+            System.assertEquals('QBAG-Y: opt-in receiver', after.BriefDescriptionTxt__c);
+            System.assertNotEquals(null, after.MarkedPredecisionalDateTime__c,
+                'Predecisional flag should be persisted on the receiver-side record so the receiver can re-emit it cross-org');
+        }
+    }
+
+    @IsTest
+    static void testNonPredecisionalInsertAllowedWhenSettingNull() {
+        // Regression guard: orgs with the gate closed must still accept normal
+        // (non-predecisional) inbound creates without interference.
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        if (settings == null) {
+            settings = new DeliveryHubSettings__c();
+        }
+        settings.EnablePredecisionalIngestDateTime__c = null;
+        upsert settings;
+
+        System.runAs(testUser) {
+            Map<String, Object> payload = new Map<String, Object>{
+                'SourceId' => 'REMOTE-NORMAL-003',
+                'BriefDescriptionTxt__c' => 'Non-predecisional inbound'
+            };
+
+            Test.startTest();
+            Id resultId = DeliverySyncItemIngestor.processInboundItem('WorkItem__c', payload);
+            Test.stopTest();
+
+            System.assertNotEquals(null, resultId, 'Non-predecisional inbound must pass through the closed gate');
+            WorkItem__c after = [
+                SELECT MarkedPredecisionalDateTime__c FROM WorkItem__c WHERE Id = :resultId
+            ];
+            System.assertEquals(null, after.MarkedPredecisionalDateTime__c,
+                'Receiver-side flag should remain null when the source did not mark the record predecisional');
+        }
+    }
+
     /**
      * @description Minimal HttpCalloutMock for the pull-callout path —
      *              tests that exercise the ingestor enqueue a fetcher

--- a/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
@@ -108,7 +108,14 @@ public without sharing class DeliveryWorkItemTriggerHandler {
             'BountyTokenTxt__c',
             'BountyDifficultyPk__c',
             'BountySkillsTxt__c',
-            'BountyMaxClaimsNumber__c'
+            'BountyMaxClaimsNumber__c',
+            // MarkedPredecisionalDateTime__c travels with the record so receivers
+            // can refuse predecisional inbound when their DeliveryHubSettings__c
+            // does not have EnablePredecisionalIngestDateTime__c set. Closes the
+            // QBAG-leakage gap (5/5: 5 proposal-staging items synced from a
+            // sandbox into a production org because nothing on the receiver
+            // side knew they were predecisional).
+            'MarkedPredecisionalDateTime__c'
         };
 
         DeliverySyncEngine.captureChanges(newRows, oldMap, syncFields);

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnablePredecisionalIngestDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnablePredecisionalIngestDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnablePredecisionalIngestDateTime__c</fullName>
+    <description>When non-null, this org accepts inbound WorkItem records whose MarkedPredecisionalDateTime__c is also set. Null = predecisional inbounds are refused (default). Sandboxes that stage proposal content for review should leave this null on the production peer and set it on themselves so predecisional content stays in the sandbox until promoted.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to allow predecisional WorkItems to land in this org via cross-org sync. Leave blank to refuse predecisional inbound (recommended for production).</inlineHelpText>
+    <label>Enable Predecisional Ingest</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/WorkItem__c/fields/MarkedPredecisionalDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/WorkItem__c/fields/MarkedPredecisionalDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>MarkedPredecisionalDateTime__c</fullName>
+    <description>When non-null, this work item is predecisional (proposal-staging only) and must not be ingested into orgs that have not enabled predecisional ingest on DeliveryHubSettings__c. The timestamp records when the record was marked predecisional. Travels with the record via the sync field set so receivers can enforce the gate locally.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time when this item is for proposal staging only. Receiving orgs without predecisional ingest enabled will refuse the inbound write.</inlineHelpText>
+    <label>Marked Predecisional</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>


### PR DESCRIPTION
## Summary

Closes the QBAG-leakage gap observed 5/5: 5 proposal-staging WorkItems (T-0101..T-0105) synced from a Nimba sandbox into MF-Prod because nothing on the receiver side knew they were predecisional. MF-Claude had to manually reparent + cancel the dupes after the fact.

This PR adds receiver-side gating so the same shape of leakage cannot recur.

## What changed

- **`WorkItem__c.MarkedPredecisionalDateTime__c`** (new DateTime field). Non-null marks the record as predecisional. Added to `DeliveryWorkItemTriggerHandler.syncFields` so the flag travels with the record cross-org.
- **`DeliveryHubSettings__c.EnablePredecisionalIngestDateTime__c`** (new DateTime field). Null default = the gate is closed (the recommended posture for production-shape orgs). Setting a DateTime opts the org in (the right posture for a sandbox that stages proposals).
- **`DeliverySyncItemIngestor.processInboundItem`** now refuses inbound WorkItem writes (insert OR update) whose payload carries a non-null `MarkedPredecisionalDateTime__c` when the receiving org has not opted in. The refusal throws `DeliverySyncEngine.SyncException` with a clear message, which the surrounding processor stamps onto the SyncItem ledger row as `Failed` with a visible reason.
- 3 new tests in `DeliverySyncItemIngestorTest`: (1) gate refuses when setting null, (2) gate passes when admin opts in, (3) non-predecisional payload passes unchanged when gate is closed (regression guard).

## Why DateTime, not Boolean

Per `CLAUDE.md`: "Use DateTime stamps, not Booleans, for feature toggles (`EnableXDateTime__c` pattern)." Both new fields follow the project's existing convention (e.g., `BountyEnabledDateTime__c`, `EnableLiveGanttEventsDateTime__c`).

## Operator runbook (for the rollout)

- **MF-Prod / dh-prod:** leave `EnablePredecisionalIngestDateTime__c` null. Predecisional inbound is refused.
- **Nimba (or any sandbox staging proposals):** set `EnablePredecisionalIngestDateTime__c` to the activation DateTime. Predecisional inbound is accepted.
- **Marking a WI predecisional:** set `MarkedPredecisionalDateTime__c` on the source WI. The flag propagates via `syncFields` and the receiving org enforces the gate.

## Test plan

- [x] Local PMD passes (`sf scanner run` against the 3 changed Apex files, custom `pmd-rules.xml`, no rule violations).
- [ ] CI scanner pass (mitchspano/sfdx-scan-pull-request, severity-threshold 4).
- [ ] `DeliverySyncItemIngestorTest` (existing 14+ + 3 new) all pass.
- [ ] Post-promote smoke: in a sandbox with the setting set, source a predecisional WI to a peer org with the setting null and confirm the SyncItem row lands as `Failed` with the expected reason.

## Followups (not in this PR)

- **Operator visibility tile** on `deliveryHubHealthDashboard` for "predecisional refused inbounds" (per the handoff doc — separate PR).
- **Strengthened dedup** for the missed-ledger case (the QBAG T-0103/T-0104 dupe — actually two distinct nimba records, so dedup wouldn't have helped, but worth a separate look).

🤖 Generated with [Claude Code](https://claude.com/claude-code)