### PR TITLE
fix(test): predecisional gate tests — use ISO 8601 DateTime format

### DIFF
--- a/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
@@ -632,10 +632,14 @@ private class DeliverySyncItemIngestorTest {
         upsert settings;
 
         System.runAs(testUser) {
+            // ISO 8601 format mirrors how outbound JSON.serialize shapes
+            // DateTime fields on the wire — what mapFields' DateTime branch
+            // expects to deserialize cleanly.
+            String isoNow = DateTime.now().formatGmt('yyyy-MM-dd\'T\'HH:mm:ss.SSS\'Z\'');
             Map<String, Object> payload = new Map<String, Object>{
                 'SourceId' => 'REMOTE-PREDECISIONAL-001',
                 'BriefDescriptionTxt__c' => 'QBAG-X: predecisional sandbox item',
-                'MarkedPredecisionalDateTime__c' => String.valueOf(DateTime.now())
+                'MarkedPredecisionalDateTime__c' => isoNow
             };
 
             Test.startTest();
@@ -673,10 +677,11 @@ private class DeliverySyncItemIngestorTest {
         upsert settings;
 
         System.runAs(testUser) {
+            String isoNow = DateTime.now().formatGmt('yyyy-MM-dd\'T\'HH:mm:ss.SSS\'Z\'');
             Map<String, Object> payload = new Map<String, Object>{
                 'SourceId' => 'REMOTE-PREDECISIONAL-002',
                 'BriefDescriptionTxt__c' => 'QBAG-Y: opt-in receiver',
-                'MarkedPredecisionalDateTime__c' => String.valueOf(DateTime.now())
+                'MarkedPredecisionalDateTime__c' => isoNow
             };
 
             Test.startTest();


### PR DESCRIPTION
## Summary

Beta_create on PR #747 merge failed in upload-beta with:

\`\`\`
Apex Test Failure: Class.delivery.DeliverySyncItemIngestorTest.testPredecisionalInsertAllowedWhenSettingEnabled:
line 692, column 1 System.AssertException: Assertion Failed:
Predecisional flag should be persisted on the receiver-side record so the receiver can re-emit it cross-org: Same value: null
\`\`\`

Run: https://github.com/Nimba-Solutions/Delivery-Hub/actions/runs/25389674648

## Root cause

\`String.valueOf(DateTime.now())\` produces \`2026-05-05 17:01:09\` (space-separated), which \`mapFields\` cannot parse via \`JSON.deserialize('"' + val + '"', DateTime.class)\` (expects ISO 8601). The exception is swallowed by the per-field try/catch in \`mapFields\`, the field silently skips, and the persisted record comes back with \`MarkedPredecisionalDateTime__c = null\` → assertion fails.

**Production path is unaffected.** Outbound \`JSON.serialize(payload)\` in \`DeliverySyncEngine.createSyncItem\` (cls:376) shapes DateTime as ISO 8601 natively. The bug was purely in how the test constructed its mock payload.

## Fix

Use \`DateTime.formatGmt('yyyy-MM-dd\'T\'HH:mm:ss.SSS\'Z\'')\` in both predecisional tests so the mock payload matches real wire format.

## Test plan

- [x] Local PMD passes
- [ ] Beta_create succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)