### PR TITLE
fix(workitem): default Status to Active (was New) — closes invisible-WI gap

### DIFF
--- a/force-app/main/default/objects/WorkItem__c/fields/StatusPk__c.field-meta.xml
+++ b/force-app/main/default/objects/WorkItem__c/fields/StatusPk__c.field-meta.xml
@@ -11,8 +11,13 @@
         <valueSetDefinition>
             <sorted>false</sorted>
             <value>
-                <fullName>New</fullName>
+                <fullName>Active</fullName>
                 <default>true</default>
+                <label>Active</label>
+            </value>
+            <value>
+                <fullName>New</fullName>
+                <default>false</default>
                 <label>New</label>
             </value>
             <value>


### PR DESCRIPTION
## Summary

`WorkItem__c.StatusPk__c` picklist field-level default was 'New', but the gantt's Active filter only renders Status='Active' rows. Result: every WI created via UI / data loader / sync-without-Status / Apex-without-explicit-Status defaulted to New and silently disappeared from the gantt.

5/6 MF-Claude audit found 14 such WIs sitting at Status=New for 5+ days despite having real Stages set (Backlog · In Development · Ready for Dev · Technical Review · Deployed to Prod). All flipped to Active manually as the data-side cleanup.

This PR is the metadata-side permanent fix.

## What changed

`force-app/main/default/objects/WorkItem__c/fields/StatusPk__c.field-meta.xml`:

- Added `Active` to the inline value set
- Marked `Active` as `<default>true</default>`
- Demoted `New` to `<default>false</default>` (kept in value set; legacy flows may still write it)

## Per CLAUDE.md

> Existing inline-defined picklists stay `<restricted>false</restricted>`. Data integrity on those is enforced at the Apex service / trigger layer.

So the picklist accepts arbitrary values today; subscriber orgs (MF-Prod) already use `Active` via subscriber-side customization. Adding `Active` to the package's inline definition is idempotent for existing subscribers and ensures fresh installs get the right default.

> SF Known Issue `a028c00000qPzYUAA0`: Unlocked packages do not reliably propagate new values added to inline picklists on subscriber upgrades.

Existing subscribers are unaffected (they already have Active). Fresh installs / future subscribers pick up the fix.

## Why not the other options

- **Trigger `before insert` to flip New → Active**: works but unnecessary code given the picklist edit achieves the same thing.
- **Remove default entirely (no default value)**: would leave Status=null on inserts, breaking Active-filter views and validation rules that assume Status is set.
- **Migrate to GlobalValueSet**: SF blocks retrofitting GVS onto an existing inline-defined picklist. Would require dropping + recreating the field — high blast radius.

## Test plan

- [x] Local PMD (no Apex changes — irrelevant)
- [ ] CI scanner pass
- [ ] Beta cut on merge
- [ ] After install: create a fresh WI in MF-Prod via the UI, confirm Status=Active

🤖 Generated with [Claude Code](https://claude.com/claude-code)