### PR TITLE
fix(install): backfill stale Status=New WorkItems on install/upgrade

### DIFF
--- a/force-app/main/default/classes/DeliveryHubInstallHandler.cls
+++ b/force-app/main/default/classes/DeliveryHubInstallHandler.cls
@@ -19,6 +19,7 @@ global class DeliveryHubInstallHandler implements InstallHandler {
         initializeDefaultSettings();
         scheduleSyncJobs();
         backfillUserPermissionSets();
+        backfillWorkItemStatusDefaults();
         enqueueInitialReconciliation();
     }
 
@@ -75,6 +76,23 @@ global class DeliveryHubInstallHandler implements InstallHandler {
         } catch (Exception e) {
             System.debug(LoggingLevel.WARN,
                 '[DeliveryHubInstallHandler] PermissionSet backfill failed: '
+                + e.getMessage());
+        }
+    }
+
+    /**
+     * @description Flips WorkItems stuck at Status=New (created before the
+     *              field-level default was corrected in PR #752) to Active
+     *              so they become visible to the gantt's Active filter.
+     *              Wrapped in try/catch — install must not fail because of
+     *              record-level data issues.
+     */
+    private static void backfillWorkItemStatusDefaults() {
+        try {
+            DeliveryWorkItemBackfillService.backfillStatusDefaults();
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryHubInstallHandler] WorkItem Status backfill failed: '
                 + e.getMessage());
         }
     }

--- a/force-app/main/default/classes/DeliveryHubInstallHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryHubInstallHandlerTest.cls
@@ -65,6 +65,25 @@ private class DeliveryHubInstallHandlerTest {
     }
 
     @IsTest
+    static void testInstallBackfillsStaleStatusNewWorkItems() {
+        System.runAs(testUser) {
+            WorkItem__c stale = new WorkItem__c(
+                BriefDescriptionTxt__c = 'Pre-upgrade stale WI',
+                StageNamePk__c         = 'In Development',
+                StatusPk__c            = 'New'
+            );
+            insert stale;
+            Test.setCreatedDate(stale.Id, Datetime.now().addDays(-7));
+
+            Test.testInstall(new DeliveryHubInstallHandler(), null, false);
+
+            WorkItem__c reloaded = [SELECT StatusPk__c FROM WorkItem__c WHERE Id = :stale.Id];
+            System.assertEquals('Active', reloaded.StatusPk__c,
+                'Install handler should backfill pre-upgrade stale Status=New records');
+        }
+    }
+
+    @IsTest
     static void testInstallIsIdempotentOnRepeatedScheduling() {
         System.runAs(testUser) {
             Test.testInstall(new DeliveryHubInstallHandler(), null, false);

--- a/force-app/main/default/classes/DeliveryWorkItemBackfillService.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemBackfillService.cls
@@ -1,0 +1,67 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Idempotent backfills for WorkItem__c records that need
+ *              correction after metadata-default changes. Today: flips
+ *              Status=New to Active for records older than 24h, closing the
+ *              invisible-WI gap on tenants who were upgraded across the
+ *              field-default change in PR #752 (Status default New → Active).
+ *
+ *              Called from DeliveryHubInstallHandler on package install /
+ *              upgrade. Safe to invoke manually too.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation')
+public with sharing class DeliveryWorkItemBackfillService {
+
+    @TestVisible
+    private static final Integer BACKFILL_LIMIT = 5000;
+
+    @TestVisible
+    private static final Integer STALE_FLOOR_HOURS = 24;
+
+    /**
+     * @description Flips Status=New to Active for WorkItems created more than
+     *              STALE_FLOOR_HOURS ago. Records that recent are presumed
+     *              in-flight (just submitted, awaiting first triage) and are
+     *              left alone.
+     *
+     *              Why this exists: PR #752 changed the field-level default
+     *              for StatusPk__c from 'New' to 'Active' so the gantt's
+     *              Active filter shows newly-created WorkItems. That fix
+     *              only applies to records created AFTER the upgrade — any
+     *              record already at Status=New (e.g., portal submissions,
+     *              data-loader imports, Apex inserts without explicit Status)
+     *              stays invisible. This service backfills them on install.
+     *
+     *              Idempotent — re-running is a no-op once the backlog is
+     *              cleared. Uses allOrNone=false so a single record-level
+     *              validation failure does not abort the install.
+     * @return Number of records successfully updated.
+     */
+    public static Integer backfillStatusDefaults() {
+        Datetime floor = Datetime.now().addHours(-STALE_FLOOR_HOURS);
+        List<WorkItem__c> stale = [
+            SELECT Id
+            FROM WorkItem__c
+            WHERE StatusPk__c = 'New'
+              AND CreatedDate < :floor
+            WITH SYSTEM_MODE
+            LIMIT :BACKFILL_LIMIT
+        ];
+        if (stale.isEmpty()) {
+            return 0;
+        }
+        for (WorkItem__c w : stale) {
+            w.StatusPk__c = 'Active';
+        }
+        Database.SaveResult[] results = Database.update(stale, false);
+        Integer succeeded = 0;
+        for (Database.SaveResult r : results) {
+            if (r.isSuccess()) {
+                succeeded++;
+            }
+        }
+        return succeeded;
+    }
+}

--- a/force-app/main/default/classes/DeliveryWorkItemBackfillService.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryWorkItemBackfillService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryWorkItemBackfillServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemBackfillServiceTest.cls
@@ -1,0 +1,116 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Tests for DeliveryWorkItemBackfillService.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryWorkItemBackfillServiceTest {
+
+    @IsTest
+    static void backfillReturnsZeroWhenNoStaleRecords() {
+        WorkItem__c fresh = new WorkItem__c(
+            BriefDescriptionTxt__c = 'Fresh WI',
+            StageNamePk__c         = 'Backlog',
+            StatusPk__c            = 'New'
+        );
+        insert fresh;
+
+        Test.startTest();
+        Integer updated = DeliveryWorkItemBackfillService.backfillStatusDefaults();
+        Test.stopTest();
+
+        System.assertEquals(0, updated,
+            'Records younger than the stale floor must not be touched');
+        WorkItem__c reloaded = [SELECT StatusPk__c FROM WorkItem__c WHERE Id = :fresh.Id];
+        System.assertEquals('New', reloaded.StatusPk__c,
+            'Recent record must remain at Status=New');
+    }
+
+    @IsTest
+    static void backfillFlipsStaleStatusNewToActive() {
+        WorkItem__c stale = new WorkItem__c(
+            BriefDescriptionTxt__c = 'Stale WI',
+            StageNamePk__c         = 'In Development',
+            StatusPk__c            = 'New'
+        );
+        insert stale;
+        Test.setCreatedDate(stale.Id, Datetime.now().addDays(-7));
+
+        Test.startTest();
+        Integer updated = DeliveryWorkItemBackfillService.backfillStatusDefaults();
+        Test.stopTest();
+
+        System.assertEquals(1, updated, 'Stale record at Status=New should be flipped');
+        WorkItem__c reloaded = [SELECT StatusPk__c FROM WorkItem__c WHERE Id = :stale.Id];
+        System.assertEquals('Active', reloaded.StatusPk__c,
+            'Stale record must be Active after backfill');
+    }
+
+    @IsTest
+    static void backfillLeavesNonNewStatusAlone() {
+        WorkItem__c done = new WorkItem__c(
+            BriefDescriptionTxt__c = 'Done WI',
+            StageNamePk__c         = 'In Development',
+            StatusPk__c            = 'Done'
+        );
+        insert done;
+        Test.setCreatedDate(done.Id, Datetime.now().addDays(-30));
+
+        Test.startTest();
+        Integer updated = DeliveryWorkItemBackfillService.backfillStatusDefaults();
+        Test.stopTest();
+
+        System.assertEquals(0, updated, 'Records not at Status=New must not be touched');
+        WorkItem__c reloaded = [SELECT StatusPk__c FROM WorkItem__c WHERE Id = :done.Id];
+        System.assertEquals('Done', reloaded.StatusPk__c,
+            'Done record must remain Done');
+    }
+
+    @IsTest
+    static void backfillIsIdempotent() {
+        WorkItem__c stale = new WorkItem__c(
+            BriefDescriptionTxt__c = 'Stale WI',
+            StageNamePk__c         = 'In Development',
+            StatusPk__c            = 'New'
+        );
+        insert stale;
+        Test.setCreatedDate(stale.Id, Datetime.now().addDays(-7));
+
+        Test.startTest();
+        Integer firstPass  = DeliveryWorkItemBackfillService.backfillStatusDefaults();
+        Integer secondPass = DeliveryWorkItemBackfillService.backfillStatusDefaults();
+        Test.stopTest();
+
+        System.assertEquals(1, firstPass,  'First pass should flip the stale record');
+        System.assertEquals(0, secondPass, 'Second pass should be a no-op');
+    }
+
+    @IsTest
+    static void backfillHandlesMixedFreshAndStale() {
+        WorkItem__c fresh = new WorkItem__c(
+            BriefDescriptionTxt__c = 'Fresh WI',
+            StageNamePk__c         = 'Backlog',
+            StatusPk__c            = 'New'
+        );
+        WorkItem__c stale = new WorkItem__c(
+            BriefDescriptionTxt__c = 'Stale WI',
+            StageNamePk__c         = 'In Development',
+            StatusPk__c            = 'New'
+        );
+        insert new List<WorkItem__c>{ fresh, stale };
+        Test.setCreatedDate(stale.Id, Datetime.now().addDays(-7));
+
+        Test.startTest();
+        Integer updated = DeliveryWorkItemBackfillService.backfillStatusDefaults();
+        Test.stopTest();
+
+        System.assertEquals(1, updated, 'Only the stale record should be flipped');
+
+        Map<Id, WorkItem__c> reloaded = new Map<Id, WorkItem__c>(
+            [SELECT Id, StatusPk__c FROM WorkItem__c WHERE Id IN :new List<Id>{fresh.Id, stale.Id}]
+        );
+        System.assertEquals('New',    reloaded.get(fresh.Id).StatusPk__c, 'Fresh record stays New');
+        System.assertEquals('Active', reloaded.get(stale.Id).StatusPk__c, 'Stale record becomes Active');
+    }
+}

--- a/force-app/main/default/classes/DeliveryWorkItemBackfillServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryWorkItemBackfillServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
## Summary
- New `DeliveryWorkItemBackfillService.backfillStatusDefaults()` flips `WorkItem__c.StatusPk__c = 'New'` → `'Active'` for any record older than 24h
- Hooked into `DeliveryHubInstallHandler.onInstall()` (mirrors the existing `backfillUserPermissionSets` pattern)
- Idempotent · governor-capped at 5000/run · `Database.update(allOrNone=false)` so install never fails on per-record validation

## Why
PR #752 changed the field-level default for Status from `New` → `Active` so the gantt's Active filter renders new WorkItems. That fix is metadata-only — it applies to records created **after** the upgrade. Records already at `Status=New` (portal submissions, data-loader imports, Apex inserts without explicit Status) stay stuck and remain invisible.

Today's prod audit found **~157 such records** across the live mesh:
| Org | Stale Status=New | Notes |
|---|---|---|
| dh-prod | 102 | Mostly cross-synced from nimba portal |
| nimba | 55 | All from cloudnimbusllc portal `Site Guest User`, oldest 4/9 |
| MF-Prod | 0 | Already clean |

Without this backfill, those 157 records remain invisible forever — even after the next package upgrade.

## How
- 24h floor preserves any literal in-flight portal submission still awaiting first triage
- Anything older is either the metadata-default-was-wrong class (now fixed forward) or a stale record the user clearly never intended to leave hidden
- Re-running on next upgrade is a no-op once the backlog clears

## Test plan
- [x] `DeliveryWorkItemBackfillServiceTest` — 5 methods covering: no-stale → 0; stale-New → flipped; non-New stays; idempotent; mixed fresh+stale
- [x] `DeliveryHubInstallHandlerTest.testInstallBackfillsStaleStatusNewWorkItems` — verifies the backfill runs as part of `Test.testInstall`

🤖 Generated with [Claude Code](https://claude.com/claude-code)