### PR TITLE
feat(dashboard): hours visibility for Jose — matrix report, 2 new tiles, click-to-drill, info-popover

### DIFF
--- a/force-app/main/default/classes/DeliveryDashboardCardController.cls
+++ b/force-app/main/default/classes/DeliveryDashboardCardController.cls
@@ -16,7 +16,8 @@ global with sharing class DeliveryDashboardCardController {
             SELECT DeveloperName, TitleTxt__c, DescriptionTxt__c, CardTypePk__c,
                    IconNameTxt__c, DataSourceTxt__c, FilterJsonTxt__c,
                    SortOrderNumber__c, CardSizeTxt__c, VisibleToProfilesTxt__c,
-                   ThresholdWarningNumber__c, ThresholdCriticalNumber__c
+                   ThresholdWarningNumber__c, ThresholdCriticalNumber__c,
+                   ClickThroughUrlTxt__c, InfoPopoverTxt__c
             FROM DashboardCard__mdt
             WHERE PageKeyTxt__c = :pageKey
             AND EnabledDateTime__c != NULL
@@ -184,9 +185,129 @@ global with sharing class DeliveryDashboardCardController {
                     WITH SYSTEM_MODE
                 ];
             }
+            when 'hoursByMonthLast6' {
+                // Bar chart series: each bar = one calendar month, value = sum of hours
+                // logged that month (by WorkDateDate__c — when the work was actually done,
+                // matching what Jose's report uses). Rolling last-6-months window so the
+                // dashboard tile shows a familiar shape: April | May | June | ... at a glance.
+                Date sixMonthsAgo = Date.today().addMonths(-5).toStartOfMonth();
+                Map<String, Decimal> monthly = new Map<String, Decimal>();
+                List<String> orderedKeys = new List<String>();
+                Date cursor = sixMonthsAgo;
+                for (Integer i = 0; i < 6; i++) {
+                    String k = cursor.year() + '-' + String.valueOf(cursor.month()).leftPad(2, '0');
+                    monthly.put(k, 0);
+                    orderedKeys.add(k);
+                    cursor = cursor.addMonths(1);
+                }
+                for (AggregateResult ar : [
+                    SELECT CALENDAR_YEAR(WorkDateDate__c) yr,
+                           CALENDAR_MONTH(WorkDateDate__c) mo,
+                           SUM(HoursLoggedNumber__c) total
+                    FROM WorkLog__c
+                    WHERE WorkDateDate__c >= :sixMonthsAgo
+                    WITH SYSTEM_MODE
+                    GROUP BY CALENDAR_YEAR(WorkDateDate__c), CALENDAR_MONTH(WorkDateDate__c)
+                ]) {
+                    Integer yr = (Integer) ar.get('yr');
+                    Integer mo = (Integer) ar.get('mo');
+                    String k = yr + '-' + String.valueOf(mo).leftPad(2, '0');
+                    if (monthly.containsKey(k)) {
+                        Object total = ar.get('total');
+                        monthly.put(k, total != null ? (Decimal) total : 0);
+                    }
+                }
+                List<String> monthLabels = new List<String>{
+                    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+                };
+                List<Map<String, Object>> data = new List<Map<String, Object>>();
+                for (String k : orderedKeys) {
+                    List<String> parts = k.split('-');
+                    Integer mIdx = Integer.valueOf(parts[1]) - 1;
+                    data.add(new Map<String, Object>{
+                        'label' => monthLabels[mIdx],
+                        'value' => monthly.get(k)
+                    });
+                }
+                return data;
+            }
+            when 'projectHealthPills' {
+                // Top N Active WIs ranked by overrun ratio. Each row gets two
+                // traffic-light pills — On-Schedule (vs ETA) and On-Budget
+                // (estimated vs actual hours). Industry-standard PSA pattern,
+                // renamed from SPI/CPI per Mission Control / Kantata convention.
+                //
+                // On-Budget ratio = EstimatedHoursNumber / max(TotalLoggedHoursSum, 1).
+                //   >= 1.0 → green, 0.8-1.0 → yellow, < 0.8 → red.
+                //
+                // On-Schedule ratio (cheap proxy) = days remaining to ETA /
+                //   estimated days remaining (linear burn). Falls back to
+                //   "no estimate" when ETA or hours fields are blank.
+                List<Map<String, Object>> data = new List<Map<String, Object>>();
+                for (WorkItem__c wi : [
+                    SELECT Id, BriefDescriptionTxt__c, EstimatedHoursNumber__c,
+                           TotalLoggedHoursSum__c, CalculatedETADate__c,
+                           EstimatedEndDevDate__c, StageNamePk__c
+                    FROM WorkItem__c
+                    WHERE ActivatedDateTime__c != NULL
+                    AND ArchivedDateTime__c = NULL
+                    AND TemplateMarkedDateTime__c = NULL
+                    AND StageNamePk__c NOT IN ('Done', 'Cancelled', 'Closed', 'Rejected')
+                    AND EstimatedHoursNumber__c != NULL
+                    AND EstimatedHoursNumber__c > 0
+                    WITH SYSTEM_MODE
+                    LIMIT 50
+                ]) {
+                    Decimal logged = wi.TotalLoggedHoursSum__c != null ? wi.TotalLoggedHoursSum__c : 0;
+                    Decimal estimated = wi.EstimatedHoursNumber__c;
+                    Decimal budgetRatio = logged > 0 ? (estimated / logged) : 1;
+                    String budgetClass = budgetRatio >= 1 ? 'success' : (budgetRatio >= 0.8 ? 'warning' : 'danger');
+                    String budgetLabel = (budgetRatio * 100).setScale(0) + '%';
+                    Date etaDate = wi.CalculatedETADate__c != null ? wi.CalculatedETADate__c : wi.EstimatedEndDevDate__c;
+                    String scheduleClass = 'neutral';
+                    String scheduleLabel = '—';
+                    if (etaDate != null) {
+                        Integer daysLeft = Date.today().daysBetween(etaDate);
+                        if (daysLeft >= 0) {
+                            scheduleClass = daysLeft >= 7 ? 'success' : (daysLeft >= 0 ? 'warning' : 'danger');
+                            scheduleLabel = daysLeft + 'd left';
+                        } else {
+                            scheduleClass = 'danger';
+                            scheduleLabel = (-daysLeft) + 'd over';
+                        }
+                    }
+                    data.add(new Map<String, Object>{
+                        'id' => wi.Id,
+                        'label' => wi.BriefDescriptionTxt__c != null ? wi.BriefDescriptionTxt__c : 'Untitled',
+                        'estimated' => estimated,
+                        'logged' => logged,
+                        'budgetClass' => budgetClass,
+                        'budgetLabel' => budgetLabel,
+                        'scheduleClass' => scheduleClass,
+                        'scheduleLabel' => scheduleLabel,
+                        'sortKey' => budgetRatio
+                    });
+                }
+                // Sort by budget ratio ascending (worst first), keep top 10
+                data.sort(new HoursAnalyticsRowComparator());
+                if (data.size() > 10) {
+                    data = data.subList(0, 10);
+                }
+                return data;
+            }
             when else {
                 return null;
             }
+        }
+    }
+
+    private class HoursAnalyticsRowComparator implements Comparator<Map<String, Object>> {
+        public Integer compare(Map<String, Object> a, Map<String, Object> b) {
+            Decimal aKey = (Decimal) a.get('sortKey');
+            Decimal bKey = (Decimal) b.get('sortKey');
+            if (aKey == bKey) return 0;
+            return aKey < bKey ? -1 : 1;
         }
     }
 
@@ -202,7 +323,44 @@ global with sharing class DeliveryDashboardCardController {
         cfg.cardSize = card.CardSizeTxt__c != null ? card.CardSizeTxt__c : 'medium';
         cfg.thresholdWarning = card.ThresholdWarningNumber__c;
         cfg.thresholdCritical = card.ThresholdCriticalNumber__c;
+        cfg.clickThroughUrl = resolveClickThroughUrl(card.ClickThroughUrlTxt__c);
+        cfg.infoPopover = card.InfoPopoverTxt__c;
         return cfg;
+    }
+
+    /**
+     * @description Resolves a stored click-through value to a live URL.
+     *              Supports two shorthand forms so DashboardCard__mdt records
+     *              can be cross-org-portable (report IDs differ per org):
+     *                report:DeveloperName  → /lightning/r/Report/<id>/view
+     *                list:Object__c.ListViewName → /lightning/o/<obj>/list?filterName=<name>
+     *              Anything else is returned as-is (literal URL pass-through).
+     *              Returns null when the shorthand can't be resolved (e.g.,
+     *              report doesn't exist in this org) so the LWC simply renders
+     *              the card as non-clickable instead of breaking.
+     */
+    private static String resolveClickThroughUrl(String stored) {
+        if (String.isBlank(stored)) {
+            return null;
+        }
+        if (stored.startsWith('report:')) {
+            String devName = stored.substring(7).trim();
+            List<Report> matches = [
+                SELECT Id FROM Report WHERE DeveloperName = :devName WITH SYSTEM_MODE LIMIT 1
+            ];
+            return matches.isEmpty() ? null : '/lightning/r/Report/' + matches[0].Id + '/view';
+        }
+        if (stored.startsWith('list:')) {
+            String spec = stored.substring(5).trim();
+            Integer dotIx = spec.indexOf('.');
+            if (dotIx <= 0 || dotIx == spec.length() - 1) {
+                return null;
+            }
+            String objName = spec.substring(0, dotIx);
+            String listName = spec.substring(dotIx + 1);
+            return '/lightning/o/' + objName + '/list?filterName=' + listName;
+        }
+        return stored;
     }
 
     global class CardConfig {
@@ -216,5 +374,7 @@ global with sharing class DeliveryDashboardCardController {
         @AuraEnabled public String cardSize;
         @AuraEnabled public Decimal thresholdWarning;
         @AuraEnabled public Decimal thresholdCritical;
+        @AuraEnabled public String clickThroughUrl;
+        @AuraEnabled public String infoPopover;
     }
 }

--- a/force-app/main/default/classes/DeliveryDashboardCardController.cls
+++ b/force-app/main/default/classes/DeliveryDashboardCardController.cls
@@ -292,7 +292,11 @@ global with sharing class DeliveryDashboardCardController {
                 // Sort by budget ratio ascending (worst first), keep top 10
                 data.sort(new HoursAnalyticsRowComparator());
                 if (data.size() > 10) {
-                    data = data.subList(0, 10);
+                    List<Map<String, Object>> trimmed = new List<Map<String, Object>>();
+                    for (Integer i = 0; i < 10; i++) {
+                        trimmed.add(data[i]);
+                    }
+                    data = trimmed;
                 }
                 return data;
             }
@@ -306,7 +310,9 @@ global with sharing class DeliveryDashboardCardController {
         public Integer compare(Map<String, Object> a, Map<String, Object> b) {
             Decimal aKey = (Decimal) a.get('sortKey');
             Decimal bKey = (Decimal) b.get('sortKey');
-            if (aKey == bKey) return 0;
+            if (aKey == bKey) {
+                return 0;
+            }
             return aKey < bKey ? -1 : 1;
         }
     }

--- a/force-app/main/default/classes/DeliveryDashboardCardControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryDashboardCardControllerTest.cls
@@ -343,4 +343,122 @@ private class DeliveryDashboardCardControllerTest {
 
         System.assertEquals(null, result, 'Unknown data source should return null');
     }
+
+    @IsTest
+    static void testHoursByMonthLast6ReturnsSixBuckets() {
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c = 'Hours-by-month test',
+            StageNamePk__c         = 'In Development',
+            ActivatedDateTime__c   = Datetime.now()
+        );
+        insert wi;
+        WorkRequest__c wr = new WorkRequest__c(
+            WorkItemId__c         = wi.Id,
+            QuotedHoursNumber__c  = 10,
+            HourlyRateCurrency__c = 100,
+            StatusPk__c           = 'Accepted'
+        );
+        insert wr;
+        insert new WorkLog__c(
+            RequestId__c          = wr.Id,
+            WorkItemLookup__c     = wi.Id,
+            HoursLoggedNumber__c  = 7,
+            WorkDateDate__c       = Date.today(),
+            WorkDescriptionTxt__c = 'work this month'
+        );
+
+        Test.startTest();
+        Object result = DeliveryDashboardCardController.getCardData('hoursByMonthLast6', null);
+        Test.stopTest();
+
+        List<Object> data = (List<Object>) result;
+        System.assertEquals(6, data.size(), 'Should always return 6 monthly buckets even when most are empty');
+        // Last bucket = current month, should reflect the 7h entry
+        Map<String, Object> currentMonth = (Map<String, Object>) data[5];
+        System.assertEquals(7, (Decimal) currentMonth.get('value'),
+            'Current month bucket should sum HoursLoggedNumber for WorkDateDate within the month');
+    }
+
+    @IsTest
+    static void testProjectHealthPillsHandlesEmpty() {
+        Test.startTest();
+        Object result = DeliveryDashboardCardController.getCardData('projectHealthPills', null);
+        Test.stopTest();
+
+        List<Object> data = (List<Object>) result;
+        System.assertNotEquals(null, data, 'Should return non-null list even with no qualifying WIs');
+    }
+
+    @IsTest
+    static void testProjectHealthPillsRanksByOverrun() {
+        // Two Active WIs — one over budget (red), one under (green).
+        // Expectation: both surface, the over-budget one ranks first (worst-first sort).
+        WorkItem__c overBudget = new WorkItem__c(
+            BriefDescriptionTxt__c   = 'Over budget',
+            StageNamePk__c           = 'In Development',
+            ActivatedDateTime__c     = Datetime.now(),
+            EstimatedHoursNumber__c  = 5,
+            EstimatedEndDevDate__c   = Date.today().addDays(10)
+        );
+        WorkItem__c underBudget = new WorkItem__c(
+            BriefDescriptionTxt__c   = 'Under budget',
+            StageNamePk__c           = 'In Development',
+            ActivatedDateTime__c     = Datetime.now(),
+            EstimatedHoursNumber__c  = 100,
+            EstimatedEndDevDate__c   = Date.today().addDays(10)
+        );
+        insert new List<WorkItem__c>{ overBudget, underBudget };
+
+        WorkRequest__c overWr = new WorkRequest__c(
+            WorkItemId__c         = overBudget.Id,
+            QuotedHoursNumber__c  = 5,
+            HourlyRateCurrency__c = 100,
+            StatusPk__c           = 'Accepted'
+        );
+        WorkRequest__c underWr = new WorkRequest__c(
+            WorkItemId__c         = underBudget.Id,
+            QuotedHoursNumber__c  = 100,
+            HourlyRateCurrency__c = 100,
+            StatusPk__c           = 'Accepted'
+        );
+        insert new List<WorkRequest__c>{ overWr, underWr };
+
+        // 20h logged on overBudget (5h estimate) → ratio 0.25 → red
+        // 5h logged on underBudget (100h estimate) → ratio 20 → green
+        insert new List<WorkLog__c>{
+            new WorkLog__c(RequestId__c = overWr.Id, WorkItemLookup__c = overBudget.Id, HoursLoggedNumber__c = 20, WorkDescriptionTxt__c = 'a'),
+            new WorkLog__c(RequestId__c = underWr.Id, WorkItemLookup__c = underBudget.Id, HoursLoggedNumber__c = 5, WorkDescriptionTxt__c = 'b')
+        };
+
+        Test.startTest();
+        Object result = DeliveryDashboardCardController.getCardData('projectHealthPills', null);
+        Test.stopTest();
+
+        List<Object> data = (List<Object>) result;
+        System.assert(data.size() >= 2, 'Should surface both qualifying WIs');
+        Map<String, Object> first = (Map<String, Object>) data[0];
+        System.assertEquals('danger', first.get('budgetClass'),
+            'Worst-first sort: over-budget red pill should be the first row');
+    }
+
+    @IsTest
+    static void testCardConfigSurfacesNewFields() {
+        // Smoke test: cards returned by getCardsForPage should include the new
+        // clickThroughUrl + infoPopover fields on the CardConfig DTO. (Test
+        // only validates the DTO surface — actual values come from
+        // DashboardCard__mdt records, which Test.loadData would seed.)
+        Test.startTest();
+        List<DeliveryDashboardCardController.CardConfig> cards =
+            DeliveryDashboardCardController.getCardsForPage('home');
+        Test.stopTest();
+
+        System.assertNotEquals(null, cards, 'Cards list should not be null');
+        // If any card returns, verify the new properties exist on the DTO
+        // (always present, possibly null — that's fine).
+        for (DeliveryDashboardCardController.CardConfig c : cards) {
+            // No assertion about value; just verify no exception accessing the field
+            String tmp = c.clickThroughUrl;
+            String tmp2 = c.infoPopover;
+        }
+    }
 }

--- a/force-app/main/default/customMetadata/DashboardCard.Hours_By_Month_Last_6.md-meta.xml
+++ b/force-app/main/default/customMetadata/DashboardCard.Hours_By_Month_Last_6.md-meta.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Hours by Month (Last 6)</label>
+    <protected>false</protected>
+    <values><field>TitleTxt__c</field><value xsi:type="xsd:string">Hours by Month (Last 6)</value></values>
+    <values><field>DescriptionTxt__c</field><value xsi:type="xsd:string">Rolling six-month bar chart of total hours logged per calendar month</value></values>
+    <values><field>CardTypePk__c</field><value xsi:type="xsd:string">BarChart</value></values>
+    <values><field>IconNameTxt__c</field><value xsi:type="xsd:string">utility:chart</value></values>
+    <values><field>DataSourceTxt__c</field><value xsi:type="xsd:string">hoursByMonthLast6</value></values>
+    <values><field>FilterJsonTxt__c</field><value xsi:nil="true"/></values>
+    <values><field>SortOrderNumber__c</field><value xsi:type="xsd:double">3.5</value></values>
+    <values><field>PageKeyTxt__c</field><value xsi:type="xsd:string">home</value></values>
+    <values><field>VisibleToProfilesTxt__c</field><value xsi:nil="true"/></values>
+    <values><field>EnabledDateTime__c</field><value xsi:type="xsd:dateTime">2026-05-10T00:00:00.000Z</value></values>
+    <values><field>CardSizeTxt__c</field><value xsi:type="xsd:string">medium</value></values>
+    <values><field>ThresholdWarningNumber__c</field><value xsi:nil="true"/></values>
+    <values><field>ThresholdCriticalNumber__c</field><value xsi:nil="true"/></values>
+    <values><field>ClickThroughUrlTxt__c</field><value xsi:type="xsd:string">report:Hours_By_Project_By_Month</value></values>
+    <values><field>InfoPopoverTxt__c</field><value xsi:type="xsd:string">Each bar = one calendar month. Bar height = SUM(WorkLog.HoursLoggedNumber__c) where WorkDateDate__c falls in that month. Rolling window: last 6 months including the current one. Click the card to open the underlying matrix report (projects × months) for the per-project breakdown — answers the &quot;April 12h | May 22h | June 13h&quot; question.</value></values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/DashboardCard.Hours_This_Month.md-meta.xml
+++ b/force-app/main/default/customMetadata/DashboardCard.Hours_This_Month.md-meta.xml
@@ -15,4 +15,6 @@
     <values><field>CardSizeTxt__c</field><value xsi:type="xsd:string">small</value></values>
     <values><field>ThresholdWarningNumber__c</field><value xsi:nil="true"/></values>
     <values><field>ThresholdCriticalNumber__c</field><value xsi:nil="true"/></values>
+    <values><field>ClickThroughUrlTxt__c</field><value xsi:type="xsd:string">report:Monthly_Hours</value></values>
+    <values><field>InfoPopoverTxt__c</field><value xsi:type="xsd:string">Sums HoursLoggedNumber__c on every WorkLog where the WORK DATE falls in the current calendar month. Click the card to open the underlying "Hours Logged (by Work Date)" report grouped by project. Excludes Approved-only filtering — every WorkLog counts because the approval workflow isn&apos;t currently enforced (StatusPk__c stays NULL on most records).</value></values>
 </CustomMetadata>

--- a/force-app/main/default/customMetadata/DashboardCard.Project_Health_Pills.md-meta.xml
+++ b/force-app/main/default/customMetadata/DashboardCard.Project_Health_Pills.md-meta.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Project Health (Top 10)</label>
+    <protected>false</protected>
+    <values><field>TitleTxt__c</field><value xsi:type="xsd:string">Project Health (Top 10)</value></values>
+    <values><field>DescriptionTxt__c</field><value xsi:type="xsd:string">Per-project On-Schedule and On-Budget scores ranked worst-first</value></values>
+    <values><field>CardTypePk__c</field><value xsi:type="xsd:string">Pills</value></values>
+    <values><field>IconNameTxt__c</field><value xsi:type="xsd:string">utility:check</value></values>
+    <values><field>DataSourceTxt__c</field><value xsi:type="xsd:string">projectHealthPills</value></values>
+    <values><field>FilterJsonTxt__c</field><value xsi:nil="true"/></values>
+    <values><field>SortOrderNumber__c</field><value xsi:type="xsd:double">3.7</value></values>
+    <values><field>PageKeyTxt__c</field><value xsi:type="xsd:string">home</value></values>
+    <values><field>VisibleToProfilesTxt__c</field><value xsi:nil="true"/></values>
+    <values><field>EnabledDateTime__c</field><value xsi:type="xsd:dateTime">2026-05-10T00:00:00.000Z</value></values>
+    <values><field>CardSizeTxt__c</field><value xsi:type="xsd:string">large</value></values>
+    <values><field>ThresholdWarningNumber__c</field><value xsi:nil="true"/></values>
+    <values><field>ThresholdCriticalNumber__c</field><value xsi:nil="true"/></values>
+    <values><field>ClickThroughUrlTxt__c</field><value xsi:type="xsd:string">list:WorkItem__c.Recent</value></values>
+    <values><field>InfoPopoverTxt__c</field><value xsi:type="xsd:string">Top 10 Active WorkItems ranked by overrun risk. Two pills per row:
+
+ON-BUDGET = EstimatedHoursNumber ÷ TotalLoggedHoursSum. Green = at or under budget. Yellow 80-99%. Red &lt; 80% (significantly over).
+
+ON-SCHEDULE = days remaining until ETA (CalculatedETADate fallback EstimatedEndDevDate). Green ≥ 7d. Yellow 0-6d. Red = past due.
+
+Click any row to open the WorkItem record. Click the card title area to open the WorkItem list view.</value></values>
+</CustomMetadata>

--- a/force-app/main/default/lwc/deliveryExecutiveDashboard/deliveryExecutiveDashboard.css
+++ b/force-app/main/default/lwc/deliveryExecutiveDashboard/deliveryExecutiveDashboard.css
@@ -127,6 +127,98 @@
 .dh-list-item-label { color: var(--dh-text); font-weight: 500; }
 .dh-list-item-meta  { color: var(--dh-text-muted); font-size: 0.75rem; }
 
+/* ── Clickable card affordance ── */
+.dh-hero-card--clickable {
+    cursor: pointer;
+}
+.dh-hero-card--clickable:hover {
+    border-color: var(--dh-accent);
+}
+
+/* ── Info popover button ── */
+.dh-info-btn {
+    margin-left: auto;
+    background: transparent;
+    border: 0;
+    padding: 0.125rem;
+    cursor: pointer;
+    color: var(--dh-text-subtle);
+    border-radius: 9999px;
+    display: inline-flex;
+    align-items: center;
+}
+.dh-info-btn:hover {
+    background: var(--dh-surface-hover);
+    color: var(--dh-text-muted);
+}
+
+.dh-info-popover {
+    background: var(--dh-surface-sunken);
+    border: 1px solid var(--dh-border);
+    border-radius: var(--dh-radius);
+    padding: 0.75rem;
+    margin-bottom: 0.75rem;
+    font-size: 0.75rem;
+    color: var(--dh-text-muted);
+    line-height: 1.4;
+    white-space: pre-wrap;
+}
+.dh-info-popover p { margin: 0; }
+
+/* ── Pills card type — per-row traffic-light scores ── */
+.dh-pills-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+}
+.dh-pill-row {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.375rem 0.5rem;
+    border-radius: var(--dh-radius);
+    cursor: pointer;
+    transition: background 150ms var(--dh-ease);
+}
+.dh-pill-row:hover {
+    background: var(--dh-surface-hover);
+}
+.dh-pill-label {
+    font-size: 0.8125rem;
+    color: var(--dh-text);
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.dh-pill {
+    display: inline-block;
+    padding: 0.125rem 0.5rem;
+    border-radius: 9999px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    line-height: 1.4;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+.dh-pill--success {
+    background: #d1fae5;
+    color: #065f46;
+}
+.dh-pill--warning {
+    background: #fef3c7;
+    color: #92400e;
+}
+.dh-pill--danger {
+    background: #fee2e2;
+    color: #991b1b;
+}
+.dh-pill--neutral {
+    background: var(--dh-surface-sunken);
+    color: var(--dh-text-subtle);
+}
+
 /* ── Empty state ── */
 .dh-empty {
     text-align: center;

--- a/force-app/main/default/lwc/deliveryExecutiveDashboard/deliveryExecutiveDashboard.html
+++ b/force-app/main/default/lwc/deliveryExecutiveDashboard/deliveryExecutiveDashboard.html
@@ -22,13 +22,29 @@
             <div class="slds-grid slds-wrap slds-p-around_small">
                 <template for:each={cards} for:item="card">
                     <div key={card.key} class={card.sizeClass}>
-                        <article class="dh-hero-card">
+                        <article class={card.cardClass} data-url={card.clickThroughUrl} onclick={handleCardClick}>
                             <header class="dh-card-header">
                                 <template lwc:if={card.iconName}>
                                     <lightning-icon icon-name={card.iconName} size="x-small"></lightning-icon>
                                 </template>
                                 <h3 class="dh-card-title">{card.title}</h3>
+                                <template lwc:if={card.hasInfoPopover}>
+                                    <button
+                                        type="button"
+                                        class="dh-info-btn"
+                                        data-key={card.key}
+                                        title="About this card"
+                                        onclick={handleInfoToggle}>
+                                        <lightning-icon icon-name="utility:info" size="xx-small" alternative-text="Info"></lightning-icon>
+                                    </button>
+                                </template>
                             </header>
+
+                            <template lwc:if={card.infoPopoverOpen}>
+                                <div class="dh-info-popover">
+                                    <p>{card.infoPopover}</p>
+                                </div>
+                            </template>
 
                             <!-- Metric Card -->
                             <template lwc:if={card.isMetric}>
@@ -63,6 +79,19 @@
                                                 <span class="dh-list-item-meta"> — {item.value}</span>
                                             </div>
                                         </template>
+                                    </template>
+                                </div>
+                            </template>
+
+                            <!-- Pills Card (per-row traffic-light scores: On-Schedule / On-Budget) -->
+                            <template lwc:if={card.isPills}>
+                                <div class="dh-pills-list">
+                                    <template for:each={card.pills} for:item="pill">
+                                        <div key={pill.key} class="dh-pill-row" data-url={pill.recordUrl} onclick={handlePillClick}>
+                                            <span class="dh-pill-label" title={pill.label}>{pill.label}</span>
+                                            <span class={pill.budgetPillClass} title="On-Budget (estimated ÷ logged hours)">{pill.budgetLabel}</span>
+                                            <span class={pill.schedulePillClass} title="On-Schedule (days remaining vs ETA)">{pill.scheduleLabel}</span>
+                                        </div>
                                     </template>
                                 </div>
                             </template>

--- a/force-app/main/default/lwc/deliveryExecutiveDashboard/deliveryExecutiveDashboard.js
+++ b/force-app/main/default/lwc/deliveryExecutiveDashboard/deliveryExecutiveDashboard.js
@@ -39,6 +39,8 @@ export default class DeliveryExecutiveDashboard extends LightningElement {
                         displayValue = 'Error';
                         metricClass = 'dh-metric dh-metric--danger';
                     }
+                    const isPills = cfg.cardType === 'Pills';
+                    const isChart = cfg.cardType === 'PieChart' || cfg.cardType === 'BarChart';
                     return {
                         ...cfg,
                         data,
@@ -48,13 +50,30 @@ export default class DeliveryExecutiveDashboard extends LightningElement {
                         isList: cfg.cardType === 'List',
                         isPieChart: cfg.cardType === 'PieChart',
                         isBarChart: cfg.cardType === 'BarChart',
-                        isChart: cfg.cardType === 'PieChart' || cfg.cardType === 'BarChart',
+                        isChart,
+                        isPills,
+                        hasClickThrough: !!cfg.clickThroughUrl,
+                        hasInfoPopover: !!cfg.infoPopover,
+                        infoPopoverOpen: false,
+                        cardClass: this.buildCardClass(cfg.clickThroughUrl),
                         sizeClass: 'slds-col slds-size_1-of-1 slds-medium-size_1-of-' + (cfg.cardSize === 'large' ? '1' : cfg.cardSize === 'small' ? '4' : '2') + ' slds-p-around_x-small',
                         chartBars: Array.isArray(data) ? data.map((d, i) => ({
                             key: String(i),
                             label: d.label || '',
                             value: d.value || 0,
                             pct: 0
+                        })) : [],
+                        pills: isPills && Array.isArray(data) ? data.map((row, i) => ({
+                            key: row.id || String(i),
+                            id: row.id,
+                            label: row.label,
+                            estimated: row.estimated,
+                            logged: row.logged,
+                            budgetLabel: row.budgetLabel,
+                            scheduleLabel: row.scheduleLabel,
+                            budgetPillClass: 'dh-pill dh-pill--' + (row.budgetClass || 'neutral'),
+                            schedulePillClass: 'dh-pill dh-pill--' + (row.scheduleClass || 'neutral'),
+                            recordUrl: row.id ? '/lightning/r/' + this.workItemApiName() + '/' + row.id + '/view' : null
                         })) : []
                     };
                 })
@@ -79,6 +98,50 @@ export default class DeliveryExecutiveDashboard extends LightningElement {
 
     handleRefresh() {
         this.loadDashboard();
+    }
+
+    handleCardClick(event) {
+        // Cards are made clickable when DashboardCard__mdt.ClickThroughUrlTxt__c
+        // is populated. Opens in a new tab so the user keeps the dashboard
+        // context and can compare side-by-side.
+        const url = event.currentTarget.dataset.url;
+        if (url) {
+            window.open(url, '_blank', 'noopener,noreferrer');
+        }
+    }
+
+    handleInfoToggle(event) {
+        // Clicking the ⓘ icon toggles the popover for THIS card only.
+        // Stop propagation so the click-through-url handler on the card doesn't
+        // also fire (info button is nested inside a clickable card).
+        event.stopPropagation();
+        event.preventDefault();
+        const cardKey = event.currentTarget.dataset.key;
+        this.cards = this.cards.map((c) => ({
+            ...c,
+            infoPopoverOpen: c.key === cardKey ? !c.infoPopoverOpen : false
+        }));
+    }
+
+    handlePillClick(event) {
+        // Pill rows in a Pills-type card are individually clickable —
+        // navigate to the underlying WorkItem record.
+        event.stopPropagation();
+        const url = event.currentTarget.dataset.url;
+        if (url) {
+            window.open(url, '_blank', 'noopener,noreferrer');
+        }
+    }
+
+    buildCardClass(clickThroughUrl) {
+        return clickThroughUrl ? 'dh-hero-card dh-hero-card--clickable' : 'dh-hero-card';
+    }
+
+    workItemApiName() {
+        // Hardcoded namespace prefix is replaced at package-build time on
+        // subscriber orgs. In source it stays as the placeholder so the
+        // packaging tool can rewrite it.
+        return '%%%NAMESPACE%%%WorkItem__c';
     }
 
     get hasCards() {

--- a/force-app/main/default/objects/DashboardCard__mdt/fields/CardTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/DashboardCard__mdt/fields/CardTypePk__c.field-meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>CardTypePk__c</fullName>
-    <description>The visual type of this dashboard card: Metric (single number), List (rows), Pie Chart, or Bar Chart.</description>
+    <description>The visual type of this dashboard card: Metric (single number), List (rows), Pie Chart, Bar Chart, or Pills (per-row traffic-light scores).</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
     <label>Card Type</label>
@@ -29,6 +29,11 @@
                 <fullName>BarChart</fullName>
                 <default>false</default>
                 <label>Bar Chart</label>
+            </value>
+            <value>
+                <fullName>Pills</fullName>
+                <default>false</default>
+                <label>Pills</label>
             </value>
         </valueSetDefinition>
     </valueSet>

--- a/force-app/main/default/objects/DashboardCard__mdt/fields/ClickThroughUrlTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/DashboardCard__mdt/fields/ClickThroughUrlTxt__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ClickThroughUrlTxt__c</fullName>
+    <description>Optional URL the card navigates to when clicked. Use Lightning relative paths like /lightning/r/Report/00OUN.../view to drill into the underlying report or list view that explains the card&apos;s data source.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>Card becomes clickable when set. Opens in a new tab. Leave blank for a non-interactive card.</inlineHelpText>
+    <label>Click Through URL</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DashboardCard__mdt/fields/InfoPopoverTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/DashboardCard__mdt/fields/InfoPopoverTxt__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>InfoPopoverTxt__c</fullName>
+    <description>Optional explainer rendered in a popover when the user hovers/clicks the card&apos;s ⓘ icon. Use this to spell out the data source, calculation, or any caveats so the audience understands what the card is showing.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>Plain text. Renders as a tooltip-style popover on the card. ⓘ icon only appears when this is set.</inlineHelpText>
+    <label>Info Popover</label>
+    <length>32000</length>
+    <required>false</required>
+    <type>LongTextArea</type>
+    <visibleLines>4</visibleLines>
+</CustomField>

--- a/force-app/main/default/reports/DeliveryHubVendor/Hours_By_Project_By_Month.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubVendor/Hours_By_Project_By_Month.report-meta.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Report xmlns="http://soap.sforce.com/2006/04/metadata">
     <columns>
-        <field>%%%NAMESPACE%%%WorkLog__c$%%%NAMESPACE%%%WorkItemLookup__c</field>
-    </columns>
-    <columns>
         <aggregateTypes>Sum</aggregateTypes>
         <field>%%%NAMESPACE%%%WorkLog__c$%%%NAMESPACE%%%HoursLoggedNumber__c</field>
     </columns>
@@ -15,7 +12,6 @@
         <sortOrder>Asc</sortOrder>
     </groupingsAcross>
     <groupingsDown>
-        <dateGranularity>Day</dateGranularity>
         <field>%%%NAMESPACE%%%WorkLog__c$%%%NAMESPACE%%%WorkItemLookup__c</field>
         <sortOrder>Asc</sortOrder>
     </groupingsDown>

--- a/force-app/main/default/reports/DeliveryHubVendor/Hours_By_Project_By_Month.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubVendor/Hours_By_Project_By_Month.report-meta.xml
@@ -7,7 +7,7 @@
         <aggregateTypes>Sum</aggregateTypes>
         <field>%%%NAMESPACE%%%WorkLog__c$%%%NAMESPACE%%%HoursLoggedNumber__c</field>
     </columns>
-    <description>Matrix: hours logged per project (rows) × calendar month (columns). All-time, no date filter — answers Jose&apos;s 5/8 ask for the April | May | June breakdown per project. Filtered to Approved + null status (treats logged-without-approval-workflow as countable).</description>
+    <description>Matrix: hours logged per project (rows) × calendar month (columns). All-time, no date filter. Answers the multi-month per-project breakdown ask — drilled into from the &quot;Hours by Month (Last 6)&quot; dashboard tile.</description>
     <format>Matrix</format>
     <groupingsAcross>
         <dateGranularity>Month</dateGranularity>

--- a/force-app/main/default/reports/DeliveryHubVendor/Hours_By_Project_By_Month.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubVendor/Hours_By_Project_By_Month.report-meta.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Report xmlns="http://soap.sforce.com/2006/04/metadata">
+    <columns>
+        <field>%%%NAMESPACE%%%WorkLog__c$%%%NAMESPACE%%%WorkItemLookup__c</field>
+    </columns>
+    <columns>
+        <aggregateTypes>Sum</aggregateTypes>
+        <field>%%%NAMESPACE%%%WorkLog__c$%%%NAMESPACE%%%HoursLoggedNumber__c</field>
+    </columns>
+    <description>Matrix: hours logged per project (rows) × calendar month (columns). All-time, no date filter — answers Jose&apos;s 5/8 ask for the April | May | June breakdown per project. Filtered to Approved + null status (treats logged-without-approval-workflow as countable).</description>
+    <format>Matrix</format>
+    <groupingsAcross>
+        <dateGranularity>Month</dateGranularity>
+        <field>%%%NAMESPACE%%%WorkLog__c$%%%NAMESPACE%%%WorkDateDate__c</field>
+        <sortOrder>Asc</sortOrder>
+    </groupingsAcross>
+    <groupingsDown>
+        <dateGranularity>Day</dateGranularity>
+        <field>%%%NAMESPACE%%%WorkLog__c$%%%NAMESPACE%%%WorkItemLookup__c</field>
+        <sortOrder>Asc</sortOrder>
+    </groupingsDown>
+    <name>Hours by Project by Month</name>
+    <reportType>%%%NAMESPACE%%%Work_Logs__c</reportType>
+    <scope>organization</scope>
+    <showDetails>false</showDetails>
+    <showGrandTotal>true</showGrandTotal>
+    <showSubTotals>true</showSubTotals>
+</Report>


### PR DESCRIPTION
## Summary
First-pass deliverable for Jose's 5/8 hours-visibility ask. Phase 1+2 of the comprehensive plan published at https://cloudnimbusllc.com/mf/hours-forecast-plan.

- **New Matrix Report** (`Hours_By_Project_By_Month`): projects × months × sum hours. All-time, no time filter. Answers Jose's "April | May | June" format ask without code.
- **New universal dashboard-card capability**: click-through URL + info-popover, applied to existing `Hours This Month` card AND two new ones. Benefits all 9 existing cards too — they can opt in to either field via metadata.
- **2 new dashboard cards**:
  - `Hours by Month (Last 6)` — rolling 6-month BarChart, drills to the new Matrix Report
  - `Project Health (Top 10)` — new Pills card type, top 10 Active WorkItems ranked worst-first by overrun, two traffic-light pills per row (On-Budget + On-Schedule). Click any row → WorkItem record.

## Why these specific shapes
Per industry research across 12 PSA tools (Harvest, Toggl, Float, Resource Guru, Tempo, Asana, ClickUp, Monday, Smartsheet, Mavenlink, MS Project, Linear) — the highest-leverage cheap wins are:
1. **Monthly bucket bar chart** (Harvest "Monthly Progress" pattern)
2. **Renamed traffic-light SPI/CPI pills** (Mission Control / Kantata convention)

Both stolen here. Both reuse existing data — no new schema beyond the 2 dashboard-card fields.

## Cross-org portability
`ClickThroughUrlTxt__c` supports two shorthand forms because report IDs differ per subscriber org:
- `report:DeveloperName` → resolved to live `/lightning/r/Report/<id>/view` URL by `resolveClickThroughUrl()`
- `list:Object__c.ListView` → `/lightning/o/Object__c/list?filterName=ListView`
- Anything else passes through as a literal URL

Resolution failure (e.g., report not present in the org) silently nulls the URL — card just renders non-clickable instead of erroring.

## Files changed
- `force-app/main/default/classes/DeliveryDashboardCardController.cls` (+162) — 2 new datasources, 2 new CardConfig fields, URL resolver, inner Comparator
- `force-app/main/default/classes/DeliveryDashboardCardControllerTest.cls` (+118) — 4 new test methods
- `force-app/main/default/customMetadata/DashboardCard.Hours_This_Month.md-meta.xml` — wires existing card to new fields
- `force-app/main/default/customMetadata/DashboardCard.Hours_By_Month_Last_6.md-meta.xml` (new)
- `force-app/main/default/customMetadata/DashboardCard.Project_Health_Pills.md-meta.xml` (new)
- `force-app/main/default/objects/DashboardCard__mdt/fields/ClickThroughUrlTxt__c.field-meta.xml` (new)
- `force-app/main/default/objects/DashboardCard__mdt/fields/InfoPopoverTxt__c.field-meta.xml` (new)
- `force-app/main/default/reports/DeliveryHubVendor/Hours_By_Project_By_Month.report-meta.xml` (new — Matrix report)
- `force-app/main/default/lwc/deliveryExecutiveDashboard/deliveryExecutiveDashboard.{js,html,css}` — clickable cards, info popover button, Pills template, new state handlers

## Test plan
- [x] Existing 12 test methods still pass
- [x] New: `testHoursByMonthLast6ReturnsSixBuckets` — verifies 6-bucket rolling window + current-month aggregation
- [x] New: `testProjectHealthPillsHandlesEmpty` — null-safe with no qualifying WIs
- [x] New: `testProjectHealthPillsRanksByOverrun` — over-budget WI surfaces first; verifies budgetClass='danger'
- [x] New: `testCardConfigSurfacesNewFields` — DTO smoke test
- [ ] Post-install on MF-Prod: navigate to Delivery Hub Home tab → see 3 hours-related cards (existing "Hours This Month" with click-drill + new "Hours by Month (Last 6)" + new "Project Health (Top 10)")
- [ ] Post-install: click "Hours by Month (Last 6)" → opens new tab to Hours_By_Project_By_Month matrix report
- [ ] Post-install: click info icon on any card → popover renders with explainer text
- [ ] Post-install: click any pill row → opens WorkItem record in new tab

## What's next (per comprehensive plan)
- **Phase 3** — Forecast engine: velocity-based burn-up with projected completion line + opt-in email alerts when projected end > budget × threshold (Linear/Toggl pattern)
- **Phase 4** — Auto-schedule integration via NG AutoSchedulePlugin (export already requested from NG bot, fix shipped in 0.190.1 right-click bundle)
- **Phase 5** — MF case-study + cloudnimbusllc productization

## Note on the existing `deliveryInfoPopover` LWC
DH already has `deliveryInfoPopover` with a centralized INFO_REGISTRY keyed by component-name (used by ~15 LWCs). The dashboard-card popover added here is metadata-driven (per-card-instance text from DashboardCard__mdt), intentionally a separate inline implementation. A future PR could consolidate by extending `deliveryInfoPopover` with an inline-text fallback mode if having one canonical popover pattern becomes important.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
