### PR TITLE
fix(sync-ingestor): cross-path dedup via GlobalSourceId — stops dh-prod CREATE duplicates

### DIFF
--- a/force-app/main/default/classes/DeliveryDashboardCardController.cls
+++ b/force-app/main/default/classes/DeliveryDashboardCardController.cls
@@ -370,17 +370,17 @@ global with sharing class DeliveryDashboardCardController {
     }
 
     global class CardConfig {
-        @AuraEnabled public String key;
-        @AuraEnabled public String title;
-        @AuraEnabled public String description;
-        @AuraEnabled public String cardType;
-        @AuraEnabled public String iconName;
-        @AuraEnabled public String dataSource;
-        @AuraEnabled public String filterJson;
-        @AuraEnabled public String cardSize;
-        @AuraEnabled public Decimal thresholdWarning;
-        @AuraEnabled public Decimal thresholdCritical;
-        @AuraEnabled public String clickThroughUrl;
-        @AuraEnabled public String infoPopover;
+        @AuraEnabled global String key;
+        @AuraEnabled global String title;
+        @AuraEnabled global String description;
+        @AuraEnabled global String cardType;
+        @AuraEnabled global String iconName;
+        @AuraEnabled global String dataSource;
+        @AuraEnabled global String filterJson;
+        @AuraEnabled global String cardSize;
+        @AuraEnabled global Decimal thresholdWarning;
+        @AuraEnabled global Decimal thresholdCritical;
+        @AuraEnabled global String clickThroughUrl;
+        @AuraEnabled global String infoPopover;
     }
 }

--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -64,6 +64,25 @@ public without sharing class DeliverySyncItemIngestor {
         Id localRequestId = null;
         Id localRecordId = findLocalId(targetType, sourceId);
 
+        // Cross-path dedup via GlobalSourceId. When a record arrives via two
+        // different sync paths (e.g. MF → dh-prod direct AND MF → Nimba →
+        // dh-prod), the two payloads carry DIFFERENT SourceIds (each one is
+        // the immediate sender's local record Id) but the SAME GlobalSourceId
+        // (the origin record Id, set once at the birthplace per
+        // DeliverySyncEngine.captureChanges:117-119 and propagated unchanged
+        // across hops). Without this check, findLocalId returns null on the
+        // second-path SourceId because the inbound ledger entry was created
+        // against the FIRST path's SourceId, and the ingestor inserts a
+        // duplicate local record. Verified 2026-05-10: dh-prod ended up with
+        // 8 copies of 4 RR Phase WIs because the 4 originals each arrived
+        // via both MF-direct and MF→Nimba paths.
+        if (localRecordId == null && String.isNotBlank(globalSourceId)) {
+            Id globalMatch = findLocalIdByGlobalSource(targetType, globalSourceId);
+            if (globalMatch != null) {
+                localRecordId = globalMatch;
+            }
+        }
+
         // If it's a Work Item, also check the WorkRequest__c bridge (Downstream Origin).
         // The bridge carries explicit downstream routing context (localRequestId), so
         // we always capture it when present. But we only promote bridge.WorkItemId__c
@@ -492,6 +511,49 @@ public without sharing class DeliverySyncItemIngestor {
             WHERE RemoteExternalIdTxt__c = :remoteId
             AND ObjectTypePk__c = :cleanName
             AND DirectionPk__c = 'Inbound'
+            WITH SYSTEM_MODE
+            ORDER BY CreatedDate DESC
+            LIMIT 50
+        ];
+
+        for (SyncItem__c entry : ledger) {
+            Id candidate = (Id) entry.LocalRecordIdTxt__c;
+            if (validateLocalIdExists(type, candidate)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @description Cross-path dedup: returns the local record Id of any
+     *              existing inbound ledger entry for the same GlobalSourceId,
+     *              regardless of which sender's SourceId originally created
+     *              it. Used to prevent duplicate inserts when the same record
+     *              arrives via two transitive paths (e.g. MF-direct AND
+     *              MF → Nimba → dh-prod) — those paths carry the same
+     *              GlobalSourceId but different SourceIds.
+     *
+     *              Returns null when no matching ledger entry exists OR when
+     *              every candidate's local record has been deleted. Falls
+     *              through to the normal insert path in either case.
+     * @param type The expected SObjectType of the local record.
+     * @param globalSourceId The origin-record Id stamped at the birthplace.
+     * @return The validated local record Id, or null if none.
+     */
+    private static Id findLocalIdByGlobalSource(Schema.SObjectType type, String globalSourceId) {
+        if (String.isBlank(globalSourceId)) {
+            return null;
+        }
+        String cleanName = stripNamespace(type.getDescribe().getName());
+
+        List<SyncItem__c> ledger = [
+            SELECT LocalRecordIdTxt__c
+            FROM SyncItem__c
+            WHERE GlobalSourceIdTxt__c = :globalSourceId
+            AND ObjectTypePk__c = :cleanName
+            AND DirectionPk__c = 'Inbound'
+            AND LocalRecordIdTxt__c != NULL
             WITH SYSTEM_MODE
             ORDER BY CreatedDate DESC
             LIMIT 50

--- a/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
@@ -761,4 +761,106 @@ private class DeliverySyncItemIngestorTest {
             return res;
         }
     }
+
+    /**
+     * @description Cross-path dedup regression guard. When the same record
+     *              arrives via two different sync paths (e.g. MF → dh-prod
+     *              direct AND MF → Nimba → dh-prod), the two payloads carry
+     *              DIFFERENT SourceIds (each path's immediate-sender record Id)
+     *              but the SAME GlobalSourceId (origin record Id). Pre-fix:
+     *              findLocalId returned null on the second path's SourceId
+     *              and the ingestor inserted a duplicate. Post-fix:
+     *              findLocalIdByGlobalSource finds the existing local twin
+     *              via the GlobalSourceId stamp on the first path's ledger
+     *              entry, the second path becomes an UPDATE.
+     *
+     *              Scenario: dh-prod's perspective. WorkItem X originates
+     *              on MF. Path A: MF → dh-prod direct (SourceId = MF's
+     *              record Id). Path B: MF → Nimba → dh-prod (SourceId =
+     *              Nimba's record Id, GlobalSourceId = MF's record Id).
+     *              Both should result in ONE local WI on dh-prod.
+     */
+    @IsTest
+    static void testInboundCrossPathDedupViaGlobalSourceId() {
+        System.runAs(testUser) {
+            // Path A already happened: an existing local WorkItem exists, with
+            // an inbound ledger entry that recorded MF's GlobalSourceId.
+            WorkItem__c existingLocal = new WorkItem__c(BriefDescriptionTxt__c = 'Path-A-arrived');
+            insert existingLocal;
+            insert new SyncItem__c(
+                DirectionPk__c = 'Inbound',
+                StatusPk__c = 'Synced',
+                ObjectTypePk__c = 'WorkItem__c',
+                RemoteExternalIdTxt__c = 'MF-PATH-A-SOURCE',
+                GlobalSourceIdTxt__c = 'MF-ORIGIN-RECORD-ID',
+                LocalRecordIdTxt__c = existingLocal.Id,
+                WorkItemLookup__c = existingLocal.Id
+            );
+
+            // Path B arrives: different SourceId (Nimba's record Id), same
+            // GlobalSourceId. Without the cross-path dedup, the ingestor
+            // would findLocalId(NIMBA-PATH-B-SOURCE) → null → INSERT new
+            // duplicate WorkItem.
+            Map<String, Object> pathBPayload = new Map<String, Object>{
+                'SourceId' => 'NIMBA-PATH-B-SOURCE',
+                'GlobalSourceId' => 'MF-ORIGIN-RECORD-ID',
+                'BriefDescriptionTxt__c' => 'Path-B-arrived (should update Path A record, not insert)'
+            };
+
+            Integer beforeCount = [SELECT COUNT() FROM WorkItem__c];
+
+            Test.startTest();
+            DeliverySyncItemIngestor.processInboundItem('WorkItem__c', pathBPayload);
+            Test.stopTest();
+
+            Integer afterCount = [SELECT COUNT() FROM WorkItem__c];
+            System.assertEquals(beforeCount, afterCount,
+                'Cross-path dedup must reuse the existing local WI rather than insert a duplicate');
+
+            WorkItem__c reloaded = [SELECT BriefDescriptionTxt__c FROM WorkItem__c WHERE Id = :existingLocal.Id];
+            System.assertEquals('Path-B-arrived (should update Path A record, not insert)', reloaded.BriefDescriptionTxt__c,
+                'Path B payload should have UPDATED the existing record (proves dedup matched)');
+        }
+    }
+
+    /**
+     * @description Confirms cross-path dedup degrades gracefully when the
+     *              ledger entry exists but its local record was deleted.
+     *              Falls through to the normal insert path so a fresh local
+     *              record gets created and a new ledger entry is written.
+     */
+    @IsTest
+    static void testInboundCrossPathDedupSkipsDeletedLocal() {
+        System.runAs(testUser) {
+            WorkItem__c orphanLocal = new WorkItem__c(BriefDescriptionTxt__c = 'Will be deleted');
+            insert orphanLocal;
+            Id orphanId = orphanLocal.Id;
+            insert new SyncItem__c(
+                DirectionPk__c = 'Inbound',
+                StatusPk__c = 'Synced',
+                ObjectTypePk__c = 'WorkItem__c',
+                RemoteExternalIdTxt__c = 'MF-PATH-A-SOURCE-DELETED',
+                GlobalSourceIdTxt__c = 'MF-ORIGIN-DELETED-LOCAL',
+                LocalRecordIdTxt__c = orphanId,
+                WorkItemLookup__c = orphanId
+            );
+            delete orphanLocal;
+
+            Map<String, Object> pathBPayload = new Map<String, Object>{
+                'SourceId' => 'NIMBA-PATH-B-SOURCE-NEW',
+                'GlobalSourceId' => 'MF-ORIGIN-DELETED-LOCAL',
+                'BriefDescriptionTxt__c' => 'Should INSERT (orphan local was deleted)'
+            };
+
+            Integer beforeCount = [SELECT COUNT() FROM WorkItem__c];
+
+            Test.startTest();
+            DeliverySyncItemIngestor.processInboundItem('WorkItem__c', pathBPayload);
+            Test.stopTest();
+
+            Integer afterCount = [SELECT COUNT() FROM WorkItem__c];
+            System.assertEquals(beforeCount + 1, afterCount,
+                'When ledger-matched local record was deleted, must insert fresh');
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Surgical fix for **Bug 2** of the 3 sync bugs surfaced by today's RR consolidation: dh-prod ended up with duplicate copies of WIs (T-0334-T-0337 are 4 originals from MF that arrived as 8 records).

Bugs 1 (DELETE propagation) and 3 (DEPENDENCY cross-org sync) deferred to separate PRs — both need fresh-eyes design (not midnight 1-line fixes).

## Root cause (verified in code, not just hypothesis)

When the same record arrives at a receiver via two different sync paths:
- **Path A:** MF → dh-prod direct
- **Path B:** MF → Nimba → dh-prod (transitive)

…the two payloads carry **DIFFERENT SourceIds** (each one is the *immediate sender's* local record Id) but the **SAME GlobalSourceId** (the origin record Id, stamped once at the birthplace per `DeliverySyncEngine.captureChanges:117-119` and propagated unchanged across hops).

`DeliverySyncItemIngestor.findLocalId()` only checked for matches by **SourceId**. So:
1. Path A arrives first: `findLocalId('MF-WI-X')` → null → INSERT new local WI, write inbound ledger entry with `RemoteExternalIdTxt__c='MF-WI-X'` + `GlobalSourceIdTxt__c='MF-WI-X'`
2. Path B arrives: `findLocalId('NIMBA-WI-X')` → null (this SourceId is unknown to local ledger) → INSERT new duplicate local WI

Result: **2 local WIs for 1 origin record.**

## The fix

New `findLocalIdByGlobalSource()` helper in `DeliverySyncItemIngestor`. Called as a fallback right after the SourceId-based `findLocalId` returns null. Looks up local records by `GlobalSourceIdTxt__c` from the inbound ledger, validates the local still exists, returns the Id. Path B then takes the UPDATE path instead of INSERT.

Degrades gracefully: if the matched ledger entry's local record was deleted, falls through to normal insert (so a fresh local + fresh ledger gets created — no permanent dedup-blocks orphans).

## Also folded in
**`DeliveryDashboardCardController.CardConfig` inner fields → `global`.** 0.228.0.1 verification agent caught this — the outer class is `global` but inner-class fields were `public`, which per CLAUDE.md (`When making Apex classes global, ALL inner classes used as return/param types must also be global`) blocks anonymous Apex on subscriber orgs from JSON-serializing the returned objects. Trivial visibility fix; no behavior change.

## Tests
- `testInboundCrossPathDedupViaGlobalSourceId` — happy path: existing local + ledger entry with GlobalSourceId; second path's payload UPDATEs the existing record instead of inserting
- `testInboundCrossPathDedupSkipsDeletedLocal` — degraded path: ledger exists but local record was deleted; ingestor falls through to normal INSERT

## Test plan
- [x] PMD apex-scan
- [x] Apex tests (existing 30+ ingestor tests + 2 new)
- [ ] Post-install on MF-Prod: insert a new WorkItem on MF, verify dh-prod ends up with exactly 1 copy (not 2)
- [ ] Post-install: anonymous Apex `JSON.serialize(delivery.DeliveryDashboardCardController.getCardsForPage('home'))` should now return populated JSON (was failing with "Type cannot be serialized" pre-fix)

## Bugs deferred (separate PRs)
- **Bug 1 — DELETE propagation**: `DeliveryWorkItemTrigger` only handles before/after insert + update — no delete handler. `captureChanges()` signature has no delete path either. Adding propagation requires (a) trigger delete handler, (b) engine-side delete-event SyncItem creation, (c) ingestor-side delete handler, (d) design call on whether to use the existing soft-delete model (right-click → Deactivate sets `ActivatedDateTime__c=null`) vs hard-delete propagation. Not 1-line.
- **Bug 3 — DEPENDENCY cross-org sync**: `DeliveryDependencyTriggerHandler` exists and fires Platform Events for live gantt UI updates but never calls `DeliverySyncEngine.captureChanges`. Adding it isn't trivial — `getWorkItemId()` returns null for `WorkItemDependency__c` (no `WorkItemId__c` field; lookup names are `BlockedWorkItemLookup__c`/`BlockingWorkItemLookup__c`), AND deps have TWO endpoints needing bidirectional routing + cross-org lookup translation. Needs design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
