### PR TITLE
feat(sync): WorkItemDependency__c cross-org sync — dual-FK translation + Pending queue

### DIFF
--- a/force-app/main/default/classes/DeliveryDependencyTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryDependencyTriggerHandler.cls
@@ -14,6 +14,20 @@
 public with sharing class DeliveryDependencyTriggerHandler {
 
     /**
+     * @description Fields included in cross-org SyncItem payloads. Both
+     *              endpoint lookups must be present so the receiver can
+     *              translate them via its inbound ledger to local twins.
+     *              TypePk__c carries the relationship semantics (Blocks /
+     *              Relates To / Clones).
+     */
+    private static final Set<String> SYNC_FIELDS = new Set<String>{
+        'BlockingWorkItemLookup__c',
+        'BlockedWorkItemLookup__c',
+        'TypePk__c',
+        'ExternalIdTxt__c'
+    };
+
+    /**
      * @description Handles after-insert: tracks creation of dependency records and
      *              fires dependency_change events for both endpoints of each new dep.
      * @param newRecords List of newly inserted WorkItemDependency__c records.
@@ -22,6 +36,7 @@ public with sharing class DeliveryDependencyTriggerHandler {
         if (!DeliveryTriggerControl.runAfterLogic) { return; }
         DeliveryFieldTrackingService.trackCreates(newRecords);
         publishDependencyChangeEvents(newRecords);
+        DeliverySyncEngine.captureChanges(newRecords, null, SYNC_FIELDS);
     }
 
     /**
@@ -35,6 +50,7 @@ public with sharing class DeliveryDependencyTriggerHandler {
         if (!DeliveryTriggerControl.runAfterLogic) { return; }
         DeliveryFieldTrackingService.trackChanges(newRecords, oldMap);
         publishDependencyChangeEvents(newRecords);
+        DeliverySyncEngine.captureChanges(newRecords, oldMap, SYNC_FIELDS);
     }
 
     /**

--- a/force-app/main/default/classes/DeliverySyncEngine.cls
+++ b/force-app/main/default/classes/DeliverySyncEngine.cls
@@ -279,8 +279,16 @@ public without sharing class DeliverySyncEngine {
 
     private static Id getWorkItemId(SObject rec) {
         String name = rec.getSObjectType().getDescribe().getName();
-        if (name.endsWithIgnoreCase('WorkItem__c') && !name.endsWithIgnoreCase('WorkItemComment__c')) {
+        if (name.endsWithIgnoreCase('WorkItem__c') && !name.endsWithIgnoreCase('WorkItemComment__c') && !name.endsWithIgnoreCase('WorkItemDependency__c')) {
             return rec.Id;
+        }
+        // WorkItemDependency__c is a 2-FK bridge — neither endpoint is named
+        // WorkItemId__c. Use BlockedWorkItemLookup__c as the routing anchor
+        // (the "owning" side semantically — the dep is rendered on the
+        // gantt as an inbound arrow on the blocked WI). The receiver-side
+        // ingestor translates BOTH lookups via the ledger before insert.
+        if (name.endsWithIgnoreCase('WorkItemDependency__c')) {
+            return (Id) getSafeValue(rec, 'BlockedWorkItemLookup__c');
         }
         return (Id) getSafeValue(rec, 'WorkItemId__c');
     }

--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -238,11 +238,53 @@ public without sharing class DeliverySyncItemIngestor {
             }
         }
 
+        // WorkItemDependency__c — dual-FK translation. Both endpoint
+        // lookups (BlockingWorkItemLookup__c + BlockedWorkItemLookup__c)
+        // carry sender-org WorkItem Ids that won't resolve locally. Translate
+        // each via the inbound SyncItem ledger. Queue as Pending if EITHER
+        // parent hasn't synced yet. Self-healing semantics match WorkLog and
+        // WorkItemComment — when whichever parent arrives later, the
+        // resolver replays this payload; if the OTHER parent is still
+        // missing the replay re-queues against that one. Eventually
+        // consistent. Lives outside the WorkLog/Comment/ContentVersion
+        // conditional above because dep has its own dual-parent shape that
+        // doesn't fit the single-parentWorkItemRef pattern.
+        if (objectType.endsWithIgnoreCase('WorkItemDependency__c') && localRecordId == null) {
+            String blockingRef = (String) payload.get('BlockingWorkItemLookup__c');
+            if (String.isBlank(blockingRef)) {
+                blockingRef = (String) payload.get('delivery__BlockingWorkItemLookup__c');
+            }
+            String blockedRef = (String) payload.get('BlockedWorkItemLookup__c');
+            if (String.isBlank(blockedRef)) {
+                blockedRef = (String) payload.get('delivery__BlockedWorkItemLookup__c');
+            }
+            Id localBlocking = resolveDependencyEndpoint(blockingRef);
+            Id localBlocked = resolveDependencyEndpoint(blockedRef);
+            if (localBlocking == null) {
+                return queuePendingChild(objectType, blockingRef, payload);
+            }
+            if (localBlocked == null) {
+                return queuePendingChild(objectType, blockedRef, payload);
+            }
+            putSafe(recordToUpsert, 'BlockingWorkItemLookup__c', localBlocking);
+            putSafe(recordToUpsert, 'BlockedWorkItemLookup__c', localBlocked);
+        }
+
         // For WorkLogs: now that the Pending-queue early-return is past, strip
         // the remote-ref lookup keys on a scoped copy so mapFields doesn't
         // overwrite the resolved local parent Id with a cross-org string value.
         // Non-WorkLog paths pass the payload through unchanged.
         Map<String, Object> fieldPayload = payload;
+        if (objectType.endsWithIgnoreCase('WorkItemDependency__c')) {
+            // Same defense as WorkLog — strip the raw sender-org FK strings
+            // on a scoped copy so mapFields doesn't overwrite the local Ids
+            // we just resolved via the ledger.
+            fieldPayload = new Map<String, Object>(payload);
+            fieldPayload.remove('BlockingWorkItemLookup__c');
+            fieldPayload.remove('delivery__BlockingWorkItemLookup__c');
+            fieldPayload.remove('BlockedWorkItemLookup__c');
+            fieldPayload.remove('delivery__BlockedWorkItemLookup__c');
+        }
         if (objectType.endsWithIgnoreCase('WorkLog__c')) {
             fieldPayload = new Map<String, Object>(payload);
             fieldPayload.remove('WorkItemLookup__c');
@@ -523,6 +565,43 @@ public without sharing class DeliverySyncItemIngestor {
             }
         }
         return null;
+    }
+
+    /**
+     * @description Translates a sender-org WorkItem reference to a local Id
+     *              for use in dual-FK records (currently
+     *              WorkItemDependency__c). Mirrors the inline lookup pattern
+     *              used for single-parent records (WorkLog/WorkItemComment)
+     *              but extracted as a helper since dep needs it called twice.
+     *              Order: ledger lookup, then "is it already a local Id"
+     *              fallback (echo path).
+     * @param ref The sender-org WorkItem Id string from the payload.
+     * @return The validated local WorkItem Id, or null if unresolvable.
+     */
+    private static Id resolveDependencyEndpoint(String ref) {
+        if (String.isBlank(ref)) {
+            return null;
+        }
+        List<SyncItem__c> ledger = [
+            SELECT LocalRecordIdTxt__c FROM SyncItem__c
+            WHERE RemoteExternalIdTxt__c = :ref
+              AND ObjectTypePk__c = 'WorkItem__c'
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (!ledger.isEmpty() && String.isNotBlank((String) ledger[0].LocalRecordIdTxt__c)) {
+            try {
+                Id ledgerId = (Id) ledger[0].LocalRecordIdTxt__c;
+                Schema.SObjectType wiType = findSObjectType('WorkItem__c');
+                if (wiType != null && validateLocalIdExists(wiType, ledgerId)) {
+                    return ledgerId;
+                }
+            } catch (Exception e) {
+                System.debug(LoggingLevel.FINE, 'Dep endpoint ledger cast failed: ' + e.getMessage());
+            }
+        }
+        // Echo-path fallback: maybe ref is already a local Id.
+        return tryAsLocalWorkItemId(ref);
     }
 
     /**

--- a/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
@@ -763,6 +763,113 @@ private class DeliverySyncItemIngestorTest {
     }
 
     /**
+     * @description Cross-org WorkItemDependency__c inbound — both endpoint
+     *              lookups resolve via the inbound ledger, dep inserts with
+     *              local FKs (not sender-org FKs which would fail).
+     */
+    @IsTest
+    static void testInboundDependencyResolvesBothEndpointsViaLedger() {
+        System.runAs(testUser) {
+            // Setup: two local WorkItems + ledger entries that map them to
+            // sender-org Ids. Mirrors the post-WI-sync state on the receiver.
+            WorkItem__c localBlocking = new WorkItem__c(BriefDescriptionTxt__c = 'Local twin of sender Blocking');
+            WorkItem__c localBlocked = new WorkItem__c(BriefDescriptionTxt__c = 'Local twin of sender Blocked');
+            insert new List<WorkItem__c>{ localBlocking, localBlocked };
+
+            insert new List<SyncItem__c>{
+                new SyncItem__c(
+                    DirectionPk__c = 'Inbound',
+                    StatusPk__c = 'Synced',
+                    ObjectTypePk__c = 'WorkItem__c',
+                    RemoteExternalIdTxt__c = 'SENDER-BLOCKING-WI-1',
+                    LocalRecordIdTxt__c = localBlocking.Id,
+                    WorkItemLookup__c = localBlocking.Id
+                ),
+                new SyncItem__c(
+                    DirectionPk__c = 'Inbound',
+                    StatusPk__c = 'Synced',
+                    ObjectTypePk__c = 'WorkItem__c',
+                    RemoteExternalIdTxt__c = 'SENDER-BLOCKED-WI-1',
+                    LocalRecordIdTxt__c = localBlocked.Id,
+                    WorkItemLookup__c = localBlocked.Id
+                )
+            };
+
+            // Inbound dep payload carries sender-org WI Ids in the lookups.
+            // Without the dual-FK translation, mapFields would write those
+            // sender Ids straight into the local fields and SF would reject
+            // with FIELD_INTEGRITY_EXCEPTION. With the fix, ingestor
+            // translates each via the ledger and inserts the dep with
+            // local FKs.
+            Map<String, Object> depPayload = new Map<String, Object>{
+                'SourceId' => 'SENDER-DEP-1',
+                'GlobalSourceId' => 'SENDER-DEP-1',
+                'BlockingWorkItemLookup__c' => 'SENDER-BLOCKING-WI-1',
+                'BlockedWorkItemLookup__c' => 'SENDER-BLOCKED-WI-1',
+                'TypePk__c' => 'Blocks'
+            };
+
+            Test.startTest();
+            DeliverySyncItemIngestor.processInboundItem('WorkItemDependency__c', depPayload);
+            Test.stopTest();
+
+            List<WorkItemDependency__c> deps = [
+                SELECT Id, BlockingWorkItemLookup__c, BlockedWorkItemLookup__c, TypePk__c
+                FROM WorkItemDependency__c
+                WHERE BlockingWorkItemLookup__c = :localBlocking.Id
+            ];
+            System.assertEquals(1, deps.size(), 'Dep should be inserted with both local FKs translated');
+            System.assertEquals(localBlocked.Id, deps[0].BlockedWorkItemLookup__c,
+                'BlockedWorkItemLookup__c must be translated to local Id');
+            System.assertEquals('Blocks', deps[0].TypePk__c, 'TypePk__c should pass through');
+        }
+    }
+
+    /**
+     * @description Cross-org WorkItemDependency__c inbound — when one
+     *              endpoint's parent WorkItem hasn't synced locally yet,
+     *              the dep is queued as Pending instead of failing with
+     *              REQUIRED_FIELD_MISSING. Self-heals when the missing
+     *              parent eventually arrives.
+     */
+    @IsTest
+    static void testInboundDependencyQueuesPendingWhenEndpointMissing() {
+        System.runAs(testUser) {
+            // Only ONE of the two parents has a local twin. The other
+            // hasn't synced yet (no ledger entry).
+            WorkItem__c localBlocking = new WorkItem__c(BriefDescriptionTxt__c = 'Only Blocking landed locally');
+            insert localBlocking;
+            insert new SyncItem__c(
+                DirectionPk__c = 'Inbound',
+                StatusPk__c = 'Synced',
+                ObjectTypePk__c = 'WorkItem__c',
+                RemoteExternalIdTxt__c = 'SENDER-BLOCKING-WI-2',
+                LocalRecordIdTxt__c = localBlocking.Id,
+                WorkItemLookup__c = localBlocking.Id
+            );
+
+            Map<String, Object> depPayload = new Map<String, Object>{
+                'SourceId' => 'SENDER-DEP-2',
+                'GlobalSourceId' => 'SENDER-DEP-2',
+                'BlockingWorkItemLookup__c' => 'SENDER-BLOCKING-WI-2',
+                'BlockedWorkItemLookup__c' => 'SENDER-BLOCKED-WI-2-NOT-YET-LOCAL',
+                'TypePk__c' => 'Blocks'
+            };
+
+            Integer beforeDepCount = [SELECT COUNT() FROM WorkItemDependency__c];
+
+            Test.startTest();
+            Id pendingId = DeliverySyncItemIngestor.processInboundItem('WorkItemDependency__c', depPayload);
+            Test.stopTest();
+
+            Integer afterDepCount = [SELECT COUNT() FROM WorkItemDependency__c];
+            System.assertEquals(beforeDepCount, afterDepCount,
+                'Dep must NOT be inserted when an endpoint parent is unresolved — must queue Pending');
+            System.assertNotEquals(null, pendingId, 'Pending SyncItem Id should be returned');
+        }
+    }
+
+    /**
      * @description Cross-path dedup regression guard. When the same record
      *              arrives via two different sync paths (e.g. MF → dh-prod
      *              direct AND MF → Nimba → dh-prod), the two payloads carry


### PR DESCRIPTION
## Summary

**Bug 3** of the 3 sync gaps surfaced by 2026-05-10's RR consolidation. WorkItemDependency__c records were never propagating cross-org, blocking the AutoSchedule pilot which needs deps populated on dh-prod.

Two-part fix mirroring existing single-FK patterns (WorkLog/WorkItemComment) but adapted for dual-FK semantics.

## Outbound

- `DeliveryDependencyTriggerHandler` now calls `DeliverySyncEngine.captureChanges` on insert + update with a 4-field `SYNC_FIELDS` set (`BlockingWorkItemLookup__c`, `BlockedWorkItemLookup__c`, `TypePk__c`, `ExternalIdTxt__c`)
- `DeliverySyncEngine.getWorkItemId` now recognizes `WorkItemDependency__c` and returns `BlockedWorkItemLookup__c` as the routing anchor (the dep is semantically owned by the WI being blocked — that's where the inbound arrow renders on the gantt)

## Inbound

- `DeliverySyncItemIngestor.processInboundItem` adds a dedicated dual-FK block for `WorkItemDependency__c`. Resolves BOTH endpoint lookups via the inbound SyncItem ledger
- If EITHER parent is missing locally, queues the dep as Pending via `queuePendingChild` — the resolver replays when whichever parent arrives, and re-queues against the OTHER missing parent if it's still not local. **Eventually consistent.**
- Strips raw sender-org FKs from a scoped `fieldPayload` before `mapFields` runs (same defense pattern as WorkLog at line 275-280) so they cannot overwrite the resolved local Ids
- New helper `resolveDependencyEndpoint(ref)` — extracted ledger lookup + echo-path fallback since dep needs it called twice

## Why this wasn't a 1-line fix

- `getWorkItemId` was hardcoded to the `WorkItem__c + WorkItemId__c` field pair. Dep is the third object class and needed a new branch
- Dual-FK records have no precedent in the ingestor. Single-FK Pending semantics needed careful adaptation so the resolver self-heals on either-parent-arrives event without infinite-looping
- Adding `WorkItemDependency__c` to the existing inner conditional (line 177) wouldn't have worked — that conditional uses `parentWorkItemRef` (single value) which dep doesn't fit. Pulled dep handling into its own top-level branch.

## Tests added
- `testInboundDependencyResolvesBothEndpointsViaLedger` — happy path: both endpoints already local, dep inserts with translated FKs (`BlockingWorkItemLookup__c` + `BlockedWorkItemLookup__c` both correct)
- `testInboundDependencyQueuesPendingWhenEndpointMissing` — degraded path: one endpoint not yet local, dep queues Pending instead of failing with REQUIRED_FIELD_MISSING

Existing 3 `DeliveryDependencyTriggerHandlerTest` tests still pass — `captureChanges` call no-ops in test context (no `NetworkEntity` edges configured) so dep DML behavior is unchanged.

## Test plan
- [x] PMD apex-scan
- [x] Apex tests (existing + 2 new)
- [ ] Post-install on MF-Prod: insert a `WorkItemDependency__c` linking T-0172 → some other test WI, verify it propagates to Nimba within sync window
- [ ] Once dh-prod URL config is fixed (separate diagnosis at `project_dh_prod_inbound_silence_0511.md`), verify dep also reaches dh-prod
- [ ] Validate AutoSchedule pilot can now operate against dep-aware data

## What's still deferred

**Bug 1 (DELETE propagation)** — needs design call: hard-delete propagation across orgs vs the existing soft-delete model (right-click → Deactivate sets `ActivatedDateTime__c=null`). Not 1-line. Separate PR.

**dh-prod URL misconfig** — diagnosed last night ([memory](https://github.com/Nimba-Solutions/Delivery-Hub) → `project_dh_prod_inbound_silence_0511.md`). MF's "Cloud Nimbus LLC" NetworkEntity has Nimba's URL instead of dh-prod's. This PR's outbound dep sync will land on Nimba (correct path) but won't reach dh-prod until the URL is fixed (single-record DML on MF, requires Glen's go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
