### PR TITLE
feat(depth-charge): scaffold for cross-org fulfillment-chain audits

### DIFF
--- a/docs/depth-charge-architecture.md
+++ b/docs/depth-charge-architecture.md
@@ -1,0 +1,93 @@
+# Depth-charge audit architecture
+
+**Status:** scaffold shipped (schema + local-segment assembly). Recursive cross-org probe + response handling is a follow-on PR.
+
+## What it is
+
+A way for an upstream client (e.g., a regulated lender, a government primary contractor, a HIPAA-covered entity) to ask their direct vendor: "**Show me the fulfillment chain for this work item.** Who actually did the work, what jurisdictions did they operate from, and how deep does the chain go?"
+
+The vendor answers based on each downstream peer's **opt-in reveal level**, returning a tree the upstream caller can visualize and attest against.
+
+## Use cases
+
+- **ITAR / export control** — verify all developers were US-located
+- **GDPR data residency** — verify data didn't leave EU
+- **State-licensed work** — verify CA-licensed contractor signed off on CA-jurisdiction work
+- **SEC compliance** — verify chain didn't cross sanctioned jurisdictions
+- **HIPAA BAA chain** — verify all peers in the chain are BAA-covered
+- **DoD subcontractor reporting** — supply chain transparency
+
+## Schema (in this PR)
+
+### `SyncItem__c.ChangeTypeTxt__c` (Text 80, free-form)
+Categorizes payload purpose. Backward-compat blank/`record_change` = standard cross-org sync. New values:
+- `depth_probe` — outbound query asking peers to reveal their chain
+- `depth_response` — inbound reply carrying chain segment
+
+Free-text on purpose so future packet types add without restricted-picklist propagation pain.
+
+### `NetworkEntity__c.RevealFulfillmentDepthPk__c` (restricted picklist, default `Off`)
+Per-peer consent setting:
+| Value | Meaning |
+|---|---|
+| `Off` | Refuse all probes. Audit chain stops here, surfaces as redacted leaf. |
+| `OrgOnly` | Reveal this peer's org identity only. No jurisdiction, no downstream. |
+| `OrgAndJurisdiction` | Reveal org + jurisdiction (country/state). Sufficient for most regulatory checks. |
+| `Full` | Reveal everything: org + jurisdiction + downstream peers + per-user attribution. |
+
+Default `Off` so consent is opt-in per-peer. Admins set this on each NetworkEntity row to participate in upstream audits.
+
+### `NetworkEntity__c.JurisdictionTxt__c` (Text 100)
+Geographic / regulatory zone. Recommended values: ISO country code (US, DE, IN), country-state (US-CA, US-NY), or named regulatory zone (EU, GDPR, ITAR-US). Surfaced when reveal level is `OrgAndJurisdiction` or higher.
+
+## API (scaffold today)
+
+```apex
+DeliveryDepthProbeService.DepthChainNode root =
+    DeliveryDepthProbeService.getFulfillmentChain(workItemId, maxDepth);
+```
+
+Returns a tree:
+```
+DepthChainNode {
+    orgId: String       // null when peer reveal=Off
+    orgName: String     // "[redacted]" when peer reveal=Off
+    jurisdiction: String  // null unless reveal>=OrgAndJurisdiction
+    revealLevel: String   // Off / OrgOnly / OrgAndJurisdiction / Full
+    children: List<DepthChainNode>
+}
+```
+
+Today: returns local segment only (this org's identity + this org's downstream Vendor peers, each filtered by its own reveal level). `children` of those peer nodes are empty until the recursive probe ships.
+
+## Follow-on PR (full implementation)
+
+1. **Outbound probe**: when `getFulfillmentChain(...)` is called and a Vendor peer has reveal != Off, emit an outbound `SyncItem` with `ChangeTypeTxt='depth_probe'` and payload `{ workItemRef, remainingDepth, requestId }`. Use the existing sync transport.
+2. **Receiver-side probe handler**: new branch in `DeliverySyncItemIngestor.processInboundItem` that recognizes `ChangeTypeTxt='depth_probe'`. Builds local segment via `getFulfillmentChain`. Emits outbound `SyncItem` with `ChangeTypeTxt='depth_response'` and the JSON-serialized chain in payload.
+3. **Aggregator**: caller-side handler that receives `depth_response` payloads, deserializes, stitches into the original DepthChainNode tree by `requestId`. Returns to the original caller (likely an LWC waiting on a Promise).
+4. **Visualization** (CN side, not DH): react-flow tree rendering, greyed leaves for opt-out vendors, jurisdiction-color coding.
+5. **Rate limiting + recursion budget**: prevent abuse / fan-out storms. Cap `maxDepth` at 5. Block re-probes within N minutes per (caller, workItem) tuple.
+6. **Audit log**: every outbound probe + inbound response logged to `ActivityLog__c` for the original caller's audit trail.
+
+## Pricing positioning (cloudnimbusllc.com)
+
+Per the 2026-05-03 4th-node round-trip goal doc — depth-charge is positioned as a billable **"Audit Chain Visibility"** feature on cloudnimbusllc pricing. Each customer tenant pays for the upstream-audit capability; downstream peers participate by setting their reveal level.
+
+Estimated effort for full implementation: ~16-24h spread across DH + cloudnimbusllc.
+
+## What this PR includes
+- 3 new fields (above)
+- `DeliveryDepthProbeService.cls` with local-only chain assembly
+- `DepthChainNode` DTO
+- 4 unit tests (root assembly + Off / OrgOnly / OrgAndJurisdiction reveal filters)
+- This doc
+
+## What this PR doesn't include
+- Recursive cross-org probe + response (the network round-trip)
+- Aggregator / response stitching
+- Caller-facing API (LWC / REST)
+- Rate limiting + recursion budget
+- ActivityLog audit trail
+- Visualization (CN-side)
+
+Glen reviews the schema + DTO shape here. Follow-on PR scopes the network machinery once the design is locked.

--- a/force-app/main/default/classes/DeliveryDepthProbeService.cls
+++ b/force-app/main/default/classes/DeliveryDepthProbeService.cls
@@ -1,0 +1,122 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Depth-charge audit service. Lets an upstream client query
+ *              the fulfillment chain of a WorkItem — returning a tree of
+ *              { org, jurisdiction, sub-vendors, users } redacted per each
+ *              peer's RevealFulfillmentDepthPk__c setting.
+ *
+ *              Use cases: regulatory compliance attestation (ITAR, GDPR
+ *              data residency, state-licensed work, SEC, HIPAA BAA chains).
+ *
+ *              SCAFFOLD STATUS — this PR ships the schema (ChangeTypeTxt
+ *              on SyncItem, RevealFulfillmentDepth + Jurisdiction on
+ *              NetworkEntity) plus the local-only chain assembly. Recursive
+ *              cross-org probe + response handling is a follow-on PR (needs
+ *              cloudnimbusllc-side endpoint + handshake design).
+ *
+ *              Architecture sketch (full vision):
+ *              1. Upstream caller (e.g., MF audit form) calls
+ *                 getFulfillmentChain(workItemId, maxDepth=N)
+ *              2. Local segment built from this org's WorkRequest edges +
+ *                 NetworkEntity Jurisdiction
+ *              3. For each Vendor edge with reveal != Off, emit an outbound
+ *                 SyncItem with ChangeTypeTxt = 'depth_probe', payload
+ *                 carries the upstream WorkItem reference + remaining depth
+ *              4. Vendor receives, evaluates its own RevealFulfillmentDepth,
+ *                 builds its segment (recursing if remaining depth > 0),
+ *                 emits SyncItem with ChangeTypeTxt = 'depth_response'
+ *                 carrying the chain JSON
+ *              5. Aggregator stitches responses into a single tree, returns
+ *                 to caller for visualization
+ *
+ *              Today's surface: local segment only — proves the schema +
+ *              DTO shape work and gives Glen something to review.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation')
+public with sharing class DeliveryDepthProbeService {
+
+    /**
+     * @description Returns this org's segment of the fulfillment chain for
+     *              the given WorkItem. Includes this org's identity (always),
+     *              jurisdiction (when this org's NetworkEntity reveal allows),
+     *              and the list of downstream Vendor edges (via WorkRequest)
+     *              filtered by each vendor's reveal setting.
+     *
+     *              Recursive cross-org probe is NOT implemented yet (scaffold
+     *              PR). When wired, the returned DepthChainNode.children will
+     *              be populated by depth_response inbound payloads.
+     * @param workItemId The local WorkItem to chain from.
+     * @param maxDepth How deep to recurse. Today: ignored (local-only).
+     *                 Will gate the recursive probe in the follow-on PR.
+     * @return A DepthChainNode with this org's segment populated.
+     */
+    public static DepthChainNode getFulfillmentChain(Id workItemId, Integer maxDepth) {
+        if (workItemId == null) {
+            return null;
+        }
+        DepthChainNode root = new DepthChainNode();
+        Organization org = [SELECT Id, Name FROM Organization WITH SYSTEM_MODE LIMIT 1];
+        root.orgId = org.Id;
+        root.orgName = org.Name;
+        root.revealLevel = 'OrgOnly';
+        root.children = new List<DepthChainNode>();
+
+        // Pull the local Vendor edges. Each WorkRequest with an active Vendor
+        // is a downstream peer — surface them as potential probe targets.
+        // Reveal-filter applied per peer's own setting.
+        for (WorkRequest__c req : [
+            SELECT Id, DeliveryEntityLookup__c,
+                   DeliveryEntityLookup__r.Name,
+                   DeliveryEntityLookup__r.OrgIdTxt__c,
+                   DeliveryEntityLookup__r.JurisdictionTxt__c,
+                   DeliveryEntityLookup__r.RevealFulfillmentDepthPk__c
+            FROM WorkRequest__c
+            WHERE WorkItemId__c = :workItemId
+              AND StatusPk__c != 'Inactive'
+              AND DeliveryEntityLookup__c != NULL
+              AND DeliveryEntityLookup__r.EntityTypePk__c IN ('Vendor', 'Both')
+            WITH SYSTEM_MODE
+        ]) {
+            String reveal = req.DeliveryEntityLookup__r.RevealFulfillmentDepthPk__c;
+            if (String.isBlank(reveal) || reveal == 'Off') {
+                // Peer refuses to be probed. Surface as redacted leaf.
+                DepthChainNode redacted = new DepthChainNode();
+                redacted.revealLevel = 'Off';
+                redacted.orgName = '[redacted — peer reveal=Off]';
+                root.children.add(redacted);
+                continue;
+            }
+            DepthChainNode peer = new DepthChainNode();
+            peer.orgName = req.DeliveryEntityLookup__r.Name;
+            peer.orgId = req.DeliveryEntityLookup__r.OrgIdTxt__c;
+            peer.revealLevel = reveal;
+            if (reveal == 'OrgAndJurisdiction' || reveal == 'Full') {
+                peer.jurisdiction = req.DeliveryEntityLookup__r.JurisdictionTxt__c;
+            }
+            // Full also reveals downstream chain + user attribution. The
+            // recursive probe handler — which would emit a depth_probe
+            // outbound and stitch the depth_response into peer.children —
+            // is the follow-on PR.
+            peer.children = new List<DepthChainNode>();
+            root.children.add(peer);
+        }
+        return root;
+    }
+
+    /**
+     * @description Tree node returned by depth-probe queries. Each level
+     *              represents one org in the fulfillment chain. Child orgs
+     *              are downstream sub-vendors. Fields are nullable — the
+     *              caller shouldn't expect anything beyond orgName + reveal
+     *              level (peers may reveal less).
+     */
+    public class DepthChainNode {
+        public String orgId;
+        public String orgName;
+        public String jurisdiction;
+        public String revealLevel;
+        public List<DepthChainNode> children;
+    }
+}

--- a/force-app/main/default/classes/DeliveryDepthProbeService.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryDepthProbeService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryDepthProbeServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryDepthProbeServiceTest.cls
@@ -1,0 +1,139 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Tests for DeliveryDepthProbeService (scaffold PR).
+ *              Verifies the local segment assembly + per-peer reveal
+ *              filtering. Recursive cross-org probe is not yet implemented;
+ *              tests for that ship with the follow-on PR.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryDepthProbeServiceTest {
+
+    @IsTest
+    static void testGetFulfillmentChainReturnsRootWithLocalOrg() {
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c = 'Audited WI',
+            StageNamePk__c         = 'In Development'
+        );
+        insert wi;
+
+        Test.startTest();
+        DeliveryDepthProbeService.DepthChainNode root =
+            DeliveryDepthProbeService.getFulfillmentChain(wi.Id, 1);
+        Test.stopTest();
+
+        System.assertNotEquals(null, root, 'Root chain node must not be null');
+        System.assertNotEquals(null, root.orgId, 'Root must include local Org Id');
+        System.assertEquals('OrgOnly', root.revealLevel, 'Root reveal defaults to OrgOnly');
+        System.assertNotEquals(null, root.children, 'children list must be initialized (possibly empty)');
+    }
+
+    @IsTest
+    static void testGetFulfillmentChainRedactsOffPeer() {
+        // Peer with reveal=Off should appear as a redacted leaf.
+        NetworkEntity__c offPeer = new NetworkEntity__c(
+            Name = 'Off Peer',
+            EntityTypePk__c = 'Vendor',
+            StatusPk__c = 'Active',
+            IntegrationEndpointUrlTxt__c = 'https://off-peer.example.com',
+            RevealFulfillmentDepthPk__c = 'Off',
+            JurisdictionTxt__c = 'US-CA'
+        );
+        insert offPeer;
+
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c = 'WI with Off peer',
+            StageNamePk__c         = 'In Development'
+        );
+        insert wi;
+        insert new WorkRequest__c(
+            WorkItemId__c = wi.Id,
+            DeliveryEntityLookup__c = offPeer.Id,
+            StatusPk__c = 'Active'
+        );
+
+        Test.startTest();
+        DeliveryDepthProbeService.DepthChainNode root =
+            DeliveryDepthProbeService.getFulfillmentChain(wi.Id, 1);
+        Test.stopTest();
+
+        System.assertEquals(1, root.children.size(), 'Should surface 1 peer (redacted leaf)');
+        DeliveryDepthProbeService.DepthChainNode child = root.children[0];
+        System.assertEquals('Off', child.revealLevel, 'Child must surface as Off');
+        System.assertEquals(null, child.jurisdiction, 'Off peer must not reveal jurisdiction');
+        System.assert(child.orgName != null && child.orgName.contains('redacted'),
+            'Off peer name must signal redaction');
+    }
+
+    @IsTest
+    static void testGetFulfillmentChainRevealsOrgAndJurisdiction() {
+        // Peer with reveal=OrgAndJurisdiction should expose both.
+        NetworkEntity__c orgJurPeer = new NetworkEntity__c(
+            Name = 'Org+Jurisdiction Peer',
+            EntityTypePk__c = 'Vendor',
+            StatusPk__c = 'Active',
+            IntegrationEndpointUrlTxt__c = 'https://orgjur-peer.example.com',
+            OrgIdTxt__c = '00DTESTORGID0001',
+            RevealFulfillmentDepthPk__c = 'OrgAndJurisdiction',
+            JurisdictionTxt__c = 'US-CA'
+        );
+        insert orgJurPeer;
+
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c = 'WI with OrgJur peer',
+            StageNamePk__c         = 'In Development'
+        );
+        insert wi;
+        insert new WorkRequest__c(
+            WorkItemId__c = wi.Id,
+            DeliveryEntityLookup__c = orgJurPeer.Id,
+            StatusPk__c = 'Active'
+        );
+
+        Test.startTest();
+        DeliveryDepthProbeService.DepthChainNode root =
+            DeliveryDepthProbeService.getFulfillmentChain(wi.Id, 1);
+        Test.stopTest();
+
+        System.assertEquals(1, root.children.size());
+        DeliveryDepthProbeService.DepthChainNode child = root.children[0];
+        System.assertEquals('OrgAndJurisdiction', child.revealLevel);
+        System.assertEquals('US-CA', child.jurisdiction, 'Jurisdiction must be surfaced at this reveal level');
+        System.assertEquals('00DTESTORGID0001', child.orgId, 'OrgId must be surfaced when reveal != Off');
+    }
+
+    @IsTest
+    static void testGetFulfillmentChainOrgOnlyHidesJurisdiction() {
+        NetworkEntity__c orgOnlyPeer = new NetworkEntity__c(
+            Name = 'OrgOnly Peer',
+            EntityTypePk__c = 'Vendor',
+            StatusPk__c = 'Active',
+            IntegrationEndpointUrlTxt__c = 'https://orgonly-peer.example.com',
+            RevealFulfillmentDepthPk__c = 'OrgOnly',
+            JurisdictionTxt__c = 'US-NY'
+        );
+        insert orgOnlyPeer;
+
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c = 'WI with OrgOnly peer',
+            StageNamePk__c         = 'In Development'
+        );
+        insert wi;
+        insert new WorkRequest__c(
+            WorkItemId__c = wi.Id,
+            DeliveryEntityLookup__c = orgOnlyPeer.Id,
+            StatusPk__c = 'Active'
+        );
+
+        Test.startTest();
+        DeliveryDepthProbeService.DepthChainNode root =
+            DeliveryDepthProbeService.getFulfillmentChain(wi.Id, 1);
+        Test.stopTest();
+
+        DeliveryDepthProbeService.DepthChainNode child = root.children[0];
+        System.assertEquals('OrgOnly', child.revealLevel);
+        System.assertEquals(null, child.jurisdiction,
+            'OrgOnly reveal must NOT expose jurisdiction');
+    }
+}

--- a/force-app/main/default/classes/DeliveryDepthProbeServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryDepthProbeServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/objects/NetworkEntity__c/fields/JurisdictionTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/NetworkEntity__c/fields/JurisdictionTxt__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>JurisdictionTxt__c</fullName>
+    <description>Geographic / regulatory jurisdiction this peer operates from. Free text but recommended ISO-style values: country code (US, DE, IN), country-state (US-CA, US-NY), or named regulatory zone (EU, GDPR, ITAR-US). Surfaced when this peer's RevealFulfillmentDepthPk__c is OrgAndJurisdiction or higher. Used by depth-charge audits to verify regulatory chain (e.g., "all work was done by contiguous US-located vendors").</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>e.g., US-CA, EU-DE, ITAR-US. Surfaced in depth-charge audits when reveal level is OrgAndJurisdiction or Full.</inlineHelpText>
+    <label>Jurisdiction</label>
+    <length>100</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/NetworkEntity__c/fields/JurisdictionTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/NetworkEntity__c/fields/JurisdictionTxt__c.field-meta.xml
@@ -3,11 +3,11 @@
     <fullName>JurisdictionTxt__c</fullName>
     <description>Geographic / regulatory jurisdiction this peer operates from. Free text but recommended ISO-style values: country code (US, DE, IN), country-state (US-CA, US-NY), or named regulatory zone (EU, GDPR, ITAR-US). Surfaced when this peer's RevealFulfillmentDepthPk__c is OrgAndJurisdiction or higher. Used by depth-charge audits to verify regulatory chain (e.g., "all work was done by contiguous US-located vendors").</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
     <inlineHelpText>e.g., US-CA, EU-DE, ITAR-US. Surfaced in depth-charge audits when reveal level is OrgAndJurisdiction or Full.</inlineHelpText>
     <label>Jurisdiction</label>
     <length>100</length>
     <required>false</required>
+    <trackTrending>false</trackTrending>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/force-app/main/default/objects/NetworkEntity__c/fields/RevealFulfillmentDepthPk__c.field-meta.xml
+++ b/force-app/main/default/objects/NetworkEntity__c/fields/RevealFulfillmentDepthPk__c.field-meta.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RevealFulfillmentDepthPk__c</fullName>
+    <description>How much of this peer's fulfillment chain is exposed when responding to a depth-charge probe. Off = refuse to reveal anything (audit chain stops here). OrgOnly = reveal this peer's own org identity but not any sub-vendors. OrgAndJurisdiction = reveal org + jurisdiction (country/state) — sufficient for most regulatory checks (ITAR / GDPR / state-licensed work). Full = reveal everything including downstream peers + per-user attribution. Defaults to Off so consent is opt-in per-peer.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>Default Off. Set to OrgOnly / OrgAndJurisdiction / Full to opt this peer into upstream depth-charge audits.</inlineHelpText>
+    <label>Reveal Fulfillment Depth</label>
+    <required>false</required>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Off</fullName>
+                <default>true</default>
+                <label>Off (refuse all probes)</label>
+            </value>
+            <value>
+                <fullName>OrgOnly</fullName>
+                <default>false</default>
+                <label>Org Only</label>
+            </value>
+            <value>
+                <fullName>OrgAndJurisdiction</fullName>
+                <default>false</default>
+                <label>Org + Jurisdiction</label>
+            </value>
+            <value>
+                <fullName>Full</fullName>
+                <default>false</default>
+                <label>Full (org + jurisdiction + downstream chain + user attribution)</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/NetworkEntity__c/fields/RevealFulfillmentDepthPk__c.field-meta.xml
+++ b/force-app/main/default/objects/NetworkEntity__c/fields/RevealFulfillmentDepthPk__c.field-meta.xml
@@ -3,10 +3,10 @@
     <fullName>RevealFulfillmentDepthPk__c</fullName>
     <description>How much of this peer's fulfillment chain is exposed when responding to a depth-charge probe. Off = refuse to reveal anything (audit chain stops here). OrgOnly = reveal this peer's own org identity but not any sub-vendors. OrgAndJurisdiction = reveal org + jurisdiction (country/state) — sufficient for most regulatory checks (ITAR / GDPR / state-licensed work). Full = reveal everything including downstream peers + per-user attribution. Defaults to Off so consent is opt-in per-peer.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
     <inlineHelpText>Default Off. Set to OrgOnly / OrgAndJurisdiction / Full to opt this peer into upstream depth-charge audits.</inlineHelpText>
     <label>Reveal Fulfillment Depth</label>
     <required>false</required>
+    <trackTrending>false</trackTrending>
     <type>Picklist</type>
     <valueSet>
         <restricted>true</restricted>

--- a/force-app/main/default/objects/SyncItem__c/fields/ChangeTypeTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/SyncItem__c/fields/ChangeTypeTxt__c.field-meta.xml
@@ -3,11 +3,11 @@
     <fullName>ChangeTypeTxt__c</fullName>
     <description>Categorizes the purpose of this SyncItem payload. Default values: record_change (the standard cross-org record sync — backward-compat default when blank), depth_probe (an outbound query asking peers to reveal their fulfillment chain at a configured depth), depth_response (an inbound reply from a peer carrying its chain segment). Free-text on purpose so future packet types can be added without restricted-picklist propagation pain.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
     <inlineHelpText>Free text. Blank or "record_change" = standard payload. "depth_probe" / "depth_response" = depth-charge audit packets.</inlineHelpText>
     <label>Change Type</label>
     <length>80</length>
     <required>false</required>
+    <trackTrending>false</trackTrending>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/force-app/main/default/objects/SyncItem__c/fields/ChangeTypeTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/SyncItem__c/fields/ChangeTypeTxt__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ChangeTypeTxt__c</fullName>
+    <description>Categorizes the purpose of this SyncItem payload. Default values: record_change (the standard cross-org record sync — backward-compat default when blank), depth_probe (an outbound query asking peers to reveal their fulfillment chain at a configured depth), depth_response (an inbound reply from a peer carrying its chain segment). Free-text on purpose so future packet types can be added without restricted-picklist propagation pain.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>Free text. Blank or "record_change" = standard payload. "depth_probe" / "depth_response" = depth-charge audit packets.</inlineHelpText>
+    <label>Change Type</label>
+    <length>80</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## Summary
Schema + local-only chain assembly for the depth-charge audit feature you asked for review of. Lets an upstream client probe down the DH fulfillment chain to verify regulatory compliance — who actually did the work, what jurisdictions did they operate from, how deep does the chain go.

**Scaffold PR — review the schema + DTO shape here. Recursive cross-org probe + response is a follow-on.**

## Use cases
- ITAR / export control (verify all developers were US-located)
- GDPR data residency (verify data didn't leave EU)
- State-licensed work (verify CA-licensed contractor signed off)
- SEC / sanctioned-jurisdiction checks
- HIPAA BAA chain attestation
- DoD subcontractor reporting

## Schema in this PR

### `SyncItem__c.ChangeTypeTxt__c` (Text 80, free-form)
Categorizes payload purpose. Backward-compat: blank or `record_change` = standard cross-org sync. New values:
- `depth_probe` — outbound query asking peers to reveal their chain
- `depth_response` — inbound reply carrying chain segment

Free-text on purpose so future packet types can be added without restricted-picklist propagation pain.

### `NetworkEntity__c.RevealFulfillmentDepthPk__c` (restricted picklist, default `Off`)
Per-peer opt-in consent setting:
| Value | Meaning |
|---|---|
| `Off` | Refuse all probes. Audit chain stops here, surfaces as redacted leaf. |
| `OrgOnly` | Reveal this peer's org identity only. No jurisdiction, no downstream. |
| `OrgAndJurisdiction` | Reveal org + jurisdiction (country/state). Sufficient for most regulatory checks. |
| `Full` | Reveal everything: org + jurisdiction + downstream peers + per-user attribution. |

Default `Off` so consent is opt-in per-peer.

### `NetworkEntity__c.JurisdictionTxt__c` (Text 100, free-form)
ISO-style recommended (US-CA, EU-DE, ITAR-US). Surfaced when reveal level is `OrgAndJurisdiction` or higher.

## API in this PR

```apex
DeliveryDepthProbeService.DepthChainNode root =
    DeliveryDepthProbeService.getFulfillmentChain(workItemId, maxDepth);
```

Returns a tree:
```
DepthChainNode {
    orgId: String       // null when peer reveal=Off
    orgName: String     // "[redacted — peer reveal=Off]" when peer reveal=Off
    jurisdiction: String  // null unless reveal>=OrgAndJurisdiction
    revealLevel: String   // Off / OrgOnly / OrgAndJurisdiction / Full
    children: List<DepthChainNode>
}
```

Today: returns local segment only (this org's identity + downstream Vendor peers, each filtered by its own reveal level). Children of those peer nodes are empty until the recursive probe ships in the follow-on PR.

## Tests
- `testGetFulfillmentChainReturnsRootWithLocalOrg`
- `testGetFulfillmentChainRedactsOffPeer` (Off peer surfaces as redacted leaf)
- `testGetFulfillmentChainRevealsOrgAndJurisdiction` (org + jurisdiction surfaced)
- `testGetFulfillmentChainOrgOnlyHidesJurisdiction` (jurisdiction hidden at OrgOnly level)

## Docs
`docs/depth-charge-architecture.md` captures the full vision: use cases, schema rationale, follow-on PR scope, pricing positioning for cloudnimbusllc productization.

## What this PR does NOT include (follow-on work)
- Recursive cross-org probe: outbound `depth_probe` SyncItem when reveal=Vendor encountered
- Receiver-side probe handler: builds local segment, emits `depth_response`
- Aggregator: caller-side handler that stitches responses by requestId
- Caller-facing API: LWC / REST endpoint
- Visualization: react-flow tree on cloudnimbusllc-side
- Rate limiting + recursion budget
- ActivityLog audit trail of probes

Estimated effort for follow-on full implementation: ~16-24h spread across DH + cloudnimbusllc.

## Test plan
- [x] PMD apex-scan
- [x] Apex tests pass (4 new)
- [ ] Post-install: query `delivery__SyncItem__c.ChangeTypeTxt__c` and `delivery__NetworkEntity__c.RevealFulfillmentDepthPk__c` exist on each org
- [ ] Post-install: anonymous Apex `delivery.DeliveryDepthProbeService.getFulfillmentChain(<some WI id>, 1)` returns a populated DepthChainNode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
