### PR TITLE
fix(test): disable auto-WorkRequest creation in DeliveryDepthProbeServiceTest

### DIFF
--- a/force-app/main/default/classes/DeliveryDepthProbeServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryDepthProbeServiceTest.cls
@@ -10,6 +10,26 @@
 @IsTest
 private class DeliveryDepthProbeServiceTest {
 
+    /**
+     * @description Disable the auto-WorkRequest-creation trigger so each
+     *              test controls exactly how many WorkRequests exist for
+     *              its WI. Without this, DeliveryWorkItemTriggerHandler.
+     *              handleNetworkEntitySync auto-creates a second WorkRequest
+     *              pointing at the first active Vendor (which IS our test
+     *              peer), inflating root.children.size() to 2 and breaking
+     *              the size-1 assertions. Caught in PR #760's beta_create
+     *              upload-beta apex test phase.
+     */
+    @TestSetup
+    static void disableAutoCreateWorkRequest() {
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        if (settings.Id == null) {
+            settings.SetupOwnerId = UserInfo.getOrganizationId();
+        }
+        settings.EnableAutoCreateWorkRequestDateTime__c = null;
+        upsert settings;
+    }
+
     @IsTest
     static void testGetFulfillmentChainReturnsRootWithLocalOrg() {
         WorkItem__c wi = new WorkItem__c(


### PR DESCRIPTION
Hot-fix for PR #760's beta_create upload-beta apex test failure.

Root cause: handleNetworkEntitySync auto-creates a WorkRequest pointing at the first active Vendor when EnableAutoCreateWorkRequestDateTime__c is set (default after install). Tests asserted 1 child but got 2 because of the auto-WorkRequest.

Fix: @TestSetup disables the toggle. Same pattern as DeliverySyncEngineTest.

Feature-test passed because scratch org didn't have the install-handler-set toggle. upload-beta exposed it because packaged orgs DO have it.