### PR TITLE
fix(workitem): refuse non-null to null transitions on gantt-critical fields

### DIFF
--- a/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
@@ -353,6 +353,7 @@ public without sharing class DeliveryWorkItemTriggerHandler {
      * @param oldMap Map of old WorkItem__c records keyed by Id
      */
     public static void handleBeforeUpdate(List<WorkItem__c> newWorkItems, Map<Id, WorkItem__c> oldMap) {
+        protectGanttCriticalFieldsFromNull(newWorkItems, oldMap);
         stampStageEnteredOnUpdate(newWorkItems, oldMap);
 
         // Auto-generate bounty token when BountyEnabledDateTime__c flips to true on update
@@ -391,6 +392,82 @@ public without sharing class DeliveryWorkItemTriggerHandler {
                 }
             }
         }
+    }
+
+    /**
+     * @description Refuses non-null → null transitions on the WI fields that
+     *              gate gantt visibility (EstimatedStartDevDate, EstimatedEndDevDate,
+     *              SortOrderNumber). These fields are how the gantt knows what to
+     *              render where; clearing them silently makes WIs vanish from the
+     *              user's view, which has surfaced as "lost the Joe-era items
+     *              again" twice now (4/30 fix, recurred 5/11).
+     *
+     *              Root cause is bulk Apex scripts that load a WI without these
+     *              fields in the SELECT, then update — the SObject in memory has
+     *              null for the un-loaded fields, the update writes null back
+     *              over real values. The fix at the script layer is to use the
+     *              partial-update pattern: `update new WorkItem__c(Id=x, field=y)`
+     *              instead of full-record update. The fix at the trigger layer
+     *              (this method) is to refuse the destructive transition outright.
+     *
+     *              Bypass for legitimate clears: set
+     *              DeliveryWorkItemTriggerHandler.triggerDisabled = true before
+     *              the DML. The bypass makes the intent explicit + auditable.
+     *
+     *              Skipped during inbound-sync context (peer org's value is
+     *              source of truth — including legitimate nulls).
+     *
+     *              Skipped in test context by default with override flag
+     *              enforceGanttFieldGuardInTest — same pattern as the hard-delete
+     *              guard from PR #759. Hundreds of existing tests patch WI
+     *              records without populating these fields and shouldn't need
+     *              triggerDisabled boilerplate.
+     * @param newWorkItems List of new WorkItem__c records (post-mutation).
+     * @param oldMap Map of old WorkItem__c records keyed by Id.
+     */
+    private static void protectGanttCriticalFieldsFromNull(List<WorkItem__c> newWorkItems, Map<Id, WorkItem__c> oldMap) {
+        if (DeliverySyncEngine.isSyncContext) {
+            return;
+        }
+        if (Test.isRunningTest() && !enforceGanttFieldGuardInTest) {
+            return;
+        }
+        for (WorkItem__c wi : newWorkItems) {
+            WorkItem__c oldWi = oldMap.get(wi.Id);
+            if (oldWi == null) {
+                continue;
+            }
+            if (oldWi.EstimatedStartDevDate__c != null && wi.EstimatedStartDevDate__c == null) {
+                wi.addError(buildGanttFieldGuardMessage('EstimatedStartDevDate__c'));
+                continue;
+            }
+            if (oldWi.EstimatedEndDevDate__c != null && wi.EstimatedEndDevDate__c == null) {
+                wi.addError(buildGanttFieldGuardMessage('EstimatedEndDevDate__c'));
+                continue;
+            }
+            if (oldWi.SortOrderNumber__c != null && wi.SortOrderNumber__c == null) {
+                wi.addError(buildGanttFieldGuardMessage('SortOrderNumber__c'));
+                continue;
+            }
+        }
+    }
+
+    /**
+     * @description Test-only override: when true, the gantt-field guard fires
+     *              inside test context too. Default false so existing tests
+     *              that update WIs without populating these fields don't need
+     *              triggerDisabled boilerplate. Refusal-test flips this.
+     */
+    @TestVisible
+    private static Boolean enforceGanttFieldGuardInTest = false;
+
+    private static String buildGanttFieldGuardMessage(String fieldName) {
+        return 'Cannot clear ' + fieldName + ' on a WorkItem — it makes the record gantt-invisible. '
+            + 'If your script intends to update other fields, use the partial-update pattern: '
+            + 'update new WorkItem__c(Id = wi.Id, otherField = newValue). If you genuinely intend '
+            + 'to remove this record from the gantt, use Deactivate (set ActivatedDateTime__c = null) '
+            + 'instead. Admin scripts that genuinely need to null this field must set '
+            + 'DeliveryWorkItemTriggerHandler.triggerDisabled = true before the DML.';
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryWorkItemTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemTriggerHandlerTest.cls
@@ -639,4 +639,213 @@ public class DeliveryWorkItemTriggerHandlerTest {
         Integer remaining = [SELECT COUNT() FROM WorkItem__c WHERE Id = :wi.Id];
         System.assertEquals(0, remaining, 'Bypass should allow the hard delete to land');
     }
+
+    /**
+     * @description Joe-era guard: refuses non-null → null transitions on
+     *              EstimatedStartDevDate__c / EstimatedEndDevDate__c /
+     *              SortOrderNumber__c. These fields gate gantt visibility;
+     *              clearing them silently makes WIs vanish from the user's
+     *              view (recurring issue per MF-Claude 5/11 finding).
+     */
+    @IsTest
+    static void testGanttFieldGuardRefusesEstimatedStartNullOut() {
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c   = 'Has start date',
+            StageNamePk__c           = 'In Development',
+            EstimatedStartDevDate__c = Date.today()
+        );
+        insert wi;
+
+        DeliveryWorkItemTriggerHandler.enforceGanttFieldGuardInTest = true;
+
+        Test.startTest();
+        Boolean caughtRefusal = false;
+        try {
+            wi.EstimatedStartDevDate__c = null;
+            update wi;
+        } catch (DmlException e) {
+            caughtRefusal = e.getMessage().containsIgnoreCase('Cannot clear EstimatedStartDevDate__c');
+        } finally {
+            DeliveryWorkItemTriggerHandler.enforceGanttFieldGuardInTest = false;
+        }
+        Test.stopTest();
+
+        System.assert(caughtRefusal, 'Null-out of EstimatedStartDevDate__c must be refused');
+        WorkItem__c reloaded = [SELECT EstimatedStartDevDate__c FROM WorkItem__c WHERE Id = :wi.Id];
+        System.assertNotEquals(null, reloaded.EstimatedStartDevDate__c,
+            'Original value must still be there after the refusal');
+    }
+
+    @IsTest
+    static void testGanttFieldGuardRefusesEstimatedEndNullOut() {
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c   = 'Has end date',
+            StageNamePk__c           = 'In Development',
+            EstimatedEndDevDate__c   = Date.today().addDays(7)
+        );
+        insert wi;
+
+        DeliveryWorkItemTriggerHandler.enforceGanttFieldGuardInTest = true;
+
+        Test.startTest();
+        Boolean caughtRefusal = false;
+        try {
+            wi.EstimatedEndDevDate__c = null;
+            update wi;
+        } catch (DmlException e) {
+            caughtRefusal = e.getMessage().containsIgnoreCase('Cannot clear EstimatedEndDevDate__c');
+        } finally {
+            DeliveryWorkItemTriggerHandler.enforceGanttFieldGuardInTest = false;
+        }
+        Test.stopTest();
+
+        System.assert(caughtRefusal, 'Null-out of EstimatedEndDevDate__c must be refused');
+    }
+
+    @IsTest
+    static void testGanttFieldGuardRefusesSortOrderNullOut() {
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c   = 'Has sort order',
+            StageNamePk__c           = 'In Development',
+            SortOrderNumber__c       = 100
+        );
+        insert wi;
+
+        DeliveryWorkItemTriggerHandler.enforceGanttFieldGuardInTest = true;
+
+        Test.startTest();
+        Boolean caughtRefusal = false;
+        try {
+            wi.SortOrderNumber__c = null;
+            update wi;
+        } catch (DmlException e) {
+            caughtRefusal = e.getMessage().containsIgnoreCase('Cannot clear SortOrderNumber__c');
+        } finally {
+            DeliveryWorkItemTriggerHandler.enforceGanttFieldGuardInTest = false;
+        }
+        Test.stopTest();
+
+        System.assert(caughtRefusal, 'Null-out of SortOrderNumber__c must be refused');
+    }
+
+    /**
+     * @description Guard must allow null → non-null transitions (setting a
+     *              date for the first time). Only blocks the destructive direction.
+     */
+    @IsTest
+    static void testGanttFieldGuardAllowsNullToValueTransition() {
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c = 'Initially no dates',
+            StageNamePk__c         = 'Backlog'
+        );
+        insert wi;
+
+        DeliveryWorkItemTriggerHandler.enforceGanttFieldGuardInTest = true;
+
+        Test.startTest();
+        try {
+            wi.EstimatedStartDevDate__c = Date.today();
+            wi.EstimatedEndDevDate__c   = Date.today().addDays(5);
+            update wi;
+        } finally {
+            DeliveryWorkItemTriggerHandler.enforceGanttFieldGuardInTest = false;
+        }
+        Test.stopTest();
+
+        WorkItem__c reloaded = [SELECT EstimatedStartDevDate__c, EstimatedEndDevDate__c FROM WorkItem__c WHERE Id = :wi.Id];
+        System.assertEquals(Date.today(), reloaded.EstimatedStartDevDate__c,
+            'Setting a previously-null date must succeed');
+        System.assertEquals(Date.today().addDays(5), reloaded.EstimatedEndDevDate__c,
+            'Setting a previously-null end date must succeed');
+    }
+
+    /**
+     * @description Guard must allow value → different-value transitions
+     *              (rescheduling). Only blocks value → null.
+     */
+    @IsTest
+    static void testGanttFieldGuardAllowsValueToValueTransition() {
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c   = 'Reschedule me',
+            StageNamePk__c           = 'In Development',
+            EstimatedStartDevDate__c = Date.today()
+        );
+        insert wi;
+
+        DeliveryWorkItemTriggerHandler.enforceGanttFieldGuardInTest = true;
+
+        Test.startTest();
+        try {
+            wi.EstimatedStartDevDate__c = Date.today().addDays(3);
+            update wi;
+        } finally {
+            DeliveryWorkItemTriggerHandler.enforceGanttFieldGuardInTest = false;
+        }
+        Test.stopTest();
+
+        WorkItem__c reloaded = [SELECT EstimatedStartDevDate__c FROM WorkItem__c WHERE Id = :wi.Id];
+        System.assertEquals(Date.today().addDays(3), reloaded.EstimatedStartDevDate__c,
+            'Rescheduling (value → different value) must succeed');
+    }
+
+    /**
+     * @description Admin-bypass: setting triggerDisabled=true before the
+     *              update allows null-out for legitimate cleanup scripts.
+     */
+    @IsTest
+    static void testGanttFieldGuardBypassedWhenTriggerDisabled() {
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c   = 'Will be force-cleared',
+            StageNamePk__c           = 'In Development',
+            EstimatedStartDevDate__c = Date.today()
+        );
+        insert wi;
+
+        Test.startTest();
+        DeliveryWorkItemTriggerHandler.triggerDisabled = true;
+        try {
+            wi.EstimatedStartDevDate__c = null;
+            update wi;
+        } finally {
+            DeliveryWorkItemTriggerHandler.triggerDisabled = false;
+        }
+        Test.stopTest();
+
+        WorkItem__c reloaded = [SELECT EstimatedStartDevDate__c FROM WorkItem__c WHERE Id = :wi.Id];
+        System.assertEquals(null, reloaded.EstimatedStartDevDate__c,
+            'Bypass must allow the null-out');
+    }
+
+    /**
+     * @description Inbound-sync context skip: the guard does NOT fire when
+     *              DeliverySyncEngine.isSyncContext is true. Source org's
+     *              value (including legitimate nulls) is the source of truth.
+     */
+    @IsTest
+    static void testGanttFieldGuardSkippedDuringInboundSync() {
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c   = 'Inbound sync nulls a date',
+            StageNamePk__c           = 'In Development',
+            EstimatedStartDevDate__c = Date.today()
+        );
+        insert wi;
+
+        DeliveryWorkItemTriggerHandler.enforceGanttFieldGuardInTest = true;
+        DeliverySyncEngine.setInboundContext('00DTESTSENDER001');
+
+        Test.startTest();
+        try {
+            wi.EstimatedStartDevDate__c = null;
+            update wi;
+        } finally {
+            DeliveryWorkItemTriggerHandler.enforceGanttFieldGuardInTest = false;
+            DeliverySyncEngine.isSyncContext = false;
+            DeliverySyncEngine.inboundSenderOrgId = null;
+        }
+        Test.stopTest();
+
+        WorkItem__c reloaded = [SELECT EstimatedStartDevDate__c FROM WorkItem__c WHERE Id = :wi.Id];
+        System.assertEquals(null, reloaded.EstimatedStartDevDate__c,
+            'Inbound-sync context must allow source-org-driven nulls');
+    }
 }


### PR DESCRIPTION
## Summary
- Refuses non-null → null transitions on `EstimatedStartDevDate__c`, `EstimatedEndDevDate__c`, `SortOrderNumber__c` in `DeliveryWorkItemTriggerHandler.handleBeforeUpdate`
- Closes the recurring "WIs vanish from gantt" failure mode driven by full-record-update bulk Apex scripts (4/30 fix, recurred 5/11)
- Same bypass / sync-skip / test-override model as the hard-delete guard from PR #759

## Why
MF-Claude's 5/11 audit found 7 WIs went gantt-invisible after a bulk Apex run that loaded WorkItem records without these three fields in the SELECT, then called `update`. The in-memory SObject had `null` for the unloaded fields, so the update wrote `null` over real values. The 4/30 fix recurred in 11 days — a DH-side guard is the durable answer.

The error message points the script writer at the partial-update pattern:
```apex
update new WorkItem__c(Id = wi.Id, otherField = newValue);
```

## Bypass / skip behavior
- **Admin bypass:** `DeliveryWorkItemTriggerHandler.triggerDisabled = true` before the DML
- **Inbound sync:** skipped when `DeliverySyncEngine.isSyncContext` is true — peer org's value (including legitimate nulls) is the source of truth
- **Test context:** skipped by default unless `enforceGanttFieldGuardInTest = true` is set, so the ~hundreds of existing tests that update WIs without populating these fields don't need triggerDisabled boilerplate

## Test plan
- [x] `testGanttFieldGuardRefusesEstimatedStartNullOut`
- [x] `testGanttFieldGuardRefusesEstimatedEndNullOut`
- [x] `testGanttFieldGuardRefusesSortOrderNullOut`
- [x] `testGanttFieldGuardAllowsNullToValueTransition` (initial-set still works)
- [x] `testGanttFieldGuardAllowsValueToValueTransition` (rescheduling still works)
- [x] `testGanttFieldGuardBypassedWhenTriggerDisabled` (admin-bypass works)
- [x] `testGanttFieldGuardSkippedDuringInboundSync` (peer-driven nulls allowed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
