### PR TITLE
fix(gantt): right-click Delete on dep arrow — depId param + optimistic local update

### DIFF
--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -1354,17 +1354,34 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
 
     /**
      * Dependency-arrow menu items routed here. 'delete' calls existing
-     * Apex; 'change-type-*' would need a new Apex setter — deferred until
-     * there's a clear product use case.
+     * Apex with optimistic local update + setData (per NG 0.191.0
+     * cascade brief — avoids the full refetch round-trip).
+     *
+     * 'change-type-*' (FS/SS/FF/SF from NG's auto-installed
+     * ContextMenuPlugin) intentionally deferred: DH's TypePk__c picklist
+     * is semantic (Blocks / Relates To / Clones), not scheduler-style.
+     * Wiring change-type without first deciding the DH dep model would
+     * either silently mis-translate or surface confusing errors.
      */
     _handleCtxDependencyAction(action, depId, _pos) {
         if (action === 'delete' && depId) {
-            // Reuse existing imperative Apex.
-            deleteWorkItemDependency({ dependencyId: depId })
-                .then(() => this._scheduleRefetch())
-                .catch((err) => this._showError('Could not delete dependency', err));
+            // Snapshot for revert-on-failure.
+            const previousDeps = this._dependencies;
+            this._dependencies = (previousDeps || []).filter(d => d.id !== depId);
+            if (this._mountHandle && typeof this._mountHandle.setData === 'function') {
+                this._mountHandle.setData(this._tasks, this._dependencies);
+            }
+            deleteWorkItemDependency({ depId })
+                .catch((err) => {
+                    // Revert local state if Apex rejected.
+                    this._dependencies = previousDeps;
+                    if (this._mountHandle && typeof this._mountHandle.setData === 'function') {
+                        this._mountHandle.setData(this._tasks, this._dependencies);
+                    }
+                    this._showError('Could not delete dependency', err);
+                });
         }
-        // change-type-* deferred.
+        // change-type-* deferred — see method docstring.
     }
 
     _navigateRecord(taskId, actionName = 'view') {


### PR DESCRIPTION
## Summary
Two issues in `_handleCtxDependencyAction` (right-click → Delete on a dependency arrow):

1. **Param typo** — LWC called `deleteWorkItemDependency({ dependencyId: depId })` but Apex signature is `deleteWorkItemDependency(String depId)`. Apex received `depId=null`, threw `"depId is required"`, `.catch` surfaced `"Could not delete dependency"` toast. Right-click → Delete on a dep arrow has been silently broken since PR #738 (0.189.0).
2. **Round-trip refetch** — Old code called `_scheduleRefetch()` after delete (full task+dep server pull). NG 0.191.0 cascade brief recommends optimistic local update + `setData()` instead with revert-on-failure.

## Why it wasn't caught earlier
- The other deletion path at line 410 (the explicit dep-management dialog) used the correct param key and worked
- The right-click menu itself wasn't reliably firing until 0.190.1's ContextMenuPlugin click-fire fix landed via PR #754, so the broken handler never ran in the field

## What I deliberately did NOT do
**Change-type-* (FS/SS/FF/SF) menu items remain unwired.** NG's auto-installed ContextMenuPlugin renders these by default. DH's `WorkItemDependency__c.TypePk__c` picklist is semantic (`Blocks` / `Relates To` / `Clones`), not scheduler-style. Wiring `change-type-FS` to `Blocks` would mis-translate; wiring `change-type-SS/FF/SF` to anything would be a fabrication. Defer until DH has an explicit dep-model decision.

The cascade brief's `updateWorkItemDependencyType` Apex setter is a forward-compat hook for that future dep-model redesign — not today's product behavior.

## Test plan
- [ ] feature-test passes (no Apex changes; pure LWC fix)
- [ ] Smoke after install: right-click any dep arrow → Delete → arrow disappears immediately, dep deleted in DB, no error toast
- [ ] Smoke error path: trigger Apex error (e.g. delete a dep tied to a record the user can't access) → arrow re-appears, toast shows error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
