### PR TITLE
feat(hours): Phase 2A — deliveryProjectMonthlyHours LWC + analytics controller

### DIFF
--- a/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
@@ -1,0 +1,241 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Provides per-month hours analytics for a WorkItem__c tree.
+ *              Walks the parent-child hierarchy via ParentWorkItemLookup__c, sums
+ *              WorkLog__c.HoursLoggedNumber__c grouped by CALENDAR_MONTH(WorkDateDate__c),
+ *              and returns monthly buckets paired with a per-month linear-amortized
+ *              estimate target derived from WorkItem__c.EstimatedHoursNumber__c +
+ *              EstimatedStartDevDate__c/EstimatedEndDevDate__c when those are populated.
+ *              Backs the deliveryProjectMonthlyHours record-page LWC.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexDoc')
+global with sharing class DeliveryHoursAnalyticsController {
+
+    /** @description Hard cap on recursion depth when walking the WI parent-child tree. */
+    private static final Integer MAX_TREE_DEPTH = 10;
+
+    /** @description Hard cap on the number of months returned. */
+    private static final Integer MAX_MONTHS = 60;
+
+    /** @description One DTO per (year, month) bucket returned to the LWC. */
+    global class MonthlyHoursDTO {
+        @AuraEnabled global Integer year;
+        @AuraEnabled global Integer month;
+        @AuraEnabled global String monthLabel;
+        @AuraEnabled global Decimal hoursLogged;
+        @AuraEnabled global Decimal monthlyTarget;
+        @AuraEnabled global Boolean overTarget;
+    }
+
+    /** @description Project-level summary returned alongside the monthly buckets. */
+    global class ProjectHoursSummary {
+        @AuraEnabled global Id rootWorkItemId;
+        @AuraEnabled global Integer descendantCount;
+        @AuraEnabled global Decimal totalEstimatedHours;
+        @AuraEnabled global Decimal totalLoggedHours;
+        @AuraEnabled global Decimal monthlyTarget;
+        @AuraEnabled global Boolean hasEstimate;
+        @AuraEnabled global Date earliestStart;
+        @AuraEnabled global Date latestEnd;
+        @AuraEnabled global List<MonthlyHoursDTO> months;
+    }
+
+    /**
+     * @description Returns monthly hours analytics for the WI tree rooted at workItemId.
+     * @param workItemId Root WorkItem__c Id. Descendants are walked via
+     *                   ParentWorkItemLookup__c up to MAX_TREE_DEPTH levels.
+     * @param monthsBack How many months of history to include, counting back from the
+     *                   start of the current month. Clamped to [1, MAX_MONTHS]. When null
+     *                   or zero, defaults to 12.
+     * @return ProjectHoursSummary with the monthly buckets + tree-level totals.
+     */
+    @AuraEnabled(cacheable=true)
+    global static ProjectHoursSummary getMonthlyHoursForProject(Id workItemId, Integer monthsBack) {
+        try {
+            if (workItemId == null) {
+                throw new AuraHandledException('workItemId is required.');
+            }
+            Integer effectiveMonths = (monthsBack == null || monthsBack <= 0) ? 12 : monthsBack;
+            if (effectiveMonths > MAX_MONTHS) {
+                effectiveMonths = MAX_MONTHS;
+            }
+
+            Set<Id> treeIds = walkDescendants(workItemId);
+            List<WorkItem__c> tree = queryTreeRollup(treeIds);
+
+            ProjectHoursSummary summary = new ProjectHoursSummary();
+            summary.rootWorkItemId = workItemId;
+            summary.descendantCount = tree.size();
+            summary.totalEstimatedHours = 0;
+            summary.totalLoggedHours = 0;
+            summary.earliestStart = null;
+            summary.latestEnd = null;
+
+            for (WorkItem__c wi : tree) {
+                if (wi.EstimatedHoursNumber__c != null) {
+                    summary.totalEstimatedHours += wi.EstimatedHoursNumber__c;
+                }
+                if (wi.TotalLoggedHoursSum__c != null) {
+                    summary.totalLoggedHours += wi.TotalLoggedHoursSum__c;
+                }
+                if (wi.EstimatedStartDevDate__c != null
+                    && (summary.earliestStart == null || wi.EstimatedStartDevDate__c < summary.earliestStart)) {
+                    summary.earliestStart = wi.EstimatedStartDevDate__c;
+                }
+                if (wi.EstimatedEndDevDate__c != null
+                    && (summary.latestEnd == null || wi.EstimatedEndDevDate__c > summary.latestEnd)) {
+                    summary.latestEnd = wi.EstimatedEndDevDate__c;
+                }
+            }
+
+            summary.hasEstimate = summary.totalEstimatedHours > 0;
+            summary.monthlyTarget = computeMonthlyTarget(summary);
+
+            List<MonthlyHoursDTO> months = buildMonthlyBuckets(effectiveMonths, summary.monthlyTarget);
+            applyLoggedHours(months, treeIds);
+            summary.months = months;
+
+            return summary;
+        } catch (AuraHandledException ahe) {
+            throw ahe;
+        } catch (Exception e) {
+            AuraHandledException ahe = new AuraHandledException(e.getMessage());
+            ahe.setMessage(e.getMessage());
+            throw ahe;
+        }
+    }
+
+    /**
+     * @description BFS walk from the root over ParentWorkItemLookup__c. Caps at
+     *              MAX_TREE_DEPTH so a runaway cycle (shouldn't exist in data, but
+     *              defensive) can't burn unbounded SOQL queries.
+     */
+    private static Set<Id> walkDescendants(Id rootId) {
+        Set<Id> collected = new Set<Id>{ rootId };
+        Set<Id> frontier = new Set<Id>{ rootId };
+        for (Integer depth = 0; depth < MAX_TREE_DEPTH && !frontier.isEmpty(); depth++) {
+            Set<Id> next = new Set<Id>();
+            for (WorkItem__c child : [
+                SELECT Id
+                FROM WorkItem__c
+                WHERE ParentWorkItemLookup__c IN :frontier
+                WITH SYSTEM_MODE
+                LIMIT 5000
+            ]) {
+                if (!collected.contains(child.Id)) {
+                    collected.add(child.Id);
+                    next.add(child.Id);
+                }
+            }
+            frontier = next;
+        }
+        return collected;
+    }
+
+    private static List<WorkItem__c> queryTreeRollup(Set<Id> treeIds) {
+        return [
+            SELECT Id, EstimatedHoursNumber__c, TotalLoggedHoursSum__c,
+                   EstimatedStartDevDate__c, EstimatedEndDevDate__c
+            FROM WorkItem__c
+            WHERE Id IN :treeIds
+            WITH SYSTEM_MODE
+            LIMIT 5000
+        ];
+    }
+
+    /**
+     * @description Linear-amortizes the total estimate across the project's
+     *              planned month span. Returns 0 when either piece is missing —
+     *              the LWC then renders only the actual bars, no target line.
+     */
+    private static Decimal computeMonthlyTarget(ProjectHoursSummary summary) {
+        if (!summary.hasEstimate || summary.earliestStart == null || summary.latestEnd == null) {
+            return 0;
+        }
+        Integer monthSpan = monthsBetween(summary.earliestStart, summary.latestEnd);
+        if (monthSpan <= 0) {
+            return summary.totalEstimatedHours;
+        }
+        return (summary.totalEstimatedHours / monthSpan).setScale(2, System.RoundingMode.HALF_UP);
+    }
+
+    private static Integer monthsBetween(Date startDate, Date endDate) {
+        Integer startMonths = startDate.year() * 12 + startDate.month();
+        Integer endMonths = endDate.year() * 12 + endDate.month();
+        return endMonths - startMonths + 1;
+    }
+
+    /**
+     * @description Builds an empty monthly skeleton spanning effectiveMonths,
+     *              ending at the current month. Hours are filled in by applyLoggedHours.
+     */
+    private static List<MonthlyHoursDTO> buildMonthlyBuckets(Integer effectiveMonths, Decimal monthlyTarget) {
+        List<MonthlyHoursDTO> out = new List<MonthlyHoursDTO>();
+        Date cursor = Date.today().toStartOfMonth().addMonths(-(effectiveMonths - 1));
+        for (Integer i = 0; i < effectiveMonths; i++) {
+            MonthlyHoursDTO row = new MonthlyHoursDTO();
+            row.year = cursor.year();
+            row.month = cursor.month();
+            row.monthLabel = formatMonthLabel(cursor);
+            row.hoursLogged = 0;
+            row.monthlyTarget = monthlyTarget;
+            row.overTarget = false;
+            out.add(row);
+            cursor = cursor.addMonths(1);
+        }
+        return out;
+    }
+
+    private static void applyLoggedHours(List<MonthlyHoursDTO> months, Set<Id> treeIds) {
+        if (months.isEmpty()) {
+            return;
+        }
+        Map<String, MonthlyHoursDTO> byKey = new Map<String, MonthlyHoursDTO>();
+        for (MonthlyHoursDTO row : months) {
+            byKey.put(bucketKey(row.year, row.month), row);
+        }
+        Date windowStart = Date.newInstance(months[0].year, months[0].month, 1);
+        Date windowEnd = Date.newInstance(months[months.size() - 1].year, months[months.size() - 1].month, 1)
+            .addMonths(1).addDays(-1);
+
+        for (AggregateResult ar : [
+            SELECT CALENDAR_YEAR(WorkDateDate__c) y,
+                   CALENDAR_MONTH(WorkDateDate__c) m,
+                   SUM(HoursLoggedNumber__c) total
+            FROM WorkLog__c
+            WHERE WorkItemLookup__c IN :treeIds
+            AND WorkDateDate__c >= :windowStart
+            AND WorkDateDate__c <= :windowEnd
+            WITH SYSTEM_MODE
+            GROUP BY CALENDAR_YEAR(WorkDateDate__c), CALENDAR_MONTH(WorkDateDate__c)
+            LIMIT 5000
+        ]) {
+            Integer y = (Integer) ar.get('y');
+            Integer m = (Integer) ar.get('m');
+            Object totalObj = ar.get('total');
+            if (totalObj == null) {
+                continue;
+            }
+            Decimal total = (Decimal) totalObj;
+            MonthlyHoursDTO bucket = byKey.get(bucketKey(y, m));
+            if (bucket != null) {
+                bucket.hoursLogged = total;
+                bucket.overTarget = bucket.monthlyTarget > 0 && total > bucket.monthlyTarget;
+            }
+        }
+    }
+
+    private static String bucketKey(Integer y, Integer m) {
+        return y + '-' + m;
+    }
+
+    private static String formatMonthLabel(Date d) {
+        List<String> names = new List<String>{
+            'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+            'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+        };
+        return names[d.month() - 1] + ' ' + String.valueOf(d.year()).substring(2);
+    }
+}

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
@@ -10,7 +10,7 @@
  *              Backs the deliveryProjectMonthlyHours record-page LWC.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexDoc')
+@SuppressWarnings('PMD.ApexDoc,PMD.AvoidGlobalModifier,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.OperationWithLimitsInLoop')
 global with sharing class DeliveryHoursAnalyticsController {
 
     /** @description Hard cap on recursion depth when walking the WI parent-child tree. */
@@ -65,32 +65,7 @@ global with sharing class DeliveryHoursAnalyticsController {
             Set<Id> treeIds = walkDescendants(workItemId);
             List<WorkItem__c> tree = queryTreeRollup(treeIds);
 
-            ProjectHoursSummary summary = new ProjectHoursSummary();
-            summary.rootWorkItemId = workItemId;
-            summary.descendantCount = tree.size();
-            summary.totalEstimatedHours = 0;
-            summary.totalLoggedHours = 0;
-            summary.earliestStart = null;
-            summary.latestEnd = null;
-
-            for (WorkItem__c wi : tree) {
-                if (wi.EstimatedHoursNumber__c != null) {
-                    summary.totalEstimatedHours += wi.EstimatedHoursNumber__c;
-                }
-                if (wi.TotalLoggedHoursSum__c != null) {
-                    summary.totalLoggedHours += wi.TotalLoggedHoursSum__c;
-                }
-                if (wi.EstimatedStartDevDate__c != null
-                    && (summary.earliestStart == null || wi.EstimatedStartDevDate__c < summary.earliestStart)) {
-                    summary.earliestStart = wi.EstimatedStartDevDate__c;
-                }
-                if (wi.EstimatedEndDevDate__c != null
-                    && (summary.latestEnd == null || wi.EstimatedEndDevDate__c > summary.latestEnd)) {
-                    summary.latestEnd = wi.EstimatedEndDevDate__c;
-                }
-            }
-
-            summary.hasEstimate = summary.totalEstimatedHours > 0;
+            ProjectHoursSummary summary = buildSummaryFromTree(workItemId, tree);
             summary.monthlyTarget = computeMonthlyTarget(summary);
 
             List<MonthlyHoursDTO> months = buildMonthlyBuckets(effectiveMonths, summary.monthlyTarget);
@@ -104,6 +79,42 @@ global with sharing class DeliveryHoursAnalyticsController {
             AuraHandledException ahe = new AuraHandledException(e.getMessage());
             ahe.setMessage(e.getMessage());
             throw ahe;
+        }
+    }
+
+    /**
+     * @description Rolls the tree's per-WI fields into a fresh summary. Extracted
+     *              from the entry point to keep per-method cyclomatic complexity low.
+     */
+    private static ProjectHoursSummary buildSummaryFromTree(Id rootId, List<WorkItem__c> tree) {
+        ProjectHoursSummary summary = new ProjectHoursSummary();
+        summary.rootWorkItemId = rootId;
+        summary.descendantCount = tree.size();
+        summary.totalEstimatedHours = 0;
+        summary.totalLoggedHours = 0;
+        summary.earliestStart = null;
+        summary.latestEnd = null;
+        for (WorkItem__c wi : tree) {
+            accumulateRollup(summary, wi);
+        }
+        summary.hasEstimate = summary.totalEstimatedHours > 0;
+        return summary;
+    }
+
+    private static void accumulateRollup(ProjectHoursSummary summary, WorkItem__c wi) {
+        if (wi.EstimatedHoursNumber__c != null) {
+            summary.totalEstimatedHours += wi.EstimatedHoursNumber__c;
+        }
+        if (wi.TotalLoggedHoursSum__c != null) {
+            summary.totalLoggedHours += wi.TotalLoggedHoursSum__c;
+        }
+        Date wiStart = wi.EstimatedStartDevDate__c;
+        if (wiStart != null && (summary.earliestStart == null || wiStart < summary.earliestStart)) {
+            summary.earliestStart = wiStart;
+        }
+        Date wiEnd = wi.EstimatedEndDevDate__c;
+        if (wiEnd != null && (summary.latestEnd == null || wiEnd > summary.latestEnd)) {
+            summary.latestEnd = wiEnd;
         }
     }
 

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
@@ -6,7 +6,7 @@
  *              estimate, no logs, deeply nested children).
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexDoc')
+@SuppressWarnings('PMD.ApexDoc,PMD.ExcessiveParameterList')
 @IsTest
 private class DeliveryHoursAnalyticsControllerTest {
 
@@ -15,9 +15,9 @@ private class DeliveryHoursAnalyticsControllerTest {
      *              used in DeliveryDepthProbeServiceTest (see PR #764). Keeps these
      *              tests focused on analytics, not auto-WR / sync side effects.
      */
-    private static WorkItem__c insertWi(String desc, Decimal estimate, Date startDate, Date endDate, Id parentId) {
+    private static WorkItem__c insertWi(String briefDesc, Decimal estimate, Date startDate, Date endDate, Id parentId) {
         WorkItem__c wi = new WorkItem__c(
-            BriefDescriptionTxt__c = desc,
+            BriefDescriptionTxt__c = briefDesc,
             EstimatedHoursNumber__c = estimate,
             EstimatedStartDevDate__c = startDate,
             EstimatedEndDevDate__c = endDate,

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
@@ -1,0 +1,264 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Unit tests for DeliveryHoursAnalyticsController. Verifies the WI tree
+ *              walk, monthly bucket assembly, target overlay, and edge cases (no
+ *              estimate, no logs, deeply nested children).
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexDoc')
+@IsTest
+private class DeliveryHoursAnalyticsControllerTest {
+
+    /**
+     * @description Bracket WI inserts with triggerDisabled — mirrors the pattern
+     *              used in DeliveryDepthProbeServiceTest (see PR #764). Keeps these
+     *              tests focused on analytics, not auto-WR / sync side effects.
+     */
+    private static WorkItem__c insertWi(String desc, Decimal estimate, Date startDate, Date endDate, Id parentId) {
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c = desc,
+            EstimatedHoursNumber__c = estimate,
+            EstimatedStartDevDate__c = startDate,
+            EstimatedEndDevDate__c = endDate,
+            ParentWorkItemLookup__c = parentId,
+            ActivatedDateTime__c = Datetime.now(),
+            StatusPk__c = 'Active'
+        );
+        DeliveryWorkItemTriggerHandler.triggerDisabled = true;
+        try {
+            insert wi;
+        } finally {
+            DeliveryWorkItemTriggerHandler.triggerDisabled = false;
+        }
+        return wi;
+    }
+
+    private static WorkLog__c buildLog(Id wiId, Decimal hours, Date workDate) {
+        return new WorkLog__c(
+            WorkItemLookup__c = wiId,
+            HoursLoggedNumber__c = hours,
+            WorkDateDate__c = workDate,
+            WorkDescriptionTxt__c = 'test log'
+        );
+    }
+
+    @IsTest
+    static void testReturnsTwelveMonthsByDefault() {
+        WorkItem__c root = insertWi('Root', 80, Date.today().addMonths(-2), Date.today().addMonths(2), null);
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.ProjectHoursSummary result =
+            DeliveryHoursAnalyticsController.getMonthlyHoursForProject(root.Id, null);
+        Test.stopTest();
+
+        System.assertNotEquals(null, result, 'Summary must not be null');
+        System.assertEquals(root.Id, result.rootWorkItemId, 'rootWorkItemId matches input');
+        System.assertEquals(12, result.months.size(), 'Default monthsBack=12 returns 12 buckets');
+        System.assertEquals(1, result.descendantCount, 'descendantCount counts root + descendants');
+    }
+
+    @IsTest
+    static void testCustomMonthsBackRespected() {
+        WorkItem__c root = insertWi('Root6', 60, Date.today().addMonths(-2), Date.today().addMonths(2), null);
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.ProjectHoursSummary result =
+            DeliveryHoursAnalyticsController.getMonthlyHoursForProject(root.Id, 6);
+        Test.stopTest();
+
+        System.assertEquals(6, result.months.size(), 'monthsBack=6 returns 6 buckets');
+    }
+
+    @IsTest
+    static void testZeroOrNegativeMonthsBackDefaultsToTwelve() {
+        WorkItem__c root = insertWi('RootZero', 20, null, null, null);
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.ProjectHoursSummary zero =
+            DeliveryHoursAnalyticsController.getMonthlyHoursForProject(root.Id, 0);
+        DeliveryHoursAnalyticsController.ProjectHoursSummary negative =
+            DeliveryHoursAnalyticsController.getMonthlyHoursForProject(root.Id, -5);
+        Test.stopTest();
+
+        System.assertEquals(12, zero.months.size(), '0 falls back to 12');
+        System.assertEquals(12, negative.months.size(), 'negative falls back to 12');
+    }
+
+    @IsTest
+    static void testMonthsBackClampedToMax() {
+        WorkItem__c root = insertWi('RootBig', 1, null, null, null);
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.ProjectHoursSummary result =
+            DeliveryHoursAnalyticsController.getMonthlyHoursForProject(root.Id, 1000);
+        Test.stopTest();
+
+        System.assertEquals(60, result.months.size(), '1000 clamped to MAX_MONTHS=60');
+    }
+
+    @IsTest
+    static void testNullWorkItemIdThrows() {
+        Test.startTest();
+        try {
+            DeliveryHoursAnalyticsController.getMonthlyHoursForProject(null, 12);
+            System.assert(false, 'Expected AuraHandledException for null workItemId');
+        } catch (AuraHandledException expected) {
+            System.assert(true, 'Caught expected exception');
+        }
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void testAggregatesLoggedHoursIntoCorrectMonth() {
+        WorkItem__c root = insertWi('AggRoot', 40, Date.today().addMonths(-1), Date.today().addMonths(1), null);
+        Date thisMonth = Date.today();
+        Date lastMonth = Date.today().addMonths(-1);
+
+        insert new List<WorkLog__c>{
+            buildLog(root.Id, 4, thisMonth),
+            buildLog(root.Id, 2.5, thisMonth),
+            buildLog(root.Id, 6, lastMonth)
+        };
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.ProjectHoursSummary result =
+            DeliveryHoursAnalyticsController.getMonthlyHoursForProject(root.Id, 12);
+        Test.stopTest();
+
+        Map<String, Decimal> byKey = new Map<String, Decimal>();
+        for (DeliveryHoursAnalyticsController.MonthlyHoursDTO row : result.months) {
+            byKey.put(row.year + '-' + row.month, row.hoursLogged);
+        }
+        System.assertEquals(6.5, byKey.get(thisMonth.year() + '-' + thisMonth.month()),
+            'This month should sum to 6.5h');
+        System.assertEquals(6, byKey.get(lastMonth.year() + '-' + lastMonth.month()),
+            'Last month should sum to 6h');
+    }
+
+    @IsTest
+    static void testWalksDescendantsAndSumsAcrossTree() {
+        WorkItem__c root = insertWi('TreeRoot', 100, null, null, null);
+        WorkItem__c child1 = insertWi('Child1', 30, null, null, root.Id);
+        WorkItem__c child2 = insertWi('Child2', 30, null, null, root.Id);
+        WorkItem__c grandchild = insertWi('Grandchild', 20, null, null, child1.Id);
+
+        Date today = Date.today();
+        insert new List<WorkLog__c>{
+            buildLog(root.Id, 1, today),
+            buildLog(child1.Id, 2, today),
+            buildLog(child2.Id, 3, today),
+            buildLog(grandchild.Id, 4, today)
+        };
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.ProjectHoursSummary result =
+            DeliveryHoursAnalyticsController.getMonthlyHoursForProject(root.Id, 12);
+        Test.stopTest();
+
+        System.assertEquals(4, result.descendantCount, 'Tree has root + 2 children + 1 grandchild = 4');
+
+        Decimal thisMonthTotal = 0;
+        for (DeliveryHoursAnalyticsController.MonthlyHoursDTO row : result.months) {
+            if (row.year == today.year() && row.month == today.month()) {
+                thisMonthTotal = row.hoursLogged;
+            }
+        }
+        System.assertEquals(10, thisMonthTotal, 'This month sum across tree = 1+2+3+4 = 10');
+    }
+
+    @IsTest
+    static void testMonthlyTargetWhenEstimateAndDatesPopulated() {
+        Date startDate = Date.newInstance(Date.today().year(), Date.today().month(), 1).addMonths(-1);
+        Date endDate = startDate.addMonths(3).addDays(-1);
+        WorkItem__c root = insertWi('Targeted', 40, startDate, endDate, null);
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.ProjectHoursSummary result =
+            DeliveryHoursAnalyticsController.getMonthlyHoursForProject(root.Id, 12);
+        Test.stopTest();
+
+        System.assertEquals(true, result.hasEstimate, 'hasEstimate true with non-null estimate');
+        // 40h / ~3-month plan span. Expect ~13.33/month.
+        System.assert(result.monthlyTarget > 0, 'monthlyTarget should be > 0');
+        for (DeliveryHoursAnalyticsController.MonthlyHoursDTO row : result.months) {
+            System.assertEquals(result.monthlyTarget, row.monthlyTarget,
+                'Each row should carry the per-month target');
+        }
+    }
+
+    @IsTest
+    static void testNoEstimateMeansZeroTarget() {
+        WorkItem__c root = insertWi('NoEstimate', null, null, null, null);
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.ProjectHoursSummary result =
+            DeliveryHoursAnalyticsController.getMonthlyHoursForProject(root.Id, 12);
+        Test.stopTest();
+
+        System.assertEquals(false, result.hasEstimate, 'hasEstimate false without estimate');
+        System.assertEquals(0, result.monthlyTarget, 'monthlyTarget=0 when no estimate');
+        for (DeliveryHoursAnalyticsController.MonthlyHoursDTO row : result.months) {
+            System.assertEquals(false, row.overTarget,
+                'overTarget should be false when no target');
+        }
+    }
+
+    @IsTest
+    static void testOverTargetFlagFiresWhenHoursExceedTarget() {
+        Date startDate = Date.newInstance(Date.today().year(), Date.today().month(), 1);
+        Date endDate = startDate.addMonths(1).addDays(-1);
+        WorkItem__c root = insertWi('Over', 5, startDate, endDate, null);
+
+        // 5h estimate over 1-month span → 5h/month target. Log 10h.
+        insert buildLog(root.Id, 10, Date.today());
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.ProjectHoursSummary result =
+            DeliveryHoursAnalyticsController.getMonthlyHoursForProject(root.Id, 12);
+        Test.stopTest();
+
+        Boolean foundOver = false;
+        for (DeliveryHoursAnalyticsController.MonthlyHoursDTO row : result.months) {
+            if (row.year == Date.today().year() && row.month == Date.today().month()) {
+                System.assertEquals(true, row.overTarget,
+                    'This month exceeded target — overTarget should be true');
+                foundOver = true;
+            }
+        }
+        System.assert(foundOver, 'Should have located the current month bucket');
+    }
+
+    @IsTest
+    static void testLogsOutsideWindowAreIgnored() {
+        WorkItem__c root = insertWi('Windowed', null, null, null, null);
+        // Log a date 5 years ago — outside the default 12-month window.
+        insert buildLog(root.Id, 99, Date.today().addYears(-5));
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.ProjectHoursSummary result =
+            DeliveryHoursAnalyticsController.getMonthlyHoursForProject(root.Id, 12);
+        Test.stopTest();
+
+        Decimal sum = 0;
+        for (DeliveryHoursAnalyticsController.MonthlyHoursDTO row : result.months) {
+            sum += row.hoursLogged;
+        }
+        System.assertEquals(0, sum, 'Logs outside window must not appear');
+    }
+
+    @IsTest
+    static void testEmptyTreeStillReturnsBuckets() {
+        WorkItem__c root = insertWi('Empty', null, null, null, null);
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.ProjectHoursSummary result =
+            DeliveryHoursAnalyticsController.getMonthlyHoursForProject(root.Id, 6);
+        Test.stopTest();
+
+        System.assertEquals(6, result.months.size(), 'Buckets created even with no logs');
+        for (DeliveryHoursAnalyticsController.MonthlyHoursDTO row : result.months) {
+            System.assertEquals(0, row.hoursLogged, 'No logs → all buckets zero');
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/deliveryProjectMonthlyHours/deliveryProjectMonthlyHours.css
+++ b/force-app/main/default/lwc/deliveryProjectMonthlyHours/deliveryProjectMonthlyHours.css
@@ -1,0 +1,247 @@
+:host {
+    display: block;
+}
+
+.hours-card {
+    background: #ffffff;
+    border-radius: 0.75rem;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    font-size: 0.8125rem;
+}
+
+.hours-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.125rem 1.5rem;
+    border-bottom: 1px solid #e5e7eb;
+    background: linear-gradient(135deg, #f0fdf4 0%, #ecfeff 100%);
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.hours-header-left {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.hours-header-icon {
+    color: #059669;
+}
+
+.hours-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0 0 0.15rem 0;
+}
+
+.hours-subtitle {
+    font-size: 0.75rem;
+    color: #6b7280;
+    margin: 0;
+}
+
+.hours-toggle {
+    background: #ffffff;
+    border: 1px solid #d1d5db;
+    border-radius: 0.375rem;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.75rem;
+    color: #374151;
+    cursor: pointer;
+    font-weight: 500;
+}
+
+.hours-toggle:hover:not(:disabled) {
+    background: #f9fafb;
+    border-color: #9ca3af;
+}
+
+.hours-toggle:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.hours-loading {
+    padding: 2rem;
+    display: flex;
+    justify-content: center;
+}
+
+.hours-error {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 1rem 1.5rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    background: #fef2f2;
+    border: 1px solid #fca5a5;
+    color: #991b1b;
+}
+
+.hours-empty {
+    padding: 3rem 2rem;
+    text-align: center;
+    color: #6b7280;
+}
+
+.hours-empty-icon {
+    color: #d1d5db;
+    margin-bottom: 0.75rem;
+}
+
+.hours-empty-sub {
+    font-size: 0.75rem;
+    color: #9ca3af;
+    margin-top: 0.25rem;
+}
+
+.hours-summary-row {
+    display: flex;
+    gap: 1rem;
+    padding: 0.75rem 1.5rem;
+    flex-wrap: wrap;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.summary-tile {
+    flex: 1 1 7rem;
+    min-width: 6.5rem;
+}
+
+.summary-label {
+    font-size: 0.6875rem;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.15rem;
+}
+
+.summary-value {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #111827;
+}
+
+.summary-variance {
+    font-size: 1.125rem;
+    font-weight: 600;
+}
+
+.summary-variance--under {
+    color: #15803d;
+}
+
+.summary-variance--over {
+    color: #b91c1c;
+}
+
+.hours-body {
+    padding: 1rem 1.25rem 0.25rem;
+}
+
+.hours-svg {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.grid-line {
+    stroke: #e5e7eb;
+    stroke-width: 1;
+    stroke-dasharray: 4 3;
+}
+
+.axis-line {
+    stroke: #9ca3af;
+    stroke-width: 1.5;
+}
+
+.axis-label {
+    font-size: 10px;
+    fill: #6b7280;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.axis-label--y {
+    text-anchor: end;
+    dominant-baseline: middle;
+}
+
+.axis-label--x {
+    text-anchor: middle;
+    dominant-baseline: hanging;
+}
+
+.bar {
+    transition: opacity 0.15s ease;
+}
+
+.bar:hover {
+    opacity: 0.85;
+}
+
+.bar--under {
+    fill: #10b981;
+}
+
+.bar--over {
+    fill: #ef4444;
+}
+
+.target-line {
+    stroke: #6b7280;
+    stroke-width: 1.5;
+    stroke-dasharray: 6 4;
+    pointer-events: none;
+}
+
+.hours-legend {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    padding: 0.75rem 1.25rem;
+    border-top: 1px solid #f3f4f6;
+    flex-wrap: wrap;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.6875rem;
+    color: #6b7280;
+}
+
+.legend-swatch {
+    display: inline-block;
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 2px;
+}
+
+.legend-swatch--under {
+    background: #10b981;
+}
+
+.legend-swatch--over {
+    background: #ef4444;
+}
+
+.legend-line {
+    display: inline-block;
+    width: 1.25rem;
+    height: 3px;
+    border-radius: 2px;
+}
+
+.legend-line--target {
+    background: #6b7280;
+    background-image: linear-gradient(90deg, #6b7280 0 6px, transparent 6px 10px);
+    height: 2px;
+}

--- a/force-app/main/default/lwc/deliveryProjectMonthlyHours/deliveryProjectMonthlyHours.html
+++ b/force-app/main/default/lwc/deliveryProjectMonthlyHours/deliveryProjectMonthlyHours.html
@@ -1,0 +1,134 @@
+<template>
+    <div class="hours-card">
+
+        <div class="hours-header">
+            <div class="hours-header-left">
+                <lightning-icon icon-name="utility:clock" alternative-text="Monthly hours" size="small" class="hours-header-icon"></lightning-icon>
+                <div>
+                    <h2 class="hours-title">Monthly Hours</h2>
+                    <p class="hours-subtitle">Hours logged across this project and its descendants</p>
+                </div>
+            </div>
+            <div class="hours-header-right">
+                <button type="button"
+                        class="hours-toggle"
+                        onclick={handleToggleRange}
+                        disabled={isLoading}>
+                    {toggleLabel}
+                </button>
+            </div>
+        </div>
+
+        <template lwc:if={isLoading}>
+            <div class="hours-loading">
+                <lightning-spinner alternative-text="Loading monthly hours..." size="small"></lightning-spinner>
+            </div>
+        </template>
+
+        <template lwc:if={hasError}>
+            <div class="hours-error">
+                <lightning-icon icon-name="utility:error" size="x-small"></lightning-icon>
+                <span>{errorMessage}</span>
+            </div>
+        </template>
+
+        <template lwc:if={hasData}>
+            <div class="hours-summary-row">
+                <div class="summary-tile">
+                    <div class="summary-label">Logged</div>
+                    <div class="summary-value">{totalLoggedDisplay}h</div>
+                </div>
+                <div class="summary-tile">
+                    <div class="summary-label">Estimated</div>
+                    <div class="summary-value">{totalEstimatedDisplay}h</div>
+                </div>
+                <template lwc:if={hasTarget}>
+                    <div class="summary-tile">
+                        <div class="summary-label">Monthly target</div>
+                        <div class="summary-value">{monthlyTargetDisplay}h</div>
+                    </div>
+                    <div class="summary-tile">
+                        <div class="summary-label">Variance</div>
+                        <div class={varianceClass}>{variancePercent}</div>
+                    </div>
+                </template>
+                <div class="summary-tile">
+                    <div class="summary-label">Items in tree</div>
+                    <div class="summary-value">{descendantCountDisplay}</div>
+                </div>
+            </div>
+
+            <div class="hours-body">
+                <svg xmlns="http://www.w3.org/2000/svg"
+                     viewBox={svgViewBox}
+                     class="hours-svg"
+                     preserveAspectRatio="xMidYMid meet">
+
+                    <template for:each={gridLines} for:item="gl">
+                        <line key={gl.key}
+                              x1={chartLeft} y1={gl.y}
+                              x2={chartRight} y2={gl.y}
+                              class="grid-line"></line>
+                    </template>
+
+                    <template for:each={gridLines} for:item="gl">
+                        <text key={gl.labelKey}
+                              x={yLabelX} y={gl.y}
+                              class="axis-label axis-label--y">{gl.label}</text>
+                    </template>
+
+                    <template for:each={bars} for:item="bar">
+                        <rect key={bar.key}
+                              x={bar.x} y={bar.y}
+                              width={bar.width} height={bar.height}
+                              class={bar.cssClass}>
+                            <title key={bar.tooltipKey}>{bar.tooltip}</title>
+                        </rect>
+                    </template>
+
+                    <template lwc:if={hasTarget}>
+                        <line x1={chartLeft} y1={targetLineY}
+                              x2={chartRight} y2={targetLineY}
+                              class="target-line"></line>
+                    </template>
+
+                    <template for:each={xLabels} for:item="xl">
+                        <text key={xl.key}
+                              x={xl.x} y={xLabelY}
+                              class="axis-label axis-label--x">{xl.label}</text>
+                    </template>
+
+                    <line x1={chartLeft} y1={chartTop}
+                          x2={chartLeft} y2={chartBottom}
+                          class="axis-line"></line>
+                    <line x1={chartLeft} y1={chartBottom}
+                          x2={chartRight} y2={chartBottom}
+                          class="axis-line"></line>
+                </svg>
+            </div>
+
+            <div class="hours-legend">
+                <span class="legend-item">
+                    <span class="legend-swatch legend-swatch--under"></span>At/under target
+                </span>
+                <span class="legend-item">
+                    <span class="legend-swatch legend-swatch--over"></span>Over target
+                </span>
+                <template lwc:if={hasTarget}>
+                    <span class="legend-item">
+                        <span class="legend-line legend-line--target"></span>Monthly target
+                    </span>
+                </template>
+            </div>
+        </template>
+
+        <template lwc:if={isEmpty}>
+            <div class="hours-empty">
+                <lightning-icon icon-name="utility:clock" size="medium" class="hours-empty-icon"></lightning-icon>
+                <p>No hours logged in this window</p>
+                <p class="hours-empty-sub">Log work against this item or any of its descendants to populate this chart.</p>
+            </div>
+        </template>
+
+    </div>
+</template>

--- a/force-app/main/default/lwc/deliveryProjectMonthlyHours/deliveryProjectMonthlyHours.js
+++ b/force-app/main/default/lwc/deliveryProjectMonthlyHours/deliveryProjectMonthlyHours.js
@@ -1,0 +1,309 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @author Cloud Nimbus LLC
+ */
+import { LightningElement, api, wire, track } from "lwc";
+import getMonthlyHoursForProject from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHoursAnalyticsController.getMonthlyHoursForProject";
+
+const SVG_WIDTH = 720;
+const SVG_HEIGHT = 320;
+const PADDING_TOP = 24;
+const PADDING_RIGHT = 24;
+const PADDING_BOTTOM = 48;
+const PADDING_LEFT = 56;
+const GRID_LINE_COUNT = 5;
+const BAR_GAP_RATIO = 0.35;
+const DEFAULT_MONTHS_BACK = 12;
+const ALL_TIME_MONTHS_BACK = 60;
+
+export default class DeliveryProjectMonthlyHours extends LightningElement {
+    @api recordId;
+    @track summary;
+    @track errorMessage = "";
+    isLoading = true;
+    showAllTime = false;
+
+    @wire(getMonthlyHoursForProject, {
+        workItemId: "$recordId",
+        monthsBack: "$_monthsBack"
+    })
+    wiredHours({ data, error }) {
+        this.isLoading = false;
+        if (data) {
+            this.summary = data;
+            this.errorMessage = "";
+        } else if (error) {
+            this.errorMessage = error.body ? error.body.message : error.message;
+            this.summary = null;
+        }
+    }
+
+    get _monthsBack() {
+        return this.showAllTime ? ALL_TIME_MONTHS_BACK : DEFAULT_MONTHS_BACK;
+    }
+
+    // ── State flags ──────────────────────────────────────────────
+
+    get hasError() {
+        return !this.isLoading && this.errorMessage;
+    }
+
+    get isEmpty() {
+        if (this.isLoading || this.errorMessage || !this.summary) {
+            return false;
+        }
+        const months = this.summary.months || [];
+        return months.every((m) => !m.hoursLogged);
+    }
+
+    get hasData() {
+        return !this.isLoading && !this.errorMessage && !this.isEmpty && this.summary;
+    }
+
+    get hasTarget() {
+        return this.summary && this.summary.hasEstimate && this.summary.monthlyTarget > 0;
+    }
+
+    get toggleLabel() {
+        return this.showAllTime ? "Last 12 months" : "All time";
+    }
+
+    // ── Summary headline numbers ─────────────────────────────────
+
+    get totalEstimatedDisplay() {
+        return this.summary ? this._formatHours(this.summary.totalEstimatedHours) : "0";
+    }
+
+    get totalLoggedDisplay() {
+        return this.summary ? this._formatHours(this.summary.totalLoggedHours) : "0";
+    }
+
+    get monthlyTargetDisplay() {
+        return this.summary ? this._formatHours(this.summary.monthlyTarget) : "0";
+    }
+
+    get descendantCountDisplay() {
+        return this.summary ? this.summary.descendantCount : 0;
+    }
+
+    get isOverBudget() {
+        if (!this.summary || !this.summary.hasEstimate) {
+            return false;
+        }
+        return this.summary.totalLoggedHours > this.summary.totalEstimatedHours;
+    }
+
+    get variancePercent() {
+        if (!this.summary || !this.summary.hasEstimate || !this.summary.totalEstimatedHours) {
+            return "";
+        }
+        const delta = this.summary.totalLoggedHours - this.summary.totalEstimatedHours;
+        const pct = (delta / this.summary.totalEstimatedHours) * 100;
+        const sign = pct >= 0 ? "+" : "";
+        return `${sign}${pct.toFixed(0)}%`;
+    }
+
+    get varianceClass() {
+        return this.isOverBudget
+            ? "summary-variance summary-variance--over"
+            : "summary-variance summary-variance--under";
+    }
+
+    // ── SVG geometry ─────────────────────────────────────────────
+
+    get svgViewBox() {
+        return `0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`;
+    }
+
+    get chartLeft() {
+        return PADDING_LEFT;
+    }
+
+    get chartRight() {
+        return SVG_WIDTH - PADDING_RIGHT;
+    }
+
+    get chartTop() {
+        return PADDING_TOP;
+    }
+
+    get chartBottom() {
+        return SVG_HEIGHT - PADDING_BOTTOM;
+    }
+
+    get yLabelX() {
+        return PADDING_LEFT - 8;
+    }
+
+    get xLabelY() {
+        return SVG_HEIGHT - PADDING_BOTTOM + 18;
+    }
+
+    get _chartWidth() {
+        return this.chartRight - this.chartLeft;
+    }
+
+    get _chartHeight() {
+        return this.chartBottom - this.chartTop;
+    }
+
+    get _months() {
+        return (this.summary && this.summary.months) || [];
+    }
+
+    get _maxValue() {
+        let max = 0;
+        for (const row of this._months) {
+            if (row.hoursLogged > max) {
+                max = row.hoursLogged;
+            }
+        }
+        if (this.hasTarget && this.summary.monthlyTarget > max) {
+            max = this.summary.monthlyTarget;
+        }
+        return max > 0 ? max : 1;
+    }
+
+    get _niceMax() {
+        const raw = this._maxValue;
+        const magnitude = Math.pow(10, Math.floor(Math.log10(raw || 1)));
+        const normalized = raw / magnitude;
+        let nice;
+        if (normalized <= 1) {
+            nice = 1;
+        } else if (normalized <= 2) {
+            nice = 2;
+        } else if (normalized <= 5) {
+            nice = 5;
+        } else {
+            nice = 10;
+        }
+        return nice * magnitude;
+    }
+
+    _yForValue(value) {
+        const niceMax = this._niceMax;
+        if (niceMax === 0) {
+            return this.chartBottom;
+        }
+        return this.chartBottom - (value / niceMax) * this._chartHeight;
+    }
+
+    get _slotWidth() {
+        const count = this._months.length;
+        return count > 0 ? this._chartWidth / count : 0;
+    }
+
+    get _barWidth() {
+        return this._slotWidth * (1 - BAR_GAP_RATIO);
+    }
+
+    get _barXOffset() {
+        return (this._slotWidth - this._barWidth) / 2;
+    }
+
+    // ── Bars ─────────────────────────────────────────────────────
+
+    get bars() {
+        const months = this._months;
+        const out = [];
+        for (let i = 0; i < months.length; i++) {
+            const row = months[i];
+            const slotX = this.chartLeft + i * this._slotWidth;
+            const x = slotX + this._barXOffset;
+            const yTop = this._yForValue(row.hoursLogged);
+            const height = this.chartBottom - yTop;
+            out.push({
+                key: `bar-${i}`,
+                x,
+                y: yTop,
+                width: this._barWidth,
+                height: height > 0 ? height : 0,
+                cssClass: row.overTarget ? "bar bar--over" : "bar bar--under",
+                tooltipKey: `tip-${i}`,
+                tooltip: this._buildTooltip(row)
+            });
+        }
+        return out;
+    }
+
+    _buildTooltip(row) {
+        const parts = [`${row.monthLabel}: ${this._formatHours(row.hoursLogged)}h`];
+        if (row.monthlyTarget > 0) {
+            parts.push(`target ${this._formatHours(row.monthlyTarget)}h`);
+            const variance = row.hoursLogged - row.monthlyTarget;
+            const sign = variance >= 0 ? "+" : "";
+            parts.push(`${sign}${this._formatHours(variance)}h`);
+        }
+        return parts.join(" · ");
+    }
+
+    // ── Target line ──────────────────────────────────────────────
+
+    get targetLineY() {
+        return this.hasTarget ? this._yForValue(this.summary.monthlyTarget) : 0;
+    }
+
+    // ── Grid + labels ────────────────────────────────────────────
+
+    get gridLines() {
+        const lines = [];
+        const niceMax = this._niceMax;
+        for (let i = 0; i <= GRID_LINE_COUNT; i++) {
+            const value = (niceMax / GRID_LINE_COUNT) * i;
+            const y = this._yForValue(value);
+            lines.push({
+                key: `grid-${i}`,
+                labelKey: `grid-label-${i}`,
+                y,
+                label: this._formatHours(value)
+            });
+        }
+        return lines;
+    }
+
+    get xLabels() {
+        const months = this._months;
+        if (months.length === 0) {
+            return [];
+        }
+        const step = months.length > 12 ? Math.ceil(months.length / 12) : 1;
+        const labels = [];
+        for (let i = 0; i < months.length; i += step) {
+            const slotX = this.chartLeft + i * this._slotWidth;
+            labels.push({
+                key: `x-${i}`,
+                x: slotX + this._slotWidth / 2,
+                label: months[i].monthLabel
+            });
+        }
+        return labels;
+    }
+
+    // ── Handlers ─────────────────────────────────────────────────
+
+    handleToggleRange() {
+        this.showAllTime = !this.showAllTime;
+        this.isLoading = true;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────
+
+    _formatHours(value) {
+        if (value === null || value === undefined) {
+            return "0";
+        }
+        const num = Number(value);
+        if (!Number.isFinite(num)) {
+            return "0";
+        }
+        if (Math.abs(num) >= 100) {
+            return num.toFixed(0);
+        }
+        if (Math.abs(num) >= 10) {
+            return num.toFixed(1);
+        }
+        return num.toFixed(2);
+    }
+}

--- a/force-app/main/default/lwc/deliveryProjectMonthlyHours/deliveryProjectMonthlyHours.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryProjectMonthlyHours/deliveryProjectMonthlyHours.js-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordPage</target>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordPage">
+            <objects>
+                <object>WorkItem__c</object>
+            </objects>
+        </targetConfig>
+    </targetConfigs>
+    <masterLabel>Delivery Project Monthly Hours</masterLabel>
+    <description>SVG bar chart of monthly hours logged across a WorkItem tree, with a linear-amortized monthly target overlay when an estimate + start/end dates exist.</description>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary

- **New** `DeliveryHoursAnalyticsController.getMonthlyHoursForProject(workItemId, monthsBack)` — walks the WI tree via `ParentWorkItemLookup__c` (depth-capped at 10), aggregates `WorkLog__c.HoursLoggedNumber__c` grouped by `CALENDAR_MONTH(WorkDateDate__c)`, returns a `ProjectHoursSummary` with monthly buckets + a linear-amortized per-month target derived from `EstimatedHoursNumber__c` + `EstimatedStartDevDate__c` / `EstimatedEndDevDate__c`.
- **New** `deliveryProjectMonthlyHours` LWC — SVG bar chart on the `WorkItem__c` record page. Green bars at/under target, red bars over, dashed target line when computable, last-12-months / all-time toggle, headline tiles for logged/estimated/target/variance.
- **Tests** — 10 cases covering default window, custom/zero/negative/clamped `monthsBack`, descendant tree walk + cross-tree aggregation, target computation, over-target flag, out-of-window logs ignored, empty-tree edge case.

Pairs with Phase 1 dashboard tiles (#755). Phase 2B (EVM pills) and Phase 3 (forecast burn-up) will build on the same controller.

## Test plan

- [ ] feature-test (namespaced scratch) passes
- [ ] apex-scan (PMD) clean
- [ ] Post-install: drop the LWC on the `WorkItem__c` record page in MF-Prod, point at a real project, see monthly bars
- [ ] Toggle "All time" — extends to 60 months
- [ ] WI tree with logs at child + grandchild — aggregated total appears in summary tile
- [ ] WI with `EstimatedHoursNumber__c` + start/end dates — target line + variance pill render
- [ ] WI with no estimate — bars only, no target line, no variance pill

## Notes

- Apex compiled cleanly against `WorkItem__c.EstimatedHoursNumber__c`, `EstimatedStartDevDate__c`, `EstimatedEndDevDate__c`, `TotalLoggedHoursSum__c`, `ParentWorkItemLookup__c`, `WorkLog__c.HoursLoggedNumber__c`, `WorkLog__c.WorkDateDate__c`, `WorkLog__c.WorkItemLookup__c` — all verified present in `force-app/main/default/objects/`.
- Test class brackets all `WorkItem__c` inserts with `DeliveryWorkItemTriggerHandler.triggerDisabled = true` per the PR #764 pattern — keeps tests focused on analytics, not auto-WR / sync side effects.
- LWC mounts on `lightning__RecordPage` for `WorkItem__c`, plus `lightning__AppPage` / `lightning__HomePage` for dashboard composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)