### PR TITLE
feat(forecast): Phase 3 — velocity-based burn-up + projection

### DIFF
--- a/force-app/main/default/classes/DeliveryForecastService.cls
+++ b/force-app/main/default/classes/DeliveryForecastService.cls
@@ -1,0 +1,347 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Velocity-based forecast service for a WorkItem__c tree. Reads the
+ *              tree's WorkLog__c history, computes rolling N-week velocity, and
+ *              projects the date at which cumulative actual hours will cross the
+ *              tree's total EstimatedHoursNumber budget. Confidence bands are
+ *              derived from ±1 std-dev of weekly velocity over the rolling window.
+ *
+ *              Used by deliveryProjectBurnUpChart LWC (record-page panel).
+ *              Phase 3 of the hours/forecast/auto-schedule plan.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexDoc,PMD.AvoidGlobalModifier,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.OperationWithLimitsInLoop')
+global with sharing class DeliveryForecastService {
+
+    /** @description Rolling window size in weeks for velocity calculation. */
+    private static final Integer VELOCITY_WINDOW_WEEKS = 4;
+
+    /** @description Hard cap on tree-walk depth (defensive against cycles). */
+    private static final Integer MAX_TREE_DEPTH = 10;
+
+    /** @description Hard cap on the number of weekly buckets returned for charting. */
+    private static final Integer MAX_HISTORY_WEEKS = 104;
+
+    /** @description Number of days in a week. */
+    private static final Integer DAYS_PER_WEEK = 7;
+
+    /** @description Forecast headline numbers returned to the LWC. */
+    global class ProjectForecast {
+        @AuraEnabled global Id rootWorkItemId;
+        @AuraEnabled global Decimal totalEstimatedHours;
+        @AuraEnabled global Decimal totalLoggedHours;
+        @AuraEnabled global Decimal currentVelocityHoursPerWeek;
+        @AuraEnabled global Decimal velocityStdDev;
+        @AuraEnabled global Decimal projectedFinalHours;
+        @AuraEnabled global Date projectedCompletionDate;
+        @AuraEnabled global Date confidenceLowDate;
+        @AuraEnabled global Date confidenceHighDate;
+        @AuraEnabled global Decimal weeksRemaining;
+        @AuraEnabled global Boolean isOverBudgetTrajectory;
+        @AuraEnabled global Boolean hasEstimate;
+        @AuraEnabled global Boolean hasVelocity;
+        @AuraEnabled global Date earliestStart;
+        @AuraEnabled global Date latestEnd;
+        @AuraEnabled global List<WeeklyPoint> history;
+        @AuraEnabled global List<WeeklyPoint> projection;
+    }
+
+    /** @description Single weekly bucket on the burn-up chart. */
+    global class WeeklyPoint {
+        @AuraEnabled global String weekStart;
+        @AuraEnabled global Decimal hoursThisWeek;
+        @AuraEnabled global Decimal cumulativeHours;
+        @AuraEnabled global Decimal scopeHours;
+    }
+
+    /**
+     * @description Computes the velocity-based forecast for the WI tree rooted at
+     *              workItemId. Walks descendants via ParentWorkItemLookup__c (depth
+     *              capped at MAX_TREE_DEPTH).
+     * @param workItemId Root WorkItem Id. Required.
+     * @return ProjectForecast populated with history + projection + headline numbers.
+     */
+    @AuraEnabled(cacheable=true)
+    global static ProjectForecast calculateProjectForecast(Id workItemId) {
+        try {
+            if (workItemId == null) {
+                throw new AuraHandledException('workItemId is required.');
+            }
+
+            Set<Id> treeIds = walkDescendants(workItemId);
+            List<WorkItem__c> tree = [
+                SELECT Id, EstimatedHoursNumber__c, TotalLoggedHoursSum__c,
+                       EstimatedStartDevDate__c, EstimatedEndDevDate__c
+                FROM WorkItem__c
+                WHERE Id IN :treeIds
+                WITH SYSTEM_MODE
+                LIMIT 5000
+            ];
+
+            ProjectForecast f = new ProjectForecast();
+            f.rootWorkItemId = workItemId;
+            f.totalEstimatedHours = 0;
+            f.totalLoggedHours = 0;
+            f.earliestStart = null;
+            f.latestEnd = null;
+
+            for (WorkItem__c wi : tree) {
+                if (wi.EstimatedHoursNumber__c != null) {
+                    f.totalEstimatedHours += wi.EstimatedHoursNumber__c;
+                }
+                if (wi.TotalLoggedHoursSum__c != null) {
+                    f.totalLoggedHours += wi.TotalLoggedHoursSum__c;
+                }
+                if (wi.EstimatedStartDevDate__c != null
+                    && (f.earliestStart == null || wi.EstimatedStartDevDate__c < f.earliestStart)) {
+                    f.earliestStart = wi.EstimatedStartDevDate__c;
+                }
+                if (wi.EstimatedEndDevDate__c != null
+                    && (f.latestEnd == null || wi.EstimatedEndDevDate__c > f.latestEnd)) {
+                    f.latestEnd = wi.EstimatedEndDevDate__c;
+                }
+            }
+            f.hasEstimate = f.totalEstimatedHours > 0;
+
+            f.history = buildWeeklyHistory(treeIds, f);
+
+            populateVelocityStats(f);
+
+            populateProjection(f);
+
+            return f;
+        } catch (AuraHandledException ahe) {
+            throw ahe;
+        } catch (Exception e) {
+            AuraHandledException ahe = new AuraHandledException(e.getMessage());
+            ahe.setMessage(e.getMessage());
+            throw ahe;
+        }
+    }
+
+    /**
+     * @description BFS walk over ParentWorkItemLookup__c. Capped at MAX_TREE_DEPTH.
+     */
+    /**
+     * @description Rounds a Decimal up to the nearest whole number, clamping to ≥ 1.
+     *              Wraps the round-then-cast dance and keeps the projection math readable.
+     */
+    private static Integer clampPositive(Decimal value) {
+        if (value == null || value <= 1) {
+            return 1;
+        }
+        Long rounded = value.round(System.RoundingMode.HALF_UP);
+        if (rounded < 1) {
+            return 1;
+        }
+        if (rounded > 10000) {
+            return 10000;
+        }
+        return rounded.intValue();
+    }
+
+    private static Set<Id> walkDescendants(Id rootId) {
+        Set<Id> collected = new Set<Id>{ rootId };
+        Set<Id> frontier = new Set<Id>{ rootId };
+        for (Integer depth = 0; depth < MAX_TREE_DEPTH && !frontier.isEmpty(); depth++) {
+            Set<Id> next = new Set<Id>();
+            for (WorkItem__c child : [
+                SELECT Id
+                FROM WorkItem__c
+                WHERE ParentWorkItemLookup__c IN :frontier
+                WITH SYSTEM_MODE
+                LIMIT 5000
+            ]) {
+                if (!collected.contains(child.Id)) {
+                    collected.add(child.Id);
+                    next.add(child.Id);
+                }
+            }
+            frontier = next;
+        }
+        return collected;
+    }
+
+    /**
+     * @description Aggregates WorkLog rows into weekly buckets (Mondays). Window
+     *              extends from the earliest log to today. Returns empty list when
+     *              the tree has no logs.
+     */
+    private static List<WeeklyPoint> buildWeeklyHistory(Set<Id> treeIds, ProjectForecast f) {
+        if (treeIds.isEmpty()) {
+            return new List<WeeklyPoint>();
+        }
+        List<AggregateResult> rows = [
+            SELECT CALENDAR_YEAR(WorkDateDate__c) y,
+                   WEEK_IN_YEAR(WorkDateDate__c) w,
+                   MIN(WorkDateDate__c) minDate,
+                   SUM(HoursLoggedNumber__c) total
+            FROM WorkLog__c
+            WHERE WorkItemLookup__c IN :treeIds
+            WITH SYSTEM_MODE
+            GROUP BY CALENDAR_YEAR(WorkDateDate__c), WEEK_IN_YEAR(WorkDateDate__c)
+            ORDER BY CALENDAR_YEAR(WorkDateDate__c), WEEK_IN_YEAR(WorkDateDate__c)
+            LIMIT 5000
+        ];
+
+        if (rows.isEmpty()) {
+            return new List<WeeklyPoint>();
+        }
+
+        Map<Date, Decimal> hoursByWeek = new Map<Date, Decimal>();
+        Date earliestWeek = null;
+        for (AggregateResult ar : rows) {
+            Date minDate = (Date) ar.get('minDate');
+            if (minDate == null) {
+                continue;
+            }
+            Date weekStart = minDate.toStartOfWeek();
+            Decimal total = (Decimal) ar.get('total');
+            if (total == null) {
+                total = 0;
+            }
+            Decimal existing = hoursByWeek.containsKey(weekStart) ? hoursByWeek.get(weekStart) : 0;
+            hoursByWeek.put(weekStart, existing + total);
+            if (earliestWeek == null || weekStart < earliestWeek) {
+                earliestWeek = weekStart;
+            }
+        }
+
+        Date todayWeek = Date.today().toStartOfWeek();
+        List<WeeklyPoint> out = new List<WeeklyPoint>();
+        Decimal cumulative = 0;
+        Date cursor = earliestWeek;
+        Integer guard = 0;
+        while (cursor <= todayWeek && guard < MAX_HISTORY_WEEKS) {
+            Decimal weeklyHours = hoursByWeek.containsKey(cursor) ? hoursByWeek.get(cursor) : 0;
+            cumulative += weeklyHours;
+            WeeklyPoint p = new WeeklyPoint();
+            p.weekStart = String.valueOf(cursor);
+            p.hoursThisWeek = weeklyHours;
+            p.cumulativeHours = cumulative;
+            p.scopeHours = f.totalEstimatedHours;
+            out.add(p);
+            cursor = cursor.addDays(DAYS_PER_WEEK);
+            guard++;
+        }
+        return out;
+    }
+
+    /**
+     * @description Computes rolling-window mean + std-dev velocity. Stores into f.
+     *              When history < 2 weeks, velocity is 0 and hasVelocity is false.
+     */
+    private static void populateVelocityStats(ProjectForecast f) {
+        f.currentVelocityHoursPerWeek = 0;
+        f.velocityStdDev = 0;
+        f.hasVelocity = false;
+        if (f.history == null || f.history.isEmpty()) {
+            return;
+        }
+
+        Integer windowSize = Math.min(VELOCITY_WINDOW_WEEKS, f.history.size());
+        if (windowSize < 2) {
+            // Single week of data — use it as a point estimate but don't claim confidence.
+            f.currentVelocityHoursPerWeek = f.history[f.history.size() - 1].hoursThisWeek;
+            return;
+        }
+
+        Decimal sum = 0;
+        Integer startIdx = f.history.size() - windowSize;
+        for (Integer i = startIdx; i < f.history.size(); i++) {
+            sum += f.history[i].hoursThisWeek;
+        }
+        Decimal mean = (sum / windowSize).setScale(3, System.RoundingMode.HALF_UP);
+
+        Decimal sumSquaredDeviations = 0;
+        for (Integer i = startIdx; i < f.history.size(); i++) {
+            Decimal delta = f.history[i].hoursThisWeek - mean;
+            sumSquaredDeviations += delta * delta;
+        }
+        Decimal variance = sumSquaredDeviations / windowSize;
+        Decimal stdDev = Decimal.valueOf(Math.sqrt(variance.doubleValue())).setScale(3, System.RoundingMode.HALF_UP);
+
+        f.currentVelocityHoursPerWeek = mean;
+        f.velocityStdDev = stdDev;
+        f.hasVelocity = mean > 0;
+    }
+
+    /**
+     * @description Extrapolates the cumulative actual line at velocity slope to the
+     *              scope intersection. Populates projectedFinalHours, weeksRemaining,
+     *              projectedCompletionDate, confidence band dates, and the projection
+     *              list (week-by-week future buckets).
+     */
+    private static void populateProjection(ProjectForecast f) {
+        f.projection = new List<WeeklyPoint>();
+        f.projectedFinalHours = f.totalLoggedHours;
+        f.weeksRemaining = 0;
+        f.projectedCompletionDate = null;
+        f.confidenceLowDate = null;
+        f.confidenceHighDate = null;
+        f.isOverBudgetTrajectory = false;
+
+        if (!f.hasEstimate || !f.hasVelocity || f.history.isEmpty()) {
+            return;
+        }
+
+        Decimal remainingScope = f.totalEstimatedHours - f.totalLoggedHours;
+        if (remainingScope <= 0) {
+            // Already at or past scope — completed (or overshot).
+            f.weeksRemaining = 0;
+            f.projectedCompletionDate = Date.today();
+            f.projectedFinalHours = f.totalLoggedHours;
+            f.isOverBudgetTrajectory = f.totalLoggedHours > f.totalEstimatedHours;
+            return;
+        }
+
+        Decimal weeksToFinishMean = remainingScope / f.currentVelocityHoursPerWeek;
+        f.weeksRemaining = weeksToFinishMean.setScale(2, System.RoundingMode.HALF_UP);
+
+        Integer weeksMean = clampPositive(weeksToFinishMean);
+        f.projectedCompletionDate = Date.today().toStartOfWeek().addDays(weeksMean * DAYS_PER_WEEK);
+
+        Decimal velocityFloor = 0.01;
+        Decimal lowVelocity = f.currentVelocityHoursPerWeek - f.velocityStdDev;
+        if (lowVelocity < velocityFloor) {
+            lowVelocity = velocityFloor;
+        }
+        Decimal highVelocity = f.currentVelocityHoursPerWeek + f.velocityStdDev;
+        if (highVelocity < velocityFloor) {
+            highVelocity = velocityFloor;
+        }
+        // Lower velocity → longer to finish → later confidenceHighDate.
+        Integer weeksHigh = clampPositive(remainingScope / lowVelocity);
+        Integer weeksLow = clampPositive(remainingScope / highVelocity);
+        f.confidenceLowDate = Date.today().toStartOfWeek().addDays(weeksLow * DAYS_PER_WEEK);
+        f.confidenceHighDate = Date.today().toStartOfWeek().addDays(weeksHigh * DAYS_PER_WEEK);
+
+        f.projectedFinalHours = f.totalLoggedHours + remainingScope;
+
+        // Over-budget if the project's planned end date is BEFORE the velocity-extrapolated
+        // completion date — i.e., we'll run past the deadline at current pace.
+        if (f.latestEnd != null && f.projectedCompletionDate > f.latestEnd) {
+            f.isOverBudgetTrajectory = true;
+        }
+
+        // Build week-by-week projection points so the LWC can render the dashed line.
+        Decimal cumulative = f.totalLoggedHours;
+        Date cursor = Date.today().toStartOfWeek().addDays(DAYS_PER_WEEK);
+        Integer guard = 0;
+        while (cumulative < f.totalEstimatedHours && guard < MAX_HISTORY_WEEKS) {
+            cumulative += f.currentVelocityHoursPerWeek;
+            if (cumulative > f.totalEstimatedHours) {
+                cumulative = f.totalEstimatedHours;
+            }
+            WeeklyPoint p = new WeeklyPoint();
+            p.weekStart = String.valueOf(cursor);
+            p.hoursThisWeek = f.currentVelocityHoursPerWeek;
+            p.cumulativeHours = cumulative;
+            p.scopeHours = f.totalEstimatedHours;
+            f.projection.add(p);
+            cursor = cursor.addDays(DAYS_PER_WEEK);
+            guard++;
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryForecastService.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryForecastService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryForecastServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryForecastServiceTest.cls
@@ -1,0 +1,218 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Unit tests for DeliveryForecastService. Verifies tree walk,
+ *              weekly history assembly, rolling-window velocity, projection
+ *              extrapolation, confidence band, and edge cases (no estimate,
+ *              no logs, already over scope, single-week history).
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexDoc,PMD.ExcessiveParameterList')
+@IsTest
+private class DeliveryForecastServiceTest {
+
+    private static WorkItem__c insertWi(String briefDesc, Decimal estimate, Date startDate, Date endDate, Id parentId) {
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c = briefDesc,
+            EstimatedHoursNumber__c = estimate,
+            EstimatedStartDevDate__c = startDate,
+            EstimatedEndDevDate__c = endDate,
+            ParentWorkItemLookup__c = parentId,
+            ActivatedDateTime__c = Datetime.now(),
+            StatusPk__c = 'Active'
+        );
+        DeliveryWorkItemTriggerHandler.triggerDisabled = true;
+        try {
+            insert wi;
+        } finally {
+            DeliveryWorkItemTriggerHandler.triggerDisabled = false;
+        }
+        return wi;
+    }
+
+    private static WorkLog__c buildLog(Id wiId, Decimal hours, Date workDate) {
+        return new WorkLog__c(
+            WorkItemLookup__c = wiId,
+            HoursLoggedNumber__c = hours,
+            WorkDateDate__c = workDate,
+            WorkDescriptionTxt__c = 'forecast test log'
+        );
+    }
+
+    @IsTest
+    static void testNullWorkItemIdThrows() {
+        Test.startTest();
+        try {
+            DeliveryForecastService.calculateProjectForecast(null);
+            System.assert(false, 'Expected AuraHandledException');
+        } catch (AuraHandledException expected) {
+            System.assert(true, 'Caught expected exception');
+        }
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void testEmptyTreeReturnsEmptyForecast() {
+        WorkItem__c root = insertWi('NoLogs', 40, Date.today(), Date.today().addDays(28), null);
+
+        Test.startTest();
+        DeliveryForecastService.ProjectForecast f =
+            DeliveryForecastService.calculateProjectForecast(root.Id);
+        Test.stopTest();
+
+        System.assertEquals(root.Id, f.rootWorkItemId, 'rootWorkItemId echoed');
+        System.assertEquals(0, f.totalLoggedHours, 'No hours logged');
+        System.assertEquals(40, f.totalEstimatedHours, 'Estimate echoed');
+        System.assertEquals(true, f.hasEstimate, 'hasEstimate true');
+        System.assertEquals(false, f.hasVelocity, 'hasVelocity false with no logs');
+        System.assertEquals(null, f.projectedCompletionDate, 'No projection without velocity');
+        System.assertEquals(0, f.history.size(), 'history empty');
+        System.assertEquals(0, f.projection.size(), 'projection empty');
+    }
+
+    @IsTest
+    static void testTotalLoggedSumsAcrossTree() {
+        WorkItem__c root = insertWi('TreeRoot', 100, null, null, null);
+        WorkItem__c childA = insertWi('ChildA', 30, null, null, root.Id);
+        WorkItem__c childB = insertWi('ChildB', 30, null, null, root.Id);
+
+        insert new List<WorkLog__c>{
+            buildLog(root.Id, 5, Date.today().addDays(-14)),
+            buildLog(childA.Id, 7, Date.today().addDays(-7)),
+            buildLog(childB.Id, 3, Date.today())
+        };
+
+        Test.startTest();
+        DeliveryForecastService.ProjectForecast f =
+            DeliveryForecastService.calculateProjectForecast(root.Id);
+        Test.stopTest();
+
+        System.assert(f.history.size() >= 1, 'history populated');
+        Decimal cumulativeAtEnd = f.history[f.history.size() - 1].cumulativeHours;
+        System.assertEquals(15, cumulativeAtEnd, 'Cumulative across tree = 5+7+3');
+    }
+
+    @IsTest
+    static void testVelocityComputedFromRollingWindow() {
+        WorkItem__c root = insertWi('Velocity', 200, Date.today().addDays(-28), Date.today().addDays(60), null);
+
+        // 4 weeks of logs at 10h each → velocity = 10h/wk, stddev = 0
+        insert new List<WorkLog__c>{
+            buildLog(root.Id, 10, Date.today().addDays(-28)),
+            buildLog(root.Id, 10, Date.today().addDays(-21)),
+            buildLog(root.Id, 10, Date.today().addDays(-14)),
+            buildLog(root.Id, 10, Date.today().addDays(-7))
+        };
+
+        Test.startTest();
+        DeliveryForecastService.ProjectForecast f =
+            DeliveryForecastService.calculateProjectForecast(root.Id);
+        Test.stopTest();
+
+        System.assertEquals(true, f.hasVelocity, 'hasVelocity true with ≥2 weeks');
+        System.assertEquals(10, f.currentVelocityHoursPerWeek, 'Velocity = 10h/wk over flat window');
+        System.assertEquals(0, f.velocityStdDev, 'StdDev = 0 over flat window');
+        System.assertNotEquals(null, f.projectedCompletionDate, 'Projection populated');
+        System.assertNotEquals(null, f.confidenceLowDate, 'Confidence band populated');
+        System.assertNotEquals(null, f.confidenceHighDate, 'Confidence band populated');
+    }
+
+    @IsTest
+    static void testProjectionExtendsPastTodayWhenScopeRemains() {
+        WorkItem__c root = insertWi('Project', 100, Date.today().addDays(-28), Date.today().addDays(60), null);
+
+        // Log 40h over 4 weeks at 10h/wk. 60h remaining → 6 weeks to finish.
+        insert new List<WorkLog__c>{
+            buildLog(root.Id, 10, Date.today().addDays(-28)),
+            buildLog(root.Id, 10, Date.today().addDays(-21)),
+            buildLog(root.Id, 10, Date.today().addDays(-14)),
+            buildLog(root.Id, 10, Date.today().addDays(-7))
+        };
+
+        Test.startTest();
+        DeliveryForecastService.ProjectForecast f =
+            DeliveryForecastService.calculateProjectForecast(root.Id);
+        Test.stopTest();
+
+        System.assert(f.projection.size() > 0, 'Projection has future weeks');
+        System.assertEquals(100, f.projectedFinalHours, 'Projected final = scope when on track');
+        System.assert(f.projectedCompletionDate > Date.today(), 'Completion in the future');
+    }
+
+    @IsTest
+    static void testOverBudgetTrajectoryWhenPastDeadline() {
+        Date deadline = Date.today().addDays(7);
+        WorkItem__c root = insertWi('TightDeadline', 200, Date.today().addDays(-28), deadline, null);
+
+        // 4 weeks at 10h/wk → 10h/wk velocity. Remaining 160h would take 16 weeks.
+        // Deadline is 1 week from today. → over-budget trajectory.
+        insert new List<WorkLog__c>{
+            buildLog(root.Id, 10, Date.today().addDays(-28)),
+            buildLog(root.Id, 10, Date.today().addDays(-21)),
+            buildLog(root.Id, 10, Date.today().addDays(-14)),
+            buildLog(root.Id, 10, Date.today().addDays(-7))
+        };
+
+        Test.startTest();
+        DeliveryForecastService.ProjectForecast f =
+            DeliveryForecastService.calculateProjectForecast(root.Id);
+        Test.stopTest();
+
+        System.assertEquals(true, f.isOverBudgetTrajectory,
+            'Velocity slips past deadline → isOverBudgetTrajectory true');
+    }
+
+    @IsTest
+    static void testAlreadyAtScopeProducesEmptyProjection() {
+        WorkItem__c root = insertWi('Done', 20, Date.today().addDays(-14), Date.today().addDays(-1), null);
+        insert new List<WorkLog__c>{
+            buildLog(root.Id, 10, Date.today().addDays(-14)),
+            buildLog(root.Id, 10, Date.today().addDays(-7))
+        };
+
+        Test.startTest();
+        DeliveryForecastService.ProjectForecast f =
+            DeliveryForecastService.calculateProjectForecast(root.Id);
+        Test.stopTest();
+
+        System.assertEquals(0, f.weeksRemaining, 'weeksRemaining=0 when scope reached');
+        System.assertEquals(Date.today(), f.projectedCompletionDate, 'Completion = today when scope reached');
+        System.assertEquals(false, f.isOverBudgetTrajectory, 'Not over budget — exactly on scope');
+    }
+
+    @IsTest
+    static void testNoEstimateMeansNoProjection() {
+        WorkItem__c root = insertWi('NoEstimate', null, null, null, null);
+        insert new List<WorkLog__c>{
+            buildLog(root.Id, 5, Date.today().addDays(-14)),
+            buildLog(root.Id, 5, Date.today().addDays(-7))
+        };
+
+        Test.startTest();
+        DeliveryForecastService.ProjectForecast f =
+            DeliveryForecastService.calculateProjectForecast(root.Id);
+        Test.stopTest();
+
+        System.assertEquals(false, f.hasEstimate, 'hasEstimate false');
+        System.assertEquals(null, f.projectedCompletionDate, 'No projection without scope');
+        System.assertEquals(0, f.projection.size(), 'projection empty');
+        System.assert(f.history.size() > 0, 'history still populated');
+    }
+
+    @IsTest
+    static void testSingleWeekHistorySetsVelocityButNoConfidence() {
+        WorkItem__c root = insertWi('SingleWeek', 40, Date.today().addDays(-7), Date.today().addDays(28), null);
+        insert buildLog(root.Id, 8, Date.today().addDays(-3));
+
+        Test.startTest();
+        DeliveryForecastService.ProjectForecast f =
+            DeliveryForecastService.calculateProjectForecast(root.Id);
+        Test.stopTest();
+
+        // With 1 week of history, populateVelocityStats sets velocity to last week's hours
+        // but flags hasVelocity=false (need ≥2 weeks for confidence).
+        System.assertEquals(8, f.currentVelocityHoursPerWeek, 'Single-week velocity point estimate');
+        System.assertEquals(false, f.hasVelocity,
+            'hasVelocity false with <2 weeks — projection suppressed');
+    }
+}

--- a/force-app/main/default/classes/DeliveryForecastServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryForecastServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/deliveryProjectBurnUpChart/deliveryProjectBurnUpChart.css
+++ b/force-app/main/default/lwc/deliveryProjectBurnUpChart/deliveryProjectBurnUpChart.css
@@ -1,0 +1,260 @@
+:host {
+    display: block;
+}
+
+.burnup-card {
+    background: #ffffff;
+    border-radius: 0.75rem;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    font-size: 0.8125rem;
+}
+
+.burnup-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.125rem 1.5rem;
+    border-bottom: 1px solid #e5e7eb;
+    background: linear-gradient(135deg, #fefce8 0%, #fff7ed 100%);
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.burnup-header-left {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.burnup-header-icon {
+    color: #ca8a04;
+}
+
+.burnup-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0 0 0.15rem 0;
+}
+
+.burnup-subtitle {
+    font-size: 0.75rem;
+    color: #6b7280;
+    margin: 0;
+}
+
+.burnup-loading {
+    padding: 2rem;
+    display: flex;
+    justify-content: center;
+}
+
+.burnup-error {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 1rem 1.5rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    background: #fef2f2;
+    border: 1px solid #fca5a5;
+    color: #991b1b;
+}
+
+.burnup-empty {
+    padding: 3rem 2rem;
+    text-align: center;
+    color: #6b7280;
+}
+
+.burnup-empty-icon {
+    color: #d1d5db;
+    margin-bottom: 0.75rem;
+}
+
+.burnup-empty-sub {
+    font-size: 0.75rem;
+    color: #9ca3af;
+    margin-top: 0.25rem;
+}
+
+.status-banner {
+    margin: 0.5rem 1rem 0;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.375rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+}
+
+.status-banner--under {
+    background: #ecfdf5;
+    color: #047857;
+    border: 1px solid #6ee7b7;
+}
+
+.status-banner--over {
+    background: #fef2f2;
+    color: #b91c1c;
+    border: 1px solid #fca5a5;
+}
+
+.burnup-summary-row {
+    display: flex;
+    gap: 1rem;
+    padding: 0.75rem 1.5rem;
+    flex-wrap: wrap;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.summary-tile {
+    flex: 1 1 8rem;
+    min-width: 7rem;
+}
+
+.summary-label {
+    font-size: 0.6875rem;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.15rem;
+}
+
+.summary-value {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #111827;
+}
+
+.summary-value--ok {
+    color: #047857;
+}
+
+.summary-value--alert {
+    color: #b91c1c;
+}
+
+.summary-sub {
+    font-size: 0.6875rem;
+    color: #9ca3af;
+    margin-top: 0.1rem;
+}
+
+.burnup-body {
+    padding: 1rem 1.25rem 0.25rem;
+}
+
+.burnup-svg {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.grid-line {
+    stroke: #e5e7eb;
+    stroke-width: 1;
+    stroke-dasharray: 4 3;
+}
+
+.axis-line {
+    stroke: #9ca3af;
+    stroke-width: 1.5;
+}
+
+.axis-label {
+    font-size: 10px;
+    fill: #6b7280;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.axis-label--y {
+    text-anchor: end;
+    dominant-baseline: middle;
+}
+
+.axis-label--x {
+    text-anchor: middle;
+    dominant-baseline: hanging;
+}
+
+.chart-line {
+    stroke-width: 2.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.chart-line--actual {
+    stroke: #2563eb;
+}
+
+.chart-line--projection {
+    stroke: #f59e0b;
+    stroke-dasharray: 6 4;
+}
+
+.scope-line {
+    stroke: #6b7280;
+    stroke-width: 1.5;
+    stroke-dasharray: 8 4;
+}
+
+.scope-label {
+    font-size: 10px;
+    fill: #6b7280;
+    text-anchor: end;
+    dominant-baseline: text-after-edge;
+}
+
+.today-marker {
+    stroke: #d1d5db;
+    stroke-width: 1;
+    stroke-dasharray: 2 2;
+}
+
+.today-label {
+    font-size: 9px;
+    fill: #9ca3af;
+    text-anchor: middle;
+    dominant-baseline: hanging;
+}
+
+.burnup-legend {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    padding: 0.75rem 1.25rem;
+    border-top: 1px solid #f3f4f6;
+    flex-wrap: wrap;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.6875rem;
+    color: #6b7280;
+}
+
+.legend-line {
+    display: inline-block;
+    width: 1.5rem;
+    height: 3px;
+    border-radius: 2px;
+}
+
+.legend-line--actual {
+    background: #2563eb;
+}
+
+.legend-line--projection {
+    background: #f59e0b;
+    background-image: linear-gradient(90deg, #f59e0b 0 6px, transparent 6px 10px);
+    height: 2px;
+}
+
+.legend-line--scope {
+    background: #6b7280;
+    background-image: linear-gradient(90deg, #6b7280 0 8px, transparent 8px 12px);
+    height: 2px;
+}

--- a/force-app/main/default/lwc/deliveryProjectBurnUpChart/deliveryProjectBurnUpChart.html
+++ b/force-app/main/default/lwc/deliveryProjectBurnUpChart/deliveryProjectBurnUpChart.html
@@ -1,0 +1,140 @@
+<template>
+    <div class="burnup-card">
+
+        <div class="burnup-header">
+            <div class="burnup-header-left">
+                <lightning-icon icon-name="utility:chart" alternative-text="Burn-up" size="small" class="burnup-header-icon"></lightning-icon>
+                <div>
+                    <h2 class="burnup-title">Velocity Forecast</h2>
+                    <p class="burnup-subtitle">Rolling 4-week velocity projected to scope</p>
+                </div>
+            </div>
+        </div>
+
+        <template lwc:if={isLoading}>
+            <div class="burnup-loading">
+                <lightning-spinner alternative-text="Computing forecast..." size="small"></lightning-spinner>
+            </div>
+        </template>
+
+        <template lwc:if={hasError}>
+            <div class="burnup-error">
+                <lightning-icon icon-name="utility:error" size="x-small"></lightning-icon>
+                <span>{errorMessage}</span>
+            </div>
+        </template>
+
+        <template lwc:if={hasData}>
+            <div class={statusBannerClass}>{statusBannerText}</div>
+
+            <div class="burnup-summary-row">
+                <div class="summary-tile">
+                    <div class="summary-label">Velocity</div>
+                    <div class="summary-value">{velocityDisplay}</div>
+                </div>
+                <div class="summary-tile">
+                    <div class="summary-label">Weeks remaining</div>
+                    <div class="summary-value">{weeksRemainingDisplay}</div>
+                </div>
+                <div class="summary-tile">
+                    <div class="summary-label">Projected completion</div>
+                    <div class="summary-value">{projectedCompletionDisplay}</div>
+                    <div class="summary-sub">{confidenceRangeDisplay}</div>
+                </div>
+                <div class="summary-tile">
+                    <div class="summary-label">Projected final</div>
+                    <div class={overBudgetClass}>{projectedFinalDisplay}</div>
+                </div>
+                <div class="summary-tile">
+                    <div class="summary-label">Scope</div>
+                    <div class="summary-value">{scopeDisplay}</div>
+                </div>
+            </div>
+
+            <div class="burnup-body">
+                <svg xmlns="http://www.w3.org/2000/svg"
+                     viewBox={svgViewBox}
+                     class="burnup-svg"
+                     preserveAspectRatio="xMidYMid meet">
+
+                    <template for:each={gridLines} for:item="gl">
+                        <line key={gl.key}
+                              x1={chartLeft} y1={gl.y}
+                              x2={chartRight} y2={gl.y}
+                              class="grid-line"></line>
+                    </template>
+
+                    <template for:each={gridLines} for:item="gl">
+                        <text key={gl.labelKey}
+                              x={yLabelX} y={gl.y}
+                              class="axis-label axis-label--y">{gl.label}</text>
+                    </template>
+
+                    <template lwc:if={hasScopeLine}>
+                        <line x1={chartLeft} y1={scopeLineY}
+                              x2={chartRight} y2={scopeLineY}
+                              class="scope-line"></line>
+                        <text x={chartRight} y={scopeLineY}
+                              class="scope-label">Scope</text>
+                    </template>
+
+                    <polyline points={actualLinePoints}
+                              class="chart-line chart-line--actual"
+                              fill="none"></polyline>
+
+                    <template lwc:if={hasProjection}>
+                        <polyline points={projectionLinePoints}
+                                  class="chart-line chart-line--projection"
+                                  fill="none"></polyline>
+                    </template>
+
+                    <template lwc:if={hasTodayMarker}>
+                        <line x1={todayMarkerX} y1={chartTop}
+                              x2={todayMarkerX} y2={chartBottom}
+                              class="today-marker"></line>
+                        <text x={todayMarkerX} y={chartTop}
+                              class="today-label">Today</text>
+                    </template>
+
+                    <template for:each={xLabels} for:item="xl">
+                        <text key={xl.key}
+                              x={xl.x} y={xLabelY}
+                              class="axis-label axis-label--x">{xl.label}</text>
+                    </template>
+
+                    <line x1={chartLeft} y1={chartTop}
+                          x2={chartLeft} y2={chartBottom}
+                          class="axis-line"></line>
+                    <line x1={chartLeft} y1={chartBottom}
+                          x2={chartRight} y2={chartBottom}
+                          class="axis-line"></line>
+                </svg>
+            </div>
+
+            <div class="burnup-legend">
+                <span class="legend-item">
+                    <span class="legend-line legend-line--actual"></span>Actual logged (cumulative)
+                </span>
+                <template lwc:if={hasProjection}>
+                    <span class="legend-item">
+                        <span class="legend-line legend-line--projection"></span>Projection at current velocity
+                    </span>
+                </template>
+                <template lwc:if={hasScopeLine}>
+                    <span class="legend-item">
+                        <span class="legend-line legend-line--scope"></span>Scope
+                    </span>
+                </template>
+            </div>
+        </template>
+
+        <template lwc:if={isEmpty}>
+            <div class="burnup-empty">
+                <lightning-icon icon-name="utility:chart" size="medium" class="burnup-empty-icon"></lightning-icon>
+                <p>No logged hours yet</p>
+                <p class="burnup-empty-sub">Log work against this project (or its descendants) to build velocity history.</p>
+            </div>
+        </template>
+
+    </div>
+</template>

--- a/force-app/main/default/lwc/deliveryProjectBurnUpChart/deliveryProjectBurnUpChart.js
+++ b/force-app/main/default/lwc/deliveryProjectBurnUpChart/deliveryProjectBurnUpChart.js
@@ -1,0 +1,350 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @author Cloud Nimbus LLC
+ */
+import { LightningElement, api, wire, track } from "lwc";
+import calculateProjectForecast from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryForecastService.calculateProjectForecast";
+
+const SVG_WIDTH = 720;
+const SVG_HEIGHT = 360;
+const PADDING_TOP = 24;
+const PADDING_RIGHT = 24;
+const PADDING_BOTTOM = 56;
+const PADDING_LEFT = 60;
+const GRID_LINE_COUNT = 5;
+
+export default class DeliveryProjectBurnUpChart extends LightningElement {
+    @api recordId;
+    @track forecast;
+    @track errorMessage = "";
+    isLoading = true;
+
+    @wire(calculateProjectForecast, { workItemId: "$recordId" })
+    wiredForecast({ data, error }) {
+        this.isLoading = false;
+        if (data) {
+            this.forecast = data;
+            this.errorMessage = "";
+        } else if (error) {
+            this.errorMessage = error.body ? error.body.message : error.message;
+            this.forecast = null;
+        }
+    }
+
+    // ── State flags ──────────────────────────────────────────────
+
+    get hasError() {
+        return !this.isLoading && this.errorMessage;
+    }
+
+    get isEmpty() {
+        if (this.isLoading || this.errorMessage || !this.forecast) {
+            return false;
+        }
+        return !this._history.length;
+    }
+
+    get hasData() {
+        return !this.isLoading && !this.errorMessage && !this.isEmpty && this.forecast;
+    }
+
+    get hasProjection() {
+        return this.forecast && this.forecast.hasVelocity && this.forecast.hasEstimate;
+    }
+
+    get isOverBudget() {
+        return this.forecast && this.forecast.isOverBudgetTrajectory;
+    }
+
+    // ── Headline numbers ─────────────────────────────────────────
+
+    get velocityDisplay() {
+        if (!this.forecast || !this.forecast.hasVelocity) {
+            return "—";
+        }
+        return `${this._formatHours(this.forecast.currentVelocityHoursPerWeek)}h/wk`;
+    }
+
+    get weeksRemainingDisplay() {
+        if (!this.forecast || !this.forecast.hasVelocity) {
+            return "—";
+        }
+        if (this.forecast.weeksRemaining === 0) {
+            return "Done";
+        }
+        return `${this.forecast.weeksRemaining}`;
+    }
+
+    get projectedCompletionDisplay() {
+        if (!this.forecast || !this.forecast.projectedCompletionDate) {
+            return "—";
+        }
+        return this._formatDate(this.forecast.projectedCompletionDate);
+    }
+
+    get confidenceRangeDisplay() {
+        if (!this.forecast || !this.forecast.confidenceLowDate || !this.forecast.confidenceHighDate) {
+            return "";
+        }
+        return `${this._formatDate(this.forecast.confidenceLowDate)} – ${this._formatDate(this.forecast.confidenceHighDate)}`;
+    }
+
+    get projectedFinalDisplay() {
+        if (!this.forecast) {
+            return "—";
+        }
+        return `${this._formatHours(this.forecast.projectedFinalHours)}h`;
+    }
+
+    get scopeDisplay() {
+        if (!this.forecast || !this.forecast.hasEstimate) {
+            return "—";
+        }
+        return `${this._formatHours(this.forecast.totalEstimatedHours)}h`;
+    }
+
+    get overBudgetClass() {
+        return this.isOverBudget
+            ? "summary-value summary-value--alert"
+            : "summary-value summary-value--ok";
+    }
+
+    get statusBannerClass() {
+        return this.isOverBudget ? "status-banner status-banner--over" : "status-banner status-banner--under";
+    }
+
+    get statusBannerText() {
+        if (!this.forecast || !this.forecast.hasVelocity) {
+            return "No velocity data yet — log work to enable forecasting.";
+        }
+        if (!this.forecast.hasEstimate) {
+            return "Set an estimated-hours total to enable scope projection.";
+        }
+        if (this.isOverBudget) {
+            return `Trending ${this._formatHours(this.forecast.projectedFinalHours - this.forecast.totalEstimatedHours)}h past scope at current velocity.`;
+        }
+        return `On track to finish around ${this.projectedCompletionDisplay} at current velocity.`;
+    }
+
+    // ── SVG geometry ─────────────────────────────────────────────
+
+    get svgViewBox() {
+        return `0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`;
+    }
+
+    get chartLeft() {
+        return PADDING_LEFT;
+    }
+
+    get chartRight() {
+        return SVG_WIDTH - PADDING_RIGHT;
+    }
+
+    get chartTop() {
+        return PADDING_TOP;
+    }
+
+    get chartBottom() {
+        return SVG_HEIGHT - PADDING_BOTTOM;
+    }
+
+    get yLabelX() {
+        return PADDING_LEFT - 8;
+    }
+
+    get xLabelY() {
+        return SVG_HEIGHT - PADDING_BOTTOM + 18;
+    }
+
+    get _chartWidth() {
+        return this.chartRight - this.chartLeft;
+    }
+
+    get _chartHeight() {
+        return this.chartBottom - this.chartTop;
+    }
+
+    get _history() {
+        return (this.forecast && this.forecast.history) || [];
+    }
+
+    get _projection() {
+        return (this.forecast && this.forecast.projection) || [];
+    }
+
+    get _allPoints() {
+        return this._history.concat(this._projection);
+    }
+
+    get _scopeMax() {
+        const points = this._allPoints;
+        let max = 0;
+        for (const p of points) {
+            if (p.cumulativeHours > max) {
+                max = p.cumulativeHours;
+            }
+            if (p.scopeHours > max) {
+                max = p.scopeHours;
+            }
+        }
+        if (this.forecast && this.forecast.totalEstimatedHours > max) {
+            max = this.forecast.totalEstimatedHours;
+        }
+        return max > 0 ? max : 1;
+    }
+
+    get _niceMax() {
+        const raw = this._scopeMax;
+        const magnitude = Math.pow(10, Math.floor(Math.log10(raw || 1)));
+        const normalized = raw / magnitude;
+        let nice;
+        if (normalized <= 1) {
+            nice = 1;
+        } else if (normalized <= 2) {
+            nice = 2;
+        } else if (normalized <= 5) {
+            nice = 5;
+        } else {
+            nice = 10;
+        }
+        return nice * magnitude;
+    }
+
+    _xForIndex(idx) {
+        const total = this._allPoints.length;
+        if (total <= 1) {
+            return this.chartLeft;
+        }
+        return this.chartLeft + (idx / (total - 1)) * this._chartWidth;
+    }
+
+    _yForValue(value) {
+        const niceMax = this._niceMax;
+        if (niceMax === 0) {
+            return this.chartBottom;
+        }
+        return this.chartBottom - (value / niceMax) * this._chartHeight;
+    }
+
+    // ── Polylines ────────────────────────────────────────────────
+
+    get actualLinePoints() {
+        const history = this._history;
+        if (!history.length) {
+            return "";
+        }
+        return history
+            .map((p, i) => `${this._xForIndex(i)},${this._yForValue(p.cumulativeHours)}`)
+            .join(" ");
+    }
+
+    get projectionLinePoints() {
+        const projection = this._projection;
+        const history = this._history;
+        if (!projection.length || !history.length) {
+            return "";
+        }
+        // Anchor the projection at the last actual point so the dashed line starts there.
+        const anchorIdx = history.length - 1;
+        const anchorX = this._xForIndex(anchorIdx);
+        const anchorY = this._yForValue(history[anchorIdx].cumulativeHours);
+        const tail = projection
+            .map((p, j) => `${this._xForIndex(history.length + j)},${this._yForValue(p.cumulativeHours)}`)
+            .join(" ");
+        return `${anchorX},${anchorY} ${tail}`;
+    }
+
+    get scopeLineY() {
+        if (!this.forecast || !this.forecast.hasEstimate) {
+            return null;
+        }
+        return this._yForValue(this.forecast.totalEstimatedHours);
+    }
+
+    get hasScopeLine() {
+        return this.scopeLineY !== null && this.forecast && this.forecast.hasEstimate;
+    }
+
+    // ── Axes ─────────────────────────────────────────────────────
+
+    get gridLines() {
+        const lines = [];
+        const niceMax = this._niceMax;
+        for (let i = 0; i <= GRID_LINE_COUNT; i++) {
+            const value = (niceMax / GRID_LINE_COUNT) * i;
+            lines.push({
+                key: `grid-${i}`,
+                labelKey: `grid-label-${i}`,
+                y: this._yForValue(value),
+                label: this._formatHours(value)
+            });
+        }
+        return lines;
+    }
+
+    get xLabels() {
+        const all = this._allPoints;
+        if (!all.length) {
+            return [];
+        }
+        const step = all.length > 12 ? Math.ceil(all.length / 8) : 1;
+        const labels = [];
+        for (let i = 0; i < all.length; i += step) {
+            labels.push({
+                key: `x-${i}`,
+                x: this._xForIndex(i),
+                label: this._formatDate(all[i].weekStart)
+            });
+        }
+        return labels;
+    }
+
+    get todayMarkerX() {
+        const history = this._history;
+        if (!history.length) {
+            return null;
+        }
+        return this._xForIndex(history.length - 1);
+    }
+
+    get hasTodayMarker() {
+        return this.todayMarkerX !== null;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────
+
+    _formatHours(value) {
+        if (value === null || value === undefined) {
+            return "0";
+        }
+        const num = Number(value);
+        if (!Number.isFinite(num)) {
+            return "0";
+        }
+        if (Math.abs(num) >= 100) {
+            return num.toFixed(0);
+        }
+        if (Math.abs(num) >= 10) {
+            return num.toFixed(1);
+        }
+        return num.toFixed(2);
+    }
+
+    _formatDate(isoString) {
+        if (!isoString) {
+            return "";
+        }
+        const parts = String(isoString).split("-");
+        if (parts.length < 3) {
+            return String(isoString);
+        }
+        const monthIdx = parseInt(parts[1], 10) - 1;
+        const day = parseInt(parts[2], 10);
+        const monthNames = [
+            "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+        ];
+        return `${monthNames[monthIdx]} ${day}`;
+    }
+}

--- a/force-app/main/default/lwc/deliveryProjectBurnUpChart/deliveryProjectBurnUpChart.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryProjectBurnUpChart/deliveryProjectBurnUpChart.js-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordPage</target>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordPage">
+            <objects>
+                <object>WorkItem__c</object>
+            </objects>
+        </targetConfig>
+    </targetConfigs>
+    <masterLabel>Delivery Project Burn-Up Chart</masterLabel>
+    <description>Velocity-based burn-up chart with projection line. Renders cumulative actual hours, scope line, and velocity-extrapolated projection to scope intersection.</description>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary

Adds velocity-based forecasting to a WorkItem__c tree. Headlined by a new burn-up chart on the WorkItem record page.

- **New** \`DeliveryForecastService.calculateProjectForecast(workItemId)\`:
  - Walks WI tree via \`ParentWorkItemLookup__c\` (depth-capped at 10).
  - Aggregates \`WorkLog__c\` into weekly buckets keyed by Monday week-start.
  - Computes rolling 4-week velocity (mean) + std-dev → confidence band.
  - Extrapolates remaining scope at velocity slope → \`projectedCompletionDate\`.
  - Confidence band: ±1 std-dev → \`confidenceLowDate\` / \`confidenceHighDate\`.
  - \`isOverBudgetTrajectory = true\` when projected completion > \`EstimatedEndDevDate\`.
  - Returns \`ProjectForecast { history[], projection[], headline numbers }\`.

- **New** \`deliveryProjectBurnUpChart\` LWC:
  - SVG burn-up: cumulative actual (solid blue), projection (dashed orange), scope (dashed gray), today marker.
  - Green/red status banner depending on trajectory.
  - Headline tiles: velocity, weeks remaining, projected completion + confidence range, projected final hours, scope.

- **Tests** — 8 cases covering: null guard, empty tree, tree-walk aggregation, rolling-window velocity, flat-window stddev=0, projection extension, over-budget flag, already-at-scope, single-week degradation.

## Test plan

- [ ] feature-test (namespaced scratch) passes
- [ ] apex-scan (PMD) clean
- [ ] Post-install: drop the LWC on the WorkItem__c record page in MF-Prod, point at a project with 4+ weeks of logged hours, see velocity + projected completion
- [ ] Project with EstimatedEndDevDate before projected completion → over-budget banner
- [ ] Project with no estimate → forecast still computes velocity, no projection line
- [ ] Project at/over scope → "Done" or over-budget messaging

## Skipped from this PR (deferred to follow-on)

- Email alert / nightly \`DeliveryHubScheduler\` hook firing on \`projectedFinalHours > EstimatedHoursNumber * threshold\` per the Phase 3 plan
- \`EnableForecastAlertsDateTime__c\` org setting

## Already shipped in flight

- Phase 1 dashboard tiles + matrix report — #755
- Phase 2A monthly hours LWC — PR #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)