### PR TITLE
fix(test): set WorkLog__c.RequestId__c on test inserts — required Master-Detail

### DIFF
--- a/force-app/main/default/classes/DeliveryForecastServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryForecastServiceTest.cls
@@ -30,9 +30,28 @@ private class DeliveryForecastServiceTest {
         return wi;
     }
 
+    /**
+     * @description WorkLog__c.RequestId__c is a Master-Detail to WorkRequest__c
+     *              and is required at insert in the packaging org. Auto-mint a
+     *              per-WorkItem bridge WorkRequest__c on first buildLog call so
+     *              callers don't have to thread it through.
+     */
+    private static Map<Id, Id> bridgeByWi = new Map<Id, Id>();
+
     private static WorkLog__c buildLog(Id wiId, Decimal hours, Date workDate) {
+        Id requestId = bridgeByWi.get(wiId);
+        if (requestId == null) {
+            WorkRequest__c bridge = new WorkRequest__c(
+                WorkItemId__c = wiId,
+                StatusPk__c = 'Active'
+            );
+            insert bridge;
+            requestId = bridge.Id;
+            bridgeByWi.put(wiId, requestId);
+        }
         return new WorkLog__c(
             WorkItemLookup__c = wiId,
+            RequestId__c = requestId,
             HoursLoggedNumber__c = hours,
             WorkDateDate__c = workDate,
             WorkDescriptionTxt__c = 'forecast test log'

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
@@ -34,9 +34,30 @@ private class DeliveryHoursAnalyticsControllerTest {
         return wi;
     }
 
+    /**
+     * @description WorkLog__c.RequestId__c is a Master-Detail to WorkRequest__c
+     *              and is required at insert in the packaging org. We auto-mint
+     *              a per-WorkItem bridge WorkRequest__c on first buildLog call
+     *              so callers don't need to thread it through. The bridge is
+     *              cached per-WI so a single test method can build multiple
+     *              logs for the same WI without spawning N bridges.
+     */
+    private static Map<Id, Id> bridgeByWi = new Map<Id, Id>();
+
     private static WorkLog__c buildLog(Id wiId, Decimal hours, Date workDate) {
+        Id requestId = bridgeByWi.get(wiId);
+        if (requestId == null) {
+            WorkRequest__c bridge = new WorkRequest__c(
+                WorkItemId__c = wiId,
+                StatusPk__c = 'Active'
+            );
+            insert bridge;
+            requestId = bridge.Id;
+            bridgeByWi.put(wiId, requestId);
+        }
         return new WorkLog__c(
             WorkItemLookup__c = wiId,
+            RequestId__c = requestId,
             HoursLoggedNumber__c = hours,
             WorkDateDate__c = workDate,
             WorkDescriptionTxt__c = 'test log'


### PR DESCRIPTION
## Why

\`WorkLog__c.RequestId__c\` is a **Master-Detail** to \`WorkRequest__c\`. MD fields are required at insert in the packaging-org context — but feature-test scratch-orgs (somehow) tolerated absent values, so the gap surfaced only in upload-beta after #767+#768 merged.

Both beta_create runs failed:
\`\`\`
Class.delivery.DeliveryHoursAnalyticsControllerTest.testAggregatesLoggedHoursIntoCorrectMonth
Class.delivery.DeliveryHoursAnalyticsControllerTest.testLogsOutsideWindowAreIgnored
Class.delivery.DeliveryHoursAnalyticsControllerTest.testOverTargetFlagFiresWhenHoursExceedTarget
Class.delivery.DeliveryHoursAnalyticsControllerTest.testWalksDescendantsAndSumsAcrossTree
  → REQUIRED_FIELD_MISSING: [delivery__RequestId__c]
\`\`\`

Same gap in \`DeliveryForecastServiceTest\`.

## Fix

Auto-mint a per-WorkItem bridge \`WorkRequest__c\` on first \`buildLog\` call (cached in a static \`Map<Id, Id>\`) so callers don't have to thread it through. Same pattern in both test classes — minimal surface change.

## Test plan

- [ ] feature-test passes (still)
- [ ] apex-scan clean
- [ ] **upload-beta passes** (the new gate this fix unblocks)
- [ ] Release auto-cuts after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)