### PR TITLE
fix(depth-probe): include WorkItemId__c in buildRootSegment SELECT

### DIFF
--- a/force-app/main/default/classes/DeliveryDepthProbeService.cls
+++ b/force-app/main/default/classes/DeliveryDepthProbeService.cls
@@ -143,7 +143,7 @@ global with sharing class DeliveryDepthProbeService {
         root.children = new List<DepthChainNode>();
 
         for (WorkRequest__c req : [
-            SELECT Id, DeliveryEntityLookup__c, RemoteWorkItemIdTxt__c,
+            SELECT Id, WorkItemId__c, DeliveryEntityLookup__c, RemoteWorkItemIdTxt__c,
                    DeliveryEntityLookup__r.Name,
                    DeliveryEntityLookup__r.OrgIdTxt__c,
                    DeliveryEntityLookup__r.JurisdictionTxt__c,


### PR DESCRIPTION
## Why

\`invokePeerProbe\` reads \`req.WorkItemId__c\` to populate the outbound probe's \`workItemRef\` — the sender's local Id, per the \`SourceId\` convention from \`DeliverySyncEngine.buildWorkItemSyncItem\`. But the SOQL in \`buildRootSegment\` only had \`WorkItemId__c\` in the WHERE clause, not the SELECT.

Feature-test (somehow) tolerated this. Upload-beta raised:

\`\`\`
System.SObjectException: SObject row was retrieved via SOQL without
querying the requested field: delivery__WorkRequest__c.delivery__WorkItemId__c
  Class.delivery.DeliveryDepthProbeService.invokePeerProbe: line 213
  ...
  Class.delivery.DeliveryDepthProbeServiceTest.testDepthZeroSuppressesRecursion: line 326
\`\`\`

## Fix

One-character — add \`WorkItemId__c\` to the SELECT.

## Test plan

- [ ] feature-test passes
- [ ] apex-scan clean
- [ ] **upload-beta passes** — this is the gate I'm trying to clear
- [ ] Release auto-cuts after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)