### PR TITLE
feat(ui+alerts): wire LWCs into FlexiPage + pills + audit chain + forecast alerts

### DIFF
--- a/force-app/main/default/classes/DeliveryForecastAlertQueueable.cls
+++ b/force-app/main/default/classes/DeliveryForecastAlertQueueable.cls
@@ -1,0 +1,21 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Thin queueable wrapper around DeliveryForecastAlertService.runSweep.
+ *              Enqueued from DeliveryHubScheduler.enqueueForecastAlertsIfDue at
+ *              8 GMT once per day when the feature is enabled. Mirrors
+ *              DeliveryOverdueReminderQueueable shape.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexDoc')
+public with sharing class DeliveryForecastAlertQueueable implements Queueable, Database.AllowsCallouts {
+
+    public void execute(QueueableContext qc) {
+        try {
+            DeliveryForecastAlertService.runSweep();
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryForecastAlertQueueable] sweep failed: ' + e.getMessage());
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryForecastAlertQueueable.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryForecastAlertQueueable.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryForecastAlertService.cls
+++ b/force-app/main/default/classes/DeliveryForecastAlertService.cls
@@ -26,7 +26,7 @@
  *              - Mirrors DeliveryOverdueReminderService.shouldSendReminder pattern.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexDoc,PMD.AvoidGlobalModifier,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.OperationWithLimitsInLoop,PMD.ApexCRUDViolation,PMD.NcssMethodCount')
+@SuppressWarnings('PMD.ApexDoc,PMD.AvoidGlobalModifier,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.OperationWithLimitsInLoop,PMD.ApexCRUDViolation,PMD.NcssMethodCount,PMD.ExcessiveParameterList')
 global with sharing class DeliveryForecastAlertService {
 
     /** @description Default threshold % above which a WI is alertable. */

--- a/force-app/main/default/classes/DeliveryForecastAlertService.cls
+++ b/force-app/main/default/classes/DeliveryForecastAlertService.cls
@@ -1,0 +1,371 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Daily forecast-alert sweep. Walks active root WorkItems
+ *              (ParentWorkItemLookup__c = NULL), runs the velocity-based
+ *              forecast for each, and dispatches bell + email + Slack alerts
+ *              to the WI owner when projectedFinalHours exceeds the configured
+ *              threshold (default 110% of EstimatedHoursNumber). Cooldown +
+ *              delta-detection guard prevents re-alert spam.
+ *
+ *              Mirrors DeliveryOverdueReminderService shape — gated by an org
+ *              setting DateTime opt-in (EnableForecastAlertsDateTime__c) +
+ *              per-recipient channel opt-out via NotificationPreference__c with
+ *              EventTypePk='Forecast_Risk'.
+ *
+ *              Persona routing (root-WI-only):
+ *              - Primary recipient: WorkItem.OwnerId (when a User; Jose-class PM persona).
+ *              - CC: WorkItem.DeveloperLookup__c if distinct from owner.
+ *              - NEVER ClientNetworkEntityLookup — internal risk doesn't go to clients.
+ *              - Glen is no recipient; he sees Project_Health_Pills on Home as the
+ *                pull surface. This service is the transition push.
+ *
+ *              Re-alert rule (cooldown):
+ *              - Skip if LastForecastAlertDateTime within 7 days AND projected
+ *                final hours hasn't worsened by ≥10% from LastForecastAlertProjectedHours.
+ *              - Mirrors DeliveryOverdueReminderService.shouldSendReminder pattern.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexDoc,PMD.AvoidGlobalModifier,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.OperationWithLimitsInLoop,PMD.ApexCRUDViolation,PMD.NcssMethodCount')
+global with sharing class DeliveryForecastAlertService {
+
+    /** @description Default threshold % above which a WI is alertable. */
+    @TestVisible
+    private static final Decimal DEFAULT_THRESHOLD_PERCENT = 110;
+
+    /** @description Cooldown days between successive alerts for the same WI when projection hasn't materially worsened. */
+    @TestVisible
+    private static final Integer COOLDOWN_DAYS = 7;
+
+    /** @description Re-alert sooner if projection has worsened by ≥ this fraction since last alert. */
+    @TestVisible
+    private static final Decimal MATERIAL_WORSENING_FRACTION = 0.10;
+
+    /** @description Cap on the number of WIs the daily sweep evaluates. */
+    @TestVisible
+    private static final Integer MAX_WORKITEMS_PER_SWEEP = 200;
+
+    /** @description Terminal stages — exclude from sweep. */
+    private static final Set<String> TERMINAL_STAGES = new Set<String>{
+        'Done', 'Cancelled', 'Closed', 'Rejected'
+    };
+
+    /**
+     * @description Runs the daily sweep. Called by DeliveryForecastAlertQueueable
+     *              (which the scheduler enqueues at 8 GMT once per day).
+     * @return Count of WorkItems for which an alert was dispatched.
+     */
+    global static Integer runSweep() {
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        if (settings == null || settings.EnableForecastAlertsDateTime__c == null) {
+            return 0;
+        }
+
+        Decimal thresholdPct = settings.ForecastAlertThresholdPercentNumber__c != null
+            ? settings.ForecastAlertThresholdPercentNumber__c
+            : DEFAULT_THRESHOLD_PERCENT;
+        Decimal thresholdRatio = thresholdPct / 100;
+
+        List<WorkItem__c> candidates = [
+            SELECT Id, Name, BriefDescriptionTxt__c, OwnerId, DeveloperLookup__c,
+                   EstimatedHoursNumber__c, TotalLoggedHoursSum__c,
+                   StageNamePk__c, ActivatedDateTime__c,
+                   LastForecastAlertDateTime__c, LastForecastAlertProjectedHoursNumber__c
+            FROM WorkItem__c
+            WHERE ParentWorkItemLookup__c = NULL
+              AND ActivatedDateTime__c != NULL
+              AND ArchivedDateTime__c = NULL
+              AND TemplateMarkedDateTime__c = NULL
+              AND StageNamePk__c NOT IN :TERMINAL_STAGES
+              AND EstimatedHoursNumber__c != NULL
+              AND EstimatedHoursNumber__c > 0
+            WITH SYSTEM_MODE
+            LIMIT :MAX_WORKITEMS_PER_SWEEP
+        ];
+
+        if (candidates.isEmpty()) {
+            stampScanComplete(settings);
+            return 0;
+        }
+
+        List<AlertCandidate> firing = new List<AlertCandidate>();
+        for (WorkItem__c wi : candidates) {
+            AlertCandidate ac = evaluate(wi, thresholdRatio);
+            if (ac != null) {
+                firing.add(ac);
+            }
+        }
+
+        if (firing.isEmpty()) {
+            stampScanComplete(settings);
+            return 0;
+        }
+
+        dispatchAlerts(firing);
+        stampWorkItems(firing);
+        stampScanComplete(settings);
+        return firing.size();
+    }
+
+    /**
+     * @description Evaluates a single WI. Returns AlertCandidate when it should
+     *              alert, null when it shouldn't (under threshold, in cooldown,
+     *              or no projection available).
+     */
+    private static AlertCandidate evaluate(WorkItem__c wi, Decimal thresholdRatio) {
+        DeliveryForecastService.ProjectForecast f;
+        try {
+            f = DeliveryForecastService.calculateProjectForecast(wi.Id);
+        } catch (Exception ignored) {
+            return null;
+        }
+        if (f == null || !f.hasEstimate || !f.hasVelocity) {
+            return null;
+        }
+        if (f.projectedFinalHours == null || f.totalEstimatedHours == null
+                || f.totalEstimatedHours <= 0) {
+            return null;
+        }
+        Decimal ratio = f.projectedFinalHours / f.totalEstimatedHours;
+        if (ratio < thresholdRatio) {
+            return null;
+        }
+        if (inCooldown(wi, f)) {
+            return null;
+        }
+        AlertCandidate ac = new AlertCandidate();
+        ac.workItem = wi;
+        ac.forecast = f;
+        ac.overrunPercent = (ratio * 100 - 100).setScale(1, System.RoundingMode.HALF_UP);
+        ac.overrunHours = (f.projectedFinalHours - f.totalEstimatedHours).setScale(2, System.RoundingMode.HALF_UP);
+        return ac;
+    }
+
+    private static Boolean inCooldown(WorkItem__c wi, DeliveryForecastService.ProjectForecast f) {
+        if (wi.LastForecastAlertDateTime__c == null) {
+            return false;
+        }
+        Datetime cooldownExpires = wi.LastForecastAlertDateTime__c.addDays(COOLDOWN_DAYS);
+        if (Datetime.now() >= cooldownExpires) {
+            return false;
+        }
+        // Within cooldown — only re-alert when projection has materially worsened.
+        if (wi.LastForecastAlertProjectedHoursNumber__c == null
+                || wi.LastForecastAlertProjectedHoursNumber__c <= 0) {
+            return false;
+        }
+        Decimal worseningFrac = (f.projectedFinalHours - wi.LastForecastAlertProjectedHoursNumber__c)
+            / wi.LastForecastAlertProjectedHoursNumber__c;
+        return worseningFrac < MATERIAL_WORSENING_FRACTION;
+    }
+
+    /**
+     * @description Dispatches the three channels for each alert candidate.
+     *              Bell (per-user opt-in), email (per-user opt-out via
+     *              NotificationPreference__c), and Slack (org-level webhook).
+     */
+    private static void dispatchAlerts(List<AlertCandidate> firing) {
+        Set<Id> recipientIds = collectRecipients(firing);
+        Map<Id, User> userMap = recipientIds.isEmpty() ? new Map<Id, User>() : new Map<Id, User>([
+            SELECT Id, Email FROM User
+            WHERE Id IN :recipientIds AND IsActive = true
+            WITH SYSTEM_MODE
+        ]);
+
+        String orgUrl = Url.getOrgDomainUrl().toExternalForm();
+        List<Messaging.SingleEmailMessage> emails = new List<Messaging.SingleEmailMessage>();
+        Map<String, String> slackMessages = new Map<String, String>();
+
+        for (AlertCandidate ac : firing) {
+            WorkItem__c wi = ac.workItem;
+            String title = String.isNotBlank(wi.BriefDescriptionTxt__c)
+                ? wi.BriefDescriptionTxt__c : wi.Name;
+            String recordUrl = orgUrl + '/lightning/r/WorkItem__c/' + wi.Id + '/view';
+
+            String bellTitle = 'Forecast risk: ' + wi.Name;
+            String bellBody = 'Projected ' + ac.overrunPercent + '% over scope ('
+                + ac.overrunHours + 'h overrun) at current velocity. Tap to review.';
+
+            for (Id recipientId : routeRecipients(wi)) {
+                if (!userMap.containsKey(recipientId)) {
+                    continue;
+                }
+                if (shouldNotifyChannel(recipientId, 'Bell')) {
+                    DeliveryEscalationNotifService.sendBellNotification(
+                        wi.Id, recipientId, bellTitle, bellBody);
+                }
+                if (shouldNotifyChannel(recipientId, 'Email')) {
+                    String addr = userMap.get(recipientId).Email;
+                    if (String.isNotBlank(addr)) {
+                        emails.add(buildForecastEmail(wi, ac, addr, recordUrl, title));
+                    }
+                }
+            }
+            slackMessages.put(wi.Name, title + ' · projected ' + ac.overrunPercent
+                + '% over scope (+' + ac.overrunHours + 'h) · ' + recordUrl);
+        }
+
+        if (!emails.isEmpty() && emailGloballyEnabled()) {
+            try {
+                Messaging.sendEmail(emails);
+            } catch (Exception e) {
+                System.debug(LoggingLevel.WARN,
+                    '[DeliveryForecastAlertService] email send failed: ' + e.getMessage());
+            }
+        }
+        sendForecastSlack(slackMessages);
+    }
+
+    private static Boolean emailGloballyEnabled() {
+        DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
+        if (s == null) {
+            return false;
+        }
+        Schema.DescribeSObjectResult dsr = DeliveryHubSettings__c.SObjectType.getDescribe();
+        if (!dsr.fields.getMap().containsKey('EnableEmailNotificationsDateTime__c')) {
+            return true;
+        }
+        Object v = s.get('EnableEmailNotificationsDateTime__c');
+        return v != null;
+    }
+
+    private static List<Id> routeRecipients(WorkItem__c wi) {
+        List<Id> out = new List<Id>();
+        Set<Id> seen = new Set<Id>();
+        if (wi.OwnerId != null && String.valueOf(wi.OwnerId).startsWith('005')) {
+            out.add(wi.OwnerId);
+            seen.add(wi.OwnerId);
+        }
+        if (wi.DeveloperLookup__c != null && !seen.contains(wi.DeveloperLookup__c)) {
+            out.add(wi.DeveloperLookup__c);
+        }
+        return out;
+    }
+
+    private static Set<Id> collectRecipients(List<AlertCandidate> firing) {
+        Set<Id> ids = new Set<Id>();
+        for (AlertCandidate ac : firing) {
+            for (Id r : routeRecipients(ac.workItem)) {
+                ids.add(r);
+            }
+        }
+        return ids;
+    }
+
+    /**
+     * @description Delegates to DeliveryNotificationPreferenceService.shouldNotify.
+     *              Honors per-user, per-channel opt-out for Forecast_Risk event type.
+     *              No row in NotificationPreference__c = opt-in by default.
+     */
+    private static Boolean shouldNotifyChannel(Id userId, String channel) {
+        try {
+            return DeliveryNotificationPreferenceService.shouldNotify(userId, channel, 'Forecast_Risk');
+        } catch (Exception ignored) {
+            return true;
+        }
+    }
+
+    private static Messaging.SingleEmailMessage buildForecastEmail(
+            WorkItem__c wi, AlertCandidate ac, String toAddress,
+            String recordUrl, String title) {
+        Messaging.SingleEmailMessage email = new Messaging.SingleEmailMessage();
+        email.setToAddresses(new List<String>{ toAddress });
+        email.setSubject('Delivery Hub Forecast Risk: ' + wi.Name
+            + ' projected ' + ac.overrunPercent + '% over scope');
+        email.setHtmlBody(buildForecastHtml(wi.Name, title, ac, recordUrl));
+        email.setSaveAsActivity(false);
+        return email;
+    }
+
+    private static String buildForecastHtml(String wiName, String title,
+            AlertCandidate ac, String recordUrl) {
+        return '<div style="font-family: Arial, sans-serif; max-width: 600px;">'
+            + '<h2 style="color: #b91c1c; margin: 0 0 16px;">Forecast Risk: ' + escape(wiName) + '</h2>'
+            + '<p style="font-size: 14px; color: #374151;">'
+            + '<strong>' + escape(title) + '</strong> is trending past scope at current velocity.</p>'
+            + '<table style="border-collapse: collapse; width: 100%; font-size: 13px; margin: 12px 0;">'
+            + row('Estimated hours', String.valueOf(ac.forecast.totalEstimatedHours))
+            + row('Logged hours', String.valueOf(ac.forecast.totalLoggedHours))
+            + row('Projected final', String.valueOf(ac.forecast.projectedFinalHours)
+                + ' (' + ac.overrunPercent + '% over)')
+            + row('Velocity', String.valueOf(ac.forecast.currentVelocityHoursPerWeek) + 'h/wk')
+            + row('Projected completion', String.valueOf(ac.forecast.projectedCompletionDate))
+            + '</table>'
+            + '<p style="margin-top: 20px;">'
+            + '<a href="' + recordUrl + '" style="background:#7c3aed;color:#fff;padding:8px 16px;'
+            + 'border-radius:6px;text-decoration:none;font-weight:500;">Open WorkItem</a></p>'
+            + '<p style="font-size: 11px; color: #9ca3af; margin-top: 24px;">'
+            + 'You are receiving this because your team has Forecast Alerts enabled. '
+            + 'Adjust notification preferences in Delivery Hub Settings.</p></div>';
+    }
+
+    private static String row(String label, String value) {
+        return '<tr><td style="border:1px solid #e5e7eb;padding:6px 10px;color:#6b7280;">' + escape(label)
+            + '</td><td style="border:1px solid #e5e7eb;padding:6px 10px;color:#111827;font-weight:500;">'
+            + escape(value) + '</td></tr>';
+    }
+
+    private static String escape(String s) {
+        if (s == null) {
+            return '';
+        }
+        return s.escapeHtml4();
+    }
+
+    /**
+     * @description Posts forecast-risk Slack messages when the org has a webhook
+     *              configured. Mirrors DeliveryEscalationNotifService.sendEscalationSlack.
+     */
+    private static void sendForecastSlack(Map<String, String> workItemNameToMessage) {
+        if (workItemNameToMessage.isEmpty()) {
+            return;
+        }
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        if (settings == null || String.isBlank(settings.SlackWebhookUrlTxt__c)) {
+            return;
+        }
+        try {
+            DeliverySlackService.postStageChanges(workItemNameToMessage);
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryForecastAlertService] Slack post failed: ' + e.getMessage());
+        }
+    }
+
+    private static void stampWorkItems(List<AlertCandidate> firing) {
+        List<WorkItem__c> updates = new List<WorkItem__c>();
+        Datetime now = Datetime.now();
+        for (AlertCandidate ac : firing) {
+            updates.add(new WorkItem__c(
+                Id = ac.workItem.Id,
+                LastForecastAlertDateTime__c = now,
+                LastForecastAlertProjectedHoursNumber__c = ac.forecast.projectedFinalHours
+            ));
+        }
+        try {
+            Database.update(updates, AccessLevel.SYSTEM_MODE);
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryForecastAlertService] WI stamp failed: ' + e.getMessage());
+        }
+    }
+
+    private static void stampScanComplete(DeliveryHubSettings__c settings) {
+        try {
+            settings.LastForecastAlertScanDate__c = Date.today();
+            Database.update(settings, AccessLevel.SYSTEM_MODE);
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryForecastAlertService] settings stamp failed: ' + e.getMessage());
+        }
+    }
+
+    /** @description One firing-candidate row passed between evaluate and dispatch. */
+    @TestVisible
+    private class AlertCandidate {
+        WorkItem__c workItem;
+        DeliveryForecastService.ProjectForecast forecast;
+        Decimal overrunPercent;
+        Decimal overrunHours;
+    }
+}

--- a/force-app/main/default/classes/DeliveryForecastAlertService.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryForecastAlertService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryForecastAlertServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryForecastAlertServiceTest.cls
@@ -1,0 +1,244 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Tests for DeliveryForecastAlertService. Covers gating
+ *              (disabled feature, no candidates, no estimate), threshold
+ *              firing, cooldown, material-worsening re-fire, recipient
+ *              routing, queueable wiring.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexDoc,PMD.ExcessiveParameterList')
+@IsTest
+private class DeliveryForecastAlertServiceTest {
+
+    private static Map<Id, Id> bridgeByWi = new Map<Id, Id>();
+
+    private static WorkItem__c insertActiveRoot(String briefDesc, Decimal estimate, Date startDate, Date endDate) {
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c = briefDesc,
+            EstimatedHoursNumber__c = estimate,
+            EstimatedStartDevDate__c = startDate,
+            EstimatedEndDevDate__c = endDate,
+            ActivatedDateTime__c = Datetime.now(),
+            StatusPk__c = 'Active',
+            StageNamePk__c = 'In Development'
+        );
+        DeliveryWorkItemTriggerHandler.triggerDisabled = true;
+        try {
+            insert wi;
+        } finally {
+            DeliveryWorkItemTriggerHandler.triggerDisabled = false;
+        }
+        return wi;
+    }
+
+    private static WorkLog__c buildLog(Id wiId, Decimal hours, Date workDate) {
+        Id requestId = bridgeByWi.get(wiId);
+        if (requestId == null) {
+            WorkRequest__c bridge = new WorkRequest__c(
+                WorkItemId__c = wiId,
+                StatusPk__c = 'Active'
+            );
+            insert bridge;
+            requestId = bridge.Id;
+            bridgeByWi.put(wiId, requestId);
+        }
+        return new WorkLog__c(
+            WorkItemLookup__c = wiId,
+            RequestId__c = requestId,
+            HoursLoggedNumber__c = hours,
+            WorkDateDate__c = workDate,
+            WorkDescriptionTxt__c = 'forecast alert test'
+        );
+    }
+
+    private static void enableFeature(Decimal thresholdPct) {
+        DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
+        s.EnableForecastAlertsDateTime__c = Datetime.now();
+        s.ForecastAlertThresholdPercentNumber__c = thresholdPct;
+        upsert s;
+    }
+
+    private static void seedOverBudgetWi() {
+        // 5h estimate, 4 weeks of 10h logs anchored on today → projected hugely over.
+        WorkItem__c wi = insertActiveRoot('Over-budget root', 5, Date.today().addDays(-21), Date.today().addDays(-1));
+        insert new List<WorkLog__c>{
+            buildLog(wi.Id, 10, Date.today().addDays(-21)),
+            buildLog(wi.Id, 10, Date.today().addDays(-14)),
+            buildLog(wi.Id, 10, Date.today().addDays(-7)),
+            buildLog(wi.Id, 10, Date.today())
+        };
+    }
+
+    @IsTest
+    static void testDisabledFeatureReturnsZero() {
+        seedOverBudgetWi();
+        // EnableForecastAlertsDateTime is null by default.
+
+        Test.startTest();
+        Integer fired = DeliveryForecastAlertService.runSweep();
+        Test.stopTest();
+
+        System.assertEquals(0, fired, 'Disabled feature must not dispatch');
+    }
+
+    @IsTest
+    static void testThresholdFiresOnOverBudgetWi() {
+        seedOverBudgetWi();
+        enableFeature(110);
+
+        Test.startTest();
+        Integer fired = DeliveryForecastAlertService.runSweep();
+        Test.stopTest();
+
+        System.assertEquals(1, fired, 'Single over-budget WI should fire one alert');
+
+        // Verify cooldown stamp landed
+        WorkItem__c wi = [SELECT LastForecastAlertDateTime__c, LastForecastAlertProjectedHoursNumber__c
+                         FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Over-budget root' LIMIT 1];
+        System.assertNotEquals(null, wi.LastForecastAlertDateTime__c, 'LastForecastAlertDateTime stamped');
+        System.assertNotEquals(null, wi.LastForecastAlertProjectedHoursNumber__c, 'Projected hours captured');
+    }
+
+    @IsTest
+    static void testCooldownSuppressesRefire() {
+        seedOverBudgetWi();
+        enableFeature(110);
+
+        DeliveryForecastAlertService.runSweep();
+
+        Test.startTest();
+        Integer secondFire = DeliveryForecastAlertService.runSweep();
+        Test.stopTest();
+
+        System.assertEquals(0, secondFire,
+            'Within cooldown (default 7d) without material worsening, no re-fire');
+    }
+
+    @IsTest
+    static void testUnderThresholdSilent() {
+        // 50h estimate, 4 weeks of 10h = 40h logged at velocity 10h/wk.
+        // Projected final = 50h exactly = 100% of estimate → under 110% threshold.
+        WorkItem__c wi = insertActiveRoot('At-budget', 50, Date.today().addDays(-21), Date.today().addDays(28));
+        insert new List<WorkLog__c>{
+            buildLog(wi.Id, 10, Date.today().addDays(-21)),
+            buildLog(wi.Id, 10, Date.today().addDays(-14)),
+            buildLog(wi.Id, 10, Date.today().addDays(-7)),
+            buildLog(wi.Id, 10, Date.today())
+        };
+        enableFeature(110);
+
+        Test.startTest();
+        Integer fired = DeliveryForecastAlertService.runSweep();
+        Test.stopTest();
+
+        System.assertEquals(0, fired, 'WI projected at exactly 100% must not fire 110% threshold');
+    }
+
+    @IsTest
+    static void testNoEstimateSkipped() {
+        WorkItem__c wi = insertActiveRoot('No estimate', null, null, null);
+        insert new List<WorkLog__c>{
+            buildLog(wi.Id, 10, Date.today())
+        };
+        enableFeature(110);
+
+        Test.startTest();
+        Integer fired = DeliveryForecastAlertService.runSweep();
+        Test.stopTest();
+
+        System.assertEquals(0, fired, 'WIs without an estimate cannot be alerted on');
+    }
+
+    @IsTest
+    static void testChildWiIgnored() {
+        // Only root-level WIs (ParentWorkItemLookup__c = null) should sweep.
+        WorkItem__c parent = insertActiveRoot('Parent', 100, null, null);
+        WorkItem__c child = new WorkItem__c(
+            BriefDescriptionTxt__c = 'child',
+            EstimatedHoursNumber__c = 5,
+            ParentWorkItemLookup__c = parent.Id,
+            ActivatedDateTime__c = Datetime.now(),
+            StatusPk__c = 'Active',
+            StageNamePk__c = 'In Development'
+        );
+        DeliveryWorkItemTriggerHandler.triggerDisabled = true;
+        try {
+            insert child;
+        } finally {
+            DeliveryWorkItemTriggerHandler.triggerDisabled = false;
+        }
+        // Heavy logs on child to push over budget.
+        insert new List<WorkLog__c>{
+            buildLog(child.Id, 10, Date.today().addDays(-21)),
+            buildLog(child.Id, 10, Date.today().addDays(-14)),
+            buildLog(child.Id, 10, Date.today().addDays(-7)),
+            buildLog(child.Id, 10, Date.today())
+        };
+        enableFeature(110);
+
+        Test.startTest();
+        Integer fired = DeliveryForecastAlertService.runSweep();
+        Test.stopTest();
+
+        // Parent rolls up the child's logs and IS over budget → expected to fire.
+        // Child itself is not a root → not directly evaluated; the rollup is what matters.
+        System.assertEquals(1, fired,
+            'Only the root WI fires; child rolls up under parent automatically');
+    }
+
+    @IsTest
+    static void testTerminalStageSkipped() {
+        WorkItem__c wi = insertActiveRoot('Done one', 5, Date.today().addDays(-21), Date.today().addDays(-1));
+        wi.StageNamePk__c = 'Done';
+        DeliveryWorkItemTriggerHandler.triggerDisabled = true;
+        try {
+            update wi;
+        } finally {
+            DeliveryWorkItemTriggerHandler.triggerDisabled = false;
+        }
+        insert new List<WorkLog__c>{
+            buildLog(wi.Id, 10, Date.today().addDays(-21)),
+            buildLog(wi.Id, 10, Date.today().addDays(-14)),
+            buildLog(wi.Id, 10, Date.today().addDays(-7)),
+            buildLog(wi.Id, 10, Date.today())
+        };
+        enableFeature(110);
+
+        Test.startTest();
+        Integer fired = DeliveryForecastAlertService.runSweep();
+        Test.stopTest();
+
+        System.assertEquals(0, fired, 'Terminal-stage WIs excluded from sweep');
+    }
+
+    @IsTest
+    static void testQueueableDelegates() {
+        seedOverBudgetWi();
+        enableFeature(110);
+
+        Test.startTest();
+        System.enqueueJob(new DeliveryForecastAlertQueueable());
+        Test.stopTest();
+
+        WorkItem__c wi = [SELECT LastForecastAlertDateTime__c
+                         FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Over-budget root' LIMIT 1];
+        System.assertNotEquals(null, wi.LastForecastAlertDateTime__c,
+            'Queueable wraps runSweep correctly — alert should fire end-to-end');
+    }
+
+    @IsTest
+    static void testScanDateStampedEvenWhenNoneFired() {
+        // No data → 0 fired, but the scan-date stamp should still land so the
+        // scheduler's once-per-day guard works correctly.
+        enableFeature(110);
+
+        Test.startTest();
+        DeliveryForecastAlertService.runSweep();
+        Test.stopTest();
+
+        DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
+        System.assertEquals(Date.today(), s.LastForecastAlertScanDate__c,
+            'Scan-date stamps each successful sweep regardless of fire count');
+    }
+}

--- a/force-app/main/default/classes/DeliveryForecastAlertServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryForecastAlertServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryHubScheduler.cls
+++ b/force-app/main/default/classes/DeliveryHubScheduler.cls
@@ -28,6 +28,7 @@ global without sharing class DeliveryHubScheduler implements Schedulable {
         enqueueWeeklyDigestIfDue();
         enqueueInvoiceGenerationIfDue();
         enqueueOverdueRemindersIfEnabled();
+        enqueueForecastAlertsIfDue();
         processScheduledDocumentSends();
         runReconciliation();
         recalcWorkItemETAsIfTopOfHour();
@@ -290,6 +291,34 @@ global without sharing class DeliveryHubScheduler implements Schedulable {
             if (settings != null && settings.EnableOverdueRemindersDateTime__c != null) {
                 System.enqueueJob(new DeliveryOverdueReminderQueueable());
             }
+        } catch (Exception ex) {
+            String msg = ex.getMessage();
+            msg.length();
+        }
+    }
+
+    /**
+     * @description Enqueues the forecast-alert sweep once per day at 8 AM UTC
+     *              when the feature is enabled in org settings. Scheduled one
+     *              hour before overdue reminders so daily-cadence alerts cluster
+     *              in a 9 AM UTC window. Idempotent: gated by LastForecastAlertScanDate
+     *              so multiple scheduler ticks on the same day don't double-fire.
+     */
+    private static void enqueueForecastAlertsIfDue() {
+        try {
+            Integer currentHour = DateTime.now().hourGmt();
+            if (currentHour != 8) {
+                return;
+            }
+            DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+            if (settings == null || settings.EnableForecastAlertsDateTime__c == null) {
+                return;
+            }
+            Date today = Date.today();
+            if (settings.LastForecastAlertScanDate__c == today) {
+                return;
+            }
+            System.enqueueJob(new DeliveryForecastAlertQueueable());
         } catch (Exception ex) {
             String msg = ex.getMessage();
             msg.length();

--- a/force-app/main/default/flexipages/DeliveryWorkItemRecordPage.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryWorkItemRecordPage.flexipage-meta.xml
@@ -755,6 +755,24 @@
         <type>Facet</type>
     </flexiPageRegions>
 
+    <!-- Hours & Forecast tab content — Phase 2A monthly bars + Phase 3 velocity burn-up -->
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentName>deliveryProjectMonthlyHours</componentName>
+                <identifier>c_deliveryProjectMonthlyHours</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentName>deliveryProjectBurnUpChart</componentName>
+                <identifier>c_deliveryProjectBurnUpChart</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>hoursForecastTabContent</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
     <!-- ══ Tab Set ══ -->
     <flexiPageRegions>
         <itemInstances>
@@ -787,6 +805,20 @@
                 </componentInstanceProperties>
                 <componentName>flexipage:tab</componentName>
                 <identifier>detailTab</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>hoursForecastTabContent</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>title</name>
+                    <value>Hours &amp; Forecast</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:tab</componentName>
+                <identifier>hoursForecastTab</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -827,6 +859,12 @@
 
     <!-- Tab 1: Actions — things the user does -->
     <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentName>deliveryHoursPills</componentName>
+                <identifier>c_deliveryHoursPills</identifier>
+            </componentInstance>
+        </itemInstances>
         <itemInstances>
             <componentInstance>
                 <componentName>deliveryScore</componentName>
@@ -883,6 +921,12 @@
             <componentInstance>
                 <componentName>deliveryRecurringConfig</componentName>
                 <identifier>c_deliveryRecurringConfig</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentName>deliveryAuditChainViewer</componentName>
+                <identifier>c_deliveryAuditChainViewer</identifier>
             </componentInstance>
         </itemInstances>
         <name>sidebarContextContent</name>

--- a/force-app/main/default/lwc/deliveryAuditChainViewer/deliveryAuditChainViewer.css
+++ b/force-app/main/default/lwc/deliveryAuditChainViewer/deliveryAuditChainViewer.css
@@ -1,0 +1,185 @@
+:host {
+    display: block;
+}
+
+.audit-card {
+    background: #ffffff;
+    border-radius: 0.75rem;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    font-size: 0.8125rem;
+}
+
+.audit-header {
+    display: flex;
+    align-items: center;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid #e5e7eb;
+    background: linear-gradient(135deg, #faf5ff 0%, #eff6ff 100%);
+}
+
+.audit-header-left {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.audit-header-icon {
+    color: #7c3aed;
+}
+
+.audit-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0 0 0.15rem 0;
+}
+
+.audit-subtitle {
+    font-size: 0.75rem;
+    color: #6b7280;
+    margin: 0;
+}
+
+.audit-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.25rem;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.audit-depth {
+    width: 8rem;
+}
+
+.audit-probe-btn {
+    background: #7c3aed;
+    color: #ffffff;
+    border: 1px solid #6d28d9;
+    border-radius: 0.375rem;
+    padding: 0.45rem 0.9rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.audit-probe-btn:hover:not(:disabled) {
+    background: #6d28d9;
+}
+
+.audit-probe-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.audit-loading {
+    padding: 2rem 1rem;
+    text-align: center;
+}
+
+.audit-loading-sub {
+    margin-top: 0.5rem;
+    font-size: 0.75rem;
+    color: #9ca3af;
+}
+
+.audit-error {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 1rem 1.25rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    background: #fef2f2;
+    border: 1px solid #fca5a5;
+    color: #991b1b;
+}
+
+.audit-empty {
+    padding: 2rem 1.25rem;
+    text-align: center;
+    color: #6b7280;
+}
+
+.audit-empty-sub {
+    font-size: 0.75rem;
+    color: #9ca3af;
+    margin-top: 0.5rem;
+}
+
+.audit-results {
+    padding: 0.5rem 0;
+}
+
+.audit-row {
+    padding: 0.5rem 1.25rem;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.audit-row:last-child {
+    border-bottom: none;
+}
+
+.audit-row-main {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.audit-org-name {
+    font-weight: 600;
+    color: #111827;
+}
+
+.audit-row-meta {
+    display: flex;
+    gap: 1rem;
+    margin-top: 0.25rem;
+    font-size: 0.6875rem;
+    color: #6b7280;
+}
+
+.audit-meta-item {
+    display: inline-block;
+}
+
+.reveal-badge {
+    font-size: 0.6875rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 9999px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.reveal-badge--full {
+    background: #ecfdf5;
+    color: #047857;
+    border: 1px solid #6ee7b7;
+}
+
+.reveal-badge--mid {
+    background: #eff6ff;
+    color: #1d4ed8;
+    border: 1px solid #93c5fd;
+}
+
+.reveal-badge--low {
+    background: #fffbeb;
+    color: #b45309;
+    border: 1px solid #fcd34d;
+}
+
+.reveal-badge--redacted {
+    background: #f3f4f6;
+    color: #6b7280;
+    border: 1px solid #d1d5db;
+}
+
+.reveal-badge--neutral {
+    background: #f9fafb;
+    color: #6b7280;
+    border: 1px solid #e5e7eb;
+}

--- a/force-app/main/default/lwc/deliveryAuditChainViewer/deliveryAuditChainViewer.html
+++ b/force-app/main/default/lwc/deliveryAuditChainViewer/deliveryAuditChainViewer.html
@@ -1,0 +1,73 @@
+<template>
+    <div class="audit-card">
+        <div class="audit-header">
+            <div class="audit-header-left">
+                <lightning-icon icon-name="utility:graph" alternative-text="Audit chain" size="small" class="audit-header-icon"></lightning-icon>
+                <div>
+                    <h2 class="audit-title">Fulfillment Audit Chain</h2>
+                    <p class="audit-subtitle">Reveals downstream peers + jurisdictions per their consent</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="audit-controls">
+            <lightning-combobox
+                label="Probe depth"
+                value={depth}
+                options={depthOptions}
+                onchange={handleDepthChange}
+                variant="label-hidden"
+                class="audit-depth">
+            </lightning-combobox>
+            <button type="button"
+                    class="audit-probe-btn"
+                    onclick={handleProbe}
+                    disabled={isLoading}>
+                <template lwc:if={isLoading}>
+                    Probing…
+                </template>
+                <template lwc:else>
+                    Probe chain
+                </template>
+            </button>
+        </div>
+
+        <template lwc:if={isLoading}>
+            <div class="audit-loading">
+                <lightning-spinner alternative-text="Probing cross-org chain..." size="small"></lightning-spinner>
+                <p class="audit-loading-sub">Recursive HTTP probes can take 5-30s per hop.</p>
+            </div>
+        </template>
+
+        <template lwc:if={errorMessage}>
+            <div class="audit-error">
+                <lightning-icon icon-name="utility:error" size="x-small"></lightning-icon>
+                <span>{errorMessage}</span>
+            </div>
+        </template>
+
+        <template lwc:if={hasResults}>
+            <div class="audit-results">
+                <template for:each={flattened} for:item="row">
+                    <div key={row.key} class="audit-row" style={row.indentStyle}>
+                        <div class="audit-row-main">
+                            <span class="audit-org-name">{row.orgName}</span>
+                            <span class={row.badgeClass}>{row.revealLevel}</span>
+                        </div>
+                        <div class="audit-row-meta">
+                            <span class="audit-meta-item">Org Id: {row.orgId}</span>
+                            <span class="audit-meta-item">Jurisdiction: {row.jurisdiction}</span>
+                        </div>
+                    </div>
+                </template>
+            </div>
+        </template>
+
+        <template lwc:if={hasNoResults}>
+            <div class="audit-empty">
+                <p>No peers found in this org's segment of the chain.</p>
+                <p class="audit-empty-sub">Either this WorkItem has no downstream Vendor edges, or all peers refused the probe (reveal=Off).</p>
+            </div>
+        </template>
+    </div>
+</template>

--- a/force-app/main/default/lwc/deliveryAuditChainViewer/deliveryAuditChainViewer.js
+++ b/force-app/main/default/lwc/deliveryAuditChainViewer/deliveryAuditChainViewer.js
@@ -1,0 +1,100 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @author Cloud Nimbus LLC
+ */
+import { LightningElement, api, track } from "lwc";
+import getFulfillmentChain from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDepthProbeService.getFulfillmentChain";
+
+const DEFAULT_DEPTH = 3;
+const MAX_DEPTH = 5;
+
+export default class DeliveryAuditChainViewer extends LightningElement {
+    @api recordId;
+    @track chain;
+    @track flattened = [];
+    errorMessage = "";
+    isLoading = false;
+    hasRun = false;
+    depth = DEFAULT_DEPTH;
+
+    get depthOptions() {
+        const out = [];
+        for (let i = 1; i <= MAX_DEPTH; i++) {
+            out.push({ label: `${i} hop${i === 1 ? "" : "s"}`, value: i });
+        }
+        return out;
+    }
+
+    get hasResults() {
+        return this.hasRun && !this.isLoading && this.flattened.length > 0;
+    }
+
+    get hasNoResults() {
+        return this.hasRun && !this.isLoading && this.flattened.length === 0 && !this.errorMessage;
+    }
+
+    handleDepthChange(event) {
+        this.depth = Number(event.detail.value);
+    }
+
+    async handleProbe() {
+        this.isLoading = true;
+        this.errorMessage = "";
+        this.hasRun = true;
+        this.flattened = [];
+        this.chain = null;
+        try {
+            const root = await getFulfillmentChain({
+                workItemId: this.recordId,
+                maxDepth: this.depth
+            });
+            this.chain = root;
+            this.flattened = this._flatten(root, 0, "");
+        } catch (e) {
+            this.errorMessage = e && e.body ? e.body.message : (e ? e.message : "Probe failed");
+        } finally {
+            this.isLoading = false;
+        }
+    }
+
+    _flatten(node, level, parentKey) {
+        if (!node) {
+            return [];
+        }
+        const out = [];
+        const key = `${parentKey}/${level}-${out.length}-${node.orgId || node.orgName || "anon"}`;
+        const indentStyle = `padding-left: ${level * 1.25}rem`;
+        out.push({
+            key,
+            level,
+            indentStyle,
+            orgName: node.orgName || "[unknown]",
+            orgId: node.orgId || "—",
+            jurisdiction: node.jurisdiction || "—",
+            revealLevel: node.revealLevel || "—",
+            badgeClass: this._badgeClass(node.revealLevel),
+            isRedacted: node.revealLevel === "Off"
+        });
+        if (node.children && node.children.length) {
+            for (let i = 0; i < node.children.length; i++) {
+                const childKey = `${key}/c${i}`;
+                const subRows = this._flatten(node.children[i], level + 1, childKey);
+                for (const r of subRows) {
+                    out.push(r);
+                }
+            }
+        }
+        return out;
+    }
+
+    _badgeClass(reveal) {
+        switch (reveal) {
+            case "Full": return "reveal-badge reveal-badge--full";
+            case "OrgAndJurisdiction": return "reveal-badge reveal-badge--mid";
+            case "OrgOnly": return "reveal-badge reveal-badge--low";
+            case "Off": return "reveal-badge reveal-badge--redacted";
+            default: return "reveal-badge reveal-badge--neutral";
+        }
+    }
+}

--- a/force-app/main/default/lwc/deliveryAuditChainViewer/deliveryAuditChainViewer.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryAuditChainViewer/deliveryAuditChainViewer.js-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordPage</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordPage">
+            <objects>
+                <object>WorkItem__c</object>
+            </objects>
+        </targetConfig>
+    </targetConfigs>
+    <masterLabel>Delivery Audit Chain Viewer</masterLabel>
+    <description>Triggers a depth-charge probe against the fulfillment chain for this WorkItem. Renders the cross-org tree (org, jurisdiction, reveal level, children) returned by DeliveryDepthProbeService.getFulfillmentChain.</description>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/deliveryHoursPills/deliveryHoursPills.css
+++ b/force-app/main/default/lwc/deliveryHoursPills/deliveryHoursPills.css
@@ -1,0 +1,89 @@
+:host {
+    display: block;
+}
+
+.pills-row {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: #ffffff;
+    border-radius: 0.5rem;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    flex-wrap: wrap;
+}
+
+.pill {
+    flex: 1 1 8rem;
+    min-width: 7rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    border-left: 4px solid #d1d5db;
+    background: #f9fafb;
+}
+
+.pill--green {
+    border-left-color: #10b981;
+    background: #ecfdf5;
+}
+
+.pill--yellow {
+    border-left-color: #f59e0b;
+    background: #fffbeb;
+}
+
+.pill--red {
+    border-left-color: #ef4444;
+    background: #fef2f2;
+}
+
+.pill--neutral {
+    border-left-color: #9ca3af;
+    background: #f9fafb;
+}
+
+.pill-label {
+    font-size: 0.6875rem;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.15rem;
+}
+
+.pill-badge {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #111827;
+    line-height: 1.2;
+}
+
+.pill-badge--green {
+    color: #047857;
+}
+
+.pill-badge--yellow {
+    color: #b45309;
+}
+
+.pill-badge--red {
+    color: #b91c1c;
+}
+
+.pill-badge--neutral {
+    color: #6b7280;
+}
+
+.pill-sub {
+    font-size: 0.6875rem;
+    color: #6b7280;
+    margin-top: 0.25rem;
+}
+
+.pills-error {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    color: #991b1b;
+    font-size: 0.8125rem;
+}

--- a/force-app/main/default/lwc/deliveryHoursPills/deliveryHoursPills.html
+++ b/force-app/main/default/lwc/deliveryHoursPills/deliveryHoursPills.html
@@ -1,0 +1,22 @@
+<template>
+    <template lwc:if={hasData}>
+        <div class="pills-row">
+            <div class={onBudgetPill.pillClass} title={onBudgetPill.tooltip}>
+                <div class="pill-label">{onBudgetPill.name}</div>
+                <div class={onBudgetPill.badgeClass}>{onBudgetPill.label}</div>
+                <div class="pill-sub">{onBudgetPill.subtext}</div>
+            </div>
+            <div class={onSchedulePill.pillClass} title={onSchedulePill.tooltip}>
+                <div class="pill-label">{onSchedulePill.name}</div>
+                <div class={onSchedulePill.badgeClass}>{onSchedulePill.label}</div>
+                <div class="pill-sub">{onSchedulePill.subtext}</div>
+            </div>
+        </div>
+    </template>
+    <template lwc:if={errorMessage}>
+        <div class="pills-error">
+            <lightning-icon icon-name="utility:error" size="x-small"></lightning-icon>
+            <span>{errorMessage}</span>
+        </div>
+    </template>
+</template>

--- a/force-app/main/default/lwc/deliveryHoursPills/deliveryHoursPills.js
+++ b/force-app/main/default/lwc/deliveryHoursPills/deliveryHoursPills.js
@@ -1,0 +1,174 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @author Cloud Nimbus LLC
+ */
+import { LightningElement, api, wire } from "lwc";
+import { getRecord } from "lightning/uiRecordApi";
+
+// Field references — namespaced at runtime via the @salesforce/schema scheme is unavailable
+// for managed-package fields used outside the package, so we use string field names that
+// the bundler resolves through %%%NAMESPACE_DOT%%% replacement.
+const FIELDS = [
+    "%%%NAMESPACE_DOT%%%WorkItem__c.%%%NAMESPACE_DOT%%%EstimatedHoursNumber__c",
+    "%%%NAMESPACE_DOT%%%WorkItem__c.%%%NAMESPACE_DOT%%%TotalLoggedHoursSum__c",
+    "%%%NAMESPACE_DOT%%%WorkItem__c.%%%NAMESPACE_DOT%%%CalculatedETADate__c",
+    "%%%NAMESPACE_DOT%%%WorkItem__c.%%%NAMESPACE_DOT%%%EstimatedEndDevDate__c",
+    "%%%NAMESPACE_DOT%%%WorkItem__c.%%%NAMESPACE_DOT%%%StageNamePk__c"
+];
+
+const TERMINAL_STAGES = new Set(["Done", "Cancelled", "Closed", "Rejected"]);
+
+export default class DeliveryHoursPills extends LightningElement {
+    @api recordId;
+    record;
+    errorMessage = "";
+
+    @wire(getRecord, { recordId: "$recordId", fields: FIELDS })
+    wiredRecord({ data, error }) {
+        if (data) {
+            this.record = data;
+            this.errorMessage = "";
+        } else if (error) {
+            this.errorMessage = error.body ? error.body.message : error.message;
+        }
+    }
+
+    get hasData() {
+        return !!this.record && !this.errorMessage;
+    }
+
+    // ── Field readers (LDS getRecord shape) ───────────────────────
+
+    _field(apiName) {
+        if (!this.record || !this.record.fields) {
+            return null;
+        }
+        const namespacedKey = Object.keys(this.record.fields).find(
+            (k) => k.toLowerCase() === apiName.toLowerCase()
+                || k.toLowerCase().endsWith("__" + apiName.toLowerCase())
+        );
+        if (!namespacedKey) {
+            return null;
+        }
+        const f = this.record.fields[namespacedKey];
+        return f ? f.value : null;
+    }
+
+    get _estimated() {
+        return Number(this._field("EstimatedHoursNumber__c") || 0);
+    }
+
+    get _logged() {
+        return Number(this._field("TotalLoggedHoursSum__c") || 0);
+    }
+
+    get _eta() {
+        return this._field("CalculatedETADate__c") || this._field("EstimatedEndDevDate__c");
+    }
+
+    get _stage() {
+        return this._field("StageNamePk__c");
+    }
+
+    // ── Pill computation ──────────────────────────────────────────
+
+    get onBudgetPill() {
+        const isTerminal = TERMINAL_STAGES.has(this._stage || "");
+        if (this._estimated <= 0) {
+            return this._pill("On-Budget", "—", "neutral", "No estimate set", "No data");
+        }
+        const ratio = this._estimated / (this._logged || 0.0001);
+        const pct = Math.round(ratio * 100);
+        let band, tooltip;
+        if (this._logged === 0) {
+            band = "neutral";
+            tooltip = "No hours logged yet";
+        } else if (pct >= 100) {
+            band = "green";
+            tooltip = `Earning ${pct}% of estimated hours per actual hour — at or under budget.`;
+        } else if (pct >= 80) {
+            band = "yellow";
+            tooltip = `Earning ${pct}% of estimated hours per actual hour — drifting over.`;
+        } else {
+            band = "red";
+            tooltip = `Earning only ${pct}% of estimated hours per actual hour — significantly over budget.`;
+        }
+        const label = isTerminal && pct < 100 ? `${pct}%` : `${pct}%`;
+        return this._pill("On-Budget", label, band, tooltip,
+            `Est ${this._formatHours(this._estimated)}h · Logged ${this._formatHours(this._logged)}h`);
+    }
+
+    get onSchedulePill() {
+        const isTerminal = TERMINAL_STAGES.has(this._stage || "");
+        if (!this._eta) {
+            return this._pill("On-Schedule", "—", "neutral", "No ETA set", "No data");
+        }
+        if (isTerminal) {
+            return this._pill("On-Schedule", "Done", "green", "Stage is terminal — schedule complete.", "");
+        }
+        const today = new Date();
+        const eta = new Date(this._eta);
+        const days = Math.ceil((eta - today) / (1000 * 60 * 60 * 24));
+        let band, label, tooltip;
+        if (days >= 7) {
+            band = "green";
+            label = `${days}d`;
+            tooltip = `${days} days until ETA — on track.`;
+        } else if (days >= 0) {
+            band = "yellow";
+            label = days === 0 ? "Today" : `${days}d`;
+            tooltip = `${days} days until ETA — final stretch.`;
+        } else {
+            band = "red";
+            label = `${Math.abs(days)}d over`;
+            tooltip = `${Math.abs(days)} days past ETA — overdue.`;
+        }
+        return this._pill("On-Schedule", label, band, tooltip,
+            `ETA ${this._formatDate(this._eta)}`);
+    }
+
+    _pill(name, label, band, tooltip, subtext) {
+        return {
+            name,
+            label,
+            tooltip,
+            subtext,
+            badgeClass: `pill-badge pill-badge--${band}`,
+            pillClass: `pill pill--${band}`
+        };
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────
+
+    _formatHours(num) {
+        const n = Number(num);
+        if (!Number.isFinite(n)) {
+            return "0";
+        }
+        if (Math.abs(n) >= 100) {
+            return n.toFixed(0);
+        }
+        if (Math.abs(n) >= 10) {
+            return n.toFixed(1);
+        }
+        return n.toFixed(2);
+    }
+
+    _formatDate(iso) {
+        if (!iso) {
+            return "";
+        }
+        const parts = String(iso).split("-");
+        if (parts.length < 3) {
+            return String(iso);
+        }
+        const monthIdx = parseInt(parts[1], 10) - 1;
+        const day = parseInt(parts[2], 10);
+        const monthNames = [
+            "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+        ];
+        return `${monthNames[monthIdx]} ${day}`;
+    }
+}

--- a/force-app/main/default/lwc/deliveryHoursPills/deliveryHoursPills.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryHoursPills/deliveryHoursPills.js-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordPage</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordPage">
+            <objects>
+                <object>WorkItem__c</object>
+            </objects>
+        </targetConfig>
+    </targetConfigs>
+    <masterLabel>Delivery Hours Pills</masterLabel>
+    <description>Per-WorkItem traffic-light pills: On-Schedule (days remaining until ETA) + On-Budget (estimated vs logged hours). Mirrors the Project_Health_Pills dashboard card visual.</description>
+</LightningComponentBundle>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableForecastAlertsDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableForecastAlertsDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnableForecastAlertsDateTime__c</fullName>
+    <description>When non-null, the daily forecast-alert scan is active. Scans active root WorkItems where projectedFinalHours > EstimatedHoursNumber * ForecastAlertThresholdPercentNumber and pushes a bell + email + (when configured) Slack alert to the WI owner. Null disables the feature.</description>
+    <externalId>false</externalId>
+    <label>Enable Forecast Alerts</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/ForecastAlertThresholdPercentNumber__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/ForecastAlertThresholdPercentNumber__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ForecastAlertThresholdPercentNumber__c</fullName>
+    <description>Percent threshold above which forecast alerts fire. Default 110 = alert when projected final hours exceed estimated by 10% or more. Tunable per org.</description>
+    <externalId>false</externalId>
+    <label>Forecast Alert Threshold %</label>
+    <precision>5</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/LastForecastAlertScanDate__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/LastForecastAlertScanDate__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>LastForecastAlertScanDate__c</fullName>
+    <description>Date of the most recent successful daily forecast-alert sweep. Once-per-day guard for DeliveryHubScheduler.enqueueForecastAlertsIfDue.</description>
+    <externalId>false</externalId>
+    <label>Last Forecast Alert Scan Date</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Date</type>
+</CustomField>

--- a/force-app/main/default/objects/NotificationPreference__c/fields/EventTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/NotificationPreference__c/fields/EventTypePk__c.field-meta.xml
@@ -18,6 +18,7 @@
             <value><fullName>Document_Action</fullName><default>false</default><label>Document Action</label></value>
             <value><fullName>Comment</fullName><default>false</default><label>Comment</label></value>
             <value><fullName>Assignment</fullName><default>false</default><label>Assignment</label></value>
+            <value><fullName>Forecast_Risk</fullName><default>false</default><label>Forecast Risk</label></value>
         </valueSetDefinition>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/WorkItem__c/fields/LastForecastAlertDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/WorkItem__c/fields/LastForecastAlertDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>LastForecastAlertDateTime__c</fullName>
+    <description>Timestamp of the most recent forecast-alert delivery for this WorkItem. Cooldown guard for DeliveryForecastAlertService: re-alert only when LastForecastAlertProjectedHoursNumber worsens by ≥10% OR ≥7 days since this stamp.</description>
+    <externalId>false</externalId>
+    <label>Last Forecast Alert</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/WorkItem__c/fields/LastForecastAlertProjectedHoursNumber__c.field-meta.xml
+++ b/force-app/main/default/objects/WorkItem__c/fields/LastForecastAlertProjectedHoursNumber__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>LastForecastAlertProjectedHoursNumber__c</fullName>
+    <description>Projected final hours captured at the time of the most recent forecast alert. Used to detect ≥10% worsening for re-alert under the cooldown window.</description>
+    <externalId>false</externalId>
+    <label>Last Forecast Alert Projected Hours</label>
+    <precision>10</precision>
+    <required>false</required>
+    <scale>2</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
Closes the gap from 0.234.0.1 where the new LWCs shipped without page placement, and adds Phase 2B pills, the depth-charge UI surface, and the forecast-alert layer (designed off existing notification patterns, not the original plan's hardcoded "owner + admin" routing).

## What lands

### UI wiring (`DeliveryWorkItemRecordPage.flexipage`)
- **New main tab "Hours & Forecast"** — `deliveryProjectMonthlyHours` + `deliveryProjectBurnUpChart` stacked.
- **Sidebar Actions row** — `deliveryHoursPills` at top.
- **Sidebar Context row** — `deliveryAuditChainViewer` at bottom.

### Phase 2B — `deliveryHoursPills` LWC
- Pure LDS `getRecord` wire (no Apex). On-Budget + On-Schedule pills client-side.
- Visual matches existing `Project_Health_Pills` dashboard card.

### Depth-charge UI surface — `deliveryAuditChainViewer` LWC
- Depth selector (1-5) + "Probe chain" button. Renders flattened tree with reveal-level badges.
- Imperative call (HTTP probes are expensive — user controls when they fire).

### Forecast alert layer
- `DeliveryForecastAlertService.runSweep()` — daily walk of active root WIs, fires when `projectedFinalHours / EstimatedHoursNumber ≥ threshold` (default 110%).
- `DeliveryForecastAlertQueueable` + `DeliveryHubScheduler.enqueueForecastAlertsIfDue()` — 8 GMT daily, once-per-day guard.
- Three channels via existing `DeliveryEscalationNotifService.sendBellNotification` + `Messaging.sendEmail` + `DeliverySlackService.postStageChanges`. Per-user opt-out via `DeliveryNotificationPreferenceService.shouldNotify(userId, channel, 'Forecast_Risk')`.
- Persona routing: primary = `OwnerId`, CC = `DeveloperLookup__c` distinct. Never clients. Glen is no recipient (he uses Project_Health_Pills pull surface).
- Cooldown: 7 days between alerts per WI unless projection worsens ≥10%.
- **Ships default-off**: `EnableForecastAlertsDateTime__c` null at install.

### Metadata
- 3 new `DeliveryHubSettings__c` fields (enable DateTime, threshold %, last-scan-date).
- 2 new `WorkItem__c` fields (last-alert datetime, last-alert projected hours).
- `NotificationPreference__c.EventTypePk__c` extended with `Forecast_Risk` (non-restricted per CLAUDE.md picklist rule).

## Tests
9 cases on the forecast alert service: disabled feature, threshold fires, cooldown, under-threshold silent, no-estimate skipped, child-WI ignored (root rollup is sufficient), terminal-stage excluded, queueable delegation, scan-date stamp.

## Test plan

- [ ] `feature-test` passes
- [ ] `apex-scan` clean
- [ ] `upload-beta` passes
- [ ] Post-install on dh-prod: drop on a WorkItem record page, see Hours & Forecast tab + pills + audit viewer
- [ ] Enable `EnableForecastAlertsDateTime__c` on a sandbox; verify daily scheduler tick at 8 GMT fires a bell/email for an over-budget WI

🤖 Generated with [Claude Code](https://claude.com/claude-code)