### PR TITLE
fix(test): testChildWiIgnored — shrink parent estimate so rollup crosses threshold

### DIFF
--- a/force-app/main/default/classes/DeliveryForecastAlertServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryForecastAlertServiceTest.cls
@@ -152,11 +152,16 @@ private class DeliveryForecastAlertServiceTest {
 
     @IsTest
     static void testChildWiIgnored() {
-        // Only root-level WIs (ParentWorkItemLookup__c = null) should sweep.
-        WorkItem__c parent = insertActiveRoot('Parent', 100, null, null);
+        // Only root-level WIs (ParentWorkItemLookup__c = null) enter the sweep.
+        // Tree-rollup combines parent + child estimates and logs, so the parent
+        // fires only when the COMBINED rollup crosses threshold. With parent=2h
+        // est and child=3h est, total estimate = 5h. Child logs 40h. Rollup
+        // projected = 40h logged at velocity 10h/wk against 5h scope → trivially
+        // > 110%. Parent fires; child never enters the candidate list.
+        WorkItem__c parent = insertActiveRoot('Parent', 2, null, null);
         WorkItem__c child = new WorkItem__c(
             BriefDescriptionTxt__c = 'child',
-            EstimatedHoursNumber__c = 5,
+            EstimatedHoursNumber__c = 3,
             ParentWorkItemLookup__c = parent.Id,
             ActivatedDateTime__c = Datetime.now(),
             StatusPk__c = 'Active',
@@ -168,7 +173,6 @@ private class DeliveryForecastAlertServiceTest {
         } finally {
             DeliveryWorkItemTriggerHandler.triggerDisabled = false;
         }
-        // Heavy logs on child to push over budget.
         insert new List<WorkLog__c>{
             buildLog(child.Id, 10, Date.today().addDays(-21)),
             buildLog(child.Id, 10, Date.today().addDays(-14)),
@@ -181,10 +185,13 @@ private class DeliveryForecastAlertServiceTest {
         Integer fired = DeliveryForecastAlertService.runSweep();
         Test.stopTest();
 
-        // Parent rolls up the child's logs and IS over budget → expected to fire.
-        // Child itself is not a root → not directly evaluated; the rollup is what matters.
         System.assertEquals(1, fired,
-            'Only the root WI fires; child rolls up under parent automatically');
+            'Parent rolls up child logs over the combined estimate → exactly one alert (root only)');
+
+        WorkItem__c childAfter = [SELECT LastForecastAlertDateTime__c
+                                 FROM WorkItem__c WHERE Id = :child.Id LIMIT 1];
+        System.assertEquals(null, childAfter.LastForecastAlertDateTime__c,
+            'Child WI must NOT be alerted directly — it was never a sweep candidate');
     }
 
     @IsTest


### PR DESCRIPTION
## Why

\`upload-beta\` failure on the previous bundle (#773):

\`\`\`
Class.delivery.DeliveryForecastAlertServiceTest.testChildWiIgnored: line 186
System.AssertException: Expected: 1, Actual: 0
\`\`\`

The test set parent=100h estimate + child=5h estimate, then 40h of logs on the child. Rollup totals: 105h estimate / 40h logged → projected final = 100h+5h = exactly 100% → doesn't cross 110% threshold → 0 alerts. The test asserted 1.

Feature-test passed it, surfaced only in packaging-org upload-beta. Third example of the meta-lesson from PR #771: feature-test silently tolerates near-threshold math, packaging-org doesn't.

## Fix

Shrink parent estimate to 2h + child to 3h → rollup 5h est / 40h logged → trivially > 110% threshold → parent fires once, child correctly never enters the sweep (which was the test's actual intent). Added explicit `LastForecastAlertDateTime__c == null` assertion on the child to lock in that semantics.

## Test plan

- [ ] \`feature-test\` passes
- [ ] \`apex-scan\` clean
- [ ] **\`upload-beta\` passes** — the gate this unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)