### PR TITLE
feat(layouts): close field-coverage gaps + dynamic page for WorkItemDependency

### DIFF
--- a/force-app/main/default/applications/DeliveryHub.app-meta.xml
+++ b/force-app/main/default/applications/DeliveryHub.app-meta.xml
@@ -169,6 +169,22 @@
         <pageOrSobjectType>PortalAccess__c</pageOrSobjectType>
     </actionOverrides>
     <actionOverrides>
+        <actionName>View</actionName>
+        <content>DeliveryWorkItemDependencyRecordPage</content>
+        <formFactor>Large</formFactor>
+        <skipRecordTypeSelect>false</skipRecordTypeSelect>
+        <type>Flexipage</type>
+        <pageOrSobjectType>WorkItemDependency__c</pageOrSobjectType>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>View</actionName>
+        <content>DeliveryWorkItemDependencyRecordPage</content>
+        <formFactor>Small</formFactor>
+        <skipRecordTypeSelect>false</skipRecordTypeSelect>
+        <type>Flexipage</type>
+        <pageOrSobjectType>WorkItemDependency__c</pageOrSobjectType>
+    </actionOverrides>
+    <actionOverrides>
         <actionName>Tab</actionName>
         <content>DeliveryHubHome</content>
         <formFactor>Large</formFactor>

--- a/force-app/main/default/applications/DeliveryHubAdmin.app-meta.xml
+++ b/force-app/main/default/applications/DeliveryHubAdmin.app-meta.xml
@@ -169,6 +169,22 @@
         <pageOrSobjectType>PortalAccess__c</pageOrSobjectType>
     </actionOverrides>
     <actionOverrides>
+        <actionName>View</actionName>
+        <content>DeliveryWorkItemDependencyRecordPage</content>
+        <formFactor>Large</formFactor>
+        <skipRecordTypeSelect>false</skipRecordTypeSelect>
+        <type>Flexipage</type>
+        <pageOrSobjectType>WorkItemDependency__c</pageOrSobjectType>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>View</actionName>
+        <content>DeliveryWorkItemDependencyRecordPage</content>
+        <formFactor>Small</formFactor>
+        <skipRecordTypeSelect>false</skipRecordTypeSelect>
+        <type>Flexipage</type>
+        <pageOrSobjectType>WorkItemDependency__c</pageOrSobjectType>
+    </actionOverrides>
+    <actionOverrides>
         <actionName>Tab</actionName>
         <content>DeliveryHubAdminHome</content>
         <formFactor>Large</formFactor>

--- a/force-app/main/default/flexipages/DeliveryDocumentRecordPage.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryDocumentRecordPage.flexipage-meta.xml
@@ -279,6 +279,132 @@
         <type>Facet</type>
     </flexiPageRegions>
 
+    <!-- Dunning: Left column (OverdueReminderCount, OverdueReminderLevel) -->
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.OverdueReminderCountNumber__c</fieldItem>
+                <identifier>RecordOverdueReminderCountNumber_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.OverdueReminderLevelPk__c</fieldItem>
+                <identifier>RecordOverdueReminderLevelPk_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-dd-dunning-left</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
+    <!-- Dunning: Right column (LastOverdueReminderDateTime) -->
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.LastOverdueReminderDateTime__c</fieldItem>
+                <identifier>RecordLastOverdueReminderDateTime_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-dd-dunning-right</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
+    <!-- Scheduled Send: Left column (ScheduledSendDateTime) -->
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.ScheduledSendDateTime__c</fieldItem>
+                <identifier>RecordScheduledSendDateTime_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-dd-sched-left</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
+    <!-- Scheduled Send: Right column (ScheduledRecipientEmail) -->
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.ScheduledRecipientEmailTxt__c</fieldItem>
+                <identifier>RecordScheduledRecipientEmailTxt_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-dd-sched-right</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
+    <!-- Signing & Versioning: Left column (RequireSigningDateTime, VersionNumber) -->
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.RequireSigningDateTime__c</fieldItem>
+                <identifier>RecordRequireSigningDateTime_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.VersionNumber__c</fieldItem>
+                <identifier>RecordVersionNumber_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-dd-signing-left</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
+    <!-- Signing & Versioning: Right column (DisputeReason, PreviousVersion) -->
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.DisputeReasonTxt__c</fieldItem>
+                <identifier>RecordDisputeReasonTxt_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.PreviousVersionLookup__c</fieldItem>
+                <identifier>RecordPreviousVersionLookup_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-dd-signing-right</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
     <!-- ══ DYNAMIC FORMS: Level 2 — Column Facets ══ -->
 
     <!-- Document Info: 2 columns -->
@@ -401,6 +527,84 @@
         <type>Facet</type>
     </flexiPageRegions>
 
+    <!-- Dunning: 2 columns -->
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-dd-dunning-left</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column_dunning1</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-dd-dunning-right</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column_dunning2</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-dd-dunning-cols</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
+    <!-- Scheduled Send: 2 columns -->
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-dd-sched-left</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column_sched1</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-dd-sched-right</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column_sched2</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-dd-sched-cols</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
+    <!-- Signing & Versioning: 2 columns -->
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-dd-signing-left</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column_signing1</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-dd-signing-right</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column_signing2</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-dd-signing-cols</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
     <!-- ══ Detail Tab Content — Level 3 field sections ══ -->
     <flexiPageRegions>
         <itemInstances>
@@ -473,6 +677,60 @@
                 </componentInstanceProperties>
                 <componentName>flexipage:fieldSection</componentName>
                 <identifier>flexipage_fieldSection_track</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>columns</name>
+                    <value>Facet-dd-sched-cols</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>label</name>
+                    <value>Scheduled Send</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:fieldSection</componentName>
+                <identifier>flexipage_fieldSection_sched</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>columns</name>
+                    <value>Facet-dd-dunning-cols</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>label</name>
+                    <value>Dunning</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:fieldSection</componentName>
+                <identifier>flexipage_fieldSection_dunning</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>columns</name>
+                    <value>Facet-dd-signing-cols</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>label</name>
+                    <value>Signing &amp; Versioning</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:fieldSection</componentName>
+                <identifier>flexipage_fieldSection_signing</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>

--- a/force-app/main/default/flexipages/DeliveryWorkItemDependencyRecordPage.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryWorkItemDependencyRecordPage.flexipage-meta.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FlexiPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <!-- ── Header ── -->
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
@@ -35,7 +34,7 @@
 
     <!-- ══ DYNAMIC FORMS: Level 1 — Field Facets ══ -->
 
-    <!-- Time Entry: Left column fields (Name, WorkItemId, WorkDateDate) -->
+    <!-- Dependency: Left column (Name, BlockingWorkItem, BlockedWorkItem) -->
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
@@ -53,8 +52,8 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.WorkItemLookup__c</fieldItem>
-                <identifier>RecordWorkItemId_cField</identifier>
+                <fieldItem>Record.BlockingWorkItemLookup__c</fieldItem>
+                <identifier>RecordBlockingWorkItemLookup_cField</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -63,15 +62,15 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.WorkDateDate__c</fieldItem>
-                <identifier>RecordWorkDateDate_cField</identifier>
+                <fieldItem>Record.BlockedWorkItemLookup__c</fieldItem>
+                <identifier>RecordBlockedWorkItemLookup_cField</identifier>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-a1b20001-0001-0001-0001-000000000001</name>
+        <name>Facet-wid-dep-left</name>
         <type>Facet</type>
     </flexiPageRegions>
 
-    <!-- Time Entry: Right column fields (StatusPk, ResourceTitle, HoursLoggedNumber, RequestId) -->
+    <!-- Dependency: Right column (TypePk, ExternalIdTxt) -->
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
@@ -79,61 +78,25 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.StatusPk__c</fieldItem>
-                <identifier>RecordStatusPk_cField</identifier>
+                <fieldItem>Record.TypePk__c</fieldItem>
+                <identifier>RecordTypePk_cField</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
                     <name>uiBehavior</name>
-                    <value>none</value>
+                    <value>readonly</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.ResourceTitleTxt__c</fieldItem>
-                <identifier>RecordResourceTitleTxt_cField</identifier>
+                <fieldItem>Record.ExternalIdTxt__c</fieldItem>
+                <identifier>RecordExternalIdTxt_cField</identifier>
             </fieldInstance>
         </itemInstances>
-        <itemInstances>
-            <fieldInstance>
-                <fieldInstanceProperties>
-                    <name>uiBehavior</name>
-                    <value>none</value>
-                </fieldInstanceProperties>
-                <fieldItem>Record.HoursLoggedNumber__c</fieldItem>
-                <identifier>RecordHoursLoggedNumber_cField</identifier>
-            </fieldInstance>
-        </itemInstances>
-        <itemInstances>
-            <fieldInstance>
-                <fieldInstanceProperties>
-                    <name>uiBehavior</name>
-                    <value>none</value>
-                </fieldInstanceProperties>
-                <fieldItem>Record.RequestId__c</fieldItem>
-                <identifier>RecordRequestId_cField</identifier>
-            </fieldInstance>
-        </itemInstances>
-        <name>Facet-a1b20001-0001-0001-0001-000000000002</name>
+        <name>Facet-wid-dep-right</name>
         <type>Facet</type>
     </flexiPageRegions>
 
-    <!-- Description: Single column fields (WorkDescriptionTxt) -->
-    <flexiPageRegions>
-        <itemInstances>
-            <fieldInstance>
-                <fieldInstanceProperties>
-                    <name>uiBehavior</name>
-                    <value>none</value>
-                </fieldInstanceProperties>
-                <fieldItem>Record.WorkDescriptionTxt__c</fieldItem>
-                <identifier>RecordWorkDescriptionTxt_cField</identifier>
-            </fieldInstance>
-        </itemInstances>
-        <name>Facet-a1b20001-0001-0001-0001-000000000003</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-
-    <!-- System: Left column fields (CreatedById) -->
+    <!-- System: Left column (CreatedById) -->
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
@@ -145,11 +108,11 @@
                 <identifier>RecordCreatedByIdField</identifier>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-a1b20001-0001-0001-0001-000000000004</name>
+        <name>Facet-wid-sys-left</name>
         <type>Facet</type>
     </flexiPageRegions>
 
-    <!-- System: Right column fields (LastModifiedById) -->
+    <!-- System: Right column (LastModifiedById) -->
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
@@ -161,51 +124,35 @@
                 <identifier>RecordLastModifiedByIdField</identifier>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-a1b20001-0001-0001-0001-000000000005</name>
+        <name>Facet-wid-sys-right</name>
         <type>Facet</type>
     </flexiPageRegions>
 
     <!-- ══ DYNAMIC FORMS: Level 2 — Column Facets ══ -->
 
-    <!-- Time Entry: 2 columns -->
+    <!-- Dependency: 2 columns -->
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-a1b20001-0001-0001-0001-000000000001</value>
+                    <value>Facet-wid-dep-left</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
-                <identifier>flexipage_column_timeEntry1</identifier>
+                <identifier>flexipage_column_dep1</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-a1b20001-0001-0001-0001-000000000002</value>
+                    <value>Facet-wid-dep-right</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
-                <identifier>flexipage_column_timeEntry2</identifier>
+                <identifier>flexipage_column_dep2</identifier>
             </componentInstance>
         </itemInstances>
-        <name>Facet-a1b20001-0001-0001-0002-000000000001</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-
-    <!-- Description: 1 column -->
-    <flexiPageRegions>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>body</name>
-                    <value>Facet-a1b20001-0001-0001-0001-000000000003</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:column</componentName>
-                <identifier>flexipage_column_desc1</identifier>
-            </componentInstance>
-        </itemInstances>
-        <name>Facet-a1b20001-0001-0001-0002-000000000002</name>
+        <name>Facet-wid-dep-cols</name>
         <type>Facet</type>
     </flexiPageRegions>
 
@@ -215,7 +162,7 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-a1b20001-0001-0001-0001-000000000004</value>
+                    <value>Facet-wid-sys-left</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
                 <identifier>flexipage_column_sys1</identifier>
@@ -225,13 +172,13 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-a1b20001-0001-0001-0001-000000000005</value>
+                    <value>Facet-wid-sys-right</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
                 <identifier>flexipage_column_sys2</identifier>
             </componentInstance>
         </itemInstances>
-        <name>Facet-a1b20001-0001-0001-0002-000000000003</name>
+        <name>Facet-wid-sys-cols</name>
         <type>Facet</type>
     </flexiPageRegions>
 
@@ -241,7 +188,7 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>columns</name>
-                    <value>Facet-a1b20001-0001-0001-0002-000000000001</value>
+                    <value>Facet-wid-dep-cols</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>horizontalAlignment</name>
@@ -249,35 +196,17 @@
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>
-                    <value>Time Entry</value>
+                    <value>Dependency</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:fieldSection</componentName>
-                <identifier>flexipage_fieldSection_timeEntry</identifier>
+                <identifier>flexipage_fieldSection_dep</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
                     <name>columns</name>
-                    <value>Facet-a1b20001-0001-0001-0002-000000000002</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>horizontalAlignment</name>
-                    <value>false</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>label</name>
-                    <value>Description</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:fieldSection</componentName>
-                <identifier>flexipage_fieldSection_desc</identifier>
-            </componentInstance>
-        </itemInstances>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>columns</name>
-                    <value>Facet-a1b20001-0001-0001-0002-000000000003</value>
+                    <value>Facet-wid-sys-cols</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>horizontalAlignment</name>
@@ -375,16 +304,16 @@
         <type>Region</type>
     </flexiPageRegions>
 
-    <!-- ══ Sidebar (empty) ══ -->
+    <!-- Sidebar (empty) -->
     <flexiPageRegions>
         <mode>Replace</mode>
         <name>sidebar</name>
         <type>Region</type>
     </flexiPageRegions>
 
-    <masterLabel>Work Log Record Page</masterLabel>
+    <masterLabel>Work Item Dependency Record Page</masterLabel>
     <parentFlexiPage>flexipage__default_rec_L</parentFlexiPage>
-    <sobjectType>WorkLog__c</sobjectType>
+    <sobjectType>WorkItemDependency__c</sobjectType>
     <template>
         <name>flexipage:recordHomeTemplateDesktop</name>
     </template>

--- a/force-app/main/default/flexipages/DeliveryWorkItemRecordPage.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryWorkItemRecordPage.flexipage-meta.xml
@@ -401,6 +401,110 @@
         <type>Facet</type>
     </flexiPageRegions>
 
+    <!-- Recurring & Templates: Left column (RecurringEnabledDateTime, RecurrenceDayTxt, RecurrenceScheduleTxt) -->
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.RecurringEnabledDateTime__c</fieldItem>
+                <identifier>RecordRecurringEnabledDateTime_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.RecurrenceDayTxt__c</fieldItem>
+                <identifier>RecordRecurrenceDayTxt_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.RecurrenceScheduleTxt__c</fieldItem>
+                <identifier>RecordRecurrenceScheduleTxt_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-wi-recur-left</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
+    <!-- Recurring & Templates: Right column (NextRecurrenceDate, TemplateMarkedDateTime, TemplateSourceLookup) -->
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.NextRecurrenceDate__c</fieldItem>
+                <identifier>RecordNextRecurrenceDate_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.TemplateMarkedDateTime__c</fieldItem>
+                <identifier>RecordTemplateMarkedDateTime_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.TemplateSourceLookup__c</fieldItem>
+                <identifier>RecordTemplateSourceLookup_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-wi-recur-right</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
+    <!-- External Integration: Left column (ExternalSourceOrgTxt) -->
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.ExternalSourceOrgTxt__c</fieldItem>
+                <identifier>RecordExternalSourceOrgTxt_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-wi-ext-left</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
+    <!-- External Integration: Right column (ExternalRequesterEmail) -->
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.ExternalRequesterEmail__c</fieldItem>
+                <identifier>RecordExternalRequesterEmail_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-wi-ext-right</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
     <!-- System: Left column (CreatedById, ActivatedDateTime) -->
     <flexiPageRegions>
         <itemInstances>
@@ -575,6 +679,58 @@
         <type>Facet</type>
     </flexiPageRegions>
 
+    <!-- Recurring & Templates: 2 columns -->
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-wi-recur-left</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column_recur1</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-wi-recur-right</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column_recur2</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-wi-recur-cols</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
+    <!-- External Integration: 2 columns -->
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-wi-ext-left</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column_ext1</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-wi-ext-right</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column_ext2</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-wi-ext-cols</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
     <!-- System: 2 columns -->
     <flexiPageRegions>
         <itemInstances>
@@ -718,6 +874,42 @@
                 </componentInstanceProperties>
                 <componentName>flexipage:fieldSection</componentName>
                 <identifier>flexipage_fieldSection_rel</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>columns</name>
+                    <value>Facet-wi-recur-cols</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>label</name>
+                    <value>Recurring &amp; Templates</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:fieldSection</componentName>
+                <identifier>flexipage_fieldSection_recur</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>columns</name>
+                    <value>Facet-wi-ext-cols</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>label</name>
+                    <value>External Integration</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:fieldSection</componentName>
+                <identifier>flexipage_fieldSection_ext</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>

--- a/force-app/main/default/layouts/DeliveryDocument__c-Delivery Document Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/DeliveryDocument__c-Delivery Document Layout.layout-meta.xml
@@ -17,6 +17,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>WorkItemLookup__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>TemplatePk__c</field>
             </layoutItems>
         </layoutColumns>
@@ -28,6 +32,14 @@
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>PublicTokenTxt__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>VersionNumber__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>PreviousVersionLookup__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>
@@ -93,6 +105,67 @@
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>ViewedDateTime__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <style>TwoColumnsTopToBottom</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>true</customLabel>
+        <detailHeading>true</detailHeading>
+        <editHeading>true</editHeading>
+        <label>Scheduled Send</label>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>ScheduledSendDateTime__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>ScheduledRecipientEmailTxt__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <style>TwoColumnsTopToBottom</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>true</customLabel>
+        <detailHeading>true</detailHeading>
+        <editHeading>true</editHeading>
+        <label>Dunning</label>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>OverdueReminderCountNumber__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>OverdueReminderLevelPk__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>LastOverdueReminderDateTime__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <style>TwoColumnsTopToBottom</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>true</customLabel>
+        <detailHeading>true</detailHeading>
+        <editHeading>true</editHeading>
+        <label>Signing &amp; Disputes</label>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>RequireSigningDateTime__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>DisputeReasonTxt__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>

--- a/force-app/main/default/layouts/DeliveryTransaction__c-Delivery Transaction Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/DeliveryTransaction__c-Delivery Transaction Layout.layout-meta.xml
@@ -33,6 +33,10 @@
                 <behavior>Edit</behavior>
                 <field>NoteTxt__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>MethodPk__c</field>
+            </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>
     </layoutSections>

--- a/force-app/main/default/layouts/WorkLog__c-Work Log Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/WorkLog__c-Work Log Layout.layout-meta.xml
@@ -36,6 +36,10 @@
                 <behavior>Edit</behavior>
                 <field>StatusPk__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>ResourceTitleTxt__c</field>
+            </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>
     </layoutSections>


### PR DESCRIPTION
## Why

Page-to-field audit on 2026-05-13 surfaced five gaps where fields exist in the package but aren't reachable from the record UI. WorkLog__c was the headline complaint — ResourceTitleTxt__c shipped 3/28 for invoice rendering and never made it onto the page. The audit also caught a worse one on DeliveryDocument__c: dunning + scheduled-send + signing/versioning clusters all invisible.

## Changes

**WorkLog__c** — `ResourceTitleTxt__c` added to FlexiPage Time Entry section + classic layout Information section. (Approval-* fields deferred until the approval workflow is populated per Jose hours-reporting plan Decision D2.)

**WorkItem__c FlexiPage** — Recurring & Templates section (6 fields) + External Integration section (2 fields). These were on the classic layout but Lightning users couldn't reach them.

**DeliveryDocument__c** — Scheduled Send + Dunning + Signing & Versioning sections on both FlexiPage and classic layout. 9 shipped-but-invisible fields. WorkItemLookup__c also added to the classic layout for parity.

**DeliveryTransaction__c** classic layout — MethodPk__c added (already on FlexiPage).

**WorkItemDependency__c** — new `DeliveryWorkItemDependencyRecordPage.flexipage-meta.xml` + View action overrides in both apps. Only object in the package that was falling through to the default Lightning page.

## What this does NOT do
- Doesn't touch any Apex / no PMD risk
- Doesn't change field-level security or restricted flags
- Doesn't add fields to objects — only surfaces existing ones

## Test plan
- [ ] `feature-test` passes (metadata-only — should be quick)
- [ ] `apex-scan` clean
- [ ] **`upload-beta` passes** — the real gate, since FlexiPage component-instance ID collisions only surface in packaging-org

🤖 Generated with [Claude Code](https://claude.com/claude-code)