### PR TITLE
fix(lwc): namespace-safe object/nav API names — fixes [WorkItem__c] vs [delivery__WorkItem__c] runtime error

### DIFF
--- a/force-app/main/default/classes/DeliveryEscalationNotifService.cls
+++ b/force-app/main/default/classes/DeliveryEscalationNotifService.cls
@@ -178,10 +178,12 @@ public with sharing class DeliveryEscalationNotifService {
                 return; // User hasn't opted in
             }
 
-            // Look up the custom notification type
+            // Look up the custom notification type. DeveloperName is prefixed in
+            // a managed-package install (delivery__Delivery_Hub_Alert) and bare
+            // in dev — accept both so this works in either context.
             List<CustomNotificationType> types = [
                 SELECT Id FROM CustomNotificationType
-                WHERE DeveloperName = 'Delivery_Hub_Alert'
+                WHERE DeveloperName IN ('Delivery_Hub_Alert', 'delivery__Delivery_Hub_Alert')
                 LIMIT 1
             ];
             if (types.isEmpty()) {

--- a/force-app/main/default/classes/DeliveryWorkItemCommentTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemCommentTriggerHandler.cls
@@ -67,10 +67,12 @@ public inherited sharing class DeliveryWorkItemCommentTriggerHandler {
 
         Id currentUserId = UserInfo.getUserId();
 
-        // Query notification type ONCE outside the loop
+        // Query notification type ONCE outside the loop. DeveloperName is
+        // prefixed on subscriber install (delivery__Delivery_Hub_Alert) and
+        // bare in dev — accept both so the notification fires in either.
         List<CustomNotificationType> notifTypes = [
             SELECT Id FROM CustomNotificationType
-            WHERE DeveloperName = 'Delivery_Hub_Alert'
+            WHERE DeveloperName IN ('Delivery_Hub_Alert', 'delivery__Delivery_Hub_Alert')
             WITH SYSTEM_MODE
             LIMIT 1
         ];

--- a/force-app/main/default/lwc/deliveryGuide/deliveryGuide.js
+++ b/force-app/main/default/lwc/deliveryGuide/deliveryGuide.js
@@ -31,14 +31,14 @@ const SECTION_CONFIG = [
     {
         key: 'board',
         navLabel: 'Open Board',
-        navTarget: 'Delivery_Board',
+        navTarget: '%%%NAMESPACE_DOT%%%Delivery_Board',
         navType: 'tab',
         personas: ['Developer', 'Project Manager', 'Client', 'Admin']
     },
     {
         key: 'workItems',
         navLabel: 'View Work Items',
-        navTarget: 'WorkItem__c',
+        navTarget: '%%%NAMESPACE_DOT%%%WorkItem__c',
         navType: 'objectList',
         personas: ['Developer', 'Project Manager', 'Admin']
     },
@@ -52,14 +52,14 @@ const SECTION_CONFIG = [
     {
         key: 'documents',
         navLabel: 'View Documents',
-        navTarget: 'DeliveryDocument__c',
+        navTarget: '%%%NAMESPACE_DOT%%%DeliveryDocument__c',
         navType: 'objectList',
         personas: ['Project Manager', 'Client', 'Admin']
     },
     {
         key: 'activityFeed',
         navLabel: 'Open Activity Feed',
-        navTarget: 'Delivery_Activity',
+        navTarget: '%%%NAMESPACE_DOT%%%Delivery_Activity',
         navType: 'tab',
         personas: ['Developer', 'Project Manager', 'Client', 'Admin']
     },
@@ -73,7 +73,7 @@ const SECTION_CONFIG = [
     {
         key: 'sync',
         navLabel: 'View Sync Items',
-        navTarget: 'SyncItem__c',
+        navTarget: '%%%NAMESPACE_DOT%%%SyncItem__c',
         navType: 'objectList',
         personas: ['Admin']
     },
@@ -87,35 +87,35 @@ const SECTION_CONFIG = [
     {
         key: 'settings',
         navLabel: 'Open Settings',
-        navTarget: 'DeliveryHubSettings',
+        navTarget: '%%%NAMESPACE_DOT%%%DeliveryHubSettings',
         navType: 'tab',
         personas: ['Admin']
     },
     {
         key: 'timeline',
         navLabel: 'Open Timeline',
-        navTarget: 'Delivery_Timeline',
+        navTarget: '%%%NAMESPACE_DOT%%%Delivery_Timeline',
         navType: 'tab',
         personas: ['Developer', 'Project Manager', 'Admin']
     },
     {
         key: 'savedFilters',
         navLabel: 'Open Board',
-        navTarget: 'Delivery_Board',
+        navTarget: '%%%NAMESPACE_DOT%%%Delivery_Board',
         navType: 'tab',
         personas: ['Developer', 'Project Manager']
     },
     {
         key: 'docVersioning',
         navLabel: 'View Documents',
-        navTarget: 'DeliveryDocument__c',
+        navTarget: '%%%NAMESPACE_DOT%%%DeliveryDocument__c',
         navType: 'objectList',
         personas: ['Project Manager', 'Admin']
     },
     {
         key: 'invoiceApproval',
         navLabel: 'View Documents',
-        navTarget: 'DeliveryDocument__c',
+        navTarget: '%%%NAMESPACE_DOT%%%DeliveryDocument__c',
         navType: 'objectList',
         personas: ['Client', 'Admin']
     },
@@ -143,35 +143,35 @@ const SECTION_CONFIG = [
     {
         key: 'configurableSettings',
         navLabel: 'Open Settings',
-        navTarget: 'DeliveryHubSettings',
+        navTarget: '%%%NAMESPACE_DOT%%%DeliveryHubSettings',
         navType: 'tab',
         personas: ['Admin']
     },
     {
         key: 'pdfHyperlinks',
         navLabel: 'View Documents',
-        navTarget: 'DeliveryDocument__c',
+        navTarget: '%%%NAMESPACE_DOT%%%DeliveryDocument__c',
         navType: 'objectList',
         personas: ['Project Manager', 'Admin']
     },
     {
         key: 'hideEmptyColumns',
         navLabel: 'Open Board',
-        navTarget: 'Delivery_Board',
+        navTarget: '%%%NAMESPACE_DOT%%%Delivery_Board',
         navType: 'tab',
         personas: ['Developer', 'Project Manager']
     },
     {
         key: 'sla',
         navLabel: 'Open Settings',
-        navTarget: 'DeliveryHubSettings',
+        navTarget: '%%%NAMESPACE_DOT%%%DeliveryHubSettings',
         navType: 'tab',
         personas: ['Project Manager', 'Admin']
     },
     {
         key: 'escalation',
         navLabel: 'Open Settings',
-        navTarget: 'DeliveryHubSettings',
+        navTarget: '%%%NAMESPACE_DOT%%%DeliveryHubSettings',
         navType: 'tab',
         personas: ['Project Manager', 'Admin']
     },
@@ -185,7 +185,7 @@ const SECTION_CONFIG = [
     {
         key: 'rateLimiting',
         navLabel: 'Open Settings',
-        navTarget: 'DeliveryHubSettings',
+        navTarget: '%%%NAMESPACE_DOT%%%DeliveryHubSettings',
         navType: 'tab',
         personas: ['Admin']
     },
@@ -206,7 +206,7 @@ const SECTION_CONFIG = [
     {
         key: 'bounty',
         navLabel: 'View Bounties',
-        navTarget: 'BountyClaim__c',
+        navTarget: '%%%NAMESPACE_DOT%%%BountyClaim__c',
         navType: 'objectList',
         personas: ['Developer', 'Admin']
     },

--- a/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.html
+++ b/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.html
@@ -710,7 +710,7 @@
                 </header>
                 <div class="slds-modal__content slds-p-around_medium">
                     <lightning-record-edit-form
-                        object-api-name="WorkItem__c"
+                        object-api-name="%%%NAMESPACE_DOT%%%WorkItem__c"
                         record-id={transitionWorkItemId}
                         onsuccess={handleTransitionSuccess}
                         onerror={handleTransitionError}>

--- a/force-app/main/default/lwc/deliveryWorkItemActionCenter/deliveryWorkItemActionCenter.html
+++ b/force-app/main/default/lwc/deliveryWorkItemActionCenter/deliveryWorkItemActionCenter.html
@@ -28,7 +28,7 @@
                         <lightning-icon icon-name="utility:warning" size="xx-small"></lightning-icon>
                         <span class="ac-missing-title">Action Required to Advance</span>
                     </div>
-                    <lightning-record-edit-form record-id={recordId} object-api-name="WorkItem__c" onsuccess={handleFixSuccess}>
+                    <lightning-record-edit-form record-id={recordId} object-api-name={workItemObjectApiName} onsuccess={handleFixSuccess}>
                         <div class="ac-fields-grid">
                             <template for:each={missingFields} for:item="field">
                                 <div key={field.apiName} class="ac-field-item">

--- a/force-app/main/default/lwc/deliveryWorkItemActionCenter/deliveryWorkItemActionCenter.js
+++ b/force-app/main/default/lwc/deliveryWorkItemActionCenter/deliveryWorkItemActionCenter.js
@@ -13,7 +13,7 @@ import updateWorkItemStage from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHub
 import getWorkflowConfig from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkflowConfigService.getWorkflowConfig';
 
 // --- SCHEMA IMPORTS ---
-// Removed ID_FIELD import
+import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
 import STAGE_FIELD from '@salesforce/schema/WorkItem__c.StageNamePk__c';
 import ESTIMATED_HOURS_FIELD from '@salesforce/schema/WorkItem__c.EstimatedHoursNumber__c';
 import PRE_APPROVED_HOURS_FIELD from '@salesforce/schema/WorkItem__c.ClientPreApprovedHoursNumber__c';
@@ -46,6 +46,10 @@ export default class DeliveryWorkItemActionCenter extends LightningElement {
 
     // --- CMT-DRIVEN WORKFLOW STATE ---
     @track _workflowConfig = null;
+
+    get workItemObjectApiName() {
+        return WORK_ITEM_OBJECT.objectApiName;
+    }
 
     @wire(getWorkflowConfig, { workflowTypeName: 'Software_Delivery' })
     wiredConfig({ data, error }) {

--- a/force-app/main/default/lwc/deliveryWorkItemActionCenter/deliveryWorkItemActionCenter.js
+++ b/force-app/main/default/lwc/deliveryWorkItemActionCenter/deliveryWorkItemActionCenter.js
@@ -119,33 +119,33 @@ export default class DeliveryWorkItemActionCenter extends LightningElement {
         
         // Rule: Need Pre-Approved Hours for Fast Track Analysis (Soft Gate - Info only)
         if (!approved && ['Scoping', 'Backlog', 'Ready for Sizing'].includes(stage)) {
-            this.missingFields.push({ 
-                apiName: 'ClientPreApprovedHoursNumber__c', 
-                reason: 'Define Budget to enable Fast Track' 
+            this.missingFields.push({
+                apiName: PRE_APPROVED_HOURS_FIELD.fieldApiName,
+                reason: 'Define Budget to enable Fast Track'
             });
         }
 
         // Rule: Need Estimate before Proposal/Sizing completion (Hard Gate for Proposal)
         if (!est && ['Ready for Sizing', 'Sizing Underway', 'Drafting Proposal', 'Ready for Prioritization'].includes(stage)) {
-            this.missingFields.push({ 
-                apiName: 'EstimatedHoursNumber__c', 
-                reason: 'Hours Estimate Required to Proceed' 
+            this.missingFields.push({
+                apiName: ESTIMATED_HOURS_FIELD.fieldApiName,
+                reason: 'Hours Estimate Required to Proceed'
             });
         }
 
         // Rule: Need Developer before Dev (Hard Gate)
         const devStages = ['Ready for Development', 'In Development', 'Dev Blocked', 'Dev Clarification Requested'];
         if (!dev && devStages.includes(stage)) {
-            this.missingFields.push({ 
-                apiName: 'DeveloperLookup__c', 
-                reason: 'Assign Developer to Start Work' 
+            this.missingFields.push({
+                apiName: DEVELOPER_FIELD.fieldApiName,
+                reason: 'Assign Developer to Start Work'
             });
         }
 
         // Rule: Need Acceptance Criteria before Dev
         if (!criteria && devStages.includes(stage)) {
             this.missingFields.push({
-                apiName: 'AcceptanceCriteriaTxt__c',
+                apiName: CRITERIA_FIELD.fieldApiName,
                 reason: 'Define Acceptance Criteria (Definition of Done)'
             });
         }

--- a/force-app/main/default/lwc/deliveryWorkItemDependencies/deliveryWorkItemDependencies.js
+++ b/force-app/main/default/lwc/deliveryWorkItemDependencies/deliveryWorkItemDependencies.js
@@ -7,6 +7,7 @@ import { LightningElement, api, wire, track } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
 import { refreshApex } from '@salesforce/apex';
 import { subscribe, unsubscribe, onError } from 'lightning/empApi';
+import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
 import getDependencies from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkItemDependenciesController.getDependencies';
 
 // Live updates — refresh when a dependency_change PE arrives. The publisher
@@ -84,7 +85,7 @@ export default class DeliveryWorkItemDependencies extends NavigationMixin(Lightn
             type: 'standard__recordPage',
             attributes: {
                 recordId:      event.currentTarget.dataset.id,
-                objectApiName: 'WorkItem__c',
+                objectApiName: WORK_ITEM_OBJECT.objectApiName,
                 actionName:    'view'
             }
         });

--- a/force-app/main/default/lwc/deliveryWorkItemRefiner/deliveryWorkItemRefiner.html
+++ b/force-app/main/default/lwc/deliveryWorkItemRefiner/deliveryWorkItemRefiner.html
@@ -15,7 +15,7 @@
             <template lwc:else>
                 <lightning-record-edit-form
                     record-id={recordId}
-                    object-api-name="WorkItem__c"
+                    object-api-name={workItemObjectApiName}
                     onsuccess={handleWorkItemSave}>
 
                     <div class="slds-text-title_caps slds-m-bottom_x-small">1. Define Success</div>

--- a/force-app/main/default/lwc/deliveryWorkItemRefiner/deliveryWorkItemRefiner.html
+++ b/force-app/main/default/lwc/deliveryWorkItemRefiner/deliveryWorkItemRefiner.html
@@ -54,17 +54,17 @@
                         </div>
                     </template>
 
-                    <lightning-input-field field-name="AcceptanceCriteriaTxt__c"></lightning-input-field>
-                    <lightning-input-field field-name="StepsToReproduceTxt__c"></lightning-input-field>
+                    <lightning-input-field field-name="%%%NAMESPACE_DOT%%%AcceptanceCriteriaTxt__c"></lightning-input-field>
+                    <lightning-input-field field-name="%%%NAMESPACE_DOT%%%StepsToReproduceTxt__c"></lightning-input-field>
 
                     <div class="slds-grid slds-gutters slds-m-top_small">
                         <div class="slds-col">
                             <div class="slds-text-title_caps slds-m-bottom_small">2. Client Constraints</div>
-                            <lightning-input-field field-name="ClientPreApprovedHoursNumber__c"></lightning-input-field>
+                            <lightning-input-field field-name="%%%NAMESPACE_DOT%%%ClientPreApprovedHoursNumber__c"></lightning-input-field>
                         </div>
                         <div class="slds-col">
                             <div class="slds-text-title_caps slds-m-bottom_small">3. Deadline</div>
-                            <lightning-input-field field-name="ProjectedUATReadyDate__c"></lightning-input-field>
+                            <lightning-input-field field-name="%%%NAMESPACE_DOT%%%ProjectedUATReadyDate__c"></lightning-input-field>
                         </div>
                     </div>
 

--- a/force-app/main/default/lwc/deliveryWorkItemRefiner/deliveryWorkItemRefiner.js
+++ b/force-app/main/default/lwc/deliveryWorkItemRefiner/deliveryWorkItemRefiner.js
@@ -64,7 +64,7 @@ export default class DeliveryWorkItemRefiner extends NavigationMixin(LightningEl
 
     handleApplyCriteria() {
         const field = this.template.querySelector(
-            'lightning-input-field[field-name="AcceptanceCriteriaTxt__c"]'
+            'lightning-input-field[field-name="%%%NAMESPACE_DOT%%%AcceptanceCriteriaTxt__c"]'
         );
         if (field) {
             field.value = this.suggestedCriteria;

--- a/force-app/main/default/lwc/deliveryWorkItemRefiner/deliveryWorkItemRefiner.js
+++ b/force-app/main/default/lwc/deliveryWorkItemRefiner/deliveryWorkItemRefiner.js
@@ -8,7 +8,8 @@ import { getRecord, getFieldValue, createRecord } from 'lightning/uiRecordApi';
 import { NavigationMixin } from 'lightning/navigation';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 
-// Work Item Fields to Read
+// Work Item Object & Fields to Read
+import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
 import WORK_ITEM_HOURS from '@salesforce/schema/WorkItem__c.ClientPreApprovedHoursNumber__c';
 
 // Request Object & Fields to Write
@@ -35,6 +36,10 @@ export default class DeliveryWorkItemRefiner extends NavigationMixin(LightningEl
 
     @wire(getRecord, { recordId: '$recordId', fields: FIELDS })
     workItem;
+
+    get workItemObjectApiName() {
+        return WORK_ITEM_OBJECT.objectApiName;
+    }
 
     // Called when the "Save Definition" button finishes
     handleWorkItemSave() {


### PR DESCRIPTION
## Why

Glen hit this on MF-Prod opening a `delivery__WorkItem__c` record page:

\`\`\`
\"fields\" query string parameter contained object api names that do not
correspond to the api names of any of the requested record ids.
The requested object api names were: [WorkItem__c], while the requested
records had object types: [delivery__WorkItem__c]
\`\`\`

Root cause: hardcoded unprefixed object/nav API names in 5 LWCs. On a packaged install all custom objects/tabs are \`delivery__\`-prefixed; LDS and NavigationMixin reject requests against the unprefixed name.

## Fixes

| LWC | What was wrong | Fix |
|---|---|---|
| deliveryWorkItemRefiner | \`object-api-name=\"WorkItem__c\"\` on \`lightning-record-edit-form\` | Schema-import getter |
| deliveryWorkItemActionCenter | Same — sidebar mounted on WorkItem page | Schema-import getter |
| deliveryHubBoard | Transition modal LDS form was unprefixed | \`%%%NAMESPACE_DOT%%%\` token (matches line 622 in same file) |
| deliveryWorkItemDependencies | \`objectApiName: 'WorkItem__c'\` in NavigationMixin | Schema-import |
| deliveryGuide | 17 navTargets across 4 objects + 4 tabs hardcoded | \`%%%NAMESPACE_DOT%%%\` token on every one |

The first two were the on-load source of Glen's error — both LWCs mount on every \`WorkItem__c\` record page (sidebar Actions tab).

## Why two patterns

Both correct, picked per-file for consistency:
- **Schema imports** for files that already use them — SF's recommended approach, no build-time replacement needed at runtime.
- **\`%%%NAMESPACE_DOT%%%\` token** for deliveryHubBoard (file already uses it at line 622) and deliveryGuide (8 distinct targets — token is much terser than 8 separate schema imports).

## Test plan
- [ ] feature-test passes
- [ ] apex-scan clean
- [ ] **upload-beta passes** — the actual gate
- [ ] Post-install on MF-Prod: open a WorkItem record page; verify no \"fields query string parameter\" error in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)