### PR TITLE
fix(runtime): close 7 runtime audit bugs — SOQL fan-out, silent catches, TZ slip, ORDER BY

### DIFF
--- a/force-app/main/default/classes/DeliveryDepthProbeService.cls
+++ b/force-app/main/default/classes/DeliveryDepthProbeService.cls
@@ -62,8 +62,25 @@ global with sharing class DeliveryDepthProbeService {
     /** @description Per-transaction probe-callout counter. Bounds fan-out. */
     private static Integer transactionCalloutCount = 0;
 
-    /** @description HTTP timeout for a single peer probe. */
-    private static final Integer PEER_TIMEOUT_MS = 30000;
+    /**
+     * @description HTTP timeout for a single peer probe. Lowered from 30s to 10s
+     *              (audit 2026-05-13: healthy peers respond in <2s; 30s × MAX_CALLOUTS
+     *              could blow the 600s Apex wall-clock budget even within the callout
+     *              count cap).
+     */
+    private static final Integer PEER_TIMEOUT_MS = 10000;
+
+    /**
+     * @description Wall-clock budget for the entire probe transaction. When exceeded,
+     *              further recursive callouts are short-circuited and the partial
+     *              chain is returned. Apex's hard cap is ~600s; 60s keeps the LWC
+     *              responsive while still allowing realistic peer-chain traversal.
+     */
+    @TestVisible
+    private static final Integer WALL_CLOCK_BUDGET_MS = 60000;
+
+    /** @description Start time of this transaction's probe — used by wall-clock budget. */
+    private static Long probeStartTimeMs = 0;
 
     /**
      * @description Returns this org's segment of the fulfillment chain for the
@@ -134,6 +151,9 @@ global with sharing class DeliveryDepthProbeService {
     }
 
     private static DepthChainNode buildRootSegment(Id workItemId, Integer remainingDepth, String requestId) {
+        if (probeStartTimeMs == 0) {
+            probeStartTimeMs = System.currentTimeMillis();
+        }
         DepthChainNode root = new DepthChainNode();
         Organization org = [SELECT Id, Name FROM Organization WITH SYSTEM_MODE LIMIT 1];
         root.orgId = org.Id;
@@ -186,13 +206,23 @@ global with sharing class DeliveryDepthProbeService {
 
         // Recursive probe — only when reveal is 'Full' (which is what authorizes
         // showing downstream chain + per-user attribution) and we have budget.
+        // Wall-clock budget short-circuits the recursion even when callout count is
+        // under MAX_CALLOUTS_PER_PROBE — without it, 5 slow peers × 10s timeout each
+        // can chain to 50+s with no log evidence of why the LWC stalled.
+        Boolean wallBudgetOk = probeStartTimeMs == 0
+            || (System.currentTimeMillis() - probeStartTimeMs) < WALL_CLOCK_BUDGET_MS;
         if (reveal == 'Full' && remainingDepth > 0
                 && transactionCalloutCount < MAX_CALLOUTS_PER_PROBE
+                && wallBudgetOk
                 && String.isNotBlank(req.DeliveryEntityLookup__r.IntegrationEndpointUrlTxt__c)) {
             List<DepthChainNode> children = invokePeerProbe(req, remainingDepth - 1, requestId);
             if (children != null) {
                 peer.children = children;
             }
+        } else if (reveal == 'Full' && remainingDepth > 0 && !wallBudgetOk) {
+            // Audit the short-circuit so admins can see why a chain was truncated.
+            recordAudit('wall-budget-exceeded', requestId, req.RemoteWorkItemIdTxt__c,
+                req.DeliveryEntityLookup__c, null);
         }
         return peer;
     }

--- a/force-app/main/default/classes/DeliveryEscalationNotifService.cls
+++ b/force-app/main/default/classes/DeliveryEscalationNotifService.cls
@@ -170,30 +170,47 @@ public with sharing class DeliveryEscalationNotifService {
      * @param title Short notification title.
      * @param body Notification body text.
      */
-    public static void sendBellNotification(Id workItemId, Id ownerId, String title, String body) {
-        try {
-            // Check user-level setting (hierarchy: user > profile > org)
-            DeliveryHubSettings__c userSettings = DeliveryHubSettings__c.getInstance(ownerId);
-            if (userSettings == null || userSettings.EnableBellNotificationsDateTime__c == null) {
-                return; // User hasn't opted in
-            }
+    // Cache the Delivery_Hub_Alert CustomNotificationType ID per transaction. Without
+    // this, every sendBellNotification call fires a SOQL — and the forecast-alert sweep
+    // dispatches per (candidate × recipient × channel), so 8 alertable WIs already
+    // burns 100+ SOQL on this lookup alone.
+    private static Boolean cachedAlertTypeLookupAttempted = false;
+    private static Id cachedDeliveryHubAlertTypeId;
 
-            // Look up the custom notification type. DeveloperName is prefixed in
-            // a managed-package install (delivery__Delivery_Hub_Alert) and bare
-            // in dev — accept both so this works in either context.
+    @TestVisible
+    private static Id getDeliveryHubAlertTypeId() {
+        if (!cachedAlertTypeLookupAttempted) {
+            // DeveloperName is prefixed in a managed-package install
+            // (delivery__Delivery_Hub_Alert) and bare in dev — accept both.
             List<CustomNotificationType> types = [
                 SELECT Id FROM CustomNotificationType
                 WHERE DeveloperName IN ('Delivery_Hub_Alert', 'delivery__Delivery_Hub_Alert')
                 LIMIT 1
             ];
-            if (types.isEmpty()) {
+            cachedDeliveryHubAlertTypeId = types.isEmpty() ? null : types[0].Id;
+            cachedAlertTypeLookupAttempted = true;
+        }
+        return cachedDeliveryHubAlertTypeId;
+    }
+
+    public static void sendBellNotification(Id workItemId, Id ownerId, String title, String body) {
+        try {
+            // Check user-level setting (hierarchy: user > profile > org).
+            // Custom-settings getInstance is hierarchical and cached by SF — no SOQL cost.
+            DeliveryHubSettings__c userSettings = DeliveryHubSettings__c.getInstance(ownerId);
+            if (userSettings == null || userSettings.EnableBellNotificationsDateTime__c == null) {
+                return; // User hasn't opted in
+            }
+
+            Id notifTypeId = getDeliveryHubAlertTypeId();
+            if (notifTypeId == null) {
                 return; // Notification type not deployed
             }
 
             Messaging.CustomNotification notification = new Messaging.CustomNotification();
             notification.setTitle(title);
             notification.setBody(body);
-            notification.setNotificationTypeId(types[0].Id);
+            notification.setNotificationTypeId(notifTypeId);
             notification.setTargetId(workItemId);
             notification.send(new Set<String>{ ownerId });
         } catch (Exception e) {

--- a/force-app/main/default/classes/DeliveryForecastAlertService.cls
+++ b/force-app/main/default/classes/DeliveryForecastAlertService.cls
@@ -41,9 +41,17 @@ global with sharing class DeliveryForecastAlertService {
     @TestVisible
     private static final Decimal MATERIAL_WORSENING_FRACTION = 0.10;
 
-    /** @description Cap on the number of WIs the daily sweep evaluates. */
+    /**
+     * @description Cap on the number of WIs the daily sweep evaluates.
+     *              evaluate() → calculateProjectForecast does ~5 SOQL per WI
+     *              (walkDescendants BFS up to ~4 levels in practice + tree pull
+     *              + weekly history). At 20 WIs × 5 SOQL = 100 SOQL, which is
+     *              the governor cap. Until the sweep is moved to a Queueable
+     *              chain or Batch Apex job, cap at 20 to stay safe.
+     *              (Audit 2026-05-13: prior cap of 200 hit governor at ~8 WIs.)
+     */
     @TestVisible
-    private static final Integer MAX_WORKITEMS_PER_SWEEP = 200;
+    private static final Integer MAX_WORKITEMS_PER_SWEEP = 20;
 
     /** @description Terminal stages — exclude from sweep. */
     private static final Set<String> TERMINAL_STAGES = new Set<String>{
@@ -172,6 +180,13 @@ global with sharing class DeliveryForecastAlertService {
             WITH SYSTEM_MODE
         ]);
 
+        // Bulk-load notification preferences for all (recipient, channel) pairs in ONE
+        // SOQL instead of per-recipient × per-channel. Previously this ran
+        // N_recipients × 2_channels SOQL inside the loop — at 50 recipients ×
+        // 2 channels = 100 SOQL just on preference checks, exceeding the governor.
+        Map<String, Boolean> prefsMap = DeliveryNotificationPreferenceService.shouldNotifyBulk(
+            recipientIds, new Set<String>{ 'Bell', 'Email' }, 'Forecast_Risk');
+
         String orgUrl = Url.getOrgDomainUrl().toExternalForm();
         List<Messaging.SingleEmailMessage> emails = new List<Messaging.SingleEmailMessage>();
         Map<String, String> slackMessages = new Map<String, String>();
@@ -190,11 +205,11 @@ global with sharing class DeliveryForecastAlertService {
                 if (!userMap.containsKey(recipientId)) {
                     continue;
                 }
-                if (shouldNotifyChannel(recipientId, 'Bell')) {
+                if (DeliveryNotificationPreferenceService.shouldNotifyFromMap(prefsMap, recipientId, 'Bell')) {
                     DeliveryEscalationNotifService.sendBellNotification(
                         wi.Id, recipientId, bellTitle, bellBody);
                 }
-                if (shouldNotifyChannel(recipientId, 'Email')) {
+                if (DeliveryNotificationPreferenceService.shouldNotifyFromMap(prefsMap, recipientId, 'Email')) {
                     String addr = userMap.get(recipientId).Email;
                     if (String.isNotBlank(addr)) {
                         emails.add(buildForecastEmail(wi, ac, addr, recordUrl, title));
@@ -250,19 +265,6 @@ global with sharing class DeliveryForecastAlertService {
             }
         }
         return ids;
-    }
-
-    /**
-     * @description Delegates to DeliveryNotificationPreferenceService.shouldNotify.
-     *              Honors per-user, per-channel opt-out for Forecast_Risk event type.
-     *              No row in NotificationPreference__c = opt-in by default.
-     */
-    private static Boolean shouldNotifyChannel(Id userId, String channel) {
-        try {
-            return DeliveryNotificationPreferenceService.shouldNotify(userId, channel, 'Forecast_Risk');
-        } catch (Exception ignored) {
-            return true;
-        }
     }
 
     private static Messaging.SingleEmailMessage buildForecastEmail(
@@ -352,7 +354,12 @@ global with sharing class DeliveryForecastAlertService {
 
     private static void stampScanComplete(DeliveryHubSettings__c settings) {
         try {
-            settings.LastForecastAlertScanDate__c = Date.today();
+            // GMT date matches the GMT-hour gate in DeliveryHubScheduler.enqueueForecastAlertsIfDue.
+            // Mixing Date.today() (user TZ) with hourGmt() flips the idempotency stamp a day early/late.
+            DateTime nowDt = DateTime.now();
+            settings.LastForecastAlertScanDate__c = Date.newInstance(
+                nowDt.yearGmt(), nowDt.monthGmt(), nowDt.dayGmt()
+            );
             Database.update(settings, AccessLevel.SYSTEM_MODE);
         } catch (Exception e) {
             System.debug(LoggingLevel.WARN,

--- a/force-app/main/default/classes/DeliveryHubScheduler.cls
+++ b/force-app/main/default/classes/DeliveryHubScheduler.cls
@@ -272,8 +272,8 @@ global without sharing class DeliveryHubScheduler implements Schedulable {
                 System.enqueueJob(new DeliveryInvoiceGenerationQueueable());
             }
         } catch (Exception ex) {
-            String msg = ex.getMessage();
-            msg.length(); // satisfy PMD empty-catch rule
+            System.debug(LoggingLevel.ERROR,
+                '[DeliveryHubScheduler] enqueueInvoiceGenerationIfDue failed: ' + ex.getMessage());
         }
     }
 
@@ -292,8 +292,8 @@ global without sharing class DeliveryHubScheduler implements Schedulable {
                 System.enqueueJob(new DeliveryOverdueReminderQueueable());
             }
         } catch (Exception ex) {
-            String msg = ex.getMessage();
-            msg.length();
+            System.debug(LoggingLevel.ERROR,
+                '[DeliveryHubScheduler] enqueueOverdueRemindersIfEnabled failed: ' + ex.getMessage());
         }
     }
 
@@ -306,7 +306,8 @@ global without sharing class DeliveryHubScheduler implements Schedulable {
      */
     private static void enqueueForecastAlertsIfDue() {
         try {
-            Integer currentHour = DateTime.now().hourGmt();
+            DateTime nowDt = DateTime.now();
+            Integer currentHour = nowDt.hourGmt();
             if (currentHour != 8) {
                 return;
             }
@@ -314,14 +315,16 @@ global without sharing class DeliveryHubScheduler implements Schedulable {
             if (settings == null || settings.EnableForecastAlertsDateTime__c == null) {
                 return;
             }
-            Date today = Date.today();
-            if (settings.LastForecastAlertScanDate__c == today) {
+            // Use GMT date to match the GMT-hour gate above. Mixing Date.today() (user TZ)
+            // with hourGmt() causes day-boundary slips that either fire twice or skip a day.
+            Date todayGmt = Date.newInstance(nowDt.yearGmt(), nowDt.monthGmt(), nowDt.dayGmt());
+            if (settings.LastForecastAlertScanDate__c == todayGmt) {
                 return;
             }
             System.enqueueJob(new DeliveryForecastAlertQueueable());
         } catch (Exception ex) {
-            String msg = ex.getMessage();
-            msg.length();
+            System.debug(LoggingLevel.ERROR,
+                '[DeliveryHubScheduler] enqueueForecastAlertsIfDue failed: ' + ex.getMessage());
         }
     }
 

--- a/force-app/main/default/classes/DeliveryNotificationPreferenceService.cls
+++ b/force-app/main/default/classes/DeliveryNotificationPreferenceService.cls
@@ -48,6 +48,7 @@ public with sharing class DeliveryNotificationPreferenceService {
      * @return Map keyed by 'userId|channel' → true (notify) / false (suppressed).
      *         Missing keys default to true (opt-out model), matching shouldNotify.
      */
+    @SuppressWarnings('PMD.CyclomaticComplexity')
     public static Map<String, Boolean> shouldNotifyBulk(Set<Id> userIds, Set<String> channels, String eventType) {
         Map<String, Boolean> out = new Map<String, Boolean>();
         if (userIds == null || userIds.isEmpty() || channels == null || channels.isEmpty()
@@ -80,6 +81,10 @@ public with sharing class DeliveryNotificationPreferenceService {
     /**
      * @description Companion lookup for bulk results. Returns true when the user
      *              should be notified (no row in the map = opt-in by default).
+     * @param bulkMap Map returned by shouldNotifyBulk.
+     * @param userId  User Id to look up.
+     * @param channel Channel key (e.g. 'Bell', 'Email').
+     * @return true when the user should be notified, false when explicitly opted out.
      */
     public static Boolean shouldNotifyFromMap(Map<String, Boolean> bulkMap, Id userId, String channel) {
         if (bulkMap == null || userId == null || String.isBlank(channel)) {

--- a/force-app/main/default/classes/DeliveryNotificationPreferenceService.cls
+++ b/force-app/main/default/classes/DeliveryNotificationPreferenceService.cls
@@ -36,6 +36,63 @@ public with sharing class DeliveryNotificationPreferenceService {
     }
 
     /**
+     * @description Bulk variant of shouldNotify — fetches preferences for all
+     *              (userId, channel) tuples for a single eventType in ONE SOQL.
+     *              Callers that dispatch over many recipients × channels should
+     *              prefer this to avoid per-call SOQL fan-out (the forecast-alert
+     *              sweep was hitting the 100-SOQL governor at ~8 candidate WIs
+     *              before this helper existed).
+     * @param userIds   Set of User Ids to evaluate.
+     * @param channels  Set of channel keys (e.g. {'Bell','Email'}).
+     * @param eventType Event type (e.g. 'Forecast_Risk').
+     * @return Map keyed by 'userId|channel' → true (notify) / false (suppressed).
+     *         Missing keys default to true (opt-out model), matching shouldNotify.
+     */
+    public static Map<String, Boolean> shouldNotifyBulk(Set<Id> userIds, Set<String> channels, String eventType) {
+        Map<String, Boolean> out = new Map<String, Boolean>();
+        if (userIds == null || userIds.isEmpty() || channels == null || channels.isEmpty()
+                || String.isBlank(eventType)) {
+            return out;
+        }
+        Set<String> userIdStrs = new Set<String>();
+        for (Id u : userIds) {
+            if (u != null) {
+                userIdStrs.add(String.valueOf(u).left(18));
+            }
+        }
+        if (userIdStrs.isEmpty()) {
+            return out;
+        }
+        for (NotificationPreference__c pref : [
+            SELECT UserIdTxt__c, ChannelPk__c, EnabledDateTime__c
+            FROM NotificationPreference__c
+            WHERE UserIdTxt__c IN :userIdStrs
+              AND ChannelPk__c IN :channels
+              AND EventTypePk__c = :eventType
+            WITH SYSTEM_MODE
+        ]) {
+            String key = pref.UserIdTxt__c + '|' + pref.ChannelPk__c;
+            out.put(key, pref.EnabledDateTime__c != null);
+        }
+        return out;
+    }
+
+    /**
+     * @description Companion lookup for bulk results. Returns true when the user
+     *              should be notified (no row in the map = opt-in by default).
+     */
+    public static Boolean shouldNotifyFromMap(Map<String, Boolean> bulkMap, Id userId, String channel) {
+        if (bulkMap == null || userId == null || String.isBlank(channel)) {
+            return true;
+        }
+        String key = String.valueOf(userId).left(18) + '|' + channel;
+        if (!bulkMap.containsKey(key)) {
+            return true;
+        }
+        return bulkMap.get(key);
+    }
+
+    /**
      * @description Returns all notification preferences for a user.
      * @param userId The Salesforce User Id
      * @return List of NotificationPreference__c records

--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -9,9 +9,20 @@
 @SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.ApexCRUDViolation')
 public without sharing class DeliverySyncItemIngestor {
 
+    // Cache the namespace prefix per transaction. Without this, getNamespacePrefix is
+    // called 6+ times per processInboundItem invocation, each firing a SOQL against
+    // Organization. An 8-item poll exceeded the 100-SOQL governor on the per-call cost
+    // alone before the rest of the ingestor's queries.
+    private static Boolean cachedNamespacePrefixSet = false;
+    private static String cachedNamespacePrefix;
+
     private static String getNamespacePrefix() {
-        String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
-        return String.isBlank(ns) ? '' : ns + '__';
+        if (!cachedNamespacePrefixSet) {
+            String ns = [SELECT NamespacePrefix FROM Organization LIMIT 1].NamespacePrefix;
+            cachedNamespacePrefix = String.isBlank(ns) ? '' : ns + '__';
+            cachedNamespacePrefixSet = true;
+        }
+        return cachedNamespacePrefix;
     }
 
     private static String stripNamespace(String apiName) {

--- a/force-app/main/default/classes/DeliveryWorkItemBackfillService.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemBackfillService.cls
@@ -57,10 +57,28 @@ public with sharing class DeliveryWorkItemBackfillService {
         }
         Database.SaveResult[] results = Database.update(stale, false);
         Integer succeeded = 0;
-        for (Database.SaveResult r : results) {
+        Integer failed = 0;
+        for (Integer i = 0; i < results.size(); i++) {
+            Database.SaveResult r = results[i];
             if (r.isSuccess()) {
                 succeeded++;
+            } else {
+                failed++;
+                // Surface the failure so install-handler logs show partial-DML breakage.
+                // Mirrors DeliveryWorkItemETAService.cls:316-320 pattern.
+                String reasons = '';
+                for (Database.Error err : r.getErrors()) {
+                    reasons += err.getStatusCode() + ': ' + err.getMessage() + '; ';
+                }
+                System.debug(LoggingLevel.WARN,
+                    '[DeliveryWorkItemBackfillService] Status backfill failed for '
+                    + stale[i].Id + ' — ' + reasons);
             }
+        }
+        if (failed > 0) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryWorkItemBackfillService] backfillStatusDefaults: '
+                + succeeded + ' succeeded, ' + failed + ' failed');
         }
         return succeeded;
     }

--- a/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
@@ -151,11 +151,16 @@ public without sharing class DeliveryWorkItemTriggerHandler {
             return;
         }
 
-        // FIX: Swapped USER_MODE for SYSTEM_MODE to prevent packaging test failures
+        // FIX: Swapped USER_MODE for SYSTEM_MODE to prevent packaging test failures.
+        // ORDER BY CreatedDate ASC LIMIT 1 mirrors the peer fix in
+        // DeliverySyncItemIngestor.cls:393-398 — without it, SF's default order is
+        // undefined and orgs with multiple Active Vendor entities get
+        // non-deterministic auto-attach.
         List<NetworkEntity__c> vendors = [
             SELECT Id FROM NetworkEntity__c
             WHERE StatusPk__c = 'Active' AND EntityTypePk__c = 'Vendor'
             WITH SYSTEM_MODE
+            ORDER BY CreatedDate ASC
             LIMIT 1
         ];
 


### PR DESCRIPTION
## Why

Runtime-bug audit on 2026-05-13 surfaced 7 confirmed bugs (full report in \`runtime-bug-audit-2026-05-13.md\`). Most ship in production today and would misbehave under realistic load — CI passes because tests run with 1-3 records and idealized mocks.

## Fixes (1-to-1 with audit findings)

| # | Severity | Fix |
|---|---|---|
| 1 | **CRITICAL** | Forecast alert sweep: cached CustomNotificationType lookup + bulk-load NotificationPreference + MAX_WORKITEMS_PER_SWEEP 200 → 20 (defensive). Was hitting 100-SOQL governor at ~8 WIs. |
| 2 | **CRITICAL** | DeliverySyncItemIngestor.getNamespacePrefix cached. Was firing 6+ Organization SOQLs per inbound item. |
| 3 | Medium | DeliveryDepthProbeService: PEER_TIMEOUT_MS 30s → 10s + 60s wall-clock short-circuit on recursive probes. |
| 4 | Medium | 3 swallowed catches in DeliveryHubScheduler (msg.length() PMD shim) replaced with System.debug(ERROR). |
| 5 | Medium | DeliveryWorkItemBackfillService iterates Database.SaveResult failures + logs them. |
| 6 | Medium | handleNetworkEntitySync Vendor query: added ORDER BY CreatedDate ASC LIMIT 1 (back-port from ingestor). |
| 7 | Medium | enqueueForecastAlertsIfDue: GMT-derived date now matches hourGmt() gate (was Date.today(), TZ slip). |

## Coverage of audit

7/7 of the **confirmed** bugs. The 6 \"likely\" + 15 lower-priority findings stay deferred — those need either subscriber-org context (PSG DeveloperName), bigger redesigns (Queueable chain for the sweep), or aren't actually broken yet.

## Test plan
- [ ] feature-test passes
- [ ] apex-scan clean
- [ ] **upload-beta passes** — the gate
- [ ] After install: trigger a forecast sweep with >8 candidate WIs and confirm no SOQL governor error
- [ ] Trigger an inbound poll with ≥8 items and confirm no SOQL governor error

🤖 Generated with [Claude Code](https://claude.com/claude-code)