### PR TITLE
fix(test): testScanDateStampedEvenWhenNoneFired — compare GMT (fixes upload-beta)

### DIFF
--- a/force-app/main/default/classes/DeliveryForecastAlertServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryForecastAlertServiceTest.cls
@@ -244,8 +244,15 @@ private class DeliveryForecastAlertServiceTest {
         DeliveryForecastAlertService.runSweep();
         Test.stopTest();
 
+        // PR #778 fixed a TZ slip: stampScanComplete now stamps with GMT date
+        // (matching DeliveryHubScheduler.enqueueForecastAlertsIfDue which gates
+        // on hourGmt()=8). The test must compare against GMT too, otherwise a
+        // packaging-org run between ~04:00–08:00 ET (GMT day +1 vs user day)
+        // fails the assertion even though the stamp is correct.
+        DateTime nowDt = DateTime.now();
+        Date expectedGmt = Date.newInstance(nowDt.yearGmt(), nowDt.monthGmt(), nowDt.dayGmt());
         DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
-        System.assertEquals(Date.today(), s.LastForecastAlertScanDate__c,
+        System.assertEquals(expectedGmt, s.LastForecastAlertScanDate__c,
             'Scan-date stamps each successful sweep regardless of fire count');
     }
 }


### PR DESCRIPTION
## Why

upload-beta failed on the autoschedule-modal PR (#779) merge:

\`\`\`
System.AssertException: Assertion Failed: Scan-date stamps each successful sweep regardless of fire count:
Expected: 2026-05-14 00:00:00, Actual: 2026-05-15 00:00:00
\`\`\`

The stamp is correct — PR #778 fixed a TZ slip by switching stampScanComplete to write GMT date (matching the hourGmt()=8 gate in DeliveryHubScheduler.enqueueForecastAlertsIfDue). The test still asserted against \`Date.today()\` (user TZ), so it failed when the packaging org ran between ~04:00–08:00 ET (GMT day vs user day mismatch — the exact slip we fixed).

The test was the bug, not the code.

## Fix

Switch the assertion to GMT date via \`Date.newInstance(now.yearGmt(), now.monthGmt(), now.dayGmt())\`. Same shape as the stamp side.

## Test plan
- [ ] feature-test passes
- [ ] apex-scan clean
- [ ] **upload-beta passes** — the gate that flagged this

🤖 Generated with [Claude Code](https://claude.com/claude-code)