### PR TITLE
fix(namespace): PSG DeveloperName lookup accepts namespaced + bare (audit Bug 4)

### DIFF
--- a/force-app/main/default/classes/DeliveryHubDashboardController.cls
+++ b/force-app/main/default/classes/DeliveryHubDashboardController.cls
@@ -580,10 +580,12 @@ global with sharing class DeliveryHubDashboardController {
      */
     @AuraEnabled(cacheable=true)
     global static Boolean isAdminUser() {
+        // PSG DeveloperName is namespace-prefixed on subscriber installs
+        // (delivery__DeliveryHubAdmin) and bare in dev — accept both.
         return ![
             SELECT Id FROM PermissionSetAssignment
             WHERE AssigneeId = :UserInfo.getUserId()
-            AND PermissionSetGroup.DeveloperName = 'DeliveryHubAdmin'
+            AND PermissionSetGroup.DeveloperName IN ('DeliveryHubAdmin', 'delivery__DeliveryHubAdmin')
             WITH SYSTEM_MODE
             LIMIT 1
         ].isEmpty();

--- a/force-app/main/default/classes/DeliverySyncDismissalService.cls
+++ b/force-app/main/default/classes/DeliverySyncDismissalService.cls
@@ -217,10 +217,12 @@ public with sharing class DeliverySyncDismissalService {
                 return true;
             }
         }
+        // PSG DeveloperName is namespace-prefixed on subscriber installs
+        // (delivery__DeliveryHubAdmin) and bare in dev — accept both.
         return ![
             SELECT Id FROM PermissionSetAssignment
             WHERE AssigneeId = :userId
-            AND PermissionSetGroup.DeveloperName = 'DeliveryHubAdmin'
+            AND PermissionSetGroup.DeveloperName IN ('DeliveryHubAdmin', 'delivery__DeliveryHubAdmin')
             WITH SYSTEM_MODE LIMIT 1
         ].isEmpty();
     }


### PR DESCRIPTION
## Summary

- Closes the last open finding from the 2026-05-13 namespace audit (Bug 4). PRs #777 already shipped the other 4 confirmed bugs in 0.238.0.1.
- `PermissionSetGroup.DeveloperName` is namespace-prefixed (`delivery__DeliveryHubAdmin`) on subscriber installs, bare in the packaging org. Two callers queried only the bare name, so `isAdminUser()` returned `false` for every subscriber-org admin — hiding admin UI in the dashboard and routing every dismissal through the non-admin code path.
- Pattern is identical to the CustomNotificationType silent-bell-notification fix in #777: `WHERE DeveloperName IN (bare, namespaced)`.
- 5-line fix across 2 classes:
  - `DeliveryHubDashboardController.cls:586` (`isAdminUser`)
  - `DeliverySyncDismissalService.cls:223` (`canDismiss`)

## Test plan

- [ ] CI green (feature-test + apex-scan + upload-beta)
- [ ] After install on subscriber, confirm `isAdminUser()` returns true for a user assigned the `DeliveryHubAdmin` PSG (visual: admin dashboard surfaces appear; admin dismissal path takes precedence over user dismissal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)