### PR TITLE
feat(layouts): close 2026-05-13 page-field audit backlog (SyncItem, NetworkEntity, ActivityLog, PortalAccess)

### DIFF
--- a/force-app/main/default/flexipages/DeliveryActivityLogRecordPage.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryActivityLogRecordPage.flexipage-meta.xml
@@ -123,6 +123,16 @@
                 <identifier>RecordSessionIdTxt_cField</identifier>
             </fieldInstance>
         </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.LegalHoldDateTime__c</fieldItem>
+                <identifier>RecordLegalHoldDateTime_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
         <name>Facet-d4e50001-0001-0001-0001-000000000002</name>
         <type>Facet</type>
     </flexiPageRegions>

--- a/force-app/main/default/flexipages/DeliveryNetworkEntityRecordPage.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryNetworkEntityRecordPage.flexipage-meta.xml
@@ -70,7 +70,7 @@
         <type>Facet</type>
     </flexiPageRegions>
 
-    <!-- Entity Info: Right column (ConnectionStatusPk, DefaultHourlyRateCurrency, OwnerId) -->
+    <!-- Entity Info: Right column (ConnectionStatusPk, DefaultHourlyRateCurrency, JurisdictionTxt, OwnerId) -->
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
@@ -90,6 +90,16 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.DefaultHourlyRateCurrency__c</fieldItem>
                 <identifier>RecordDefaultHourlyRateCurrency_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.JurisdictionTxt__c</fieldItem>
+                <identifier>RecordJurisdictionTxt_cField</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -148,7 +158,7 @@
         <type>Facet</type>
     </flexiPageRegions>
 
-    <!-- Integration: Left column (IntegrationEndpointUrlTxt, OrgIdTxt, ApiKeyTxt) -->
+    <!-- Integration: Left column (IntegrationEndpointUrlTxt, OrgIdTxt, ApiKeyTxt, RevealFulfillmentDepthPk) -->
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
@@ -180,11 +190,21 @@
                 <identifier>RecordApiKeyTxt_cField</identifier>
             </fieldInstance>
         </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.RevealFulfillmentDepthPk__c</fieldItem>
+                <identifier>RecordRevealFulfillmentDepthPk_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
         <name>Facet-ne-integ-left</name>
         <type>Facet</type>
     </flexiPageRegions>
 
-    <!-- Integration: Right column (EnableVendorPushDateTime, GithubUsernameTxt, RemoteExternalIdTxt, LastInboundSyncDateTime) -->
+    <!-- Integration: Right column (EnableVendorPushDateTime, GithubUsernameTxt, RemoteExternalIdTxt, LastInboundSyncDateTime, LastOutboundSyncDateTime) -->
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
@@ -226,7 +246,49 @@
                 <identifier>RecordLastInboundSyncDateTime_cField</identifier>
             </fieldInstance>
         </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.LastOutboundSyncDateTime__c</fieldItem>
+                <identifier>RecordLastOutboundSyncDateTime_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
         <name>Facet-ne-integ-right</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
+    <!-- Billing: Left column (BillingFrequencyPk) -->
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.BillingFrequencyPk__c</fieldItem>
+                <identifier>RecordBillingFrequencyPk_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-ne-billing-left</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
+    <!-- Billing: Right column (EnableBillingDateTime) -->
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.EnableBillingDateTime__c</fieldItem>
+                <identifier>RecordEnableBillingDateTime_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-ne-billing-right</name>
         <type>Facet</type>
     </flexiPageRegions>
 
@@ -326,6 +388,32 @@
         <type>Facet</type>
     </flexiPageRegions>
 
+    <!-- Billing: 2 columns -->
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-ne-billing-left</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column_billing1</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-ne-billing-right</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column_billing2</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-ne-billing-cols</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+
     <!-- Vendor Management: 1 column -->
     <flexiPageRegions>
         <itemInstances>
@@ -396,6 +484,24 @@
                 </componentInstanceProperties>
                 <componentName>flexipage:fieldSection</componentName>
                 <identifier>flexipage_fieldSection_integ</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>columns</name>
+                    <value>Facet-ne-billing-cols</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>label</name>
+                    <value>Billing</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:fieldSection</componentName>
+                <identifier>flexipage_fieldSection_billing</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>

--- a/force-app/main/default/flexipages/DeliveryPortalAccessRecordPage.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryPortalAccessRecordPage.flexipage-meta.xml
@@ -83,6 +83,16 @@
                 <identifier>RecordRolePk_cField</identifier>
             </fieldInstance>
         </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.PermissionsTxt__c</fieldItem>
+                <identifier>RecordPermissionsTxt_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
         <name>Facet-c3d40001-0001-0001-0001-000000000002</name>
         <type>Facet</type>
     </flexiPageRegions>

--- a/force-app/main/default/flexipages/DeliverySyncItemRecordPage.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliverySyncItemRecordPage.flexipage-meta.xml
@@ -77,11 +77,21 @@
                 <identifier>RecordStatusPk_cField</identifier>
             </fieldInstance>
         </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.ChangeTypeTxt__c</fieldItem>
+                <identifier>RecordChangeTypeTxt_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
         <name>Facet-e5f60001-0001-0001-0001-000000000001</name>
         <type>Facet</type>
     </flexiPageRegions>
 
-    <!-- Sync Summary: Right column (SourceEventTimestampDateTime, GlobalSourceIdTxt, LocalRecordIdTxt, RemoteExternalIDTxt) -->
+    <!-- Sync Summary: Right column (SourceEventTimestampDateTime, GlobalSourceIdTxt, LocalRecordIdTxt, RemoteExternalIDTxt, DismissedDateTime) -->
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
@@ -121,6 +131,16 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.RemoteExternalIDTxt__c</fieldItem>
                 <identifier>RecordRemoteExternalIDTxt_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.DismissedDateTime__c</fieldItem>
+                <identifier>RecordDismissedDateTime_cField</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-e5f60001-0001-0001-0001-000000000002</name>

--- a/force-app/main/default/layouts/ActivityLog__c-Activity Log Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/ActivityLog__c-Activity Log Layout.layout-meta.xml
@@ -32,6 +32,10 @@
                 <behavior>Edit</behavior>
                 <field>SessionIdTxt__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>LegalHoldDateTime__c</field>
+            </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>
     </layoutSections>

--- a/force-app/main/default/layouts/NetworkEntity__c-Network Entity Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/NetworkEntity__c-Network Entity Layout.layout-meta.xml
@@ -37,6 +37,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>LastOutboundSyncDateTime__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>RemoteExternalIdTxt__c</field>
             </layoutItems>
             <layoutItems>
@@ -48,6 +52,10 @@
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>OwnerId</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>JurisdictionTxt__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>
@@ -94,6 +102,29 @@
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>EnableVendorPushDateTime__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>RevealFulfillmentDepthPk__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <style>TwoColumnsTopToBottom</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>true</customLabel>
+        <detailHeading>true</detailHeading>
+        <editHeading>true</editHeading>
+        <label>Billing</label>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>BillingFrequencyPk__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>EnableBillingDateTime__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>

--- a/force-app/main/default/layouts/PortalAccess__c-Portal Access Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/PortalAccess__c-Portal Access Layout.layout-meta.xml
@@ -25,6 +25,10 @@
                 <behavior>Edit</behavior>
                 <field>RolePk__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>PermissionsTxt__c</field>
+            </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>
     </layoutSections>

--- a/force-app/main/default/layouts/SyncItem__c-Sync Item Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/SyncItem__c-Sync Item Layout.layout-meta.xml
@@ -26,6 +26,10 @@
                 <behavior>Edit</behavior>
                 <field>GlobalSourceIdTxt__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>ChangeTypeTxt__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -39,6 +43,10 @@
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>RetryCountNumber__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>DismissedDateTime__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>


### PR DESCRIPTION
## Summary

Closes the remaining ~55-min backlog from [docs/audits/delivery-hub-page-field-audit-2026-05-13.md](docs/audits/delivery-hub-page-field-audit-2026-05-13.md). PR #776 (released as 0.238.0.1 / 0.239.0.1) already closed 4 of 5 headline findings — this PR surfaces the small admin-facing fields that were present on the object but absent from BOTH the FlexiPage AND the classic layout (gap on both surfaces, not drift).

After merge, the audit's status header can be updated to RESOLVED.

## Per-object changes

### SyncItem (2 fields)
- `ChangeTypeTxt__c` — operators need to see packet type (record_change / depth_probe / depth_response) when triaging
- `DismissedDateTime__c` — operator-relevant for Failed SyncItem triage (already vs. not yet dismissed)

### NetworkEntity (5 fields, new Billing section)
- `JurisdictionTxt__c` — regulatory chain visibility, used by depth-charge audits (ITAR / GDPR / state-licensed)
- `LastOutboundSyncDateTime__c` — twin to existing `LastInboundSyncDateTime__c`; stamped by DeliverySyncItemProcessor
- `RevealFulfillmentDepthPk__c` — per-peer opt-in for the depth-charge feature (defaults Off, opt-in is the whole point of the field)
- New "Billing" section with `BillingFrequencyPk__c` + `EnableBillingDateTime__c` — wired in `DeliveryInvoiceGenerationService` today, was invisible

### ActivityLog (1 field)
- `LegalHoldDateTime__c` — when non-null, cleanup job skips; admin needs to see hold state on a record

### PortalAccess (1 field)
- `PermissionsTxt__c` — JSON override of role-based defaults; admin needs visibility into granular grants

## Deferred per audit guidance

Kept hidden — secret / forensic / pure plumbing:
- `SyncItem.ParentRefTxt__c` (defensible to hide)
- `NetworkEntity.HmacSecretTxt__c` (secret) + `UsageAnalyticsJsonTxt__c` (JSON blob)
- `ActivityLog.HashChainTxt__c` (forensic hash)
- `PortalAccess.AccessTokenTxt__c` (secret)

## Mirroring both surfaces

Per the WorkLog finding in the audit, the package ships both FlexiPage and classic layout — every field added to one surface here is mirrored on the other so a subscriber that re-points to the classic layout doesn't lose the field.

## Test plan

- [ ] PR CI passes (PMD scanner unchanged — pure metadata)
- [ ] On scratch org install: verify each FlexiPage renders without component errors and the new fields appear in the expected sections
- [ ] Sanity-check the new "Billing" section on NetworkEntity record page (2-col, BillingFrequency picklist on left, EnableBillingDateTime on right)
- [ ] Confirm classic-layout edit page in Setup shows each newly-added field in its target section

## Follow-on

After this merges and is promoted, update `docs/audits/delivery-hub-page-field-audit-2026-05-13.md` status header to RESOLVED.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>