### PR TITLE
docs(claude.md): correct stale picklist-trigger enforcement claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 - When making Apex classes `global`, ALL inner classes used as return/param types must also be `global`.
 - Use DateTime stamps, not Booleans, for feature toggles (`EnableXDateTime__c` pattern).
 - **Picklist fields must use `GlobalValueSet` references from day one (`<valueSetName>`), never inline `<valueSetDefinition>`.** Unlocked packages do not reliably propagate new values added to restricted inline picklists on subscriber upgrades (SF Known Issue `a028c00000qPzYUAA0`), and SF blocks retrofitting GVS onto an existing inline-defined field ("Cannot change which global value set this picklist uses"). GVS from day one is the only durable path.
-- Existing inline-defined picklists stay `<restricted>false</restricted>`. Data integrity on those is enforced at the Apex service / trigger layer (see `DeliveryPicklistIntegrityService`), not via the field's restricted flag. This survives bulk-data-loader imports and subscriber customization.
+- Existing inline-defined picklists stay `<restricted>false</restricted>`. There is **no longer a runtime picklist-allowlist trigger** — `DeliverySyncItemTriggerHandler.onBeforeInsertOrUpdate` is a documented no-op (enforcement deprecated 2026-04-26 because GVS seed data wasn't reliably present across orgs and beta_create kept failing on empty-describe paths). Apex services that write picklist values should pass safe known values directly; `TestDataFactory` defaults to allowlist-compliant values for the same reason.
 
 ## Org Aliases
 - `MF-Prod` — <your-prod-org-username>@<domain>.com
@@ -31,7 +31,7 @@
 ## Data Integrity
 - NEVER fabricate realistic financial data, statistics, or quotes. Use obviously placeholder values and flag them.
 - NEVER run DML against production orgs unless explicitly asked. Always sandbox first.
-- SyncItem StatusPk__c is NOT restricted (legacy inline-defined field, unrestricted since 2026-04-23). Allowed values enforced via trigger at `DeliveryPicklistIntegrityService`. Never insert records with unknown picklist values — they will pass SF restriction but fail the trigger.
+- SyncItem StatusPk__c is NOT restricted (legacy inline-defined field, unrestricted since 2026-04-23). There is **no trigger-level enforcement** as of 2026-04-26 (`DeliverySyncItemTriggerHandler` is a no-op — see Salesforce Development Rules above). Apex services should pass safe, known picklist values directly; SF will accept anything since the field is unrestricted.
 
 ## Workflow Discipline
 - Do NOT jump ahead or start building before the user confirms the approach.

--- a/force-app/main/default/triggers/DeliverySyncItemTrigger.trigger
+++ b/force-app/main/default/triggers/DeliverySyncItemTrigger.trigger
@@ -1,8 +1,10 @@
 /**
  * @name         Delivery Hub
  * @license      BSL 1.1 — See LICENSE.md
- * @description  Trigger for SyncItem__c — enforces picklist allowlist integrity on
- *               StatusPk__c and ObjectTypePk__c via DeliveryPicklistIntegrityService.
+ * @description  Trigger for SyncItem__c. Picklist-allowlist enforcement was
+ *               deprecated 2026-04-26 because the GVS seed data wasn't reliably
+ *               present across orgs; handler is intentionally a no-op. Trigger
+ *               declaration kept stable as the future callback target.
  * @author       Cloud Nimbus LLC
  */
 trigger DeliverySyncItemTrigger on SyncItem__c (before insert, before update) { //NOPMD - AvoidLogicInTrigger: single-line delegation only


### PR DESCRIPTION
## Summary

CLAUDE.md and the SyncItem trigger header both still referenced a `DeliveryPicklistIntegrityService` trigger that hasn't existed in months:

- `DeliveryPicklistIntegrityService` class is **not in the codebase** (verified via repo-wide grep — 0 results).
- `DeliverySyncItemTriggerHandler.onBeforeInsertOrUpdate` is a documented **no-op since 2026-04-26**. Per its header: enforcement was removed because GVS seed data wasn't reliably present across orgs and `beta_create` kept failing on empty-describe paths.

Surfaced by the Phase 1 TestDataFactory agent (#787) during a scope review — the factory was going to bracket inserts to defeat the trigger, then noticed there was no trigger to defeat.

## Changes

- **CLAUDE.md → Salesforce Development Rules**: replaced the "enforced via trigger at DeliveryPicklistIntegrityService" bullet with the actual current state — no runtime enforcement, services pass safe known values, factory defaults to allowlist-compliant values.
- **CLAUDE.md → Data Integrity**: same correction for the SyncItem StatusPk__c bullet.
- **`DeliverySyncItemTrigger.trigger`**: replaced the misleading description with the deprecation note that matches the handler.

No code behavior change. Docs and one trigger comment.

## Test plan

- [ ] CI green (docs + comment-only change; apex-scan + feature-test should sail through)
- [ ] No regression — the trigger handler itself is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)