### PR TITLE
docs(audits): reconcile status headers with shipped fixes

### DIFF
--- a/docs/audits/dead-code-audit-2026-05-13.md
+++ b/docs/audits/dead-code-audit-2026-05-13.md
@@ -1,12 +1,29 @@
 # Dead Code / Orphan Metadata Audit (2026-05-13)
 
-> **Status as of 2026-05-16: OPEN / INFORMATIONAL.** No deletions have been
-> shipped against this audit. Findings preserved as a punch-list for a future
-> dead-code-removal pass — `DeliveryTimelineController`, `DeliveryWorkItemQueryService`,
-> `DeliveryHubCalloutService`, `DeliveryArchivalService`, Experience Cloud
-> portal LWC cluster, analytics widget cluster, Bounty marketplace cluster.
-> Confirm with Glen before deleting any class with `@RestResource` (Bounty)
-> since external HTTP traffic is not visible from the repo.
+> **Status as of 2026-05-18: MOSTLY RESOLVED.** "Definitely safe to delete"
+> cluster shipped via PR #789 (merged 2026-05-18) — 4,323 LOC removed across
+> 48 files: 5 Apex classes + tests/metas (`DeliveryTimelineController`,
+> `DeliveryWorkItemQueryService`, `DeliveryHubCalloutService`,
+> `DeliveryArchivalService`, `DeliveryActivityTrackerController`), 6 LWC
+> folders (4 Experience-Cloud portal LWCs + `deliveryPartnerSettingsCard` +
+> `deliveryActivityTracker`), plus 2 permset entries + 3 test-suite entries.
+>
+> **Audit was wrong about `DeliveryPortalController`.** The audit claimed the
+> 5 portal-bound methods (`getPortalDashboard`, `getPortalWorkItems`,
+> `getPortalWorkItemDetail`, `submitPortalRequest`, `addPortalComment`) were
+> "exclusively bound" to the 4 deleted portal LWCs. They are ALSO consumed by
+> `DeliveryPublicApiService.cls` (live `@RestResource` at `/deliveryhub/v1/api/*`,
+> serving the cloudnimbusllc.com Next.js portal) at lines 104, 128, 134, 289,
+> 297, 302. Following the audit blindly would have 500'd the public portal API.
+> `DeliveryPortalController` left intact in #789.
+>
+> **Deferred (Glen sign-off required):**
+> - `deliveryDocumentSignPortal/` — audit cited a "Coleman demo" commit reference.
+> - "Likely safe" cluster — Bounty marketplace (`@RestResource`, external HTTP
+>   traffic not visible from repo) + 7 analytics widget LWCs (need confirmation
+>   none are queued for "wire to DashboardCard__mdt" follow-on).
+>
+> File preserved as the punch-list for the "likely safe" follow-on PR.
 
 Scope: `force-app/main/default/` — 275 Apex classes, 75 LWCs, 35 objects, 29 reports, 3 report types, 6 VF pages, 2 Aura apps. Method: each class/component/field cross-referenced against every other file type in the package (cls/trigger/js/html/page/cmp/-meta.xml/permset/flexipage/layout/report), with externally-invoked entry points (`@RestResource`, `@AuraEnabled` LWC bindings, Aura `aura:application`, VF pages, tabs, app utility bars, scheduled cron via `DeliveryHubScheduler`) treated as live.
 

--- a/docs/audits/delivery-hub-page-field-audit-2026-05-13.md
+++ b/docs/audits/delivery-hub-page-field-audit-2026-05-13.md
@@ -1,13 +1,12 @@
 # Delivery Hub — Page Layout / Field Audit (2026-05-13)
 
-> **Status as of 2026-05-16: PARTIALLY RESOLVED.** 4 of 5 headline findings
-> closed by PR #776 (merged 2026-05-13, released 0.238.0.1 / 0.239.0.1):
-> WorkLog FlexiPage gap (ResourceTitleTxt__c surfaced), WorkItem layout-vs-FlexiPage
-> drift closed, DeliveryDocument dunning + scheduled-send cluster surfaced,
-> WorkItemDependency dynamic FlexiPage added, DeliveryTransaction reverse-drift
-> resolved. **Remaining backlog (~55 min):** small gaps on SyncItem,
-> NetworkEntity, ActivityLog, PortalAccess (admin-facing fields not on either
-> FlexiPage or layout — low operator impact). File preserved for backlog triage.
+> **Status as of 2026-05-18: RESOLVED.** Headline findings closed by PR #776
+> (0.238.0.1 / 0.239.0.1, merged 2026-05-13). Remaining ~55-min backlog closed
+> by PR #786 (0.241.0.3, merged 2026-05-16) — 9 admin fields surfaced across
+> SyncItem (2), NetworkEntity (5 incl. new Billing section), ActivityLog (1),
+> PortalAccess (1). Hidden plumbing fields (HashChainTxt, AccessTokenTxt,
+> HmacSecretTxt, UsageAnalyticsJsonTxt, ParentRefTxt) deferred per audit
+> recommendation. File preserved as a record.
 
 Scope: 11 user-facing custom objects in `force-app/main/default/objects/`. Method: parsed every `layout-meta.xml` and `flexipage-meta.xml` to extract field references, then diffed against the `fields/` directory. FlexiPage assignment confirmed via `force-app/main/default/applications/DeliveryHub.app-meta.xml` and `DeliveryHubAdmin.app-meta.xml`.
 

--- a/docs/audits/namespace-audit-2026-05-13.md
+++ b/docs/audits/namespace-audit-2026-05-13.md
@@ -1,13 +1,11 @@
 # Namespace Hygiene Audit (2026-05-13)
 
-> **Status as of 2026-05-16: PARTIALLY RESOLVED.** 4 of 5 confirmed bugs closed
-> by PR #777 (merged 2026-05-13, released 0.238.0.1): Bug 1 (deliveryWorkItemRefiner
-> field-name namespacing), Bug 2 (deliveryWorkItemActionCenter apiName strings),
-> Bug 3 (CustomNotificationType DeveloperName — silent bell-notification regression),
-> Bug 5 (FlexiPage dynamic-related-list parent-field refs). **Remaining: Bug 4
-> (PermissionSetGroup DeveloperName) at `DeliveryHubDashboardController.cls:586`
-> and `DeliverySyncDismissalService.cls:223` — 5-line fix, queued as a separate
-> PR.** File preserved for Bug 4 follow-on.
+> **Status as of 2026-05-18: RESOLVED.** All 5 confirmed bugs shipped.
+> Bugs 1, 2, 3, 5 closed by PR #777 (0.238.0.1, merged 2026-05-13). Bug 4
+> (PermissionSetGroup DeveloperName) closed by PR #784 (0.241.0.3, merged
+> 2026-05-16) — `IN ('DeliveryHubAdmin', 'delivery__DeliveryHubAdmin')` clause
+> at `DeliveryHubDashboardController.cls:586` and
+> `DeliverySyncDismissalService.cls:223`. File preserved as a record.
 
 Branch scanned: `fix/lwc-namespace-workitem-refs` (7 files in flight; their target patterns excluded per the PR-in-progress notice).
 


### PR DESCRIPTION
## Summary

Three audit docs now reflect the PRs that have closed their findings — bringing the status headers up to date so future readers don't re-read a stale claim.

| Audit | Was | Now | Why |
|---|---|---|---|
| `namespace-audit-2026-05-13.md` | PARTIALLY RESOLVED | **RESOLVED** | Bug 4 closed by #784 in 0.241.0.3 |
| `delivery-hub-page-field-audit-2026-05-13.md` | PARTIALLY RESOLVED | **RESOLVED** | ~55-min backlog closed by #786 in 0.241.0.3 |
| `dead-code-audit-2026-05-13.md` | OPEN / INFORMATIONAL | **MOSTLY RESOLVED** | "Definitely safe" cluster shipped via #789 (4,323 LOC across 48 files) |

## Notable correction in dead-code header

The audit claimed `DeliveryPortalController`'s 5 portal methods were "exclusively bound" to the 4 deleted portal LWCs. They are also consumed by `DeliveryPublicApiService.cls` for the cloudnimbusllc.com Next.js portal (lines 104, 128, 134, 289, 297, 302). Following the audit blindly would have 500'd the public API. The header now records that miss so it doesn't trip the next pass.

## Still deferred (need your sign-off)

- `deliveryDocumentSignPortal/` (audit's Coleman-demo caveat)
- Bounty marketplace cluster (`@RestResource` — external traffic not visible from repo)
- 7 analytics widget LWCs (need confirmation none are queued for `DashboardCard__mdt` wiring)

Docs only. No code change.

## Test plan

- [ ] CI green (docs-only — should sail through apex-scan + feature-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)