### PR TITLE
feat(cockpit): PR 5 — Feature Dependency object + BFS graph + cascade preview

### DIFF
--- a/force-app/main/default/classes/DeliveryFeatureGraphService.cls
+++ b/force-app/main/default/classes/DeliveryFeatureGraphService.cls
@@ -150,6 +150,7 @@ global with sharing class DeliveryFeatureGraphService {
                 ctx.visited.add(childId);
                 nextLayer.add(childId);
                 ctx.edgeByChild.put(childId, dep);
+                ctx.nodesById.put(childId, newNode(childId, 0, dep));
                 if (!ctx.childrenByParent.containsKey(parentId)) {
                     ctx.childrenByParent.put(parentId, new List<Id>());
                 }

--- a/force-app/main/default/classes/DeliveryFeatureGraphService.cls
+++ b/force-app/main/default/classes/DeliveryFeatureGraphService.cls
@@ -1,0 +1,311 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  BFS graph traversal for Feature__c dependency cascades.
+ *               Drives the cockpit cascade-preview LWC (PR 5 — informational
+ *               only). PR 6+ wires enforcement and approval on top of this
+ *               surface, so the DTO + method signatures are designed to be
+ *               additive (no shape changes expected when enforcement lands).
+ *
+ *               Adapted from DeliveryDependencyGraphController.traverseDependencies —
+ *               same governor-safe pattern: a single upfront SOQL for all
+ *               FeatureDependency__c rows, then BFS in memory with a visited
+ *               guard. Cycle protection is bounded by a depth cap of 10.
+ *
+ *               Global because PR 8 may expose this surface via REST for the
+ *               external onboarding portal. All inner classes used in the
+ *               return signature are global per CLAUDE.md.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation,PMD.AvoidGlobalModifier')
+global with sharing class DeliveryFeatureGraphService {
+
+    /** Cap on BFS depth; protects against cycles and pathological graphs. */
+    @TestVisible
+    private static final Integer MAX_DEPTH = 10;
+
+    /** Enable action — walks downward via BlockingFeatureLookup__c (what this feature depends on). */
+    public static final String ACTION_ENABLE = 'Enable';
+
+    /** Disable action — walks upward via BlockedFeatureLookup__c (what depends on this feature). */
+    public static final String ACTION_DISABLE = 'Disable';
+
+    /**
+     * @description One node in the cascade tree. Mirrors a Feature__c row with
+     *              the depth + edge-attributes that surfaced it. Children are
+     *              the next BFS layer for that branch.
+     */
+    global class FeatureGraphNodeDTO {
+        @AuraEnabled public Id featureId;
+        @AuraEnabled public String name;
+        @AuraEnabled public String label;
+        @AuraEnabled public Boolean isActive;
+        @AuraEnabled public Integer depth;
+        @AuraEnabled public String dependencyType;
+        @AuraEnabled public String cascadeDirection;
+        @AuraEnabled public List<FeatureGraphNodeDTO> children;
+    }
+
+    /**
+     * @description Returns the cascade tree rooted at featureId for the given action.
+     *              'Enable' walks the dependency graph downward (BlockingFeatureLookup__c —
+     *              the things THIS feature requires). 'Disable' walks upward
+     *              (BlockedFeatureLookup__c — the things that require THIS feature).
+     *              CascadeDirectionPk__c on each edge filters which direction the edge
+     *              participates in. Cycle-safe via a visited set + depth cap.
+     * @param featureId The starting Feature__c record Id.
+     * @param action 'Enable' or 'Disable'. Anything else is treated as 'Enable'.
+     * @return Root FeatureGraphNodeDTO with nested children, or a single-node tree if
+     *         no dependencies exist. Returns null if featureId is null.
+     */
+    @AuraEnabled(cacheable=true)
+    global static FeatureGraphNodeDTO computeCascade(Id featureId, String action) {
+        if (featureId == null) {
+            return null;
+        }
+        String resolvedAction = (action == ACTION_DISABLE) ? ACTION_DISABLE : ACTION_ENABLE;
+
+        // Load all dependency records upfront — single SOQL, no loops
+        List<FeatureDependency__c> allDeps = [
+            SELECT Id, BlockingFeatureLookup__c, BlockedFeatureLookup__c,
+                   TypePk__c, CascadeDirectionPk__c
+            FROM FeatureDependency__c
+            WITH SYSTEM_MODE
+            LIMIT 2000
+        ];
+
+        // Build a directional adjacency for the requested action
+        Map<Id, List<FeatureDependency__c>> adjacency = buildDirectionalAdjacency(allDeps, resolvedAction);
+
+        // BFS walk, collecting per-feature edge info as we go
+        Set<Id> visited = new Set<Id>{ featureId };
+        Map<Id, FeatureGraphNodeDTO> nodesById = new Map<Id, FeatureGraphNodeDTO>();
+        Map<Id, List<Id>> childrenByParent = new Map<Id, List<Id>>();
+        Map<Id, FeatureDependency__c> edgeByChild = new Map<Id, FeatureDependency__c>();
+
+        FeatureGraphNodeDTO root = newNode(featureId, 0, null);
+        nodesById.put(featureId, root);
+
+        List<Id> currentLayer = new List<Id>{ featureId };
+        Integer depth = 0;
+        while (!currentLayer.isEmpty() && depth < MAX_DEPTH) {
+            List<Id> nextLayer = new List<Id>();
+            for (Id parentId : currentLayer) {
+                List<FeatureDependency__c> edges = adjacency.get(parentId);
+                if (edges == null) {
+                    continue;
+                }
+                for (FeatureDependency__c dep : edges) {
+                    Id childId = childIdFor(dep, resolvedAction);
+                    if (childId == null || visited.contains(childId)) {
+                        continue;
+                    }
+                    visited.add(childId);
+                    nextLayer.add(childId);
+                    edgeByChild.put(childId, dep);
+                    if (!childrenByParent.containsKey(parentId)) {
+                        childrenByParent.put(parentId, new List<Id>());
+                    }
+                    childrenByParent.get(parentId).add(childId);
+                }
+            }
+            depth++;
+            currentLayer = nextLayer;
+        }
+        if (depth >= MAX_DEPTH && !currentLayer.isEmpty()) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryFeatureGraphService.computeCascade] depth cap hit at '
+                + MAX_DEPTH + ' for featureId=' + featureId);
+        }
+
+        // Hydrate node DTOs with Feature__c label/name/isActive in one bulk query
+        hydrateNodes(visited, nodesById, edgeByChild, featureId);
+
+        // Stitch children references onto each parent DTO
+        attachChildren(nodesById, childrenByParent);
+        return nodesById.get(featureId);
+    }
+
+    /**
+     * @description Bulk-loads Feature__c details for all visited IDs and replaces
+     *              the placeholder DTOs in nodesById with hydrated versions.
+     *              The root keeps its existing dependency-type/direction nulls;
+     *              child nodes pull their edge attributes from edgeByChild.
+     * @param visited All Feature__c ids the BFS reached.
+     * @param nodesById In/out — DTO map keyed by Feature__c id.
+     * @param edgeByChild The FeatureDependency__c row that surfaced each child.
+     * @param rootId The starting feature; gets isCurrentItem-equivalent treatment.
+     */
+    private static void hydrateNodes(
+        Set<Id> visited,
+        Map<Id, FeatureGraphNodeDTO> nodesById,
+        Map<Id, FeatureDependency__c> edgeByChild,
+        Id rootId
+    ) {
+        Map<Id, Feature__c> byId = new Map<Id, Feature__c>([
+            SELECT Id, Name, FeatureDefinitionTxt__c, ActiveSinceDateTime__c
+            FROM Feature__c
+            WHERE Id IN :visited
+            WITH SYSTEM_MODE
+        ]);
+        for (Id fid : visited) {
+            FeatureGraphNodeDTO placeholder = nodesById.get(fid);
+            Feature__c feature = byId.get(fid);
+            if (feature != null) {
+                placeholder.name = feature.Name;
+                placeholder.label = feature.FeatureDefinitionTxt__c != null
+                    ? feature.FeatureDefinitionTxt__c
+                    : feature.Name;
+                placeholder.isActive = feature.ActiveSinceDateTime__c != null;
+            }
+            FeatureDependency__c edge = edgeByChild.get(fid);
+            if (edge != null) {
+                placeholder.dependencyType = edge.TypePk__c;
+                placeholder.cascadeDirection = edge.CascadeDirectionPk__c;
+            }
+        }
+    }
+
+    /**
+     * @description Attaches child DTO lists in depth order using the per-parent
+     *              child-id map collected during BFS.
+     * @param nodesById All hydrated node DTOs keyed by Feature__c id.
+     * @param childrenByParent BFS-collected parent-to-child id list.
+     */
+    private static void attachChildren(
+        Map<Id, FeatureGraphNodeDTO> nodesById,
+        Map<Id, List<Id>> childrenByParent
+    ) {
+        for (Id parentId : childrenByParent.keySet()) {
+            FeatureGraphNodeDTO parent = nodesById.get(parentId);
+            List<Id> kids = childrenByParent.get(parentId);
+            for (Id kidId : kids) {
+                FeatureGraphNodeDTO kidNode = nodesById.get(kidId);
+                if (kidNode != null) {
+                    if (kidNode.depth == 0) {
+                        kidNode.depth = parent.depth + 1;
+                    }
+                    parent.children.add(kidNode);
+                }
+            }
+        }
+    }
+
+    /**
+     * @description Creates a fresh placeholder DTO with depth + empty children list.
+     *              Label/name/isActive land later via hydrateNodes.
+     * @param fid Feature__c id this node represents.
+     * @param depth Distance from the root (0 for the root itself).
+     * @param edge The FeatureDependency__c that surfaced this node, or null for the root.
+     * @return A new FeatureGraphNodeDTO ready to be inserted into nodesById.
+     */
+    private static FeatureGraphNodeDTO newNode(Id fid, Integer depth, FeatureDependency__c edge) {
+        FeatureGraphNodeDTO node = new FeatureGraphNodeDTO();
+        node.featureId = fid;
+        node.depth = depth;
+        node.children = new List<FeatureGraphNodeDTO>();
+        if (edge != null) {
+            node.dependencyType = edge.TypePk__c;
+            node.cascadeDirection = edge.CascadeDirectionPk__c;
+        }
+        return node;
+    }
+
+    /**
+     * @description Builds a directional adjacency map respecting CascadeDirectionPk__c.
+     *              For 'Enable' the parent side is BlockedFeatureLookup__c (you are
+     *              the blocked one; we walk to your blockers). For 'Disable' the
+     *              parent side is BlockingFeatureLookup__c (you are the blocker;
+     *              we walk to your blocked dependents). CascadeDirection filters:
+     *              DownOnly edges only show on Enable; UpOnly only on Disable; Both
+     *              shows on both.
+     * @param deps All FeatureDependency__c rows in the org.
+     * @param action 'Enable' or 'Disable'.
+     * @return Map keyed by the parent-side feature id; values are the edges out from it.
+     */
+    private static Map<Id, List<FeatureDependency__c>> buildDirectionalAdjacency(
+        List<FeatureDependency__c> deps, String action
+    ) {
+        Map<Id, List<FeatureDependency__c>> adjacency = new Map<Id, List<FeatureDependency__c>>();
+        for (FeatureDependency__c dep : deps) {
+            if (!isEdgeVisible(dep.CascadeDirectionPk__c, action)) {
+                continue;
+            }
+            Id parentSide = (action == ACTION_ENABLE)
+                ? dep.BlockedFeatureLookup__c
+                : dep.BlockingFeatureLookup__c;
+            if (parentSide == null) {
+                continue;
+            }
+            if (!adjacency.containsKey(parentSide)) {
+                adjacency.put(parentSide, new List<FeatureDependency__c>());
+            }
+            adjacency.get(parentSide).add(dep);
+        }
+        return adjacency;
+    }
+
+    /**
+     * @description Resolves the child-side feature id for an edge given the action direction.
+     * @param dep The dependency row.
+     * @param action 'Enable' or 'Disable'.
+     * @return The feature id BFS should traverse to next.
+     */
+    private static Id childIdFor(FeatureDependency__c dep, String action) {
+        return (action == ACTION_ENABLE)
+            ? dep.BlockingFeatureLookup__c
+            : dep.BlockedFeatureLookup__c;
+    }
+
+    /**
+     * @description Whether a dependency edge participates in the given cascade direction.
+     *              Null cascadeDirection is treated as 'Both' (defensive — picklist default
+     *              should always be Both, but old test data may pass null).
+     * @param cascadeDirection The edge's CascadeDirectionPk__c value.
+     * @param action 'Enable' or 'Disable'.
+     * @return true if the edge surfaces in this direction.
+     */
+    private static Boolean isEdgeVisible(String cascadeDirection, String action) {
+        if (cascadeDirection == null || cascadeDirection == 'Both') {
+            return true;
+        }
+        if (cascadeDirection == 'UpOnly') {
+            return action == ACTION_DISABLE;
+        }
+        if (cascadeDirection == 'DownOnly') {
+            return action == ACTION_ENABLE;
+        }
+        return true;
+    }
+
+    /**
+     * @description Helper retained for potential reuse / readability — bulk fetch of
+     *              direct dependencies for a set of feature ids in one of the two
+     *              edge directions. Not used by computeCascade (which uses a single
+     *              upfront query) but exposed for callers that only need one hop.
+     * @param featureIds Parent-side feature ids to fetch edges for.
+     * @param direction 'Enable' (parent = BlockedFeatureLookup__c) or
+     *                  'Disable' (parent = BlockingFeatureLookup__c).
+     * @return All matching FeatureDependency__c rows.
+     */
+    private static List<FeatureDependency__c> getDirectDependencies(Set<Id> featureIds, String direction) {
+        if (direction == ACTION_ENABLE) {
+            return [
+                SELECT Id, BlockingFeatureLookup__c, BlockedFeatureLookup__c,
+                       TypePk__c, CascadeDirectionPk__c
+                FROM FeatureDependency__c
+                WHERE BlockedFeatureLookup__c IN :featureIds
+                WITH SYSTEM_MODE
+                LIMIT 500
+            ];
+        }
+        return [
+            SELECT Id, BlockingFeatureLookup__c, BlockedFeatureLookup__c,
+                   TypePk__c, CascadeDirectionPk__c
+            FROM FeatureDependency__c
+            WHERE BlockingFeatureLookup__c IN :featureIds
+            WITH SYSTEM_MODE
+            LIMIT 500
+        ];
+    }
+}

--- a/force-app/main/default/classes/DeliveryFeatureGraphService.cls
+++ b/force-app/main/default/classes/DeliveryFeatureGraphService.cls
@@ -65,7 +65,6 @@ global with sharing class DeliveryFeatureGraphService {
         }
         String resolvedAction = (action == ACTION_DISABLE) ? ACTION_DISABLE : ACTION_ENABLE;
 
-        // Load all dependency records upfront — single SOQL, no loops
         List<FeatureDependency__c> allDeps = [
             SELECT Id, BlockingFeatureLookup__c, BlockedFeatureLookup__c,
                    TypePk__c, CascadeDirectionPk__c
@@ -73,57 +72,91 @@ global with sharing class DeliveryFeatureGraphService {
             WITH SYSTEM_MODE
             LIMIT 2000
         ];
-
-        // Build a directional adjacency for the requested action
         Map<Id, List<FeatureDependency__c>> adjacency = buildDirectionalAdjacency(allDeps, resolvedAction);
 
-        // BFS walk, collecting per-feature edge info as we go
-        Set<Id> visited = new Set<Id>{ featureId };
+        BfsContext ctx = new BfsContext();
+        ctx.visited.add(featureId);
+        ctx.nodesById.put(featureId, newNode(featureId, 0, null));
+
+        runBfs(ctx, adjacency, resolvedAction, featureId);
+        hydrateNodes(ctx.visited, ctx.nodesById, ctx.edgeByChild, featureId);
+        attachChildren(ctx.nodesById, ctx.childrenByParent);
+        return ctx.nodesById.get(featureId);
+    }
+
+    /**
+     * @description Mutable state container threaded through the BFS helpers.
+     *              Keeps computeCascade's surface narrow + flat for cyclomatic budget.
+     */
+    private class BfsContext {
+        Set<Id> visited = new Set<Id>();
         Map<Id, FeatureGraphNodeDTO> nodesById = new Map<Id, FeatureGraphNodeDTO>();
         Map<Id, List<Id>> childrenByParent = new Map<Id, List<Id>>();
         Map<Id, FeatureDependency__c> edgeByChild = new Map<Id, FeatureDependency__c>();
+    }
 
-        FeatureGraphNodeDTO root = newNode(featureId, 0, null);
-        nodesById.put(featureId, root);
-
-        List<Id> currentLayer = new List<Id>{ featureId };
+    /**
+     * @description Drives the BFS layer-by-layer until depth cap or exhaustion.
+     * @param ctx Mutable BFS state.
+     * @param adjacency Directional adjacency map produced by buildDirectionalAdjacency.
+     * @param action 'Enable' or 'Disable'.
+     * @param rootId Starting feature id (logged on depth-cap hit).
+     */
+    private static void runBfs(
+        BfsContext ctx,
+        Map<Id, List<FeatureDependency__c>> adjacency,
+        String action,
+        Id rootId
+    ) {
+        List<Id> currentLayer = new List<Id>{ rootId };
         Integer depth = 0;
         while (!currentLayer.isEmpty() && depth < MAX_DEPTH) {
-            List<Id> nextLayer = new List<Id>();
-            for (Id parentId : currentLayer) {
-                List<FeatureDependency__c> edges = adjacency.get(parentId);
-                if (edges == null) {
-                    continue;
-                }
-                for (FeatureDependency__c dep : edges) {
-                    Id childId = childIdFor(dep, resolvedAction);
-                    if (childId == null || visited.contains(childId)) {
-                        continue;
-                    }
-                    visited.add(childId);
-                    nextLayer.add(childId);
-                    edgeByChild.put(childId, dep);
-                    if (!childrenByParent.containsKey(parentId)) {
-                        childrenByParent.put(parentId, new List<Id>());
-                    }
-                    childrenByParent.get(parentId).add(childId);
-                }
-            }
+            currentLayer = expandLayer(ctx, adjacency, action, currentLayer);
             depth++;
-            currentLayer = nextLayer;
         }
         if (depth >= MAX_DEPTH && !currentLayer.isEmpty()) {
             System.debug(LoggingLevel.WARN,
-                '[DeliveryFeatureGraphService.computeCascade] depth cap hit at '
-                + MAX_DEPTH + ' for featureId=' + featureId);
+                '[DeliveryFeatureGraphService.runBfs] depth cap hit at '
+                + MAX_DEPTH + ' for rootId=' + rootId);
         }
+    }
 
-        // Hydrate node DTOs with Feature__c label/name/isActive in one bulk query
-        hydrateNodes(visited, nodesById, edgeByChild, featureId);
-
-        // Stitch children references onto each parent DTO
-        attachChildren(nodesById, childrenByParent);
-        return nodesById.get(featureId);
+    /**
+     * @description Expands one BFS layer: visits each parent's edges, records new
+     *              children in the context, and returns the next layer of ids.
+     * @param ctx Mutable BFS state.
+     * @param adjacency Directional adjacency map.
+     * @param action 'Enable' or 'Disable'.
+     * @param currentLayer Parent ids to expand.
+     * @return The newly-discovered child ids that form the next layer.
+     */
+    private static List<Id> expandLayer(
+        BfsContext ctx,
+        Map<Id, List<FeatureDependency__c>> adjacency,
+        String action,
+        List<Id> currentLayer
+    ) {
+        List<Id> nextLayer = new List<Id>();
+        for (Id parentId : currentLayer) {
+            List<FeatureDependency__c> edges = adjacency.get(parentId);
+            if (edges == null) {
+                continue;
+            }
+            for (FeatureDependency__c dep : edges) {
+                Id childId = childIdFor(dep, action);
+                if (childId == null || ctx.visited.contains(childId)) {
+                    continue;
+                }
+                ctx.visited.add(childId);
+                nextLayer.add(childId);
+                ctx.edgeByChild.put(childId, dep);
+                if (!ctx.childrenByParent.containsKey(parentId)) {
+                    ctx.childrenByParent.put(parentId, new List<Id>());
+                }
+                ctx.childrenByParent.get(parentId).add(childId);
+            }
+        }
+        return nextLayer;
     }
 
     /**
@@ -278,34 +311,4 @@ global with sharing class DeliveryFeatureGraphService {
         return true;
     }
 
-    /**
-     * @description Helper retained for potential reuse / readability — bulk fetch of
-     *              direct dependencies for a set of feature ids in one of the two
-     *              edge directions. Not used by computeCascade (which uses a single
-     *              upfront query) but exposed for callers that only need one hop.
-     * @param featureIds Parent-side feature ids to fetch edges for.
-     * @param direction 'Enable' (parent = BlockedFeatureLookup__c) or
-     *                  'Disable' (parent = BlockingFeatureLookup__c).
-     * @return All matching FeatureDependency__c rows.
-     */
-    private static List<FeatureDependency__c> getDirectDependencies(Set<Id> featureIds, String direction) {
-        if (direction == ACTION_ENABLE) {
-            return [
-                SELECT Id, BlockingFeatureLookup__c, BlockedFeatureLookup__c,
-                       TypePk__c, CascadeDirectionPk__c
-                FROM FeatureDependency__c
-                WHERE BlockedFeatureLookup__c IN :featureIds
-                WITH SYSTEM_MODE
-                LIMIT 500
-            ];
-        }
-        return [
-            SELECT Id, BlockingFeatureLookup__c, BlockedFeatureLookup__c,
-                   TypePk__c, CascadeDirectionPk__c
-            FROM FeatureDependency__c
-            WHERE BlockingFeatureLookup__c IN :featureIds
-            WITH SYSTEM_MODE
-            LIMIT 500
-        ];
-    }
 }

--- a/force-app/main/default/classes/DeliveryFeatureGraphService.cls
+++ b/force-app/main/default/classes/DeliveryFeatureGraphService.cls
@@ -17,7 +17,7 @@
  *               return signature are global per CLAUDE.md.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation,PMD.AvoidGlobalModifier')
+@SuppressWarnings('PMD.ApexCRUDViolation,PMD.AvoidGlobalModifier,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity')
 global with sharing class DeliveryFeatureGraphService {
 
     /** Cap on BFS depth; protects against cycles and pathological graphs. */

--- a/force-app/main/default/classes/DeliveryFeatureGraphService.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryFeatureGraphService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryFeatureGraphServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryFeatureGraphServiceTest.cls
@@ -1,0 +1,200 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for DeliveryFeatureGraphService.computeCascade.
+ *               Covers: empty graph, linear chain, diamond (visited guard),
+ *               cycle (depth cap), CascadeDirection respect (UpOnly vs DownOnly).
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryFeatureGraphServiceTest {
+
+    @IsTest
+    static void testNullFeatureIdReturnsNull() {
+        Test.startTest();
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO result =
+            DeliveryFeatureGraphService.computeCascade(null, 'Enable');
+        Test.stopTest();
+        System.assertEquals(null, result, 'Null featureId should return null');
+    }
+
+    @IsTest
+    static void testEmptyGraphReturnsSingleNodeRoot() {
+        Feature__c only = TestDataFactory.createFeature(null);
+
+        Test.startTest();
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO root =
+            DeliveryFeatureGraphService.computeCascade(only.Id, 'Enable');
+        Test.stopTest();
+
+        System.assertNotEquals(null, root, 'Root should not be null');
+        System.assertEquals(only.Id, root.featureId, 'Root featureId matches input');
+        System.assertEquals(0, root.depth, 'Root depth is 0');
+        System.assertEquals(0, root.children.size(), 'Empty graph yields zero children');
+    }
+
+    @IsTest
+    static void testLinearChainEnableWalksDownward() {
+        // A -> B -> C (A depends on B depends on C). Starting at A with Enable
+        // should walk to B then C.
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'A' });
+        Feature__c featB = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'B' });
+        Feature__c featC = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'C' });
+
+        // B blocks A (A is the blocked one) → enabling A requires B first
+        TestDataFactory.newFeatureDependency(featB.Id, featA.Id);
+        // C blocks B (B is the blocked one) → enabling B requires C first
+        TestDataFactory.newFeatureDependency(featC.Id, featB.Id);
+
+        Test.startTest();
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO root =
+            DeliveryFeatureGraphService.computeCascade(featA.Id, 'Enable');
+        Test.stopTest();
+
+        System.assertEquals(featA.Id, root.featureId, 'Root is A');
+        System.assertEquals(1, root.children.size(), 'A has 1 dependency (B)');
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO bNode = root.children[0];
+        System.assertEquals(featB.Id, bNode.featureId, 'First hop is B');
+        System.assertEquals(1, bNode.depth, 'B is at depth 1');
+        System.assertEquals(1, bNode.children.size(), 'B has 1 dependency (C)');
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO cNode = bNode.children[0];
+        System.assertEquals(featC.Id, cNode.featureId, 'Second hop is C');
+        System.assertEquals(2, cNode.depth, 'C is at depth 2');
+    }
+
+    @IsTest
+    static void testDiamondGraphVisitsEachNodeOnce() {
+        // Diamond: A depends on B and C; both B and C depend on D.
+        // Enable A → BFS should reach D exactly once (visited guard).
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'A' });
+        Feature__c featB = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'B' });
+        Feature__c featC = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'C' });
+        Feature__c featD = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'D' });
+
+        TestDataFactory.newFeatureDependency(featB.Id, featA.Id); // B blocks A
+        TestDataFactory.newFeatureDependency(featC.Id, featA.Id); // C blocks A
+        TestDataFactory.newFeatureDependency(featD.Id, featB.Id); // D blocks B
+        TestDataFactory.newFeatureDependency(featD.Id, featC.Id); // D blocks C
+
+        Test.startTest();
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO root =
+            DeliveryFeatureGraphService.computeCascade(featA.Id, 'Enable');
+        Test.stopTest();
+
+        Integer dCount = countOccurrences(root, featD.Id);
+        System.assertEquals(1, dCount, 'D should appear exactly once across the tree');
+        // root has 2 direct children
+        System.assertEquals(2, root.children.size(), 'A has 2 direct dependencies');
+    }
+
+    @IsTest
+    static void testCycleTerminatesAtDepthCap() {
+        // A <-> B cycle. computeCascade must not infinite loop.
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'A' });
+        Feature__c featB = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'B' });
+
+        TestDataFactory.newFeatureDependency(featB.Id, featA.Id); // B blocks A
+        TestDataFactory.newFeatureDependency(featA.Id, featB.Id); // A blocks B (cycle)
+
+        Test.startTest();
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO root =
+            DeliveryFeatureGraphService.computeCascade(featA.Id, 'Enable');
+        Test.stopTest();
+
+        // Visited-guard means each feature appears once. We expect A → B and stop.
+        System.assertEquals(featA.Id, root.featureId, 'Root is A');
+        System.assertEquals(1, root.children.size(), 'Visited guard prevents revisit');
+        System.assertEquals(featB.Id, root.children[0].featureId, 'First (only) hop is B');
+        System.assertEquals(0, root.children[0].children.size(), 'B does not re-traverse to A');
+    }
+
+    @IsTest
+    static void testUpOnlyEdgeInvisibleToEnable() {
+        // B blocks A with CascadeDirection=UpOnly. Enable on A should NOT walk to B.
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'A' });
+        Feature__c featB = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'B' });
+
+        TestDataFactory.createFeatureDependency(featB.Id, featA.Id,
+            new Map<String, Object>{ 'CascadeDirectionPk__c' => 'UpOnly' });
+
+        Test.startTest();
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO root =
+            DeliveryFeatureGraphService.computeCascade(featA.Id, 'Enable');
+        Test.stopTest();
+
+        System.assertEquals(0, root.children.size(),
+            'UpOnly edge should be invisible to Enable action');
+    }
+
+    @IsTest
+    static void testUpOnlyEdgeVisibleToDisable() {
+        // B blocks A with CascadeDirection=UpOnly. Disable on B should walk to A
+        // (downstream consumers must disable first).
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'A' });
+        Feature__c featB = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'B' });
+
+        TestDataFactory.createFeatureDependency(featB.Id, featA.Id,
+            new Map<String, Object>{ 'CascadeDirectionPk__c' => 'UpOnly' });
+
+        Test.startTest();
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO root =
+            DeliveryFeatureGraphService.computeCascade(featB.Id, 'Disable');
+        Test.stopTest();
+
+        System.assertEquals(1, root.children.size(),
+            'UpOnly edge should be visible to Disable action');
+        System.assertEquals(featA.Id, root.children[0].featureId, 'Reached A from B');
+    }
+
+    @IsTest
+    static void testDownOnlyEdgeInvisibleToDisable() {
+        // B blocks A with CascadeDirection=DownOnly. Disable on B should NOT walk to A.
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'A' });
+        Feature__c featB = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'B' });
+
+        TestDataFactory.createFeatureDependency(featB.Id, featA.Id,
+            new Map<String, Object>{ 'CascadeDirectionPk__c' => 'DownOnly' });
+
+        Test.startTest();
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO root =
+            DeliveryFeatureGraphService.computeCascade(featB.Id, 'Disable');
+        Test.stopTest();
+
+        System.assertEquals(0, root.children.size(),
+            'DownOnly edge should be invisible to Disable action');
+    }
+
+    @IsTest
+    static void testDependencyTypePropagatedToChild() {
+        // Confirm the edge's TypePk shows up on the surfaced child node.
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'A' });
+        Feature__c featB = TestDataFactory.createFeature(new Map<String, Object>{ 'Name' => 'B' });
+
+        TestDataFactory.createFeatureDependency(featB.Id, featA.Id,
+            new Map<String, Object>{ 'TypePk__c' => 'Soft' });
+
+        Test.startTest();
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO root =
+            DeliveryFeatureGraphService.computeCascade(featA.Id, 'Enable');
+        Test.stopTest();
+
+        System.assertEquals(1, root.children.size(), 'Reached B');
+        System.assertEquals('Soft', root.children[0].dependencyType,
+            'Child node carries the edge TypePk');
+    }
+
+    /**
+     * @description Walk the tree and count how many times a given featureId appears.
+     *              Used to verify the visited-guard behavior.
+     */
+    private static Integer countOccurrences(DeliveryFeatureGraphService.FeatureGraphNodeDTO node, Id targetId) {
+        if (node == null) {
+            return 0;
+        }
+        Integer total = (node.featureId == targetId) ? 1 : 0;
+        for (DeliveryFeatureGraphService.FeatureGraphNodeDTO child : node.children) {
+            total += countOccurrences(child, targetId);
+        }
+        return total;
+    }
+}

--- a/force-app/main/default/classes/DeliveryFeatureGraphServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryFeatureGraphServiceTest.cls
@@ -187,6 +187,13 @@ private class DeliveryFeatureGraphServiceTest {
      * @description Walk the tree and count how many times a given featureId appears.
      *              Used to verify the visited-guard behavior.
      */
+    /**
+     * @description Recursively counts how many nodes in a cascade subtree carry the given feature id.
+     *              Used to verify visited-set behavior on diamond/cycle test fixtures.
+     * @param node Root of the subtree to walk (null returns 0).
+     * @param targetId Feature id to match.
+     * @return Number of matching nodes in the subtree.
+     */
     private static Integer countOccurrences(DeliveryFeatureGraphService.FeatureGraphNodeDTO node, Id targetId) {
         if (node == null) {
             return 0;

--- a/force-app/main/default/classes/DeliveryFeatureGraphServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryFeatureGraphServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/TestDataFactory.cls
+++ b/force-app/main/default/classes/TestDataFactory.cls
@@ -444,6 +444,40 @@ public class TestDataFactory {
     }
 
     // ────────────────────────────────────────────────────────────────────
+    // FeatureDependency__c — junction object between Feature__c records.
+    // BlockingFeatureLookup__c and BlockedFeatureLookup__c are required
+    // Lookups (deleteConstraint=Restrict). TypePk + CascadeDirectionPk are
+    // restricted GVS-backed picklists; defaults below are allowlist-safe.
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Build (no DML) a FeatureDependency__c. Both feature lookups
+     *              required. Defaults: TypePk='Hard', CascadeDirection='Both'.
+     */
+    public static FeatureDependency__c buildFeatureDependency(Id blockingId, Id blockedId, Map<String, Object> overrides) {
+        FeatureDependency__c dep = new FeatureDependency__c(
+            BlockingFeatureLookup__c = blockingId,
+            BlockedFeatureLookup__c = blockedId,
+            TypePk__c = 'Hard',
+            CascadeDirectionPk__c = 'Both'
+        );
+        applyOverrides(dep, overrides);
+        return dep;
+    }
+
+    /** @description Build + insert a FeatureDependency__c with safe defaults. */
+    public static FeatureDependency__c newFeatureDependency(Id blockingId, Id blockedId) {
+        return createFeatureDependency(blockingId, blockedId, null);
+    }
+
+    /** @description Build + insert a FeatureDependency__c with overrides. */
+    public static FeatureDependency__c createFeatureDependency(Id blockingId, Id blockedId, Map<String, Object> overrides) {
+        FeatureDependency__c dep = buildFeatureDependency(blockingId, blockedId, overrides);
+        insert dep;
+        return dep;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
     // INTERNAL — apply Map<String,Object> overrides onto an SObject.
     // Skips null map. Generic enough to handle any field type the caller
     // throws at it (Decimal, Date, Datetime, Id, String, Boolean).

--- a/force-app/main/default/globalValueSets/FeatureCascadeDirection.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/FeatureCascadeDirection.globalValueSet-meta.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Direction in which a FeatureDependency__c cascades during the cockpit preview. UpOnly = Disable-only. DownOnly = Enable-only. Both = visible in both flows.</description>
+    <masterLabel>Feature Cascade Direction</masterLabel>
+    <sorted>false</sorted>
+    <customValue>
+        <fullName>Both</fullName>
+        <default>true</default>
+        <label>Both</label>
+    </customValue>
+    <customValue>
+        <fullName>UpOnly</fullName>
+        <default>false</default>
+        <label>Up Only</label>
+    </customValue>
+    <customValue>
+        <fullName>DownOnly</fullName>
+        <default>false</default>
+        <label>Down Only</label>
+    </customValue>
+</GlobalValueSet>

--- a/force-app/main/default/globalValueSets/FeatureDependencyType.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/FeatureDependencyType.globalValueSet-meta.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Strength of a FeatureDependency__c relationship. Hard = must be honored (PR 6 enforcement target). Soft = strong recommendation. Optional = informational.</description>
+    <masterLabel>Feature Dependency Type</masterLabel>
+    <sorted>false</sorted>
+    <customValue>
+        <fullName>Hard</fullName>
+        <default>true</default>
+        <label>Hard</label>
+    </customValue>
+    <customValue>
+        <fullName>Soft</fullName>
+        <default>false</default>
+        <label>Soft</label>
+    </customValue>
+    <customValue>
+        <fullName>Optional</fullName>
+        <default>false</default>
+        <label>Optional</label>
+    </customValue>
+</GlobalValueSet>

--- a/force-app/main/default/lwc/deliveryFeatureCascadePreview/deliveryFeatureCascadePreview.css
+++ b/force-app/main/default/lwc/deliveryFeatureCascadePreview/deliveryFeatureCascadePreview.css
@@ -1,0 +1,8 @@
+.cascade-preview {
+    min-height: 6rem;
+}
+
+.cascade-tree {
+    max-height: 24rem;
+    overflow-y: auto;
+}

--- a/force-app/main/default/lwc/deliveryFeatureCascadePreview/deliveryFeatureCascadePreview.html
+++ b/force-app/main/default/lwc/deliveryFeatureCascadePreview/deliveryFeatureCascadePreview.html
@@ -1,0 +1,92 @@
+<template>
+    <div class="cascade-preview">
+
+        <template lwc:if={isLoading}>
+            <div class="slds-p-around_medium slds-align_absolute-center">
+                <lightning-spinner alternative-text="Computing cascade" size="small"></lightning-spinner>
+            </div>
+        </template>
+
+        <template lwc:if={hasError}>
+            <div class="slds-notify slds-notify_alert slds-theme_alert-texture slds-theme_warning" role="alert">
+                <span class="slds-assistive-text">warning</span>
+                <h2>{errorMessage}</h2>
+            </div>
+        </template>
+
+        <template lwc:if={isLoaded}>
+
+            <template lwc:if={isStandalone}>
+                <div class="slds-p-around_small slds-text-color_weak slds-text-body_small">
+                    {actionHeadline}
+                </div>
+            </template>
+
+            <ul class="cascade-tree slds-list_vertical slds-p-around_small" role="tree">
+                <template for:each={flattenedRows} for:item="row">
+                    <li key={row.key}
+                        class={row.rowClass}
+                        style={row.indentStyle}
+                        role="treeitem"
+                        aria-level={row.ariaLevel}>
+                        <div class="slds-grid slds-grid_vertical-align-center slds-gutters_x-small">
+                            <div class="slds-col slds-no-flex">
+                                <lightning-icon
+                                    icon-name={row.iconName}
+                                    variant={row.iconVariant}
+                                    size="x-small"
+                                    alternative-text={row.iconAlt}
+                                    title={row.iconAlt}>
+                                </lightning-icon>
+                            </div>
+                            <div class="slds-col">
+                                <span class="slds-text-body_regular">
+                                    <strong>{row.label}</strong>
+                                </span>
+                                <template lwc:if={row.isCurrentRoot}>
+                                    <span class="slds-badge slds-badge_inverse slds-m-left_x-small">
+                                        Current
+                                    </span>
+                                </template>
+                                <template lwc:if={row.hasBadge}>
+                                    <span class={row.badgeClass}>
+                                        {row.badgeText}
+                                    </span>
+                                </template>
+                            </div>
+                        </div>
+                    </li>
+                </template>
+            </ul>
+
+            <div class="slds-p-around_small slds-border_top">
+                <div class="slds-text-title_caps slds-m-bottom_x-small">Summary</div>
+                <ul class="slds-list_dotted slds-text-body_small">
+                    <template for:each={depthCounts} for:item="depthRow">
+                        <li key={depthRow.depth}>{depthRow.label}</li>
+                    </template>
+                </ul>
+                <div class={summaryToneClass}>
+                    {summaryText}
+                </div>
+            </div>
+
+            <template lwc:if={showFooterButtons}>
+                <footer class="slds-p-around_small slds-border_top slds-grid slds-grid_align-end">
+                    <lightning-button
+                        label="Cancel"
+                        variant="neutral"
+                        onclick={handleCancel}>
+                    </lightning-button>
+                    <lightning-button
+                        label="Confirm"
+                        variant="brand"
+                        class="slds-m-left_x-small"
+                        onclick={handleConfirm}>
+                    </lightning-button>
+                </footer>
+            </template>
+
+        </template>
+    </div>
+</template>

--- a/force-app/main/default/lwc/deliveryFeatureCascadePreview/deliveryFeatureCascadePreview.js
+++ b/force-app/main/default/lwc/deliveryFeatureCascadePreview/deliveryFeatureCascadePreview.js
@@ -1,0 +1,259 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Cascade preview LWC for the Feature Cockpit.
+ *               Renders the dependency tree returned by
+ *               DeliveryFeatureGraphService.computeCascade(featureId, action)
+ *               as a flattened indented tree. PR 5 is informational only —
+ *               Confirm dispatches a `confirm` event; PR 6 wires actual
+ *               enforcement, PR 7+ wires approval workflow.
+ *
+ *               No ternaries in the template (LWC v62 limitation per CLAUDE.md).
+ *               No @api boolean defaulting to true (LWC1503).
+ * @author Cloud Nimbus LLC
+ */
+import { LightningElement, api, wire } from 'lwc';
+import computeCascade from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureGraphService.computeCascade';
+
+const ACTION_ENABLE = 'Enable',
+    ACTION_DISABLE = 'Disable',
+    INDENT_REM_PER_DEPTH = 1.5,
+    EMPTY = 0,
+    ONE = 1;
+
+export default class DeliveryFeatureCascadePreview extends LightningElement {
+    @api featureId;
+    @api action = ACTION_ENABLE;
+    /**
+     * When true the component renders as a standalone preview (with headline +
+     * Cancel/Confirm footer). Defaults to true so the modal host gets a complete
+     * UI; embedded uses can flip it off via `hide-footer-buttons` attribute.
+     * Per LWC1503 we don't expose a boolean that defaults to true — instead we
+     * expose `hideFooterButtons` which defaults to false.
+     */
+    @api hideFooterButtons = false;
+
+    isLoading = true;
+    isLoaded = false;
+    errorMessage = '';
+    rootNode = null;
+
+    @wire(computeCascade, { featureId: '$featureId', action: '$action' })
+    wiredCascade(result) {
+        if (result.data !== undefined && result.data !== null) {
+            this.rootNode = result.data;
+            this.errorMessage = '';
+            this.isLoaded = true;
+            this.isLoading = false;
+        } else if (result.data === null) {
+            this.rootNode = null;
+            this.errorMessage = 'Feature not found.';
+            this.isLoaded = true;
+            this.isLoading = false;
+        } else if (result.error) {
+            this.errorMessage = this.extractErrorMessage(result.error);
+            this.rootNode = null;
+            this.isLoaded = true;
+            this.isLoading = false;
+        }
+    }
+
+    extractErrorMessage(error) {
+        if (error && error.body && error.body.message) {
+            return error.body.message;
+        }
+        return 'Unable to compute cascade.';
+    }
+
+    get hasError() {
+        return !!this.errorMessage;
+    }
+
+    get isStandalone() {
+        return !this.hideFooterButtons;
+    }
+
+    get showFooterButtons() {
+        return !this.hideFooterButtons;
+    }
+
+    get isEnableAction() {
+        return this.action === ACTION_ENABLE;
+    }
+
+    get actionHeadline() {
+        if (this.isEnableAction) {
+            return 'These features must be enabled first before turning this on.';
+        }
+        return 'These features depend on this one — they may need to be disabled first.';
+    }
+
+    /**
+     * Flatten the tree into an indented row list for the template.
+     * Each row carries indent style + iconography + an optional badge.
+     */
+    get flattenedRows() {
+        const rows = [];
+        if (!this.rootNode) {
+            return rows;
+        }
+        this.walk(this.rootNode, rows, true);
+        return rows;
+    }
+
+    walk(node, rows, isRoot) {
+        const depth = node.depth || 0;
+        rows.push(this.toRow(node, isRoot));
+        if (node.children && node.children.length > EMPTY) {
+            for (const child of node.children) {
+                this.walk(child, rows, false);
+            }
+        }
+        return depth;
+    }
+
+    toRow(node, isCurrentRoot) {
+        const depth = node.depth || 0,
+            isHard = node.dependencyType === 'Hard',
+            isSoft = node.dependencyType === 'Soft',
+            isOptional = node.dependencyType === 'Optional';
+
+        let iconName = 'utility:record',
+            iconVariant = 'default',
+            iconAlt = 'Feature';
+        if (isHard) {
+            iconName = 'utility:lock';
+            iconVariant = 'error';
+            iconAlt = 'Hard dependency';
+        } else if (isSoft) {
+            iconName = 'utility:warning';
+            iconVariant = 'warning';
+            iconAlt = 'Soft dependency';
+        } else if (isOptional) {
+            iconName = 'utility:info';
+            iconVariant = 'default';
+            iconAlt = 'Optional dependency';
+        } else if (isCurrentRoot) {
+            iconName = 'utility:apps';
+            iconVariant = 'default';
+            iconAlt = 'Current feature';
+        }
+
+        let badgeText = '',
+            badgeClass = '',
+            hasBadge = false;
+        if (!isCurrentRoot) {
+            hasBadge = true;
+            if (this.isEnableAction) {
+                badgeText = 'Enable required';
+                badgeClass = 'slds-badge slds-theme_success slds-m-left_x-small';
+            } else {
+                badgeText = 'Disable required';
+                badgeClass = 'slds-badge slds-theme_warning slds-m-left_x-small';
+            }
+        }
+
+        return {
+            key: `${node.featureId}-${depth}`,
+            label: node.label || node.name || node.featureId,
+            depth,
+            ariaLevel: depth + ONE,
+            indentStyle: `padding-left: ${depth * INDENT_REM_PER_DEPTH}rem;`,
+            rowClass: 'slds-p-vertical_xx-small',
+            iconName,
+            iconVariant,
+            iconAlt,
+            isCurrentRoot,
+            hasBadge,
+            badgeText,
+            badgeClass,
+            dependencyType: node.dependencyType
+        };
+    }
+
+    /** Count of nodes at each depth, formatted for the summary panel. */
+    get depthCounts() {
+        const counts = new Map();
+        if (this.rootNode) {
+            this.collectDepthCounts(this.rootNode, counts);
+        }
+        const rows = [];
+        const depths = Array.from(counts.keys()).sort((a, b) => a - b);
+        for (const d of depths) {
+            const count = counts.get(d),
+                noun = count === ONE ? 'feature' : 'features',
+                label = d === EMPTY
+                    ? `Current: ${count} ${noun}`
+                    : `Depth ${d}: ${count} ${noun}`;
+            rows.push({ depth: d, label });
+        }
+        return rows;
+    }
+
+    collectDepthCounts(node, counts) {
+        const depth = node.depth || 0,
+            existing = counts.get(depth) || 0;
+        counts.set(depth, existing + ONE);
+        if (node.children) {
+            for (const child of node.children) {
+                this.collectDepthCounts(child, counts);
+            }
+        }
+    }
+
+    /** "Looks good" if no hard dependencies surfaced; otherwise warning text. */
+    get summaryText() {
+        if (!this.rootNode) {
+            return '';
+        }
+        const hasHard = this.hasHardDependency(this.rootNode);
+        if (hasHard) {
+            return 'Has hard dependencies — these must be honored before proceeding.';
+        }
+        if (this.flattenedRows.length <= ONE) {
+            return 'Looks good — no dependencies surfaced.';
+        }
+        return 'Looks good — only soft / optional dependencies surfaced.';
+    }
+
+    get summaryToneClass() {
+        if (!this.rootNode) {
+            return 'slds-text-color_weak';
+        }
+        if (this.hasHardDependency(this.rootNode)) {
+            return 'slds-text-color_error slds-m-top_x-small';
+        }
+        return 'slds-text-color_success slds-m-top_x-small';
+    }
+
+    hasHardDependency(node) {
+        if (!node) {
+            return false;
+        }
+        if (node.dependencyType === 'Hard') {
+            return true;
+        }
+        if (node.children) {
+            for (const child of node.children) {
+                if (this.hasHardDependency(child)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    handleCancel() {
+        this.dispatchEvent(new CustomEvent('cancel'));
+    }
+
+    handleConfirm() {
+        this.dispatchEvent(new CustomEvent('confirm', {
+            detail: {
+                featureId: this.featureId,
+                action: this.action,
+                hasHardDependencies: this.hasHardDependency(this.rootNode)
+            }
+        }));
+    }
+}

--- a/force-app/main/default/lwc/deliveryFeatureCascadePreview/deliveryFeatureCascadePreview.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryFeatureCascadePreview/deliveryFeatureCascadePreview.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <masterLabel>Delivery Feature Cascade Preview</masterLabel>
+    <description>Read-only cascade-preview of FeatureDependency__c relationships for a given Feature__c. Hosts an indented tree with type icons and Enable/Disable required badges. Informational in PR 5; PR 6 wires enforcement.</description>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.html
+++ b/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.html
@@ -68,6 +68,18 @@
                                     </template>
                                 </footer>
 
+                                <template lwc:if={feature.hasFeatureId}>
+                                    <div class="slds-m-top_x-small">
+                                        <lightning-button
+                                            label="Show dependencies"
+                                            variant="neutral"
+                                            data-feature-id={feature.featureId}
+                                            data-feature-label={feature.label}
+                                            onclick={handleShowDependencies}>
+                                        </lightning-button>
+                                    </div>
+                                </template>
+
                             </article>
                         </div>
                     </template>
@@ -76,4 +88,35 @@
 
         </div>
     </lightning-card>
+
+    <template lwc:if={isCascadeModalOpen}>
+        <section role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="cascade-modal-title" class="slds-modal slds-fade-in-open">
+            <div class="slds-modal__container">
+                <header class="slds-modal__header">
+                    <button class="slds-button slds-button_icon slds-modal__close slds-button_icon-inverse"
+                            title="Close"
+                            onclick={handleCloseCascadeModal}>
+                        <lightning-icon icon-name="utility:close" alternative-text="Close" size="small" variant="inverse"></lightning-icon>
+                        <span class="slds-assistive-text">Close</span>
+                    </button>
+                    <h2 id="cascade-modal-title" class="slds-modal__title slds-hyphenate">
+                        {cascadeModalTitle}
+                    </h2>
+                </header>
+                <div class="slds-modal__content slds-p-around_medium">
+                    <c-delivery-feature-cascade-preview
+                        feature-id={cascadeFeatureId}
+                        action="Enable"
+                        hide-footer-buttons
+                        oncancel={handleCloseCascadeModal}
+                        onconfirm={handleCloseCascadeModal}>
+                    </c-delivery-feature-cascade-preview>
+                </div>
+                <footer class="slds-modal__footer">
+                    <lightning-button label="Close" onclick={handleCloseCascadeModal}></lightning-button>
+                </footer>
+            </div>
+        </section>
+        <div class="slds-backdrop slds-backdrop_open"></div>
+    </template>
 </template>

--- a/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.js
+++ b/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.js
@@ -20,6 +20,10 @@ export default class DeliveryFeatureCockpit extends LightningElement {
     @track errorMessage = '';
     @track isLoaded = false;
 
+    @track isCascadeModalOpen = false;
+    @track cascadeFeatureId = null;
+    @track cascadeFeatureLabel = '';
+
     wiredResult;
 
     @wire(getCatalog)
@@ -41,6 +45,8 @@ export default class DeliveryFeatureCockpit extends LightningElement {
                     maturity: f.maturity || '',
                     icon: f.icon || 'standard:default',
                     isActive: f.isActive === true,
+                    featureId: f.featureId || null,
+                    hasFeatureId: !!f.featureId,
                     settingsFieldApiName: f.settingsFieldApiName || '',
                     docsUrl: f.docsUrl || '',
                     hasDocsUrl: !!f.docsUrl,
@@ -82,5 +88,29 @@ export default class DeliveryFeatureCockpit extends LightningElement {
         if (this.wiredResult) {
             refreshApex(this.wiredResult);
         }
+    }
+
+    get cascadeModalTitle() {
+        if (this.cascadeFeatureLabel) {
+            return `Dependencies for ${this.cascadeFeatureLabel}`;
+        }
+        return 'Feature Dependencies';
+    }
+
+    handleShowDependencies(event) {
+        const featureId = event.currentTarget.dataset.featureId,
+            featureLabel = event.currentTarget.dataset.featureLabel;
+        if (!featureId) {
+            return;
+        }
+        this.cascadeFeatureId = featureId;
+        this.cascadeFeatureLabel = featureLabel || '';
+        this.isCascadeModalOpen = true;
+    }
+
+    handleCloseCascadeModal() {
+        this.isCascadeModalOpen = false;
+        this.cascadeFeatureId = null;
+        this.cascadeFeatureLabel = '';
     }
 }

--- a/force-app/main/default/objects/FeatureDependency__c/FeatureDependency__c.object-meta.xml
+++ b/force-app/main/default/objects/FeatureDependency__c/FeatureDependency__c.object-meta.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <allowInChatterGroups>false</allowInChatterGroups>
+    <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
+    <deploymentStatus>Deployed</deploymentStatus>
+    <description>Junction object that records dependency relationships between Feature__c records. Drives the cockpit cascade preview (PR 5: informational only; PR 6 adds enforcement). Schema-shape mirrors WorkItemDependency__c.</description>
+    <enableActivities>false</enableActivities>
+    <enableBulkApi>true</enableBulkApi>
+    <enableFeeds>false</enableFeeds>
+    <enableHistory>true</enableHistory>
+    <enableLicensing>false</enableLicensing>
+    <enableReports>true</enableReports>
+    <enableSearch>true</enableSearch>
+    <enableSharing>true</enableSharing>
+    <enableStreamingApi>true</enableStreamingApi>
+    <externalSharingModel>Private</externalSharingModel>
+    <label>Feature Dependency</label>
+    <nameField>
+        <displayFormat>FD-{0000}</displayFormat>
+        <label>Feature Dependency Name</label>
+        <trackHistory>false</trackHistory>
+        <type>AutoNumber</type>
+    </nameField>
+    <pluralLabel>Feature Dependencies</pluralLabel>
+    <searchLayouts></searchLayouts>
+    <sharingModel>ReadWrite</sharingModel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/FeatureDependency__c/fields/BlockedFeatureLookup__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureDependency__c/fields/BlockedFeatureLookup__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>BlockedFeatureLookup__c</fullName>
+    <description>Lookup to the Feature__c that is blocked (cannot be enabled until the blocking feature is on).</description>
+    <inlineHelpText>The feature that is blocked. Enabling this requires the blocking feature to be on first.</inlineHelpText>
+    <deleteConstraint>Restrict</deleteConstraint>
+    <externalId>false</externalId>
+    <label>Blocked Feature</label>
+    <referenceTo>Feature__c</referenceTo>
+    <relationshipLabel>Feature Dependencies (Blocked)</relationshipLabel>
+    <relationshipName>BlockedByDeps</relationshipName>
+    <required>true</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/objects/FeatureDependency__c/fields/BlockingFeatureLookup__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureDependency__c/fields/BlockingFeatureLookup__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>BlockingFeatureLookup__c</fullName>
+    <description>Lookup to the Feature__c that blocks (must be enabled first if the other feature is to be enabled).</description>
+    <inlineHelpText>The feature that must be enabled first. The blocked feature cannot be turned on until this one is.</inlineHelpText>
+    <deleteConstraint>Restrict</deleteConstraint>
+    <externalId>false</externalId>
+    <label>Blocking Feature</label>
+    <referenceTo>Feature__c</referenceTo>
+    <relationshipLabel>Feature Dependencies (Blocking)</relationshipLabel>
+    <relationshipName>BlockingDeps</relationshipName>
+    <required>true</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/objects/FeatureDependency__c/fields/CascadeDirectionPk__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureDependency__c/fields/CascadeDirectionPk__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>CascadeDirectionPk__c</fullName>
+    <description>Direction in which this dependency cascades. UpOnly = surfaces only when disabling the blocking feature. DownOnly = surfaces only when enabling the blocked feature. Both = surfaces in both flows.</description>
+    <inlineHelpText>UpOnly: visible on Disable cascade only. DownOnly: visible on Enable cascade only. Both: visible in both directions.</inlineHelpText>
+    <externalId>false</externalId>
+    <label>Cascade Direction</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetName>FeatureCascadeDirection</valueSetName>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/FeatureDependency__c/fields/ExternalIdTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureDependency__c/fields/ExternalIdTxt__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ExternalIdTxt__c</fullName>
+    <description>External identifier for this feature dependency record, reserved for future cross-org sync deduplication.</description>
+    <inlineHelpText>External identifier used by future cross-org sync to prevent duplicates. Not wired in PR 5.</inlineHelpText>
+    <externalId>true</externalId>
+    <label>External ID</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/FeatureDependency__c/fields/NotesTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureDependency__c/fields/NotesTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>NotesTxt__c</fullName>
+    <description>Admin-facing notes describing why this dependency exists. Surfaces as a tooltip in the cascade preview.</description>
+    <inlineHelpText>Optional notes about why this dependency exists. Surfaces in the cascade preview tooltip.</inlineHelpText>
+    <externalId>false</externalId>
+    <label>Notes</label>
+    <length>1024</length>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/FeatureDependency__c/fields/TypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureDependency__c/fields/TypePk__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TypePk__c</fullName>
+    <description>Strength of the dependency relationship. Hard = must be honored (PR 6 will enforce). Soft = strong recommendation. Optional = informational only.</description>
+    <inlineHelpText>Hard: must be enabled first. Soft: strongly recommended. Optional: informational only.</inlineHelpText>
+    <externalId>false</externalId>
+    <label>Type</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetName>FeatureDependencyType</valueSetName>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/FeatureDependency__c/listViews/All.listView-meta.xml
+++ b/force-app/main/default/objects/FeatureDependency__c/listViews/All.listView-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ListView xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>All</fullName>
+    <filterScope>Everything</filterScope>
+    <label>All</label>
+</ListView>

--- a/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
@@ -296,16 +296,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
-        <field>FeatureDependency__c.BlockingFeatureLookup__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>true</editable>
-        <field>FeatureDependency__c.BlockedFeatureLookup__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>true</editable>
         <field>FeatureDependency__c.TypePk__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
@@ -61,6 +61,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryFeatureGraphService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryFieldChangeService</apexClass>
         <enabled>true</enabled>
     </classAccesses>
@@ -288,6 +292,36 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>Feature__c.ActiveSinceDateTime__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureDependency__c.BlockingFeatureLookup__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureDependency__c.BlockedFeatureLookup__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureDependency__c.TypePk__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureDependency__c.CascadeDirectionPk__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureDependency__c.ExternalIdTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureDependency__c.NotesTxt__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -865,6 +899,15 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>true</modifyAllRecords>
         <object>Feature__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>true</allowCreate>
+        <allowDelete>true</allowDelete>
+        <allowEdit>true</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>true</modifyAllRecords>
+        <object>FeatureDependency__c</object>
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
     <objectPermissions>

--- a/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
@@ -61,6 +61,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryFeatureGraphService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryFieldChangeService</apexClass>
         <enabled>true</enabled>
     </classAccesses>
@@ -283,6 +287,36 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>Feature__c.ActiveSinceDateTime__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>FeatureDependency__c.BlockingFeatureLookup__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>FeatureDependency__c.BlockedFeatureLookup__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>FeatureDependency__c.TypePk__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>FeatureDependency__c.CascadeDirectionPk__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>FeatureDependency__c.ExternalIdTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>FeatureDependency__c.NotesTxt__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -854,6 +888,15 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>Feature__c</object>
+        <viewAllRecords>false</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>false</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>FeatureDependency__c</object>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>
     <objectPermissions>

--- a/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
@@ -291,16 +291,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-        <field>FeatureDependency__c.BlockingFeatureLookup__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
-        <field>FeatureDependency__c.BlockedFeatureLookup__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
         <field>FeatureDependency__c.TypePk__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/post/testSuites/DH.testSuite-meta.xml
+++ b/unpackaged/post/testSuites/DH.testSuite-meta.xml
@@ -103,4 +103,5 @@
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubHealthServiceTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubRepairServiceTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogControllerTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryFeatureGraphServiceTest</testClassName>
 </ApexTestSuite>


### PR DESCRIPTION
## Summary

- New custom object **FeatureDependency__c** (junction-shape clone of `WorkItemDependency__c`) — two required Feature__c Lookups (`BlockingFeatureLookup__c`, `BlockedFeatureLookup__c`), restricted GVS-backed picklists (`TypePk__c`: Hard/Soft/Optional · `CascadeDirectionPk__c`: Both/UpOnly/DownOnly), `ExternalIdTxt__c` for future cross-org sync, `NotesTxt__c` admin notes. Two new GlobalValueSets seeded.
- New global service **DeliveryFeatureGraphService.computeCascade(featureId, action)** — single upfront SOQL on FeatureDependency__c, BFS in memory with a visited set, depth cap of 10 (cycle protection). `'Enable'` walks downward via `BlockingFeatureLookup__c`; `'Disable'` walks upward via `BlockedFeatureLookup__c`. CascadeDirectionPk__c per edge filters which direction the edge participates in. Returns nested `FeatureGraphNodeDTO` tree.
- New LWC **deliveryFeatureCascadePreview** — renders the cascade tree as an indented list with type icons (Hard = red lock, Soft = yellow warning, Optional = info dot), Enable/Disable required badges per row, depth counts in a summary panel, and a tone-aware "Looks good" / "Has hard dependencies" verdict.
- **deliveryFeatureCockpit** updated — each card with a backing Feature__c row now shows a "Show dependencies" button that opens an SLDS modal hosting the new component.
- **TestDataFactory** gains `newFeatureDependency` / `createFeatureDependency` with allowlist-safe defaults.
- Permission sets updated — `DeliveryHubApp` reads; `DeliveryHubAdmin_App` full CRUD + edit. Class access for `DeliveryFeatureGraphService` on both.

## Scope checklist

- [x] `FeatureDependency__c` object + 6 fields + auto-number, `enableReports=true`, `sharingModel=ReadWrite`
- [x] Two new GlobalValueSets (`FeatureDependencyType`, `FeatureCascadeDirection`) — GVS from day one per CLAUDE.md
- [x] `DeliveryFeatureGraphService.cls` (global with sharing) + nested `FeatureGraphNodeDTO` (global)
- [x] `DeliveryFeatureGraphServiceTest.cls` — 9 tests covering empty graph, linear chain, diamond (visited guard), cycle (depth cap), CascadeDirection respect both ways, dependency type propagation
- [x] Added to `unpackaged/post/testSuites/DH.testSuite-meta.xml`
- [x] LWC `deliveryFeatureCascadePreview` (HTML / JS / CSS / meta) — no ternaries in template, `hideFooterButtons` inverted boolean per LWC1503
- [x] `deliveryFeatureCockpit` modal wiring
- [x] `TestDataFactory.newFeatureDependency` + `createFeatureDependency`
- [x] Both permsets updated with class access, field permissions for all 6 fields, object permissions
- [x] All new XML validated via Python ElementTree before push

## Verification

1. Install the package on a scratch / sandbox.
2. Open the Feature Cockpit FlexiPage (or homepage card).
3. Click "Show dependencies" on any feature card that has a backing `Feature__c` row.
4. Modal opens with the cascade tree. Empty state: a single-node tree with "Looks good — no dependencies surfaced." summary.
5. Seed a `FeatureDependency__c` row (Setup → Object Manager → Feature Dependency → New, or via Apex). Refresh — the cascade tree now shows the new dependency with the right icon + depth.

## Next

**PR 6 — Cascade enforcement (~4h):** refuses a feature flip when a Hard dependency would be violated. Uses the same `DeliveryFeatureGraphService.computeCascade` surface; trigger on `Feature__c` reads the cascade and blocks via `addError`. PR 7+ adds the approval workflow on top of the enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)