### PR TITLE
fix(cockpit): namespace-safe describeSettingsFields (upload-beta NPE)

### DIFF
--- a/force-app/main/default/classes/DeliveryFeatureSyncService.cls
+++ b/force-app/main/default/classes/DeliveryFeatureSyncService.cls
@@ -126,11 +126,9 @@ public with sharing class DeliveryFeatureSyncService {
      * @return Field map keyed by lowercased API name.
      */
     private static Map<String, Schema.SObjectField> describeSettingsFields() {
-        return Schema.getGlobalDescribe()
-            .get('DeliveryHubSettings__c')
-            .getDescribe()
-            .fields
-            .getMap();
+        // Typed sObject reference is namespace-safe — getGlobalDescribe().get('DeliveryHubSettings__c')
+        // returns null in the namespaced packaging context (key is delivery__DeliveryHubSettings__c).
+        return DeliveryHubSettings__c.SObjectType.getDescribe().fields.getMap();
     }
 
     /**


### PR DESCRIPTION
## Summary

Hotfix for upload-beta failure on 0.244 — `DeliveryFeatureSyncService.describeSettingsFields()` NPE'd in the packaging org's namespaced (`delivery__`) context because `Schema.getGlobalDescribe().get('DeliveryHubSettings__c')` returns null when the actual key is `delivery__DeliveryHubSettings__c`.

Replaced the global-describe lookup with the typed sObject reference `DeliveryHubSettings__c.SObjectType.getDescribe().fields.getMap()` — namespace-safe because the compiler resolves the typed reference against the current namespace at compile time.

## Why this only surfaced post-merge

The PR-level feature-test deploys to a non-namespaced scratch org where `Schema.getGlobalDescribe().get('DeliveryHubSettings__c')` works fine. The upload-beta job uses the namespaced packaging org, where it does not. Same class of error covered in CLAUDE.md for field/object-name resolution.

## Impact if unfixed

Every `Feature__c` insert/update in subscriber orgs running 0.244+ would throw on the AfterInsert trigger — the cockpit toggle UI would be completely broken.

## Test plan

- [ ] apex-scan green
- [ ] feature-test green
- [ ] After merge, upload-beta succeeds and 0.244 promotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)