### PR TITLE
feat(cockpit): PR 7 — Approval framework single-step (request + approval + inbox)

### DIFF
--- a/force-app/main/default/classes/DeliveryFeatureApprovalService.cls
+++ b/force-app/main/default/classes/DeliveryFeatureApprovalService.cls
@@ -1,0 +1,575 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  PR 7 — Single-step approval framework for Feature__c toggles
+ *               (Layer 5 of the cockpit architecture).
+ *
+ *               The lifecycle:
+ *                 submit(featureId, action, reason)
+ *                   -> creates FeatureToggleRequest__c (Status=Pending) with a
+ *                      frozen CascadeSnapshotJsonTxt__c
+ *                   -> creates ONE FeatureToggleApproval__c row
+ *                      (Step=1, Status=Pending, Required=now)
+ *                 grant(approvalId, note)
+ *                   -> stamps Approval row Status=Approved + Decision fields
+ *                   -> applyIfFullyGranted() — if every approval row on the
+ *                      request is Approved or Auto, flips the underlying
+ *                      Feature__c and marks request Status=Applied. The
+ *                      Feature__c trigger handles the settings-mirror cascade
+ *                      and ActivityLog__c audit row (with SHA-256 hash chain
+ *                      contributed by DeliveryActivityLogTrigger).
+ *                 reject(approvalId, note)
+ *                   -> stamps Approval row Status=Rejected
+ *                   -> propagates to the request (Status=Rejected) so a
+ *                      single dissent halts the chain.
+ *                 rollback(requestId, note)
+ *                   -> reverses an Applied request by flipping the Feature__c
+ *                      back to its pre-Apply state. Marks request RolledBack.
+ *
+ *               PR 8 adds multi-step cascading approvals, REST endpoints, and
+ *               explicit hash-chain audit on apply.
+ *
+ *               Global because PR 8 may expose this surface via REST for the
+ *               external onboarding portal; all DTO classes used in the
+ *               return signature are global per CLAUDE.md.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation,PMD.AvoidGlobalModifier,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity')
+global with sharing class DeliveryFeatureApprovalService {
+
+    /** Action value: enable the feature. */
+    public static final String ACTION_ENABLE = 'Enable';
+    /** Action value: disable the feature. */
+    public static final String ACTION_DISABLE = 'Disable';
+
+    /** Request status values. */
+    public static final String STATUS_PENDING = 'Pending';
+    public static final String STATUS_GRANTED = 'Granted';
+    public static final String STATUS_REJECTED = 'Rejected';
+    public static final String STATUS_APPLIED = 'Applied';
+    public static final String STATUS_ROLLED_BACK = 'RolledBack';
+
+    /** Approval row status values. */
+    public static final String APPROVAL_PENDING = 'Pending';
+    public static final String APPROVAL_APPROVED = 'Approved';
+    public static final String APPROVAL_REJECTED = 'Rejected';
+    public static final String APPROVAL_AUTO = 'Auto';
+
+    /** Recursion guard so the request trigger doesn't re-enter applyIfFullyGranted. */
+    @TestVisible
+    private static Boolean inApplyContext = false;
+
+    /**
+     * @description DTO for the approval inbox LWC. One row per pending
+     *              FeatureToggleApproval__c assigned to the running user.
+     */
+    global class ApprovalInboxDTO {
+        @AuraEnabled public Id approvalId;
+        @AuraEnabled public Id requestId;
+        @AuraEnabled public Id featureId;
+        @AuraEnabled public String featureLabel;
+        @AuraEnabled public String action;
+        @AuraEnabled public String reason;
+        @AuraEnabled public DateTime requestedAt;
+        @AuraEnabled public String requestedByName;
+        @AuraEnabled public Integer stepNumber;
+        @AuraEnabled public String status;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // SUBMIT
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Submits a new toggle request. Creates the request row in
+     *              Pending status with a frozen cascade snapshot, then one
+     *              FeatureToggleApproval__c row in Pending status with
+     *              StepNumber=1 and RequiredDateTime__c=now.
+     * @param featureId The Feature__c being toggled.
+     * @param action 'Enable' or 'Disable'.
+     * @param reason Optional rationale from the requester.
+     * @return The new FeatureToggleRequest__c Id.
+     */
+    @AuraEnabled
+    global static Id submit(Id featureId, String action, String reason) {
+        validateSubmitInputs(featureId, action);
+
+        String snapshot = serializeCascadeSnapshot(featureId, action);
+
+        FeatureToggleRequest__c req = new FeatureToggleRequest__c(
+            FeatureLookup__c = featureId,
+            ActionPk__c = action,
+            StatusPk__c = STATUS_PENDING,
+            ReasonTxt__c = String.isBlank(reason) ? null : reason.left(1024),
+            RequestedByUserLookup__c = UserInfo.getUserId(),
+            RequestedDateTime__c = DateTime.now(),
+            CascadeSnapshotJsonTxt__c = snapshot
+        );
+        try {
+            insert req;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryFeatureApprovalService.submit] insert request failed: ' + e.getMessage());
+            throw new AuraHandledException('Unable to submit toggle request.');
+        }
+
+        insertSingleStepApproval(req.Id, featureId);
+        return req.Id;
+    }
+
+    private static void validateSubmitInputs(Id featureId, String action) {
+        if (featureId == null) {
+            throw new AuraHandledException('featureId is required.');
+        }
+        if (action != ACTION_ENABLE && action != ACTION_DISABLE) {
+            throw new AuraHandledException('action must be Enable or Disable.');
+        }
+    }
+
+    private static String serializeCascadeSnapshot(Id featureId, String action) {
+        try {
+            DeliveryFeatureGraphService.FeatureGraphNodeDTO root =
+                DeliveryFeatureGraphService.computeCascade(featureId, action);
+            return JSON.serialize(root);
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryFeatureApprovalService.serializeCascadeSnapshot] failed: '
+                + e.getMessage());
+            return null;
+        }
+    }
+
+    private static void insertSingleStepApproval(Id requestId, Id featureId) {
+        FeatureToggleApproval__c row = new FeatureToggleApproval__c(
+            RequestLookup__c = requestId,
+            FeatureLookup__c = featureId,
+            StepNumber__c = 1,
+            StatusPk__c = APPROVAL_PENDING,
+            RequiredDateTime__c = DateTime.now()
+        );
+        try {
+            insert row;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryFeatureApprovalService.insertSingleStepApproval] failed: '
+                + e.getMessage());
+            throw new AuraHandledException('Unable to create approval row.');
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // GRANT
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Approver-side grant. Stamps the approval row Approved +
+     *              decision fields, then re-evaluates the request: if every
+     *              row on the request is Approved or Auto, applyIfFullyGranted
+     *              flips the underlying feature and stamps the request
+     *              Applied.
+     * @param approvalId The FeatureToggleApproval__c row being decided.
+     * @param note Optional decision note from the approver.
+     */
+    @AuraEnabled
+    global static void grant(Id approvalId, String note) {
+        FeatureToggleApproval__c row = loadApprovalForDecision(approvalId);
+        stampDecision(row, APPROVAL_APPROVED, note);
+        applyIfFullyGranted(row.RequestLookup__c);
+    }
+
+    /**
+     * @description Approver-side reject. Stamps the row Rejected + propagates
+     *              Status=Rejected to the parent request (single dissent
+     *              halts the chain).
+     * @param approvalId The FeatureToggleApproval__c row being decided.
+     * @param note Optional decision note from the approver.
+     */
+    @AuraEnabled
+    global static void reject(Id approvalId, String note) {
+        FeatureToggleApproval__c row = loadApprovalForDecision(approvalId);
+        stampDecision(row, APPROVAL_REJECTED, note);
+        markRequestRejected(row.RequestLookup__c);
+    }
+
+    private static FeatureToggleApproval__c loadApprovalForDecision(Id approvalId) {
+        if (approvalId == null) {
+            throw new AuraHandledException('approvalId is required.');
+        }
+        List<FeatureToggleApproval__c> rows = [
+            SELECT Id, RequestLookup__c, FeatureLookup__c, StepNumber__c,
+                   StatusPk__c, ApproverUserLookup__c
+            FROM FeatureToggleApproval__c
+            WHERE Id = :approvalId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (rows.isEmpty()) {
+            throw new AuraHandledException('Approval row not found.');
+        }
+        return rows.get(0);
+    }
+
+    private static void stampDecision(FeatureToggleApproval__c row, String status, String note) {
+        row.StatusPk__c = status;
+        row.DecisionDateTime__c = DateTime.now();
+        row.DecisionNoteTxt__c = String.isBlank(note) ? null : note.left(1024);
+        if (row.ApproverUserLookup__c == null) {
+            row.ApproverUserLookup__c = UserInfo.getUserId();
+        }
+        try {
+            update row;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryFeatureApprovalService.stampDecision] update failed: '
+                + e.getMessage());
+            throw new AuraHandledException('Unable to record decision.');
+        }
+    }
+
+    private static void markRequestRejected(Id requestId) {
+        if (requestId == null) {
+            return;
+        }
+        FeatureToggleRequest__c req = new FeatureToggleRequest__c(
+            Id = requestId,
+            StatusPk__c = STATUS_REJECTED
+        );
+        try {
+            update req;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryFeatureApprovalService.markRequestRejected] failed: '
+                + e.getMessage());
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // APPLY (private — called from grant + the request trigger)
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description When every approval row on a request is Approved (or
+     *              Auto), flips the underlying Feature__c and stamps the
+     *              request Applied. No-ops if any row is still Pending or
+     *              already Rejected. Recursion-guarded so the request
+     *              trigger and the explicit grant path don't double-apply.
+     * @param requestId The FeatureToggleRequest__c to evaluate.
+     */
+    public static void applyIfFullyGranted(Id requestId) {
+        if (inApplyContext || requestId == null) {
+            return;
+        }
+        FeatureToggleRequest__c req = loadRequestOrNull(requestId);
+        if (req == null || req.StatusPk__c == STATUS_APPLIED
+            || req.StatusPk__c == STATUS_REJECTED
+            || req.StatusPk__c == STATUS_ROLLED_BACK) {
+            return;
+        }
+        if (!allApprovalsGranted(requestId)) {
+            return;
+        }
+        runApply(req);
+    }
+
+    private static FeatureToggleRequest__c loadRequestOrNull(Id requestId) {
+        List<FeatureToggleRequest__c> reqs = [
+            SELECT Id, FeatureLookup__c, ActionPk__c, StatusPk__c,
+                   EffectiveDateTime__c, RequestedByUserLookup__c
+            FROM FeatureToggleRequest__c
+            WHERE Id = :requestId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        return reqs.isEmpty() ? null : reqs.get(0);
+    }
+
+    private static Boolean allApprovalsGranted(Id requestId) {
+        List<FeatureToggleApproval__c> rows = [
+            SELECT Id, StatusPk__c
+            FROM FeatureToggleApproval__c
+            WHERE RequestLookup__c = :requestId
+            WITH SYSTEM_MODE
+        ];
+        if (rows.isEmpty()) {
+            return false;
+        }
+        for (FeatureToggleApproval__c row : rows) {
+            if (row.StatusPk__c != APPROVAL_APPROVED && row.StatusPk__c != APPROVAL_AUTO) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void runApply(FeatureToggleRequest__c req) {
+        inApplyContext = true;
+        try {
+            flipFeature(req.FeatureLookup__c, req.ActionPk__c);
+            req.StatusPk__c = STATUS_APPLIED;
+            req.AppliedDateTime__c = DateTime.now();
+            update req;
+            writeAuditRow(req.FeatureLookup__c, req.ActionPk__c, req.Id);
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryFeatureApprovalService.runApply] failed: ' + e.getMessage());
+            throw new AuraHandledException('Unable to apply toggle.');
+        } finally {
+            inApplyContext = false;
+        }
+    }
+
+    private static void flipFeature(Id featureId, String action) {
+        Feature__c f = loadFeatureForFlipOrThrow(featureId);
+        applyFlipFields(f, action == ACTION_ENABLE);
+        update f;
+    }
+
+    private static Feature__c loadFeatureForFlipOrThrow(Id featureId) {
+        List<Feature__c> rows = [
+            SELECT Id, EnabledDateTime__c, DisabledDateTime__c, LastToggledByUserLookup__c
+            FROM Feature__c
+            WHERE Id = :featureId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (rows.isEmpty()) {
+            throw new AuraHandledException('Feature not found.');
+        }
+        return rows.get(0);
+    }
+
+    private static void applyFlipFields(Feature__c f, Boolean enable) {
+        DateTime now = DateTime.now();
+        if (enable) {
+            f.EnabledDateTime__c = now;
+            f.DisabledDateTime__c = null;
+        } else {
+            f.DisabledDateTime__c = now;
+        }
+        f.LastToggledByUserLookup__c = UserInfo.getUserId();
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // ROLLBACK
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Reverses a previously-Applied request. Flips the
+     *              underlying Feature__c back to its pre-Apply state (the
+     *              inverse of the request's Action) and marks the request
+     *              RolledBack with AppliedDateTime cleared. Emits an audit
+     *              row for the reversal.
+     * @param requestId The FeatureToggleRequest__c to roll back.
+     * @param note Optional rollback note recorded in the audit ContextData.
+     */
+    @AuraEnabled
+    global static void rollback(Id requestId, String note) {
+        FeatureToggleRequest__c req = loadRequestForRollbackOrThrow(requestId);
+        String inverse = (req.ActionPk__c == ACTION_ENABLE) ? ACTION_DISABLE : ACTION_ENABLE;
+        inApplyContext = true;
+        try {
+            flipFeature(req.FeatureLookup__c, inverse);
+            req.StatusPk__c = STATUS_ROLLED_BACK;
+            req.AppliedDateTime__c = null;
+            update req;
+            writeAuditRowWithNote(
+                req.FeatureLookup__c,
+                'Rollback_' + req.ActionPk__c,
+                req.Id,
+                note);
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryFeatureApprovalService.rollback] failed: ' + e.getMessage());
+            throw new AuraHandledException('Unable to roll back the request.');
+        } finally {
+            inApplyContext = false;
+        }
+    }
+
+    private static FeatureToggleRequest__c loadRequestForRollbackOrThrow(Id requestId) {
+        if (requestId == null) {
+            throw new AuraHandledException('requestId is required.');
+        }
+        List<FeatureToggleRequest__c> reqs = [
+            SELECT Id, FeatureLookup__c, ActionPk__c, StatusPk__c, AppliedDateTime__c
+            FROM FeatureToggleRequest__c
+            WHERE Id = :requestId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (reqs.isEmpty()) {
+            throw new AuraHandledException('Request not found.');
+        }
+        FeatureToggleRequest__c req = reqs.get(0);
+        if (req.StatusPk__c != STATUS_APPLIED) {
+            throw new AuraHandledException(
+                'Only Applied requests can be rolled back.');
+        }
+        return req;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // INBOX (LWC-facing)
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Returns Pending approval rows assigned to the running user,
+     *              joined with their request + feature for one-screen render.
+     *              Rows with no assigned approver are filtered out (the
+     *              single-step inbox shape will be widened by PR 8 when
+     *              ApproverUserLookup__c is populated by the chain builder).
+     * @return List of ApprovalInboxDTO ordered by request RequestedDateTime__c
+     *         ASC (oldest first).
+     */
+    @AuraEnabled(cacheable=true)
+    global static List<ApprovalInboxDTO> getInbox() {
+        List<ApprovalInboxDTO> out = new List<ApprovalInboxDTO>();
+        Id userId = UserInfo.getUserId();
+        try {
+            for (FeatureToggleApproval__c row : [
+                SELECT Id, RequestLookup__c, FeatureLookup__c, StepNumber__c,
+                       StatusPk__c,
+                       RequestLookup__r.ActionPk__c,
+                       RequestLookup__r.ReasonTxt__c,
+                       RequestLookup__r.RequestedDateTime__c,
+                       RequestLookup__r.RequestedByUserLookup__c,
+                       RequestLookup__r.RequestedByUserLookup__r.Name,
+                       FeatureLookup__r.Name,
+                       FeatureLookup__r.FeatureDefinitionTxt__c
+                FROM FeatureToggleApproval__c
+                WHERE StatusPk__c = :APPROVAL_PENDING
+                  AND ApproverUserLookup__c = :userId
+                WITH SYSTEM_MODE
+                ORDER BY RequestLookup__r.RequestedDateTime__c ASC NULLS LAST
+                LIMIT 200
+            ]) {
+                out.add(toInboxDto(row));
+            }
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryFeatureApprovalService.getInbox] failed: ' + e.getMessage());
+            throw new AuraHandledException('Unable to load approval inbox.');
+        }
+        return out;
+    }
+
+    private static ApprovalInboxDTO toInboxDto(FeatureToggleApproval__c row) {
+        ApprovalInboxDTO dto = new ApprovalInboxDTO();
+        dto.approvalId = row.Id;
+        dto.requestId = row.RequestLookup__c;
+        dto.featureId = row.FeatureLookup__c;
+        dto.stepNumber = (row.StepNumber__c == null) ? 1 : row.StepNumber__c.intValue();
+        dto.status = row.StatusPk__c;
+        if (row.RequestLookup__r != null) {
+            dto.action = row.RequestLookup__r.ActionPk__c;
+            dto.reason = row.RequestLookup__r.ReasonTxt__c;
+            dto.requestedAt = row.RequestLookup__r.RequestedDateTime__c;
+            if (row.RequestLookup__r.RequestedByUserLookup__r != null) {
+                dto.requestedByName = row.RequestLookup__r.RequestedByUserLookup__r.Name;
+            }
+        }
+        if (row.FeatureLookup__r != null) {
+            String defName = row.FeatureLookup__r.FeatureDefinitionTxt__c;
+            dto.featureLabel = String.isNotBlank(defName)
+                ? defName
+                : row.FeatureLookup__r.Name;
+        }
+        return dto;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // TRIGGER ENTRY POINT
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Trigger entry point. Re-evaluates applyIfFullyGranted for
+     *              every request whose status moved into Pending or Granted
+     *              in this transaction (or was inserted Pending). The
+     *              recursion guard inside applyIfFullyGranted prevents
+     *              double-application when the apply path mutates the
+     *              request row.
+     * @param op Trigger.operationType.
+     * @param newRows Trigger.new.
+     * @param oldMap Trigger.oldMap (null on insert).
+     */
+    public static void onRequestAfterChange(
+        TriggerOperation op,
+        List<FeatureToggleRequest__c> newRows,
+        Map<Id, FeatureToggleRequest__c> oldMap
+    ) {
+        if (inApplyContext || newRows == null || newRows.isEmpty()) {
+            return;
+        }
+        Set<Id> requestIds = collectRequestIdsToEvaluate(newRows, oldMap);
+        for (Id rid : requestIds) {
+            applyIfFullyGranted(rid);
+        }
+    }
+
+    private static Set<Id> collectRequestIdsToEvaluate(
+        List<FeatureToggleRequest__c> newRows,
+        Map<Id, FeatureToggleRequest__c> oldMap
+    ) {
+        Set<Id> ids = new Set<Id>();
+        for (FeatureToggleRequest__c req : newRows) {
+            String oldStatus = (oldMap == null || !oldMap.containsKey(req.Id))
+                ? null
+                : oldMap.get(req.Id).StatusPk__c;
+            if (isRequestEvaluatable(req.StatusPk__c, oldStatus)) {
+                ids.add(req.Id);
+            }
+        }
+        return ids;
+    }
+
+    private static Boolean isRequestEvaluatable(String newStatus, String oldStatus) {
+        if (newStatus != STATUS_PENDING && newStatus != STATUS_GRANTED) {
+            return false;
+        }
+        return newStatus != oldStatus || oldStatus == null;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // AUDIT
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Emits one ActivityLog__c per Apply / Rollback. The
+     *              DeliveryActivityLogTrigger handles SHA-256 hash chain
+     *              insertion (via DeliveryAuditChainService.setHashOnInsert),
+     *              so this method only populates the visible fields.
+     * @param featureId Feature__c whose toggle just flipped.
+     * @param action The Action picklist value from the request.
+     * @param requestId The FeatureToggleRequest__c Id (carried in ContextData).
+     */
+    private static void writeAuditRow(Id featureId, String action, Id requestId) {
+        writeAuditRowWithNote(featureId, action, requestId, null);
+    }
+
+    private static void writeAuditRowWithNote(
+        Id featureId, String action, Id requestId, String note
+    ) {
+        Map<String, Object> ctx = new Map<String, Object>{
+            'requestId' => requestId,
+            'action' => action,
+            'approverUserId' => UserInfo.getUserId()
+        };
+        if (String.isNotBlank(note)) {
+            ctx.put('note', note.left(500));
+        }
+        ActivityLog__c row = new ActivityLog__c(
+            ActionTypePk__c = 'Feature_Toggle',
+            RecordIdTxt__c = (featureId == null) ? null : String.valueOf(featureId),
+            ContextDataTxt__c = JSON.serialize(ctx),
+            UserIdTxt__c = UserInfo.getUserId(),
+            ComponentNameTxt__c = 'DeliveryFeatureApprovalService'
+        );
+        try {
+            insert row;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryFeatureApprovalService.writeAuditRow] insert failed: '
+                + e.getMessage());
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryFeatureApprovalService.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryFeatureApprovalService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryFeatureApprovalServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryFeatureApprovalServiceTest.cls
@@ -1,0 +1,309 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for the PR 7 single-step approval framework:
+ *               submit / grant / reject / apply / rollback / audit.
+ *
+ *               Each test starts with a Feature__c seeded via TestDataFactory.
+ *               The default Feature__c has EnabledDateTime__c=now() so we
+ *               explicitly toggle starting state per scenario.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryFeatureApprovalServiceTest {
+
+    /**
+     * @description Submit creates a Pending request + ONE Pending approval row.
+     */
+    @IsTest
+    static void testSubmitCreatesRequestAndApproval() {
+        Feature__c feat = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+
+        Test.startTest();
+        Id requestId = DeliveryFeatureApprovalService.submit(
+            feat.Id, 'Enable', 'Need this on for client demo');
+        Test.stopTest();
+
+        System.assertNotEquals(null, requestId, 'submit should return a request id');
+        FeatureToggleRequest__c req = [
+            SELECT Id, StatusPk__c, ActionPk__c, FeatureLookup__c,
+                   CascadeSnapshotJsonTxt__c, RequestedByUserLookup__c
+            FROM FeatureToggleRequest__c
+            WHERE Id = :requestId
+        ];
+        System.assertEquals('Pending', req.StatusPk__c, 'request should be Pending');
+        System.assertEquals('Enable', req.ActionPk__c, 'action propagates');
+        System.assertEquals(feat.Id, req.FeatureLookup__c, 'feature linked');
+        System.assertEquals(UserInfo.getUserId(), req.RequestedByUserLookup__c,
+            'requester stamped');
+
+        Integer approvalCount = [
+            SELECT COUNT() FROM FeatureToggleApproval__c WHERE RequestLookup__c = :requestId
+        ];
+        System.assertEquals(1, approvalCount,
+            'single-step: exactly one approval row');
+    }
+
+    /**
+     * @description Grant on the last (only) approval flips the request to
+     *              Applied and toggles the underlying Feature__c.
+     */
+    @IsTest
+    static void testGrantAppliesWhenLastApprovalGranted() {
+        Feature__c feat = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        Id requestId = DeliveryFeatureApprovalService.submit(feat.Id, 'Enable', null);
+        FeatureToggleApproval__c approval = [
+            SELECT Id FROM FeatureToggleApproval__c WHERE RequestLookup__c = :requestId LIMIT 1
+        ];
+
+        Test.startTest();
+        DeliveryFeatureApprovalService.grant(approval.Id, 'looks good');
+        Test.stopTest();
+
+        FeatureToggleRequest__c req = [
+            SELECT StatusPk__c, AppliedDateTime__c FROM FeatureToggleRequest__c WHERE Id = :requestId
+        ];
+        System.assertEquals('Applied', req.StatusPk__c, 'request should be Applied');
+        System.assertNotEquals(null, req.AppliedDateTime__c, 'AppliedDateTime stamped');
+
+        Feature__c after = [
+            SELECT EnabledDateTime__c, DisabledDateTime__c, LastToggledByUserLookup__c
+            FROM Feature__c WHERE Id = :feat.Id
+        ];
+        System.assertNotEquals(null, after.EnabledDateTime__c,
+            'feature should now have EnabledDateTime');
+        System.assertEquals(null, after.DisabledDateTime__c,
+            'Disable stamp cleared on enable');
+    }
+
+    /**
+     * @description Single-step shape: when there is more than one approval row
+     *              on a request and only one is granted, apply does NOT fire.
+     *              PR 7 always inserts one row; this test stubs the multi-row
+     *              shape PR 8 will introduce to lock the gating contract.
+     */
+    @IsTest
+    static void testGrantPendingWhenOtherApprovalsPending() {
+        Feature__c feat = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        Id requestId = DeliveryFeatureApprovalService.submit(feat.Id, 'Enable', null);
+        // Inject a second pending approval row directly (PR 8 shape stub).
+        TestDataFactory.newFeatureToggleApproval(requestId, feat.Id);
+
+        FeatureToggleApproval__c first = [
+            SELECT Id FROM FeatureToggleApproval__c
+            WHERE RequestLookup__c = :requestId
+            ORDER BY CreatedDate ASC LIMIT 1
+        ];
+
+        Test.startTest();
+        DeliveryFeatureApprovalService.grant(first.Id, null);
+        Test.stopTest();
+
+        FeatureToggleRequest__c req = [
+            SELECT StatusPk__c FROM FeatureToggleRequest__c WHERE Id = :requestId
+        ];
+        System.assertEquals('Pending', req.StatusPk__c,
+            'one row granted while another still pending should NOT apply');
+    }
+
+    /**
+     * @description Reject on any single approval propagates Status=Rejected
+     *              to the parent request and does NOT apply.
+     */
+    @IsTest
+    static void testRejectFailsTheRequest() {
+        Feature__c feat = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        Id requestId = DeliveryFeatureApprovalService.submit(feat.Id, 'Enable', null);
+        FeatureToggleApproval__c approval = [
+            SELECT Id FROM FeatureToggleApproval__c WHERE RequestLookup__c = :requestId LIMIT 1
+        ];
+
+        Test.startTest();
+        DeliveryFeatureApprovalService.reject(approval.Id, 'risky');
+        Test.stopTest();
+
+        FeatureToggleRequest__c req = [
+            SELECT StatusPk__c, AppliedDateTime__c FROM FeatureToggleRequest__c WHERE Id = :requestId
+        ];
+        System.assertEquals('Rejected', req.StatusPk__c,
+            'request should be Rejected after a reject');
+        System.assertEquals(null, req.AppliedDateTime__c,
+            'AppliedDateTime should remain null');
+
+        Feature__c after = [
+            SELECT EnabledDateTime__c, DisabledDateTime__c FROM Feature__c WHERE Id = :feat.Id
+        ];
+        System.assertEquals(null, after.EnabledDateTime__c,
+            'feature should NOT have been enabled');
+    }
+
+    /**
+     * @description Apply path on Disable flips DisabledDateTime__c, leaving
+     *              EnabledDateTime__c null (or unchanged).
+     */
+    @IsTest
+    static void testApplyFlipsFeatureDateTime() {
+        Feature__c feat = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => Datetime.now().addDays(-1),
+            'DisabledDateTime__c' => null
+        });
+        Id requestId = DeliveryFeatureApprovalService.submit(feat.Id, 'Disable', null);
+        FeatureToggleApproval__c approval = [
+            SELECT Id FROM FeatureToggleApproval__c WHERE RequestLookup__c = :requestId LIMIT 1
+        ];
+
+        Test.startTest();
+        DeliveryFeatureApprovalService.grant(approval.Id, null);
+        Test.stopTest();
+
+        Feature__c after = [
+            SELECT EnabledDateTime__c, DisabledDateTime__c FROM Feature__c WHERE Id = :feat.Id
+        ];
+        System.assertNotEquals(null, after.DisabledDateTime__c,
+            'feature should now have DisabledDateTime');
+    }
+
+    /**
+     * @description Rollback on an Applied request reverses the flip. After
+     *              an Enable+Apply, rollback should leave the feature disabled
+     *              (DisabledDateTime populated, EnabledDateTime cleared).
+     */
+    @IsTest
+    static void testRollbackReversesFeatureState() {
+        Feature__c feat = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        Id requestId = DeliveryFeatureApprovalService.submit(feat.Id, 'Enable', null);
+        FeatureToggleApproval__c approval = [
+            SELECT Id FROM FeatureToggleApproval__c WHERE RequestLookup__c = :requestId LIMIT 1
+        ];
+        DeliveryFeatureApprovalService.grant(approval.Id, null);
+
+        Test.startTest();
+        DeliveryFeatureApprovalService.rollback(requestId, 'undo it');
+        Test.stopTest();
+
+        FeatureToggleRequest__c req = [
+            SELECT StatusPk__c, AppliedDateTime__c FROM FeatureToggleRequest__c WHERE Id = :requestId
+        ];
+        System.assertEquals('RolledBack', req.StatusPk__c, 'status should be RolledBack');
+        System.assertEquals(null, req.AppliedDateTime__c, 'AppliedDateTime cleared');
+
+        Feature__c after = [
+            SELECT EnabledDateTime__c, DisabledDateTime__c FROM Feature__c WHERE Id = :feat.Id
+        ];
+        System.assertNotEquals(null, after.DisabledDateTime__c,
+            'feature should be disabled after rollback');
+    }
+
+    /**
+     * @description Each Apply emits an ActivityLog__c with
+     *              ActionTypePk__c='Feature_Toggle' and RecordIdTxt__c set
+     *              to the feature id.
+     */
+    @IsTest
+    static void testAuditRowWrittenPerApply() {
+        Feature__c feat = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        Id requestId = DeliveryFeatureApprovalService.submit(feat.Id, 'Enable', null);
+        FeatureToggleApproval__c approval = [
+            SELECT Id FROM FeatureToggleApproval__c WHERE RequestLookup__c = :requestId LIMIT 1
+        ];
+
+        Test.startTest();
+        DeliveryFeatureApprovalService.grant(approval.Id, null);
+        Test.stopTest();
+
+        String featureIdStr = String.valueOf(feat.Id);
+        Integer auditCount = [
+            SELECT COUNT() FROM ActivityLog__c
+            WHERE ActionTypePk__c = 'Feature_Toggle'
+              AND RecordIdTxt__c = :featureIdStr
+        ];
+        System.assert(auditCount >= 1,
+            'at least one ActivityLog row should reference the feature toggle');
+    }
+
+    /**
+     * @description Inbox returns rows assigned to the running user.
+     */
+    @IsTest
+    static void testGetInboxReturnsAssignedRows() {
+        Feature__c feat = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null
+        });
+        Id requestId = DeliveryFeatureApprovalService.submit(feat.Id, 'Enable', 'demo');
+        FeatureToggleApproval__c approval = [
+            SELECT Id FROM FeatureToggleApproval__c WHERE RequestLookup__c = :requestId LIMIT 1
+        ];
+        approval.ApproverUserLookup__c = UserInfo.getUserId();
+        update approval;
+
+        Test.startTest();
+        List<DeliveryFeatureApprovalService.ApprovalInboxDTO> inbox =
+            DeliveryFeatureApprovalService.getInbox();
+        Test.stopTest();
+
+        System.assertEquals(1, inbox.size(), 'should return the one assigned row');
+        DeliveryFeatureApprovalService.ApprovalInboxDTO row = inbox.get(0);
+        System.assertEquals(approval.Id, row.approvalId, 'approval id propagates');
+        System.assertEquals(feat.Id, row.featureId, 'feature id propagates');
+        System.assertEquals('Enable', row.action, 'action propagates');
+    }
+
+    /**
+     * @description Submit rejects bad input.
+     */
+    @IsTest
+    static void testSubmitValidatesInputs() {
+        Feature__c feat = TestDataFactory.createFeature(null);
+        Boolean threw = false;
+        try {
+            DeliveryFeatureApprovalService.submit(null, 'Enable', null);
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        System.assert(threw, 'null featureId should throw');
+
+        threw = false;
+        try {
+            DeliveryFeatureApprovalService.submit(feat.Id, 'Bogus', null);
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        System.assert(threw, 'invalid action should throw');
+    }
+
+    /**
+     * @description Rollback is only valid from Applied. Calling it on a
+     *              Pending or RolledBack request must throw.
+     */
+    @IsTest
+    static void testRollbackOnlyFromApplied() {
+        Feature__c feat = TestDataFactory.createFeature(null);
+        Id requestId = DeliveryFeatureApprovalService.submit(feat.Id, 'Enable', null);
+
+        Boolean threw = false;
+        try {
+            DeliveryFeatureApprovalService.rollback(requestId, null);
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        System.assert(threw, 'rollback of a Pending request should throw');
+    }
+}

--- a/force-app/main/default/classes/DeliveryFeatureApprovalServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryFeatureApprovalServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/FeatureToggleRequestTriggerHandler.cls
+++ b/force-app/main/default/classes/FeatureToggleRequestTriggerHandler.cls
@@ -1,0 +1,34 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Handler for FeatureToggleRequest__c triggers (PR 7 of the
+ *               cockpit plan). Delegates to
+ *               DeliveryFeatureApprovalService.onRequestAfterChange so the
+ *               apply path automatically re-evaluates whenever a request row
+ *               transitions into Pending / Granted. Kept thin so the service
+ *               class owns all the decision logic and remains the single
+ *               surface for PR 8's REST endpoints to call.
+ * @author Cloud Nimbus LLC
+ */
+public with sharing class FeatureToggleRequestTriggerHandler {
+
+    /**
+     * @description Trigger entry point. Bails when the apply path is the
+     *              originator of the DML (recursion guard inside the
+     *              service); otherwise forwards Trigger.new + Trigger.oldMap
+     *              to the service for evaluation.
+     * @param op Trigger.operationType.
+     * @param newRows Trigger.new.
+     * @param oldMap Trigger.oldMap (null on insert).
+     */
+    public static void handle(
+        TriggerOperation op,
+        List<FeatureToggleRequest__c> newRows,
+        Map<Id, FeatureToggleRequest__c> oldMap
+    ) {
+        if (newRows == null || newRows.isEmpty()) {
+            return;
+        }
+        DeliveryFeatureApprovalService.onRequestAfterChange(op, newRows, oldMap);
+    }
+}

--- a/force-app/main/default/classes/FeatureToggleRequestTriggerHandler.cls-meta.xml
+++ b/force-app/main/default/classes/FeatureToggleRequestTriggerHandler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/FeatureToggleRequestTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/FeatureToggleRequestTriggerHandlerTest.cls
@@ -1,0 +1,113 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for FeatureToggleRequestTriggerHandler. Covers:
+ *                 - trigger fires on insert (status transition into Pending)
+ *                 - trigger fires on update (status transition Pending->Granted)
+ *                 - recursion guard: the apply path's own update of the
+ *                   request row (Pending->Applied) does NOT re-enter
+ *                   applyIfFullyGranted (inApplyContext blocks it).
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class FeatureToggleRequestTriggerHandlerTest {
+
+    /**
+     * @description Inserting a Pending request with all approvals already
+     *              Approved should immediately fire applyIfFullyGranted
+     *              from the trigger and Apply the request.
+     */
+    @IsTest
+    static void testTriggerAppliesOnInsertWhenApprovalsAlreadyGranted() {
+        Feature__c feat = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+
+        // Build the request as Draft so insert doesn't auto-trigger apply yet.
+        FeatureToggleRequest__c req = TestDataFactory.buildFeatureToggleRequest(
+            feat.Id, new Map<String, Object>{ 'StatusPk__c' => 'Draft' });
+        insert req;
+        // Insert a pre-approved row, then flip the request to Pending so the
+        // trigger re-evaluates and finds nothing pending.
+        TestDataFactory.createNetworkEntity(null); // touch unrelated DML so test isn't empty
+        FeatureToggleApproval__c row = TestDataFactory.buildFeatureToggleApproval(
+            req.Id, feat.Id, new Map<String, Object>{ 'StatusPk__c' => 'Approved' });
+        insert row;
+
+        Test.startTest();
+        req.StatusPk__c = 'Pending';
+        update req;
+        Test.stopTest();
+
+        FeatureToggleRequest__c after = [
+            SELECT StatusPk__c, AppliedDateTime__c FROM FeatureToggleRequest__c WHERE Id = :req.Id
+        ];
+        System.assertEquals('Applied', after.StatusPk__c,
+            'trigger should re-evaluate on Pending transition and Apply');
+        System.assertNotEquals(null, after.AppliedDateTime__c, 'AppliedDateTime stamped');
+    }
+
+    /**
+     * @description Inserting a Draft request does NOT trigger apply (status
+     *              isn't Pending or Granted), so the feature remains
+     *              untouched.
+     */
+    @IsTest
+    static void testTriggerSkipsDraftStatus() {
+        Feature__c feat = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+
+        Test.startTest();
+        FeatureToggleRequest__c draft = TestDataFactory.buildFeatureToggleRequest(
+            feat.Id, new Map<String, Object>{ 'StatusPk__c' => 'Draft' });
+        insert draft;
+        Test.stopTest();
+
+        Feature__c after = [
+            SELECT EnabledDateTime__c FROM Feature__c WHERE Id = :feat.Id
+        ];
+        System.assertEquals(null, after.EnabledDateTime__c,
+            'Draft request should NOT trigger an apply');
+    }
+
+    /**
+     * @description Recursion guard sanity check — the apply path's own update
+     *              of the request row to Applied must NOT re-fire the trigger.
+     *              Verified indirectly: a successful single-step grant ends
+     *              with exactly one Applied stamp (no error from double-apply).
+     */
+    @IsTest
+    static void testApplyPathDoesNotReEnterTrigger() {
+        Feature__c feat = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        Id requestId = DeliveryFeatureApprovalService.submit(feat.Id, 'Enable', null);
+        FeatureToggleApproval__c approval = [
+            SELECT Id FROM FeatureToggleApproval__c WHERE RequestLookup__c = :requestId LIMIT 1
+        ];
+
+        Test.startTest();
+        DeliveryFeatureApprovalService.grant(approval.Id, null);
+        Test.stopTest();
+
+        // If the trigger had re-entered, we'd see an extra Applied audit
+        // row. Audit count should equal exactly 1 toggle for this feature
+        // (the rows include only THIS feature's RecordIdTxt__c).
+        String featureIdStr = String.valueOf(feat.Id);
+        Integer toggleAudits = [
+            SELECT COUNT() FROM ActivityLog__c
+            WHERE ActionTypePk__c = 'Feature_Toggle'
+              AND RecordIdTxt__c = :featureIdStr
+        ];
+        // PR 2 trigger ALSO writes an audit row on the underlying flip,
+        // so we expect >= 1 (apply service emits one + feature trigger
+        // emits one for the flip itself). The contract is "no runaway
+        // duplication" — fewer than 5 is the practical bound.
+        System.assert(toggleAudits >= 1 && toggleAudits < 5,
+            'audit row count should be bounded; got ' + toggleAudits);
+    }
+}

--- a/force-app/main/default/classes/FeatureToggleRequestTriggerHandlerTest.cls-meta.xml
+++ b/force-app/main/default/classes/FeatureToggleRequestTriggerHandlerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/TestDataFactory.cls
+++ b/force-app/main/default/classes/TestDataFactory.cls
@@ -478,6 +478,77 @@ public class TestDataFactory {
     }
 
     // ────────────────────────────────────────────────────────────────────
+    // FeatureToggleRequest__c / FeatureToggleApproval__c — PR 7 approval
+    // framework. Request requires a Feature__c parent (Lookup, required).
+    // Approval requires both a request and feature parent (Lookups, required).
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Build (no DML) a FeatureToggleRequest__c with safe defaults.
+     *              ActionPk__c='Enable', StatusPk__c='Pending',
+     *              RequestedByUserLookup__c=running user,
+     *              RequestedDateTime__c=now. featureId required (Lookup).
+     * @param featureId Feature__c parent.
+     * @param overrides Optional field overrides.
+     * @return Unpersisted FeatureToggleRequest__c.
+     */
+    public static FeatureToggleRequest__c buildFeatureToggleRequest(Id featureId, Map<String, Object> overrides) {
+        FeatureToggleRequest__c req = new FeatureToggleRequest__c(
+            FeatureLookup__c = featureId,
+            ActionPk__c = 'Enable',
+            StatusPk__c = 'Pending',
+            RequestedByUserLookup__c = UserInfo.getUserId(),
+            RequestedDateTime__c = Datetime.now()
+        );
+        applyOverrides(req, overrides);
+        return req;
+    }
+
+    /**
+     * @description Build + insert a FeatureToggleRequest__c with safe defaults.
+     * @param featureId Feature__c parent.
+     * @return Inserted FeatureToggleRequest__c.
+     */
+    public static FeatureToggleRequest__c newFeatureToggleRequest(Id featureId) {
+        FeatureToggleRequest__c req = buildFeatureToggleRequest(featureId, null);
+        insert req;
+        return req;
+    }
+
+    /**
+     * @description Build (no DML) a FeatureToggleApproval__c with safe defaults.
+     *              StepNumber__c=1, StatusPk__c='Pending',
+     *              RequiredDateTime__c=now. Both parent ids required.
+     * @param requestId FeatureToggleRequest__c parent.
+     * @param featureId Feature__c referenced by the approval row.
+     * @param overrides Optional field overrides.
+     * @return Unpersisted FeatureToggleApproval__c.
+     */
+    public static FeatureToggleApproval__c buildFeatureToggleApproval(Id requestId, Id featureId, Map<String, Object> overrides) {
+        FeatureToggleApproval__c row = new FeatureToggleApproval__c(
+            RequestLookup__c = requestId,
+            FeatureLookup__c = featureId,
+            StepNumber__c = 1,
+            StatusPk__c = 'Pending',
+            RequiredDateTime__c = Datetime.now()
+        );
+        applyOverrides(row, overrides);
+        return row;
+    }
+
+    /**
+     * @description Build + insert a FeatureToggleApproval__c with safe defaults.
+     * @param requestId FeatureToggleRequest__c parent.
+     * @param featureId Feature__c referenced by the approval row.
+     * @return Inserted FeatureToggleApproval__c.
+     */
+    public static FeatureToggleApproval__c newFeatureToggleApproval(Id requestId, Id featureId) {
+        FeatureToggleApproval__c row = buildFeatureToggleApproval(requestId, featureId, null);
+        insert row;
+        return row;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
     // OnboardingProgress__c — runtime per-user per-track state (PR 3).
     // No required Master-Detail; UserLookup__c defaults to the running user.
     // ────────────────────────────────────────────────────────────────────

--- a/force-app/main/default/flexipages/DeliveryHubHome.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryHubHome.flexipage-meta.xml
@@ -39,6 +39,12 @@
                 <identifier>c_deliveryFeatureCockpit_home</identifier>
             </componentInstance>
         </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentName>deliveryFeatureApprovalInbox</componentName>
+                <identifier>c_deliveryFeatureApprovalInbox_home</identifier>
+            </componentInstance>
+        </itemInstances>
         <name>top</name>
         <type>Region</type>
     </flexiPageRegions>

--- a/force-app/main/default/globalValueSets/ApprovalStatus.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/ApprovalStatus.globalValueSet-meta.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Status of a single FeatureToggleApproval__c row. Pending = awaiting the approver. Approved/Rejected = explicit human decision. Auto = the row was satisfied without a human (informational step / blanket grant).</description>
+    <masterLabel>Approval Status</masterLabel>
+    <sorted>false</sorted>
+    <customValue>
+        <fullName>Pending</fullName>
+        <default>true</default>
+        <label>Pending</label>
+    </customValue>
+    <customValue>
+        <fullName>Approved</fullName>
+        <default>false</default>
+        <label>Approved</label>
+    </customValue>
+    <customValue>
+        <fullName>Rejected</fullName>
+        <default>false</default>
+        <label>Rejected</label>
+    </customValue>
+    <customValue>
+        <fullName>Auto</fullName>
+        <default>false</default>
+        <label>Auto</label>
+    </customValue>
+</GlobalValueSet>

--- a/force-app/main/default/globalValueSets/FeatureToggleAction.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/FeatureToggleAction.globalValueSet-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Action requested by a FeatureToggleRequest__c. Enable turns a Feature__c on (sets EnabledDateTime__c, clears DisabledDateTime__c). Disable turns it off (sets DisabledDateTime__c).</description>
+    <masterLabel>Feature Toggle Action</masterLabel>
+    <sorted>false</sorted>
+    <customValue>
+        <fullName>Enable</fullName>
+        <default>true</default>
+        <label>Enable</label>
+    </customValue>
+    <customValue>
+        <fullName>Disable</fullName>
+        <default>false</default>
+        <label>Disable</label>
+    </customValue>
+</GlobalValueSet>

--- a/force-app/main/default/globalValueSets/FeatureToggleStatus.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/FeatureToggleStatus.globalValueSet-meta.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Lifecycle status of a FeatureToggleRequest__c. Draft = unsubmitted. Pending = awaiting approvals. Granted = all approvals received, ready to apply. Rejected = an approver said no. Applied = the Feature__c flip has been persisted. RolledBack = a previously-Applied request was reversed.</description>
+    <masterLabel>Feature Toggle Status</masterLabel>
+    <sorted>false</sorted>
+    <customValue>
+        <fullName>Draft</fullName>
+        <default>true</default>
+        <label>Draft</label>
+    </customValue>
+    <customValue>
+        <fullName>Pending</fullName>
+        <default>false</default>
+        <label>Pending</label>
+    </customValue>
+    <customValue>
+        <fullName>Granted</fullName>
+        <default>false</default>
+        <label>Granted</label>
+    </customValue>
+    <customValue>
+        <fullName>Rejected</fullName>
+        <default>false</default>
+        <label>Rejected</label>
+    </customValue>
+    <customValue>
+        <fullName>Applied</fullName>
+        <default>false</default>
+        <label>Applied</label>
+    </customValue>
+    <customValue>
+        <fullName>RolledBack</fullName>
+        <default>false</default>
+        <label>Rolled Back</label>
+    </customValue>
+</GlobalValueSet>

--- a/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.css
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.css
@@ -1,0 +1,7 @@
+.approval-row {
+    border-bottom: 1px solid #e5e5e5;
+}
+
+.approval-row:last-child {
+    border-bottom: none;
+}

--- a/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.html
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.html
@@ -1,0 +1,84 @@
+<template>
+    <lightning-card title="Pending Approvals" icon-name="standard:approval">
+        <lightning-button-icon
+            slot="actions"
+            icon-name="utility:refresh"
+            alternative-text="Refresh"
+            title="Refresh"
+            onclick={handleRefresh}>
+        </lightning-button-icon>
+
+        <div class="slds-p-around_medium">
+            <template lwc:if={hasError}>
+                <div class="slds-text-color_error">{errorMessage}</div>
+            </template>
+
+            <template lwc:if={isEmpty}>
+                <div class="slds-text-color_weak">
+                    No approvals waiting on you. New requests will appear here.
+                </div>
+            </template>
+
+            <template lwc:if={hasRows}>
+                <ul class="slds-has-dividers_around-space">
+                    <template for:each={rows} for:item="row">
+                        <li key={row.key} class="slds-item slds-p-around_small approval-row">
+                            <div class="slds-grid slds-grid_vertical-align-center slds-grid_align-spread">
+                                <div class="slds-col">
+                                    <div class="slds-text-heading_small">{row.featureLabel}</div>
+                                    <div class="slds-m-top_xx-small">
+                                        <span class={row.actionBadgeClass}>{row.action}</span>
+                                        <span class="slds-m-left_x-small slds-text-body_small slds-text-color_weak">
+                                            Step {row.stepNumber} · requested by {row.requestedByName}
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="slds-col slds-text-align_right slds-text-body_small slds-text-color_weak">
+                                    <lightning-formatted-date-time
+                                        value={row.requestedAt}
+                                        year="numeric" month="short" day="2-digit"
+                                        hour="2-digit" minute="2-digit">
+                                    </lightning-formatted-date-time>
+                                </div>
+                            </div>
+
+                            <template lwc:if={row.hasReason}>
+                                <div class="slds-m-top_x-small slds-text-body_small">
+                                    <strong>Reason:</strong> {row.truncatedReason}
+                                </div>
+                            </template>
+
+                            <div class="slds-m-top_small">
+                                <lightning-textarea
+                                    label="Decision note (optional)"
+                                    placeholder="Add a note for the audit trail"
+                                    data-approval-id={row.approvalId}
+                                    onchange={handleNoteChange}>
+                                </lightning-textarea>
+                            </div>
+
+                            <div class="slds-m-top_small slds-grid slds-gutters_x-small">
+                                <div class="slds-col">
+                                    <lightning-button
+                                        variant="brand"
+                                        label="Approve"
+                                        data-approval-id={row.approvalId}
+                                        onclick={handleApprove}>
+                                    </lightning-button>
+                                </div>
+                                <div class="slds-col">
+                                    <lightning-button
+                                        variant="destructive-text"
+                                        label="Reject"
+                                        data-approval-id={row.approvalId}
+                                        onclick={handleReject}>
+                                    </lightning-button>
+                                </div>
+                            </div>
+                        </li>
+                    </template>
+                </ul>
+            </template>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.js
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.js
@@ -1,0 +1,150 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Approval inbox card for the Feature Cockpit (Layer 5).
+ *               Lists Pending FeatureToggleApproval__c rows assigned to the
+ *               running user, with inline Approve / Reject buttons + an
+ *               optional decision-note field. PR 7 — single-step only.
+ *               PR 8 will widen to multi-step chains + REST.
+ * @author Cloud Nimbus LLC
+ */
+import { LightningElement, wire, track } from 'lwc';
+import { refreshApex } from '@salesforce/apex';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import getInbox from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.getInbox';
+import grantApex from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.grant';
+import rejectApex from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.reject';
+
+const REASON_TRUNCATE_AT = 160,
+    ELLIPSIS = '…',
+    EMPTY = 0;
+
+export default class DeliveryFeatureApprovalInbox extends LightningElement {
+    @track rows = [];
+    @track errorMessage = '';
+    @track isLoaded = false;
+    @track noteByApproval = {};
+
+    wiredResult;
+
+    @wire(getInbox)
+    wiredInbox(result) {
+        this.wiredResult = result;
+        if (result.data) {
+            this.rows = (result.data || []).map((r, idx) => this.shapeRow(r, idx));
+            this.errorMessage = '';
+            this.isLoaded = true;
+        } else if (result.error) {
+            this.errorMessage = (result.error && result.error.body && result.error.body.message)
+                ? result.error.body.message
+                : 'Unable to load approval inbox.';
+            this.rows = [];
+            this.isLoaded = true;
+        }
+    }
+
+    shapeRow(r, idx) {
+        const reason = r.reason || '';
+        const truncatedReason = reason.length > REASON_TRUNCATE_AT
+            ? reason.substring(0, REASON_TRUNCATE_AT) + ELLIPSIS
+            : reason;
+        const action = r.action || '';
+        const isEnable = action === 'Enable';
+        return {
+            key: r.approvalId || `row-${idx}`,
+            approvalId: r.approvalId,
+            requestId: r.requestId,
+            featureId: r.featureId,
+            featureLabel: r.featureLabel || '(unnamed feature)',
+            action,
+            actionBadgeClass: isEnable
+                ? 'slds-badge slds-theme_success'
+                : 'slds-badge slds-theme_warning',
+            reason,
+            truncatedReason,
+            hasReason: reason.length > EMPTY,
+            requestedAt: r.requestedAt,
+            requestedByName: r.requestedByName || '(unknown)',
+            stepNumber: r.stepNumber || 1,
+            status: r.status || 'Pending'
+        };
+    }
+
+    get hasRows() {
+        return this.rows.length > EMPTY;
+    }
+
+    get isEmpty() {
+        return this.isLoaded && !this.hasRows && !this.errorMessage;
+    }
+
+    get hasError() {
+        return this.errorMessage.length > EMPTY;
+    }
+
+    handleRefresh() {
+        if (this.wiredResult) {
+            refreshApex(this.wiredResult);
+        }
+    }
+
+    handleNoteChange(event) {
+        const approvalId = event.currentTarget.dataset.approvalId;
+        if (!approvalId) {
+            return;
+        }
+        this.noteByApproval = {
+            ...this.noteByApproval,
+            [approvalId]: event.target.value || ''
+        };
+    }
+
+    handleApprove(event) {
+        const approvalId = event.currentTarget.dataset.approvalId;
+        if (!approvalId) {
+            return;
+        }
+        const note = this.noteByApproval[approvalId] || '';
+        grantApex({ approvalId, note })
+            .then(() => this.onDecisionSuccess('Approved', approvalId))
+            .catch(err => this.onDecisionError('approve', err));
+    }
+
+    handleReject(event) {
+        const approvalId = event.currentTarget.dataset.approvalId;
+        if (!approvalId) {
+            return;
+        }
+        const note = this.noteByApproval[approvalId] || '';
+        rejectApex({ approvalId, note })
+            .then(() => this.onDecisionSuccess('Rejected', approvalId))
+            .catch(err => this.onDecisionError('reject', err));
+    }
+
+    onDecisionSuccess(label, approvalId) {
+        this.dispatchEvent(new ShowToastEvent({
+            title: `${label}`,
+            message: 'Approval decision recorded.',
+            variant: 'success'
+        }));
+        if (approvalId && this.noteByApproval[approvalId] !== undefined) {
+            const next = { ...this.noteByApproval };
+            delete next[approvalId];
+            this.noteByApproval = next;
+        }
+        if (this.wiredResult) {
+            refreshApex(this.wiredResult);
+        }
+    }
+
+    onDecisionError(verb, err) {
+        const msg = (err && err.body && err.body.message)
+            ? err.body.message
+            : `Unable to ${verb} this request.`;
+        this.dispatchEvent(new ShowToastEvent({
+            title: 'Decision failed',
+            message: msg,
+            variant: 'error'
+        }));
+    }
+}

--- a/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.js-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <masterLabel>Delivery Feature Approval Inbox</masterLabel>
+    <description>Pending Feature__c toggle approvals assigned to the running user. PR 7 of the cockpit plan — single-step approvals. PR 8 will add multi-step + REST.</description>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+</LightningComponentBundle>

--- a/force-app/main/default/objects/FeatureToggleApproval__c/FeatureToggleApproval__c.object-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleApproval__c/FeatureToggleApproval__c.object-meta.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <allowInChatterGroups>false</allowInChatterGroups>
+    <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
+    <deploymentStatus>Deployed</deploymentStatus>
+    <description>One row per approver-step for a FeatureToggleRequest__c. PR 7 ships single-step (exactly one row per request, StepNumber__c=1). PR 8 wires multi-step cascading approvals. Field shape intentionally aligned with WorkLog__c approval fields (StatusPk__c, StepNumber__c, DecisionDateTime__c) so a future PR can unify both approval surfaces under one generic Approval__c without renames.</description>
+    <enableActivities>false</enableActivities>
+    <enableBulkApi>true</enableBulkApi>
+    <enableFeeds>false</enableFeeds>
+    <enableHistory>true</enableHistory>
+    <enableLicensing>false</enableLicensing>
+    <enableReports>true</enableReports>
+    <enableSearch>true</enableSearch>
+    <enableSharing>true</enableSharing>
+    <enableStreamingApi>true</enableStreamingApi>
+    <externalSharingModel>Private</externalSharingModel>
+    <label>Feature Toggle Approval</label>
+    <nameField>
+        <displayFormat>FTA-{0000}</displayFormat>
+        <label>Feature Toggle Approval Name</label>
+        <trackHistory>false</trackHistory>
+        <type>AutoNumber</type>
+    </nameField>
+    <pluralLabel>Feature Toggle Approvals</pluralLabel>
+    <searchLayouts></searchLayouts>
+    <sharingModel>ReadWrite</sharingModel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/FeatureToggleApproval__c/fields/ApproverUserLookup__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleApproval__c/fields/ApproverUserLookup__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ApproverUserLookup__c</fullName>
+    <description>The User assigned to decide on this approval row. Falls to null if the user is deleted; the row is preserved.</description>
+    <inlineHelpText>The user who needs to approve this row.</inlineHelpText>
+    <deleteConstraint>SetNull</deleteConstraint>
+    <externalId>false</externalId>
+    <label>Approver</label>
+    <referenceTo>User</referenceTo>
+    <relationshipLabel>Feature Toggle Approvals (Approver)</relationshipLabel>
+    <relationshipName>FeatureToggleApprovals_Approver</relationshipName>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleApproval__c/fields/DecisionDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleApproval__c/fields/DecisionDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DecisionDateTime__c</fullName>
+    <description>Timestamp when the approver granted or rejected this row.</description>
+    <inlineHelpText>When the approver made their decision.</inlineHelpText>
+    <label>Decision</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleApproval__c/fields/DecisionNoteTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleApproval__c/fields/DecisionNoteTxt__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DecisionNoteTxt__c</fullName>
+    <description>Optional free-text note the approver supplies along with their decision.</description>
+    <inlineHelpText>Why did you approve or reject? Optional but helpful for audit.</inlineHelpText>
+    <label>Decision Note</label>
+    <length>1024</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>4</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleApproval__c/fields/FeatureLookup__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleApproval__c/fields/FeatureLookup__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>FeatureLookup__c</fullName>
+    <description>The Feature__c this approval row gates. For single-step (PR 7) this mirrors the request's feature; for multi-step cascading approvals (PR 8) each row in the chain can target a distinct dependency node.</description>
+    <inlineHelpText>The feature this approval row gates. Usually the request's own feature.</inlineHelpText>
+    <deleteConstraint>Restrict</deleteConstraint>
+    <externalId>false</externalId>
+    <label>Feature</label>
+    <referenceTo>Feature__c</referenceTo>
+    <relationshipLabel>Approval Rows</relationshipLabel>
+    <relationshipName>ApprovalRows</relationshipName>
+    <required>true</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleApproval__c/fields/RequestLookup__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleApproval__c/fields/RequestLookup__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RequestLookup__c</fullName>
+    <description>The FeatureToggleRequest__c this approval row participates in. Restrict-delete to preserve the audit trail.</description>
+    <inlineHelpText>The toggle request this approval row belongs to.</inlineHelpText>
+    <deleteConstraint>Restrict</deleteConstraint>
+    <externalId>false</externalId>
+    <label>Request</label>
+    <referenceTo>FeatureToggleRequest__c</referenceTo>
+    <relationshipLabel>Approvals</relationshipLabel>
+    <relationshipName>Approvals</relationshipName>
+    <required>true</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleApproval__c/fields/RequiredDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleApproval__c/fields/RequiredDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RequiredDateTime__c</fullName>
+    <description>DateTime stamp marking this approval row as required (per DH no-booleans rule). Populated = the row blocks apply until decided. Null = the row is informational / auto-satisfied. Pattern mirrors the EnabledDateTime__c convention from FIELD_NAMING.md.</description>
+    <inlineHelpText>Set this when this approval row must be decided before applying the toggle. Leave blank for informational rows.</inlineHelpText>
+    <label>Required</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleApproval__c/fields/StatusPk__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleApproval__c/fields/StatusPk__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>StatusPk__c</fullName>
+    <description>Decision status. Pending awaits the approver. Approved/Rejected = explicit human choice. Auto = satisfied without a human (informational step or blanket grant).</description>
+    <inlineHelpText>Pending, Approved, Rejected, or Auto.</inlineHelpText>
+    <externalId>false</externalId>
+    <label>Status</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetName>ApprovalStatus</valueSetName>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleApproval__c/fields/StepNumber__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleApproval__c/fields/StepNumber__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>StepNumber__c</fullName>
+    <description>1-based step index in the approval chain. Always 1 for single-step requests (PR 7); multi-step requests (PR 8) increment to walk the cascade.</description>
+    <inlineHelpText>Which step in the approval chain this row represents (1-based).</inlineHelpText>
+    <defaultValue>1</defaultValue>
+    <externalId>false</externalId>
+    <label>Step</label>
+    <precision>4</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleRequest__c/FeatureToggleRequest__c.object-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleRequest__c/FeatureToggleRequest__c.object-meta.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <allowInChatterGroups>false</allowInChatterGroups>
+    <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
+    <deploymentStatus>Deployed</deploymentStatus>
+    <description>A request to flip a Feature__c on or off, gated by one or more FeatureToggleApproval__c rows. PR 7 ships single-step approvals; PR 8 wires multi-step cascading approvals + REST endpoints. The CascadeSnapshotJsonTxt__c field freezes the dependency graph at request time so the approver sees what they're approving even if dependencies change between submission and grant.</description>
+    <enableActivities>false</enableActivities>
+    <enableBulkApi>true</enableBulkApi>
+    <enableFeeds>false</enableFeeds>
+    <enableHistory>true</enableHistory>
+    <enableLicensing>false</enableLicensing>
+    <enableReports>true</enableReports>
+    <enableSearch>true</enableSearch>
+    <enableSharing>true</enableSharing>
+    <enableStreamingApi>true</enableStreamingApi>
+    <externalSharingModel>Private</externalSharingModel>
+    <label>Feature Toggle Request</label>
+    <nameField>
+        <displayFormat>FTR-{0000}</displayFormat>
+        <label>Feature Toggle Request Name</label>
+        <trackHistory>false</trackHistory>
+        <type>AutoNumber</type>
+    </nameField>
+    <pluralLabel>Feature Toggle Requests</pluralLabel>
+    <searchLayouts></searchLayouts>
+    <sharingModel>ReadWrite</sharingModel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/FeatureToggleRequest__c/fields/ActionPk__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleRequest__c/fields/ActionPk__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ActionPk__c</fullName>
+    <description>Whether this request is to Enable or Disable the target feature.</description>
+    <inlineHelpText>Enable turns the feature on. Disable turns it off.</inlineHelpText>
+    <externalId>false</externalId>
+    <label>Action</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetName>FeatureToggleAction</valueSetName>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleRequest__c/fields/AppliedDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleRequest__c/fields/AppliedDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AppliedDateTime__c</fullName>
+    <description>Timestamp when applyIfFullyGranted actually flipped the underlying Feature__c. Null until Status=Applied; cleared again when Status=RolledBack.</description>
+    <inlineHelpText>When the underlying feature flip ran.</inlineHelpText>
+    <label>Applied</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleRequest__c/fields/CascadeSnapshotJsonTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleRequest__c/fields/CascadeSnapshotJsonTxt__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>CascadeSnapshotJsonTxt__c</fullName>
+    <description>JSON-serialized FeatureGraphNodeDTO tree captured at submission time via DeliveryFeatureGraphService.computeCascade. Frozen so the approver evaluates the request against the dependency state at submission, not at grant time.</description>
+    <inlineHelpText>Frozen dependency graph as of submission. Do not edit by hand.</inlineHelpText>
+    <label>Cascade Snapshot (JSON)</label>
+    <length>32768</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>6</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleRequest__c/fields/EffectiveDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleRequest__c/fields/EffectiveDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EffectiveDateTime__c</fullName>
+    <description>Optional scheduled-apply timestamp. Null means apply immediately on grant. PR 7 honors null only; the scheduled path lights up in a later PR.</description>
+    <inlineHelpText>When the toggle should take effect. Leave blank to apply as soon as all approvals are granted.</inlineHelpText>
+    <label>Effective</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleRequest__c/fields/FeatureLookup__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleRequest__c/fields/FeatureLookup__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>FeatureLookup__c</fullName>
+    <description>The Feature__c being toggled by this request. Restrict-delete to keep the audit trail intact when a feature is removed in the catalog.</description>
+    <inlineHelpText>The feature this request will enable or disable.</inlineHelpText>
+    <deleteConstraint>Restrict</deleteConstraint>
+    <externalId>false</externalId>
+    <label>Feature</label>
+    <referenceTo>Feature__c</referenceTo>
+    <relationshipLabel>Toggle Requests</relationshipLabel>
+    <relationshipName>ToggleRequests</relationshipName>
+    <required>true</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleRequest__c/fields/ReasonTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleRequest__c/fields/ReasonTxt__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ReasonTxt__c</fullName>
+    <description>Optional free-text rationale the requester supplies to help the approver decide.</description>
+    <inlineHelpText>Why are you requesting this toggle? Helps reviewers approve quickly.</inlineHelpText>
+    <label>Reason</label>
+    <length>1024</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>4</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleRequest__c/fields/RequestedByUserLookup__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleRequest__c/fields/RequestedByUserLookup__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RequestedByUserLookup__c</fullName>
+    <description>The User who submitted this request. Falls to null if that user is later deleted, preserving the request row.</description>
+    <inlineHelpText>The user who submitted this toggle request.</inlineHelpText>
+    <deleteConstraint>SetNull</deleteConstraint>
+    <externalId>false</externalId>
+    <label>Requested By</label>
+    <referenceTo>User</referenceTo>
+    <relationshipLabel>Feature Toggle Requests (Requested By)</relationshipLabel>
+    <relationshipName>FeatureToggleRequests_RequestedBy</relationshipName>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleRequest__c/fields/RequestedDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleRequest__c/fields/RequestedDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RequestedDateTime__c</fullName>
+    <description>Timestamp when the request transitioned from Draft to Pending.</description>
+    <inlineHelpText>When the request was submitted for approval.</inlineHelpText>
+    <label>Requested</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/FeatureToggleRequest__c/fields/StatusPk__c.field-meta.xml
+++ b/force-app/main/default/objects/FeatureToggleRequest__c/fields/StatusPk__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>StatusPk__c</fullName>
+    <description>Lifecycle status. Draft (unsubmitted) -&gt; Pending (awaiting approvals) -&gt; Granted (approvers said yes) -&gt; Applied (feature flip persisted). Or Rejected from Pending. Or RolledBack from Applied.</description>
+    <inlineHelpText>Draft, Pending, Granted, Rejected, Applied, or RolledBack.</inlineHelpText>
+    <externalId>false</externalId>
+    <label>Status</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetName>FeatureToggleStatus</valueSetName>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
@@ -57,6 +57,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryFeatureApprovalService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryFeatureCatalogController</apexClass>
         <enabled>true</enabled>
     </classAccesses>
@@ -316,6 +320,76 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>FeatureDependency__c.NotesTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.ActionPk__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.StatusPk__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.ReasonTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.RequestedByUserLookup__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.RequestedDateTime__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.EffectiveDateTime__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.AppliedDateTime__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.CascadeSnapshotJsonTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleApproval__c.StepNumber__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleApproval__c.ApproverUserLookup__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleApproval__c.RequiredDateTime__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleApproval__c.StatusPk__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleApproval__c.DecisionDateTime__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleApproval__c.DecisionNoteTxt__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -957,6 +1031,24 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>true</modifyAllRecords>
         <object>FeatureDependency__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>true</allowCreate>
+        <allowDelete>true</allowDelete>
+        <allowEdit>true</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>true</modifyAllRecords>
+        <object>FeatureToggleRequest__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>true</allowCreate>
+        <allowDelete>true</allowDelete>
+        <allowEdit>true</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>true</modifyAllRecords>
+        <object>FeatureToggleApproval__c</object>
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
     <objectPermissions>

--- a/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
@@ -57,6 +57,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryFeatureApprovalService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryFeatureCatalogController</apexClass>
         <enabled>true</enabled>
     </classAccesses>
@@ -311,6 +315,76 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>FeatureDependency__c.NotesTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.ActionPk__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.StatusPk__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.ReasonTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.RequestedByUserLookup__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.RequestedDateTime__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.EffectiveDateTime__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.AppliedDateTime__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleRequest__c.CascadeSnapshotJsonTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleApproval__c.StepNumber__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleApproval__c.ApproverUserLookup__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleApproval__c.RequiredDateTime__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleApproval__c.StatusPk__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleApproval__c.DecisionDateTime__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>FeatureToggleApproval__c.DecisionNoteTxt__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -946,6 +1020,24 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>FeatureDependency__c</object>
+        <viewAllRecords>false</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>true</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>false</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>FeatureToggleRequest__c</object>
+        <viewAllRecords>false</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>true</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>true</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>FeatureToggleApproval__c</object>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>
     <objectPermissions>

--- a/force-app/main/default/triggers/FeatureToggleRequestTrigger.trigger
+++ b/force-app/main/default/triggers/FeatureToggleRequestTrigger.trigger
@@ -1,0 +1,12 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Trigger for FeatureToggleRequest__c. Delegates all logic to
+ *               FeatureToggleRequestTriggerHandler. After-insert / after-update
+ *               so the handler always sees the post-DML row state and can
+ *               re-evaluate applyIfFullyGranted safely.
+ * @author Cloud Nimbus LLC
+ */
+trigger FeatureToggleRequestTrigger on FeatureToggleRequest__c (after insert, after update) { //NOPMD - AvoidLogicInTrigger: trivial handler delegation only
+    FeatureToggleRequestTriggerHandler.handle(Trigger.operationType, Trigger.new, Trigger.oldMap);
+}

--- a/force-app/main/default/triggers/FeatureToggleRequestTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/FeatureToggleRequestTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>

--- a/unpackaged/post/testSuites/DH.testSuite-meta.xml
+++ b/unpackaged/post/testSuites/DH.testSuite-meta.xml
@@ -106,5 +106,7 @@
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryFeatureSyncServiceTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryFeatureTriggerHandlerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryFeatureGraphServiceTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalServiceTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%FeatureToggleRequestTriggerHandlerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryOnboardingServiceTest</testClassName>
 </ApexTestSuite>


### PR DESCRIPTION
## Summary
- PR 7 of the Delivery Hub Cockpit plan. Introduces the toggle-request + approval-record schema (Layer 5), the `DeliveryFeatureApprovalService`, a request-trigger that auto-applies on grant, the `deliveryFeatureApprovalInbox` LWC, and permset wiring on both `DeliveryHubApp` + `DeliveryHubAdmin_App`.
- **Single-step only.** Multi-step cascading approvals + REST endpoints are PR 8.
- Skips ahead of PR 6 (cascade enforcement) per the brief; PR 6 will be retrofitted onto the hotfix baseline.

## What's in this PR

**Schema (commit 1)**
- `FeatureToggleRequest__c` — 9 fields tracking Draft -> Pending -> Granted -> Applied (or Rejected / RolledBack). `CascadeSnapshotJsonTxt__c` freezes the dependency graph at submission via `DeliveryFeatureGraphService.computeCascade`.
- `FeatureToggleApproval__c` — 9 fields per approver-step. PR 7 always inserts exactly one (Step=1).
- 3 new restricted GVS: `FeatureToggleAction`, `FeatureToggleStatus`, `ApprovalStatus`.
- AutoNumber names (FTR-{0000} / FTA-{0000}). enableReports=true, sharingModel=ReadWrite. No booleans.

**Service + trigger (commit 2)**
- `DeliveryFeatureApprovalService` (global with sharing) — `submit`, `grant`, `reject`, `rollback`, `applyIfFullyGranted`, `getInbox`, `onRequestAfterChange`. Helper methods extracted for cyclomatic budget. Static `inApplyContext` recursion guard prevents the request trigger from re-entering apply.
- `FeatureToggleRequestTrigger` + `FeatureToggleRequestTriggerHandler` — after insert/update; delegates to the service so Pending/Granted transitions auto-apply when every approval row is Approved or Auto.
- Apply path emits one `ActivityLog__c` per flip with `ActionTypePk__c='Feature_Toggle'` and the request id in `ContextDataTxt__c`. SHA-256 hash chain is contributed automatically by `DeliveryActivityLogTrigger -> DeliveryAuditChainService.setHashOnInsert`.

**LWC (commit 3)**
- `deliveryFeatureApprovalInbox` — wires `getInbox` (cacheable), renders one row per pending approval with badges + Approve/Reject buttons + optional decision-note textarea. No template ternaries; every conditional is a getter or pre-computed in `shapeRow`. Exposed for App + Home.
- Added to `DeliveryHubHome.flexipage` as a new itemInstance.

**Tests (commit 5)**
- `DeliveryFeatureApprovalServiceTest` (10 tests): submit / grant happy path / multi-row gating stub / reject / Disable apply / rollback / audit row / inbox / input validation / rollback-only-from-Applied.
- `FeatureToggleRequestTriggerHandlerTest` (3 tests): insert-time apply, Draft skip, recursion-guard sanity.
- Both classes added to `DH.testSuite`.
- `TestDataFactory` gets `buildFeatureToggleRequest` / `newFeatureToggleRequest` / `buildFeatureToggleApproval` / `newFeatureToggleApproval` (allowlist-compliant picklist defaults).

**Permsets (commit 6)**
- `DeliveryFeatureApprovalService` class added to both permsets.
- `DeliveryHubApp` (end-user): `FeatureToggleRequest__c` read+create; `FeatureToggleApproval__c` read+create+edit; all non-required fields readable+editable.
- `DeliveryHubAdmin_App`: full CRUD + modifyAll on both objects.

## Deviations from brief

1. **Field naming vs WorkLog precedent.** WorkLog uses `ApprovalStepNumber__c` + `ApprovalRequestedDateTime__c` on the parent (because WorkLog IS the thing being approved). Here, `FeatureToggleApproval__c` IS the approval-row object — so step / decision fields live on it without the `Approval` prefix (`StepNumber__c`, `DecisionDateTime__c`). `StatusPk__c` matches. Cleaner for the future-unification path: a generic `Approval__c` should look more like `FeatureToggleApproval__c` than like the embedded WorkLog approval fields.
2. **`DeliveryHubApp` perms on `FeatureToggleApproval__c`** bumped from brief's "read+create" to "read+create+edit" so non-admin approvers can record grant/reject decisions through the inbox LWC. Required for the LWC to function; flagged.
3. **`appendHash()` API on `DeliveryAuditChainService`** referenced in the brief doesn't exist as a public surface — the actual pattern is "insert an `ActivityLog__c`; the trigger calls `setHashOnInsert` automatically." That is what this PR uses. End result is identical: every Apply lands a chained audit row.

## Test plan
- [ ] Local sf scanner --pmd passes on the new files (CI runs this on push)
- [ ] CI feature_test green
- [ ] CI upload-beta green
- [ ] Smoke: install the upload-beta on dh-prod, open Home, verify Approval Inbox card appears (empty for now)
- [ ] Smoke (after PR 8 wires approver assignment): submit a request from cockpit, see it appear in the inbox of the assigned approver

## Next
- **PR 8** wires multi-step cascading approvals + REST endpoints + explicit hash-chain audit-row signing on apply. Approver-assignment logic (who gets which step) also lives there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>