### PR TITLE
fix(cockpit): namespace-safe describeSettingsFields in sync tests too

### DIFF
--- a/force-app/main/default/classes/DeliveryFeatureSyncServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryFeatureSyncServiceTest.cls
@@ -57,11 +57,7 @@ private class DeliveryFeatureSyncServiceTest {
         DeliveryHubSettings__c refreshed = DeliveryHubSettings__c.getOrgDefaults();
         // Resolve the local key (namespace-safe).
         Map<String, Schema.SObjectField> settingsFields =
-            Schema.getGlobalDescribe()
-                .get('DeliveryHubSettings__c')
-                .getDescribe()
-                .fields
-                .getMap();
+            DeliveryHubSettings__c.SObjectType.getDescribe().fields.getMap();
         String targetLocal = def.SettingsFieldApiNameTxt__c.toLowerCase();
         String matchedKey;
         for (String k : settingsFields.keySet()) {
@@ -102,11 +98,7 @@ private class DeliveryFeatureSyncServiceTest {
             SetupOwnerId = UserInfo.getOrganizationId()
         );
         Map<String, Schema.SObjectField> settingsFields =
-            Schema.getGlobalDescribe()
-                .get('DeliveryHubSettings__c')
-                .getDescribe()
-                .fields
-                .getMap();
+            DeliveryHubSettings__c.SObjectType.getDescribe().fields.getMap();
         String targetLocal = def.SettingsFieldApiNameTxt__c.toLowerCase();
         String matchedKey;
         for (String k : settingsFields.keySet()) {

--- a/force-app/main/default/classes/DeliveryFeatureTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryFeatureTriggerHandlerTest.cls
@@ -147,11 +147,7 @@ private class DeliveryFeatureTriggerHandlerTest {
         // Verify the legacy field was mirrored.
         DeliveryHubSettings__c refreshed = DeliveryHubSettings__c.getOrgDefaults();
         Map<String, Schema.SObjectField> settingsFields =
-            Schema.getGlobalDescribe()
-                .get('DeliveryHubSettings__c')
-                .getDescribe()
-                .fields
-                .getMap();
+            DeliveryHubSettings__c.SObjectType.getDescribe().fields.getMap();
         String target = def.SettingsFieldApiNameTxt__c.toLowerCase();
         String matchedKey;
         for (String k : settingsFields.keySet()) {


### PR DESCRIPTION
## Summary

Follow-up to PR #797. The production hotfix landed but upload-beta still failed because three test helpers carried the same `Schema.getGlobalDescribe().get('DeliveryHubSettings__c')` pattern, which returns null in the packaging org's `delivery__` namespace.

3 test methods NPE'd:
- `DeliveryFeatureSyncServiceTest.testSyncFeaturesToSettingsMirrorsEnabledTimestamp` (line 62)
- `DeliveryFeatureSyncServiceTest.testSyncSettingsToFeaturesCopiesValueBack` (line 107)
- `DeliveryFeatureTriggerHandlerTest.testFullToggleCycleMirrorsToSettings` (line 152)

Replaced with the same typed-reference pattern: `DeliveryHubSettings__c.SObjectType.getDescribe().fields.getMap()`.

## Why this snuck through

PR-level feature-test runs in a non-namespaced scratch org where the bug doesn't manifest. Upload-beta uses the namespaced packaging org. Same divergence that drove PR #797 — applied to test code this time.

## Impact

Without this fix, 0.244 can't promote — every beta_create on main fails upload-beta.

## Test plan

- [ ] apex-scan green
- [ ] feature-test green (it always was — the bug is namespace-context only)
- [ ] After merge, beta_create's upload-beta succeeds and 0.244 promotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)