### PR TITLE
feat(cockpit): PR 6 — Cascade enforcement on toggleFeature (refuses Hard violations)

### DIFF
--- a/force-app/main/default/classes/DeliveryFeatureCatalogController.cls
+++ b/force-app/main/default/classes/DeliveryFeatureCatalogController.cls
@@ -136,9 +136,126 @@ global with sharing class DeliveryFeatureCatalogController {
             throw new AuraHandledException('featureId is required.');
         }
         Feature__c f = loadFeatureOrThrow(featureId);
-        assertCanToggle(f, enable == true);
-        applyToggleFields(f, enable == true);
+        Boolean enableFlag = enable == true;
+        assertCanToggle(f, enableFlag);
+        enforceCascadeOrThrow(featureId, enableFlag);
+        applyToggleFields(f, enableFlag);
         persistToggle(f);
+    }
+
+    /**
+     * @description Loads the cascade tree via DeliveryFeatureGraphService and
+     *              refuses the toggle when any Hard child violates the rule:
+     *                - Enable path: a Hard blocker is inactive (must be enabled first).
+     *                - Disable path: a Hard dependent is active (must be disabled first).
+     *              Soft / Optional edges are informational only — logged at INFO
+     *              and never block. No-op when no cascade tree exists.
+     * @param featureId The feature about to be toggled.
+     * @param enable    True for Enable, false for Disable.
+     */
+    private static void enforceCascadeOrThrow(Id featureId, Boolean enable) {
+        String action = enable
+            ? DeliveryFeatureGraphService.ACTION_ENABLE
+            : DeliveryFeatureGraphService.ACTION_DISABLE;
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO root =
+            DeliveryFeatureGraphService.computeCascade(featureId, action);
+        if (root == null || root.children == null || root.children.isEmpty()) {
+            return;
+        }
+        List<DeliveryFeatureGraphService.FeatureGraphNodeDTO> violations =
+            collectHardViolations(root, enable);
+        if (violations.isEmpty()) {
+            return;
+        }
+        throw new AuraHandledException(formatViolationMessage(violations, enable));
+    }
+
+    /**
+     * @description Flattens the cascade tree (BFS, excluding the root) and
+     *              returns the subset of nodes that violate the Hard-dependency
+     *              rule for the requested action. Soft / Optional edges are
+     *              logged at INFO level and excluded from the returned list.
+     * @param root   Root cascade node (ignored — only its descendants are checked).
+     * @param enable True for Enable, false for Disable.
+     * @return Hard-violating descendant nodes, in BFS order.
+     */
+    private static List<DeliveryFeatureGraphService.FeatureGraphNodeDTO> collectHardViolations(
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO root,
+        Boolean enable
+    ) {
+        List<DeliveryFeatureGraphService.FeatureGraphNodeDTO> violations =
+            new List<DeliveryFeatureGraphService.FeatureGraphNodeDTO>();
+        if (root == null || root.children == null) {
+            return violations;
+        }
+        List<DeliveryFeatureGraphService.FeatureGraphNodeDTO> queue =
+            new List<DeliveryFeatureGraphService.FeatureGraphNodeDTO>();
+        queue.addAll(root.children);
+        while (!queue.isEmpty()) {
+            DeliveryFeatureGraphService.FeatureGraphNodeDTO node = queue.remove(0);
+            if (node == null) {
+                continue;
+            }
+            classifyCascadeNode(node, enable, violations);
+            if (node.children != null && !node.children.isEmpty()) {
+                queue.addAll(node.children);
+            }
+        }
+        return violations;
+    }
+
+    /**
+     * @description Classifies a single cascade descendant against the Hard rule.
+     *              Hard + blocking-condition → appended to violations. Soft /
+     *              Optional → debug log only. Hard but condition satisfied → no-op.
+     * @param node       Cascade tree node (a descendant — never the root).
+     * @param enable     True for Enable, false for Disable.
+     * @param violations Out-list — appended when this node violates.
+     */
+    private static void classifyCascadeNode(
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO node,
+        Boolean enable,
+        List<DeliveryFeatureGraphService.FeatureGraphNodeDTO> violations
+    ) {
+        String depType = node.dependencyType;
+        Boolean isHard = (depType == 'Hard');
+        if (!isHard) {
+            System.debug(LoggingLevel.INFO,
+                '[DeliveryFeatureCatalogController.enforceCascadeOrThrow] non-Hard edge ('
+                + depType + ') to ' + node.name + ' — informational only.');
+            return;
+        }
+        Boolean childActive = node.isActive == true;
+        // Enable path: child is a feature THIS feature depends on. Block if inactive.
+        // Disable path: child is a feature that depends on THIS feature. Block if active.
+        Boolean blocks = enable ? !childActive : childActive;
+        if (blocks) {
+            violations.add(node);
+        }
+    }
+
+    /**
+     * @description Builds the user-facing AuraHandledException message for one
+     *              or more Hard violations. Uses the first violation's label so
+     *              the user sees the concrete blocker; suffixes "(+N more)" when
+     *              multiple Hard violations surfaced in the same cascade.
+     * @param violations Non-empty list of Hard-violating cascade nodes.
+     * @param enable     True for Enable, false for Disable.
+     * @return Formatted message ready to hand to AuraHandledException.
+     */
+    private static String formatViolationMessage(
+        List<DeliveryFeatureGraphService.FeatureGraphNodeDTO> violations,
+        Boolean enable
+    ) {
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO first = violations.get(0);
+        String displayName = String.isBlank(first.label) ? first.name : first.label;
+        String more = violations.size() > 1
+            ? ' (+' + (violations.size() - 1) + ' more)'
+            : '';
+        if (enable) {
+            return 'Cannot enable: depends on inactive feature "' + displayName + '" (Hard).' + more;
+        }
+        return 'Cannot disable: blocked by active dependent "' + displayName + '" (Hard).' + more;
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryFeatureCatalogControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryFeatureCatalogControllerTest.cls
@@ -421,6 +421,177 @@ private class DeliveryFeatureCatalogControllerTest {
             'Non-admin must always be able to disable a feature (no gate on disable).');
     }
 
+    // ────────────────────────────────────────────────────────────────────
+    // PR 6 — cascade enforcement on toggleFeature() coverage
+    //
+    // Strategy: all PR-6 tests use synthetic FeatureDefinitionTxt__c values
+    // (no matching FeatureDefinition__mdt row) so the onboarding-track gate
+    // returns early — the cascade-enforcement path then runs deterministically
+    // for both admin and non-admin running users. EnabledDateTime__c controls
+    // activity via the ActiveSinceDateTime__c formula (active when
+    // EnabledDateTime__c <= NOW() AND DisabledDateTime__c is null/future).
+    // ────────────────────────────────────────────────────────────────────
+
+    @IsTest
+    static void testToggleFeatureRefusesEnableWhenHardBlockerInactive() {
+        // Feature A depends on Feature B (Hard, Both). B inactive → enable A must fail.
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => null
+        });
+        Feature__c featB = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => null
+        });
+        TestDataFactory.createFeatureDependency(featB.Id, featA.Id,
+            new Map<String, Object>{ 'TypePk__c' => 'Hard', 'CascadeDirectionPk__c' => 'Both' });
+
+        Boolean threw = false;
+        Test.startTest();
+        try {
+            DeliveryFeatureCatalogController.toggleFeature(featA.Id, true);
+        } catch (AuraHandledException e) {
+            threw = true;
+        } catch (Exception e) {
+            threw = true;
+        }
+        Test.stopTest();
+        System.assertEquals(true, threw,
+            'Enable must be refused when a Hard blocker is inactive.');
+        Feature__c refreshed = [
+            SELECT EnabledDateTime__c FROM Feature__c WHERE Id = :featA.Id LIMIT 1
+        ];
+        System.assertEquals(null, refreshed.EnabledDateTime__c,
+            'EnabledDateTime__c must remain unset when the cascade gate rejects.');
+    }
+
+    @IsTest
+    static void testToggleFeatureAllowsEnableWhenHardBlockerActive() {
+        // Same shape but B is active → enable A must succeed.
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => null
+        });
+        Feature__c featB = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => Datetime.now().addMinutes(-5),
+            'DisabledDateTime__c' => null
+        });
+        TestDataFactory.createFeatureDependency(featB.Id, featA.Id,
+            new Map<String, Object>{ 'TypePk__c' => 'Hard', 'CascadeDirectionPk__c' => 'Both' });
+
+        Test.startTest();
+        try {
+            DeliveryFeatureCatalogController.toggleFeature(featA.Id, true);
+            Feature__c refreshed = [
+                SELECT EnabledDateTime__c FROM Feature__c WHERE Id = :featA.Id LIMIT 1
+            ];
+            System.assertNotEquals(null, refreshed.EnabledDateTime__c,
+                'Enable must succeed when the Hard blocker is active.');
+        } catch (AuraHandledException e) {
+            // CI running user without admin PSG would have been caught by the
+            // onboarding-track gate (the synthetic def name dodges that path),
+            // so any throw here is a real cascade-enforcement failure.
+            System.assert(false,
+                'Cascade should not have blocked when the blocker is active: ' + e.getMessage());
+        }
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void testToggleFeatureRefusesDisableWhenHardDependentActive() {
+        // A is active; B depends on A (Hard); B is also active.
+        // Disable A → must be refused because the active dependent B still needs it.
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => Datetime.now().addMinutes(-10),
+            'DisabledDateTime__c' => null
+        });
+        Feature__c featB = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => Datetime.now().addMinutes(-5),
+            'DisabledDateTime__c' => null
+        });
+        // A blocks B (B is the blocked one, A is the blocker → walking Disable
+        // from A surfaces B as a dependent).
+        TestDataFactory.createFeatureDependency(featA.Id, featB.Id,
+            new Map<String, Object>{ 'TypePk__c' => 'Hard', 'CascadeDirectionPk__c' => 'Both' });
+
+        Boolean threw = false;
+        Test.startTest();
+        try {
+            DeliveryFeatureCatalogController.toggleFeature(featA.Id, false);
+        } catch (AuraHandledException e) {
+            threw = true;
+        } catch (Exception e) {
+            threw = true;
+        }
+        Test.stopTest();
+        System.assertEquals(true, threw,
+            'Disable must be refused when a Hard dependent is still active.');
+        Feature__c refreshed = [
+            SELECT DisabledDateTime__c FROM Feature__c WHERE Id = :featA.Id LIMIT 1
+        ];
+        System.assertEquals(null, refreshed.DisabledDateTime__c,
+            'DisabledDateTime__c must remain unset when the cascade gate rejects disable.');
+    }
+
+    @IsTest
+    static void testToggleFeatureAllowsDisableWhenDependentsInactive() {
+        // Same shape but B is inactive → disable A must succeed.
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => Datetime.now().addMinutes(-10),
+            'DisabledDateTime__c' => null
+        });
+        Feature__c featB = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => null
+        });
+        TestDataFactory.createFeatureDependency(featA.Id, featB.Id,
+            new Map<String, Object>{ 'TypePk__c' => 'Hard', 'CascadeDirectionPk__c' => 'Both' });
+
+        Test.startTest();
+        try {
+            DeliveryFeatureCatalogController.toggleFeature(featA.Id, false);
+            Feature__c refreshed = [
+                SELECT DisabledDateTime__c FROM Feature__c WHERE Id = :featA.Id LIMIT 1
+            ];
+            System.assertNotEquals(null, refreshed.DisabledDateTime__c,
+                'Disable must succeed when all Hard dependents are inactive.');
+        } catch (AuraHandledException e) {
+            System.assert(false,
+                'Cascade should not have blocked when dependents are inactive: ' + e.getMessage());
+        }
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void testToggleFeatureIgnoresSoftDependencies() {
+        // Feature A depends on Feature B with Soft type. B inactive →
+        // enable A must STILL succeed because Soft does not block.
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => null
+        });
+        Feature__c featB = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => null
+        });
+        TestDataFactory.createFeatureDependency(featB.Id, featA.Id,
+            new Map<String, Object>{ 'TypePk__c' => 'Soft', 'CascadeDirectionPk__c' => 'Both' });
+
+        Test.startTest();
+        try {
+            DeliveryFeatureCatalogController.toggleFeature(featA.Id, true);
+            Feature__c refreshed = [
+                SELECT EnabledDateTime__c FROM Feature__c WHERE Id = :featA.Id LIMIT 1
+            ];
+            System.assertNotEquals(null, refreshed.EnabledDateTime__c,
+                'Soft dependency must not block enable.');
+        } catch (AuraHandledException e) {
+            System.assert(false,
+                'Soft dependency must not block enable: ' + e.getMessage());
+        }
+        Test.stopTest();
+    }
+
     @IsTest
     static void testToggleFeatureNoTrackRequiredAllowsNonAdmin() {
         // Pick any FeatureDefinition__mdt whose RequiresOnboardingTrackTxt__c is blank.

--- a/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.js
+++ b/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.js
@@ -122,6 +122,7 @@ export default class DeliveryFeatureCockpit extends LightningElement {
 
     handleToggle(event) {
         const featureId = event.currentTarget.dataset.featureId;
+        const featureLabel = event.currentTarget.dataset.featureName || '';
         const isActive = event.currentTarget.dataset.isActive === 'true';
         const enable = !isActive;
         if (!featureId) {
@@ -147,12 +148,26 @@ export default class DeliveryFeatureCockpit extends LightningElement {
                 // can launch the track.
                 const isOnboardingGate = typeof msg === 'string'
                     && msg.toLowerCase().indexOf('onboarding track') !== -1;
+                // PR 6: the cascade enforcement gate throws a message of the
+                // shape `Cannot enable: depends on inactive feature "X" (Hard).`
+                // or `Cannot disable: blocked by active dependent "X" (Hard).`
+                // — auto-open the cascade preview modal so the user can see
+                // the graph that prompted the refusal.
+                const isCascadeGate = typeof msg === 'string'
+                    && /^Cannot (enable|disable):/i.test(msg);
                 if (isOnboardingGate) {
                     this.dispatchEvent(new ShowToastEvent({
                         title: 'Onboarding required',
                         message: 'Open the feature record page to complete the track, then try again.',
                         variant: 'warning'
                     }));
+                } else if (isCascadeGate) {
+                    this.dispatchEvent(new ShowToastEvent({
+                        title: 'Dependency blocked toggle',
+                        message: msg + ' View the dependency graph for details.',
+                        variant: 'warning'
+                    }));
+                    this.openCascadeModal(featureId, featureLabel);
                 } else {
                     this.dispatchEvent(new ShowToastEvent({
                         title: 'Unable to toggle feature',
@@ -161,6 +176,15 @@ export default class DeliveryFeatureCockpit extends LightningElement {
                     }));
                 }
             });
+    }
+
+    openCascadeModal(featureId, featureLabel) {
+        if (!featureId) {
+            return;
+        }
+        this.cascadeFeatureId = featureId;
+        this.cascadeFeatureLabel = featureLabel || '';
+        this.isCascadeModalOpen = true;
     }
 
     get cascadeModalTitle() {


### PR DESCRIPTION
## Summary

PR 6 of the Delivery Hub Cockpit plan. Wires `DeliveryFeatureGraphService.computeCascade()` (shipped in PR 5 / #794) into `DeliveryFeatureCatalogController.toggleFeature()` so the cockpit refuses Hard-dependency violations **before** flipping the feature.

Admin-direct path only. PR 8 will wire multi-step cascading approvals + REST on top of this (the cascade enforcement here is admin-direct; PR 8 adds the request/approval pipeline for non-admins).

## Scope checklist

- [x] `toggleFeature()` now calls `enforceCascadeOrThrow()` after the admin/onboarding-gate checks and before persist.
- [x] Enable path refuses when any Hard descendant edge surfaces an inactive blocker.
- [x] Disable path refuses when any Hard descendant edge surfaces an active dependent.
- [x] Soft / Optional edges logged at `LoggingLevel.INFO`, never block.
- [x] User-facing message format: `Cannot enable: depends on inactive feature "X" (Hard).` / `Cannot disable: blocked by active dependent "X" (Hard).` (+ `(+N more)` suffix when multiple).
- [x] Helpers extracted (`enforceCascadeOrThrow` / `collectHardViolations` / `classifyCascadeNode` / `formatViolationMessage`) to keep `toggleFeature` under cyclomatic budget.
- [x] LWC catches the cascade-shaped error in the toggle handler and **auto-opens the cascade preview modal** in addition to surfacing a warning toast.
- [x] Five new tests in `DeliveryFeatureCatalogControllerTest`:
  - `testToggleFeatureRefusesEnableWhenHardBlockerInactive`
  - `testToggleFeatureAllowsEnableWhenHardBlockerActive`
  - `testToggleFeatureRefusesDisableWhenHardDependentActive`
  - `testToggleFeatureAllowsDisableWhenDependentsInactive`
  - `testToggleFeatureIgnoresSoftDependencies`
- [x] No new schema, no new permsets, no new REST endpoints, no GVS changes, no `Schema.getGlobalDescribe()` patterns.

## Non-goals

- **No approval-workflow integration.** PR 8 owns the multi-step cascading approval surface; PR 6 is the admin-direct gate only.
- **No cross-org cascade.** Deferred to Phase 5+ of the cockpit plan.
- **No schema edits** to `Feature__c` / `FeatureDependency__c` / picklist GVS values.

## Next

PR 8 wires multi-step cascading approvals + REST (cascade enforcement here is admin-direct only; PR 8 adds the request/approval pipeline for non-admins).

## Test plan

- [ ] CI feature_test passes (all `DeliveryFeatureCatalogControllerTest` + `DeliveryFeatureGraphServiceTest` green).
- [ ] PMD clean (no new cyclomatic-complexity or apex-doc violations).
- [ ] upload-beta passes.
- [ ] Manual smoke in a scratch org: seed two features + one Hard dep, try the blocked Enable from the cockpit, confirm the cascade preview modal auto-opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)