### PR TITLE
feat(cockpit): PR 8 — Multi-step cascading approvals + REST endpoints

### DIFF
--- a/force-app/main/default/classes/DeliveryFeatureApprovalService.cls
+++ b/force-app/main/default/classes/DeliveryFeatureApprovalService.cls
@@ -1,40 +1,47 @@
 /**
  * @name         Delivery Hub
  * @license      BSL 1.1 — See LICENSE.md
- * @description  PR 7 — Single-step approval framework for Feature__c toggles
- *               (Layer 5 of the cockpit architecture).
+ * @description  Multi-step cascading approval framework for Feature__c toggles
+ *               (Layer 5 of the cockpit architecture). PR 8 generalizes the
+ *               single-step PR 7 surface:
  *
- *               The lifecycle:
- *                 submit(featureId, action, reason)
- *                   -> creates FeatureToggleRequest__c (Status=Pending) with a
- *                      frozen CascadeSnapshotJsonTxt__c
- *                   -> creates ONE FeatureToggleApproval__c row
- *                      (Step=1, Status=Pending, Required=now)
- *                 grant(approvalId, note)
- *                   -> stamps Approval row Status=Approved + Decision fields
- *                   -> applyIfFullyGranted() — if every approval row on the
- *                      request is Approved or Auto, flips the underlying
- *                      Feature__c and marks request Status=Applied. The
- *                      Feature__c trigger handles the settings-mirror cascade
- *                      and ActivityLog__c audit row (with SHA-256 hash chain
- *                      contributed by DeliveryActivityLogTrigger).
- *                 reject(approvalId, note)
- *                   -> stamps Approval row Status=Rejected
- *                   -> propagates to the request (Status=Rejected) so a
- *                      single dissent halts the chain.
- *                 rollback(requestId, note)
- *                   -> reverses an Applied request by flipping the Feature__c
- *                      back to its pre-Apply state. Marks request RolledBack.
+ *               submit(featureId, action, reason)
+ *                 -> creates FeatureToggleRequest__c (Status=Pending) with a
+ *                    frozen CascadeSnapshotJsonTxt__c.
+ *                 -> walks the cascade graph (BFS via DeliveryFeatureGraphService)
+ *                    and inserts ONE FeatureToggleApproval__c per non-Optional
+ *                    cascade node, plus a root-level (StepNumber=0) row that
+ *                    represents the final sign-off on the requested feature.
+ *                    Hard edges get RequiredDateTime__c=now (blocking). Soft
+ *                    edges get RequiredDateTime__c=null (informational; auto-
+ *                    satisfied when all required rows resolve). The root row
+ *                    is always required.
+ *               grant(approvalId, note)
+ *                 -> stamps approval row Status=Approved + decision fields.
+ *                 -> applyIfFullyGranted() — when every REQUIRED approval row
+ *                    is Approved or Auto, flips the underlying Feature__c,
+ *                    auto-marks every Soft/non-required row Status='Auto',
+ *                    stamps the request Status=Applied + AppliedDateTime, and
+ *                    writes an ActivityLog__c row. The activity-log trigger
+ *                    contributes the SHA-256 hash chain via
+ *                    DeliveryAuditChainService.setHashOnInsert.
+ *               reject(approvalId, note)
+ *                 -> stamps row Status=Rejected and propagates Status=Rejected
+ *                    to the parent request so a single dissent halts the chain.
+ *               rollback(requestId, note)
+ *                 -> reverses an Applied request by flipping the Feature__c
+ *                    back to its pre-Apply state. Marks request RolledBack.
+ *               getApprovalChain(requestId)
+ *                 -> Ordered list of every approval row for a request, shaped
+ *                    for the LWC "Show chain" modal.
  *
- *               PR 8 adds multi-step cascading approvals, REST endpoints, and
- *               explicit hash-chain audit on apply.
- *
- *               Global because PR 8 may expose this surface via REST for the
- *               external onboarding portal; all DTO classes used in the
- *               return signature are global per CLAUDE.md.
+ *               Global because PR 8 exposes this surface via REST for the
+ *               external onboarding portal (see DeliveryPublicApiService);
+ *               all DTO classes used in the return signature are global per
+ *               CLAUDE.md.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation,PMD.AvoidGlobalModifier,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity')
+@SuppressWarnings('PMD.ApexCRUDViolation,PMD.AvoidGlobalModifier,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.ExcessivePublicCount')
 global with sharing class DeliveryFeatureApprovalService {
 
     /** Action value: enable the feature. */
@@ -54,6 +61,11 @@ global with sharing class DeliveryFeatureApprovalService {
     public static final String APPROVAL_APPROVED = 'Approved';
     public static final String APPROVAL_REJECTED = 'Rejected';
     public static final String APPROVAL_AUTO = 'Auto';
+
+    /** Dependency type values from FeatureDependencyType GVS. */
+    public static final String DEP_HARD = 'Hard';
+    public static final String DEP_SOFT = 'Soft';
+    public static final String DEP_OPTIONAL = 'Optional';
 
     /** Recursion guard so the request trigger doesn't re-enter applyIfFullyGranted. */
     @TestVisible
@@ -76,15 +88,35 @@ global with sharing class DeliveryFeatureApprovalService {
         @AuraEnabled public String status;
     }
 
+    /**
+     * @description DTO row for getApprovalChain(). One entry per
+     *              FeatureToggleApproval__c on the request, ordered by
+     *              StepNumber then DecisionDateTime. Used by the LWC
+     *              "Show chain" modal to render the full multi-step chain.
+     */
+    global class ApprovalChainNodeDTO {
+        @AuraEnabled public Id approvalId;
+        @AuraEnabled public Id featureId;
+        @AuraEnabled public String featureLabel;
+        @AuraEnabled public Integer stepNumber;
+        @AuraEnabled public String status;
+        @AuraEnabled public Boolean requiredBoolean;
+        @AuraEnabled public Id approverUserId;
+        @AuraEnabled public String approverUserName;
+        @AuraEnabled public DateTime decisionDateTime;
+        @AuraEnabled public String decisionNote;
+    }
+
     // ────────────────────────────────────────────────────────────────────
     // SUBMIT
     // ────────────────────────────────────────────────────────────────────
 
     /**
      * @description Submits a new toggle request. Creates the request row in
-     *              Pending status with a frozen cascade snapshot, then one
-     *              FeatureToggleApproval__c row in Pending status with
-     *              StepNumber=1 and RequiredDateTime__c=now.
+     *              Pending status with a frozen cascade snapshot, then walks
+     *              the cascade graph to insert one FeatureToggleApproval__c
+     *              per non-Optional dependency node plus a root-level
+     *              sign-off row.
      * @param featureId The Feature__c being toggled.
      * @param action 'Enable' or 'Disable'.
      * @param reason Optional rationale from the requester.
@@ -94,7 +126,9 @@ global with sharing class DeliveryFeatureApprovalService {
     global static Id submit(Id featureId, String action, String reason) {
         validateSubmitInputs(featureId, action);
 
-        String snapshot = serializeCascadeSnapshot(featureId, action);
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO root =
+            computeCascadeRootOrNull(featureId, action);
+        String snapshot = serializeRootOrNull(root);
 
         FeatureToggleRequest__c req = new FeatureToggleRequest__c(
             FeatureLookup__c = featureId,
@@ -113,7 +147,14 @@ global with sharing class DeliveryFeatureApprovalService {
             throw new AuraHandledException('Unable to submit toggle request.');
         }
 
-        insertSingleStepApproval(req.Id, featureId);
+        List<FeatureToggleApproval__c> approvals = buildApprovalsForCascade(req.Id, featureId, root);
+        try {
+            insert approvals;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryFeatureApprovalService.submit] insert approvals failed: ' + e.getMessage());
+            throw new AuraHandledException('Unable to create approval rows.');
+        }
         return req.Id;
     }
 
@@ -126,35 +167,130 @@ global with sharing class DeliveryFeatureApprovalService {
         }
     }
 
-    private static String serializeCascadeSnapshot(Id featureId, String action) {
+    private static DeliveryFeatureGraphService.FeatureGraphNodeDTO computeCascadeRootOrNull(
+        Id featureId, String action
+    ) {
         try {
-            DeliveryFeatureGraphService.FeatureGraphNodeDTO root =
-                DeliveryFeatureGraphService.computeCascade(featureId, action);
-            return JSON.serialize(root);
+            return DeliveryFeatureGraphService.computeCascade(featureId, action);
         } catch (Exception e) {
             System.debug(LoggingLevel.WARN,
-                '[DeliveryFeatureApprovalService.serializeCascadeSnapshot] failed: '
+                '[DeliveryFeatureApprovalService.computeCascadeRootOrNull] failed: '
                 + e.getMessage());
             return null;
         }
     }
 
-    private static void insertSingleStepApproval(Id requestId, Id featureId) {
-        FeatureToggleApproval__c row = new FeatureToggleApproval__c(
-            RequestLookup__c = requestId,
-            FeatureLookup__c = featureId,
-            StepNumber__c = 1,
-            StatusPk__c = APPROVAL_PENDING,
-            RequiredDateTime__c = DateTime.now()
-        );
-        try {
-            insert row;
-        } catch (Exception e) {
-            System.debug(LoggingLevel.WARN,
-                '[DeliveryFeatureApprovalService.insertSingleStepApproval] failed: '
-                + e.getMessage());
-            throw new AuraHandledException('Unable to create approval row.');
+    private static String serializeRootOrNull(DeliveryFeatureGraphService.FeatureGraphNodeDTO root) {
+        if (root == null) {
+            return null;
         }
+        try {
+            return JSON.serialize(root);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * @description Walks the cascade tree and produces one approval row per
+     *              non-Optional cascade node + one root-level (StepNumber=0)
+     *              row representing the final sign-off on the requested
+     *              feature. Hard rows are Required (RequiredDateTime__c=now).
+     *              Soft rows are not required (RequiredDateTime__c=null) and
+     *              get auto-marked at apply time. If the cascade graph could
+     *              not be computed (e.g. transient SOQL error), falls back to
+     *              a single root row so submit still produces a valid request.
+     * @param requestId Parent FeatureToggleRequest__c.
+     * @param rootFeatureId The Feature__c the request targets.
+     * @param root Cascade tree root, or null if computeCascade returned null.
+     * @return List of unsaved FeatureToggleApproval__c rows ready to insert.
+     */
+    private static List<FeatureToggleApproval__c> buildApprovalsForCascade(
+        Id requestId,
+        Id rootFeatureId,
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO root
+    ) {
+        List<FeatureToggleApproval__c> rows = new List<FeatureToggleApproval__c>();
+        DateTime nowTs = DateTime.now();
+        // Root-level sign-off row — always required, StepNumber=0.
+        rows.add(new FeatureToggleApproval__c(
+            RequestLookup__c = requestId,
+            FeatureLookup__c = rootFeatureId,
+            StepNumber__c = 0,
+            StatusPk__c = APPROVAL_PENDING,
+            RequiredDateTime__c = nowTs
+        ));
+        if (root == null) {
+            return rows;
+        }
+        List<CascadeNodeWithDepth> flat = flattenCascadeWithDepth(root);
+        for (CascadeNodeWithDepth entry : flat) {
+            // Skip the root itself (depth 0 handled above) and Optional edges.
+            if (entry.depth == 0 || entry.node == null) {
+                continue;
+            }
+            String depType = entry.node.dependencyType;
+            if (depType == DEP_OPTIONAL) {
+                continue;
+            }
+            Boolean isHard = (depType == DEP_HARD);
+            rows.add(new FeatureToggleApproval__c(
+                RequestLookup__c = requestId,
+                FeatureLookup__c = entry.node.featureId,
+                StepNumber__c = entry.depth,
+                StatusPk__c = APPROVAL_PENDING,
+                // Hard => required (blocking). Soft => informational (auto on apply).
+                RequiredDateTime__c = isHard ? nowTs : null
+            ));
+        }
+        return rows;
+    }
+
+    /** Internal tuple — keeps flattenCascadeWithDepth's signature flat. */
+    private class CascadeNodeWithDepth {
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO node;
+        Integer depth;
+        CascadeNodeWithDepth(DeliveryFeatureGraphService.FeatureGraphNodeDTO n, Integer d) {
+            this.node = n;
+            this.depth = d;
+        }
+    }
+
+    /**
+     * @description Flattens a cascade tree into a depth-ordered list using
+     *              an iterative BFS — Apex caps recursive call depth at ~1000
+     *              and the graph service caps cascade depth at 10, but BFS
+     *              is also more natural here because we want shallow nodes
+     *              earliest (StepNumber matches BFS layer).
+     * @param root Root cascade node from DeliveryFeatureGraphService.computeCascade.
+     * @return Flat list of (node, depth) tuples in BFS layer order.
+     */
+    private static List<CascadeNodeWithDepth> flattenCascadeWithDepth(
+        DeliveryFeatureGraphService.FeatureGraphNodeDTO root
+    ) {
+        List<CascadeNodeWithDepth> out = new List<CascadeNodeWithDepth>();
+        if (root == null) {
+            return out;
+        }
+        List<DeliveryFeatureGraphService.FeatureGraphNodeDTO> currentLayer =
+            new List<DeliveryFeatureGraphService.FeatureGraphNodeDTO>{ root };
+        Integer depth = 0;
+        while (!currentLayer.isEmpty()) {
+            List<DeliveryFeatureGraphService.FeatureGraphNodeDTO> nextLayer =
+                new List<DeliveryFeatureGraphService.FeatureGraphNodeDTO>();
+            for (DeliveryFeatureGraphService.FeatureGraphNodeDTO node : currentLayer) {
+                if (node == null) {
+                    continue;
+                }
+                out.add(new CascadeNodeWithDepth(node, depth));
+                if (node.children != null) {
+                    nextLayer.addAll(node.children);
+                }
+            }
+            currentLayer = nextLayer;
+            depth++;
+        }
+        return out;
     }
 
     // ────────────────────────────────────────────────────────────────────
@@ -164,9 +300,9 @@ global with sharing class DeliveryFeatureApprovalService {
     /**
      * @description Approver-side grant. Stamps the approval row Approved +
      *              decision fields, then re-evaluates the request: if every
-     *              row on the request is Approved or Auto, applyIfFullyGranted
-     *              flips the underlying feature and stamps the request
-     *              Applied.
+     *              required row on the request is Approved or Auto,
+     *              applyIfFullyGranted flips the underlying feature and
+     *              stamps the request Applied.
      * @param approvalId The FeatureToggleApproval__c row being decided.
      * @param note Optional decision note from the approver.
      */
@@ -248,10 +384,11 @@ global with sharing class DeliveryFeatureApprovalService {
     // ────────────────────────────────────────────────────────────────────
 
     /**
-     * @description When every approval row on a request is Approved (or
-     *              Auto), flips the underlying Feature__c and stamps the
-     *              request Applied. No-ops if any row is still Pending or
-     *              already Rejected. Recursion-guarded so the request
+     * @description When every REQUIRED approval row on a request is Approved
+     *              (or Auto), flips the underlying Feature__c, auto-marks the
+     *              non-required rows Status='Auto', and stamps the request
+     *              Applied. No-ops if any required row is still Pending or
+     *              has been Rejected. Recursion-guarded so the request
      *              trigger and the explicit grant path don't double-apply.
      * @param requestId The FeatureToggleRequest__c to evaluate.
      */
@@ -265,10 +402,11 @@ global with sharing class DeliveryFeatureApprovalService {
             || req.StatusPk__c == STATUS_ROLLED_BACK) {
             return;
         }
-        if (!allApprovalsGranted(requestId)) {
+        List<FeatureToggleApproval__c> rows = loadApprovalRows(requestId);
+        if (!allRequiredApprovalsGranted(rows)) {
             return;
         }
-        runApply(req);
+        applyAndAudit(req, rows);
     }
 
     private static FeatureToggleRequest__c loadRequestOrNull(Id requestId) {
@@ -283,38 +421,96 @@ global with sharing class DeliveryFeatureApprovalService {
         return reqs.isEmpty() ? null : reqs.get(0);
     }
 
-    private static Boolean allApprovalsGranted(Id requestId) {
-        List<FeatureToggleApproval__c> rows = [
-            SELECT Id, StatusPk__c
+    private static List<FeatureToggleApproval__c> loadApprovalRows(Id requestId) {
+        return [
+            SELECT Id, StatusPk__c, RequiredDateTime__c
             FROM FeatureToggleApproval__c
             WHERE RequestLookup__c = :requestId
             WITH SYSTEM_MODE
         ];
-        if (rows.isEmpty()) {
+    }
+
+    /**
+     * @description Multi-step gating contract: every approval row whose
+     *              RequiredDateTime__c is populated must be either Approved
+     *              or Auto. Non-required rows do not block apply (they are
+     *              auto-marked at the apply step). Empty row set returns
+     *              false defensively (every request should have at least
+     *              the root sign-off row).
+     * @param rows All approval rows for the request.
+     * @return true when every required row is decided in the affirmative.
+     */
+    private static Boolean allRequiredApprovalsGranted(List<FeatureToggleApproval__c> rows) {
+        if (rows == null || rows.isEmpty()) {
             return false;
         }
+        Boolean sawRequired = false;
         for (FeatureToggleApproval__c row : rows) {
+            if (row.RequiredDateTime__c == null) {
+                continue;
+            }
+            sawRequired = true;
             if (row.StatusPk__c != APPROVAL_APPROVED && row.StatusPk__c != APPROVAL_AUTO) {
                 return false;
             }
         }
-        return true;
+        return sawRequired;
     }
 
-    private static void runApply(FeatureToggleRequest__c req) {
+    /**
+     * @description Performs the actual apply: flip the feature, auto-mark
+     *              non-required rows, stamp the request, and write the audit
+     *              row. Wrapped in the recursion guard.
+     * @param req The request being applied.
+     * @param rows All approval rows for the request (for the Auto sweep).
+     */
+    private static void applyAndAudit(
+        FeatureToggleRequest__c req,
+        List<FeatureToggleApproval__c> rows
+    ) {
         inApplyContext = true;
         try {
             flipFeature(req.FeatureLookup__c, req.ActionPk__c);
+            autoMarkNonRequired(rows);
             req.StatusPk__c = STATUS_APPLIED;
             req.AppliedDateTime__c = DateTime.now();
             update req;
             writeAuditRow(req.FeatureLookup__c, req.ActionPk__c, req.Id);
         } catch (Exception e) {
             System.debug(LoggingLevel.WARN,
-                '[DeliveryFeatureApprovalService.runApply] failed: ' + e.getMessage());
+                '[DeliveryFeatureApprovalService.applyAndAudit] failed: ' + e.getMessage());
             throw new AuraHandledException('Unable to apply toggle.');
         } finally {
             inApplyContext = false;
+        }
+    }
+
+    private static void autoMarkNonRequired(List<FeatureToggleApproval__c> rows) {
+        List<FeatureToggleApproval__c> updates = new List<FeatureToggleApproval__c>();
+        DateTime nowTs = DateTime.now();
+        for (FeatureToggleApproval__c row : rows) {
+            if (row.RequiredDateTime__c != null) {
+                continue;
+            }
+            if (row.StatusPk__c == APPROVAL_APPROVED
+                || row.StatusPk__c == APPROVAL_REJECTED
+                || row.StatusPk__c == APPROVAL_AUTO) {
+                continue;
+            }
+            updates.add(new FeatureToggleApproval__c(
+                Id = row.Id,
+                StatusPk__c = APPROVAL_AUTO,
+                DecisionDateTime__c = nowTs
+            ));
+        }
+        if (!updates.isEmpty()) {
+            try {
+                update updates;
+            } catch (Exception e) {
+                System.debug(LoggingLevel.WARN,
+                    '[DeliveryFeatureApprovalService.autoMarkNonRequired] failed: '
+                    + e.getMessage());
+            }
         }
     }
 
@@ -415,9 +611,10 @@ global with sharing class DeliveryFeatureApprovalService {
     /**
      * @description Returns Pending approval rows assigned to the running user,
      *              joined with their request + feature for one-screen render.
-     *              Rows with no assigned approver are filtered out (the
-     *              single-step inbox shape will be widened by PR 8 when
-     *              ApproverUserLookup__c is populated by the chain builder).
+     *              Rows with no assigned approver are filtered out — PR 8
+     *              leaves ApproverUserLookup__c null at submit time, so
+     *              admins assign approvers out-of-band on the record page;
+     *              PR 9+ will wire automatic approver resolution.
      * @return List of ApprovalInboxDTO ordered by request RequestedDateTime__c
      *         ASC (oldest first).
      */
@@ -468,6 +665,66 @@ global with sharing class DeliveryFeatureApprovalService {
                 dto.requestedByName = row.RequestLookup__r.RequestedByUserLookup__r.Name;
             }
         }
+        if (row.FeatureLookup__r != null) {
+            String defName = row.FeatureLookup__r.FeatureDefinitionTxt__c;
+            dto.featureLabel = String.isNotBlank(defName)
+                ? defName
+                : row.FeatureLookup__r.Name;
+        }
+        return dto;
+    }
+
+    /**
+     * @description Returns every approval row on the request, ordered by
+     *              StepNumber then DecisionDateTime. Used by the LWC "Show
+     *              chain" modal and by the REST surface to expose the full
+     *              multi-step chain to external onboarding portals.
+     * @param requestId FeatureToggleRequest__c to inspect.
+     * @return Ordered list of ApprovalChainNodeDTO entries.
+     */
+    @AuraEnabled(cacheable=true)
+    global static List<ApprovalChainNodeDTO> getApprovalChain(Id requestId) {
+        List<ApprovalChainNodeDTO> out = new List<ApprovalChainNodeDTO>();
+        if (requestId == null) {
+            return out;
+        }
+        try {
+            for (FeatureToggleApproval__c row : [
+                SELECT Id, FeatureLookup__c, StepNumber__c, StatusPk__c,
+                       RequiredDateTime__c, DecisionDateTime__c, DecisionNoteTxt__c,
+                       ApproverUserLookup__c, ApproverUserLookup__r.Name,
+                       FeatureLookup__r.Name, FeatureLookup__r.FeatureDefinitionTxt__c
+                FROM FeatureToggleApproval__c
+                WHERE RequestLookup__c = :requestId
+                WITH SYSTEM_MODE
+                ORDER BY StepNumber__c ASC NULLS LAST,
+                         DecisionDateTime__c ASC NULLS LAST,
+                         CreatedDate ASC
+                LIMIT 200
+            ]) {
+                out.add(toChainDto(row));
+            }
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryFeatureApprovalService.getApprovalChain] failed: ' + e.getMessage());
+            throw new AuraHandledException('Unable to load approval chain.');
+        }
+        return out;
+    }
+
+    private static ApprovalChainNodeDTO toChainDto(FeatureToggleApproval__c row) {
+        ApprovalChainNodeDTO dto = new ApprovalChainNodeDTO();
+        dto.approvalId = row.Id;
+        dto.featureId = row.FeatureLookup__c;
+        dto.stepNumber = (row.StepNumber__c == null) ? null : row.StepNumber__c.intValue();
+        dto.status = row.StatusPk__c;
+        dto.requiredBoolean = row.RequiredDateTime__c != null;
+        dto.approverUserId = row.ApproverUserLookup__c;
+        if (row.ApproverUserLookup__r != null) {
+            dto.approverUserName = row.ApproverUserLookup__r.Name;
+        }
+        dto.decisionDateTime = row.DecisionDateTime__c;
+        dto.decisionNote = row.DecisionNoteTxt__c;
         if (row.FeatureLookup__r != null) {
             String defName = row.FeatureLookup__r.FeatureDefinitionTxt__c;
             dto.featureLabel = String.isNotBlank(defName)

--- a/force-app/main/default/classes/DeliveryFeatureApprovalService.cls
+++ b/force-app/main/default/classes/DeliveryFeatureApprovalService.cls
@@ -246,10 +246,18 @@ global with sharing class DeliveryFeatureApprovalService {
         return rows;
     }
 
-    /** Internal tuple — keeps flattenCascadeWithDepth's signature flat. */
+    /**
+     * @description Internal tuple — pairs a cascade node DTO with its BFS depth.
+     *              Keeps flattenCascadeWithDepth's return signature flat.
+     */
     private class CascadeNodeWithDepth {
         DeliveryFeatureGraphService.FeatureGraphNodeDTO node;
         Integer depth;
+        /**
+         * @description Constructs a node-with-depth pair.
+         * @param n Cascade node DTO from DeliveryFeatureGraphService.computeCascade.
+         * @param d BFS depth (0 = root).
+         */
         CascadeNodeWithDepth(DeliveryFeatureGraphService.FeatureGraphNodeDTO n, Integer d) {
             this.node = n;
             this.depth = d;

--- a/force-app/main/default/classes/DeliveryFeatureApprovalServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryFeatureApprovalServiceTest.cls
@@ -306,4 +306,247 @@ private class DeliveryFeatureApprovalServiceTest {
         }
         System.assert(threw, 'rollback of a Pending request should throw');
     }
+
+    // ────────────────────────────────────────────────────────────────────
+    // PR 8 — multi-step cascade chain tests
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Submit on a feature with a 2-level Hard cascade (A -> B -> C
+     *              via BlockingFeatureLookup__c, walked on Enable) produces
+     *              exactly one root approval (Step=0) plus one approval per
+     *              cascade layer. With A as the requested feature and B, C as
+     *              blockers, the BFS surfaces B at depth 1 and C at depth 2,
+     *              for a total of 3 approval rows.
+     */
+    @IsTest
+    static void testSubmitGeneratesMultiStepChainForCascade() {
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        Feature__c featB = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        Feature__c featC = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        // A depends on B (A blocked by B); B depends on C (B blocked by C).
+        TestDataFactory.createFeatureDependency(featB.Id, featA.Id, new Map<String, Object>{
+            'TypePk__c' => 'Hard',
+            'CascadeDirectionPk__c' => 'Both'
+        });
+        TestDataFactory.createFeatureDependency(featC.Id, featB.Id, new Map<String, Object>{
+            'TypePk__c' => 'Hard',
+            'CascadeDirectionPk__c' => 'Both'
+        });
+
+        Test.startTest();
+        Id requestId = DeliveryFeatureApprovalService.submit(featA.Id, 'Enable', 'cascade test');
+        Test.stopTest();
+
+        List<FeatureToggleApproval__c> approvals = [
+            SELECT Id, StepNumber__c, FeatureLookup__c, RequiredDateTime__c
+            FROM FeatureToggleApproval__c
+            WHERE RequestLookup__c = :requestId
+            ORDER BY StepNumber__c ASC
+        ];
+        System.assertEquals(3, approvals.size(),
+            'expected root + 2 cascade approvals for A -> B -> C chain');
+        System.assertEquals(0, approvals[0].StepNumber__c.intValue(),
+            'root sign-off row is StepNumber=0');
+        System.assertEquals(featA.Id, approvals[0].FeatureLookup__c,
+            'root row references the requested feature');
+        // Hard edges => RequiredDateTime__c populated.
+        for (FeatureToggleApproval__c a : approvals) {
+            System.assertNotEquals(null, a.RequiredDateTime__c,
+                'Hard cascade edges must be Required');
+        }
+    }
+
+    /**
+     * @description When a chain has 3 required approvals, granting only 2
+     *              must NOT apply. Granting the 3rd flips Apply.
+     */
+    @IsTest
+    static void testApplyIfFullyGrantedRequiresAllRequiredApprovals() {
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        Feature__c featB = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        TestDataFactory.createFeatureDependency(featB.Id, featA.Id, new Map<String, Object>{
+            'TypePk__c' => 'Hard',
+            'CascadeDirectionPk__c' => 'Both'
+        });
+
+        Id requestId = DeliveryFeatureApprovalService.submit(featA.Id, 'Enable', null);
+        List<FeatureToggleApproval__c> approvals = [
+            SELECT Id, StepNumber__c
+            FROM FeatureToggleApproval__c
+            WHERE RequestLookup__c = :requestId
+            ORDER BY StepNumber__c ASC
+        ];
+        System.assertEquals(2, approvals.size(),
+            'expected root + 1 cascade approval for A -> B chain');
+
+        Test.startTest();
+        // Grant only the cascade-leaf approval first. The root remains pending.
+        DeliveryFeatureApprovalService.grant(approvals[1].Id, 'leaf ok');
+
+        FeatureToggleRequest__c reqMid = [
+            SELECT StatusPk__c FROM FeatureToggleRequest__c WHERE Id = :requestId
+        ];
+        System.assertEquals('Pending', reqMid.StatusPk__c,
+            'only one required grant should not flip the request');
+
+        // Now grant the root.
+        DeliveryFeatureApprovalService.grant(approvals[0].Id, 'final sign-off');
+        Test.stopTest();
+
+        FeatureToggleRequest__c reqFinal = [
+            SELECT StatusPk__c, AppliedDateTime__c FROM FeatureToggleRequest__c WHERE Id = :requestId
+        ];
+        System.assertEquals('Applied', reqFinal.StatusPk__c,
+            'all required grants should flip to Applied');
+        System.assertNotEquals(null, reqFinal.AppliedDateTime__c,
+            'AppliedDateTime stamped on apply');
+    }
+
+    /**
+     * @description Soft (non-required) dependencies are auto-marked
+     *              Status='Auto' when all required rows resolve. Soft rows
+     *              do not block apply.
+     */
+    @IsTest
+    static void testSoftDependenciesAreAutoApproved() {
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        Feature__c featSoft = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        TestDataFactory.createFeatureDependency(featSoft.Id, featA.Id, new Map<String, Object>{
+            'TypePk__c' => 'Soft',
+            'CascadeDirectionPk__c' => 'Both'
+        });
+
+        Id requestId = DeliveryFeatureApprovalService.submit(featA.Id, 'Enable', null);
+        List<FeatureToggleApproval__c> approvals = [
+            SELECT Id, StepNumber__c, RequiredDateTime__c, StatusPk__c
+            FROM FeatureToggleApproval__c
+            WHERE RequestLookup__c = :requestId
+            ORDER BY StepNumber__c ASC
+        ];
+        System.assertEquals(2, approvals.size(),
+            'soft dependencies still produce an approval row');
+
+        // The Soft row (depth 1) should NOT be Required.
+        FeatureToggleApproval__c softRow;
+        FeatureToggleApproval__c rootRow;
+        for (FeatureToggleApproval__c a : approvals) {
+            if (a.StepNumber__c == 0) { rootRow = a; }
+            else { softRow = a; }
+        }
+        System.assertNotEquals(null, rootRow, 'root row created');
+        System.assertNotEquals(null, softRow, 'soft row created');
+        System.assertNotEquals(null, rootRow.RequiredDateTime__c, 'root row is required');
+        System.assertEquals(null, softRow.RequiredDateTime__c,
+            'Soft dependency row must have RequiredDateTime__c=null');
+
+        Test.startTest();
+        // Grant only the root — soft should be auto-marked on apply.
+        DeliveryFeatureApprovalService.grant(rootRow.Id, null);
+        Test.stopTest();
+
+        FeatureToggleApproval__c softAfter = [
+            SELECT StatusPk__c, DecisionDateTime__c FROM FeatureToggleApproval__c
+            WHERE Id = :softRow.Id
+        ];
+        System.assertEquals('Auto', softAfter.StatusPk__c,
+            'Soft row should be auto-marked at apply');
+        System.assertNotEquals(null, softAfter.DecisionDateTime__c,
+            'Auto row gets a DecisionDateTime stamp');
+        FeatureToggleRequest__c reqFinal = [
+            SELECT StatusPk__c FROM FeatureToggleRequest__c WHERE Id = :requestId
+        ];
+        System.assertEquals('Applied', reqFinal.StatusPk__c, 'request applied');
+    }
+
+    /**
+     * @description getApprovalChain returns one DTO per approval row, ordered
+     *              by StepNumber. Required/Optional flag derived from
+     *              RequiredDateTime__c presence.
+     */
+    @IsTest
+    static void testGetApprovalChainReturnsOrderedDtos() {
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        Feature__c featB = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        TestDataFactory.createFeatureDependency(featB.Id, featA.Id, new Map<String, Object>{
+            'TypePk__c' => 'Hard',
+            'CascadeDirectionPk__c' => 'Both'
+        });
+        Id requestId = DeliveryFeatureApprovalService.submit(featA.Id, 'Enable', null);
+
+        Test.startTest();
+        List<DeliveryFeatureApprovalService.ApprovalChainNodeDTO> chain =
+            DeliveryFeatureApprovalService.getApprovalChain(requestId);
+        Test.stopTest();
+
+        System.assertEquals(2, chain.size(), 'expected 2 chain entries');
+        System.assertEquals(0, chain.get(0).stepNumber,
+            'first entry is root (Step 0)');
+        System.assertEquals(true, chain.get(0).requiredBoolean,
+            'root row is required');
+        System.assertEquals(featA.Id, chain.get(0).featureId,
+            'root references the requested feature');
+        System.assertEquals(1, chain.get(1).stepNumber,
+            'second entry is the cascade row at depth 1');
+        System.assertEquals(featB.Id, chain.get(1).featureId,
+            'cascade row references the blocker feature');
+        // Both rows still pending; status DTO carries that through.
+        System.assertEquals('Pending', chain.get(0).status, 'pending status');
+    }
+
+    /**
+     * @description Optional cascade edges must NOT produce an approval row.
+     */
+    @IsTest
+    static void testOptionalDependenciesProduceNoApprovalRow() {
+        Feature__c featA = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        Feature__c featOpt = TestDataFactory.createFeature(new Map<String, Object>{
+            'EnabledDateTime__c' => null,
+            'DisabledDateTime__c' => Datetime.now()
+        });
+        TestDataFactory.createFeatureDependency(featOpt.Id, featA.Id, new Map<String, Object>{
+            'TypePk__c' => 'Optional',
+            'CascadeDirectionPk__c' => 'Both'
+        });
+
+        Test.startTest();
+        Id requestId = DeliveryFeatureApprovalService.submit(featA.Id, 'Enable', null);
+        Test.stopTest();
+
+        Integer approvalCount = [
+            SELECT COUNT() FROM FeatureToggleApproval__c WHERE RequestLookup__c = :requestId
+        ];
+        System.assertEquals(1, approvalCount,
+            'Optional edges should be skipped — only the root row exists');
+    }
 }

--- a/force-app/main/default/classes/DeliveryPublicApiService.cls
+++ b/force-app/main/default/classes/DeliveryPublicApiService.cls
@@ -116,6 +116,10 @@ global without sharing class DeliveryPublicApiService {
         if (resource == 'board-summary') { getBoardSummary(); return true; }
         if (resource == 'documents') { sendSuccess(DeliveryDocumentController.getDocumentsForEntity(entityId)); return true; }
         if (resource.startsWith('documents/')) { getDocumentByToken(resource); return true; }
+        // Feature cockpit endpoints (PR 8) — org-wide, not entity-scoped. The
+        // API key still authenticates the caller via authenticateRequest(); the
+        // feature toggle registry isn't per-tenant.
+        if (resource == 'feature-toggle-requests') { getFeatureToggleRequests(); return true; }
         return false;
     }
 
@@ -257,7 +261,229 @@ global without sharing class DeliveryPublicApiService {
         else if (resource == 'log-hours') { postLogHours(jsonBody, entityId); }
         else if (resource == 'document-approve') { postDocumentApprove(jsonBody); }
         else if (resource == 'document-dispute') { postDocumentDispute(jsonBody); }
+        else if (routePostFeatureCockpit(resource, jsonBody)) { return; }
         else { sendError(404, 'Unknown resource: ' + resource); }
+    }
+
+    // ── POST Feature Cockpit Routes (PR 8) ─────────────────────────────
+
+    /**
+     * @description Routes the feature-cockpit POST endpoints. Each operates on
+     *              org-wide feature catalog state (Feature__c, FeatureToggleRequest__c,
+     *              FeatureToggleApproval__c) rather than per-tenant data, so they
+     *              don't take the entityId. Authentication still happens via X-Api-Key
+     *              in handlePost. Returns true if the path matched.
+     * @param resource Path segment after /api/.
+     * @param jsonBody The raw request body.
+     * @return true if a feature-cockpit route was matched and handled.
+     */
+    private static Boolean routePostFeatureCockpit(String resource, String jsonBody) {
+        if (resource.startsWith('features/') && resource.endsWith('/toggle')) {
+            postFeatureToggle(resource, jsonBody);
+            return true;
+        }
+        if (resource.startsWith('feature-toggle-approvals/')) {
+            if (resource.endsWith('/grant')) {
+                postFeatureApprovalDecision(resource, jsonBody, true);
+                return true;
+            }
+            if (resource.endsWith('/reject')) {
+                postFeatureApprovalDecision(resource, jsonBody, false);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @description POST /features/{name}/toggle — submits a new
+     *              FeatureToggleRequest__c. Body shape:
+     *                { "action": "Enable" | "Disable", "reason": "..." }
+     *              The {name} segment matches Feature__c.Name or
+     *              FeatureDefinitionTxt__c (case-insensitive).
+     * @param resource Path segment.
+     * @param jsonBody Raw request body.
+     */
+    private static void postFeatureToggle(String resource, String jsonBody) {
+        String featureName = resource.substringBetween('features/', '/toggle');
+        if (String.isBlank(featureName)) { sendError(400, 'Feature name is required.'); return; }
+        Map<String, Object> body = (Map<String, Object>) JSON.deserializeUntyped(jsonBody);
+        String action = (String) body.get('action');
+        String reason = (String) body.get('reason');
+        if (action != 'Enable' && action != 'Disable') {
+            sendError(400, 'action must be Enable or Disable.'); return;
+        }
+        Id featureId = resolveFeatureIdByName(featureName);
+        if (featureId == null) { sendError(404, 'Feature not found: ' + featureName); return; }
+        try {
+            Id requestId = DeliveryFeatureApprovalService.submit(featureId, action, reason);
+            sendSuccess(new Map<String, Object>{
+                'requestId' => requestId,
+                'featureId' => featureId,
+                'status' => 'Pending'
+            }, 201);
+        } catch (AuraHandledException e) {
+            sendError(400, e.getMessage());
+        }
+    }
+
+    /**
+     * @description POST /feature-toggle-approvals/{id}/grant or /reject.
+     *              Body shape: { "note": "..." }
+     * @param resource Path segment.
+     * @param jsonBody Raw request body.
+     * @param grant true for grant, false for reject.
+     */
+    private static void postFeatureApprovalDecision(String resource, String jsonBody, Boolean grant) {
+        String suffix = grant ? '/grant' : '/reject';
+        String approvalIdStr = resource.substringBetween('feature-toggle-approvals/', suffix);
+        if (String.isBlank(approvalIdStr)) { sendError(400, 'Approval Id is required.'); return; }
+        Id approvalId;
+        try { approvalId = Id.valueOf(approvalIdStr); }
+        catch (Exception e) { sendError(400, 'Invalid approval Id.'); return; }
+        Map<String, Object> body = (Map<String, Object>) JSON.deserializeUntyped(jsonBody);
+        String note = (String) body.get('note');
+        try {
+            if (grant) {
+                DeliveryFeatureApprovalService.grant(approvalId, note);
+            } else {
+                DeliveryFeatureApprovalService.reject(approvalId, note);
+            }
+            Map<String, Object> resp = describeApprovalAfterDecision(approvalId);
+            sendSuccess(resp);
+        } catch (AuraHandledException e) {
+            sendError(400, e.getMessage());
+        }
+    }
+
+    private static Map<String, Object> describeApprovalAfterDecision(Id approvalId) {
+        List<FeatureToggleApproval__c> rows = [
+            SELECT Id, StatusPk__c, RequestLookup__c, RequestLookup__r.StatusPk__c
+            FROM FeatureToggleApproval__c
+            WHERE Id = :approvalId
+            WITH SYSTEM_MODE LIMIT 1
+        ];
+        Map<String, Object> resp = new Map<String, Object>{
+            'approvalId' => approvalId
+        };
+        if (!rows.isEmpty()) {
+            FeatureToggleApproval__c row = rows[0];
+            resp.put('status', row.StatusPk__c);
+            resp.put('requestId', row.RequestLookup__c);
+            if (row.RequestLookup__r != null) {
+                resp.put('requestStatus', row.RequestLookup__r.StatusPk__c);
+            }
+        }
+        return resp;
+    }
+
+    /**
+     * @description GET /feature-toggle-requests — paginated list of
+     *              FeatureToggleRequest__c rows. Optional query params:
+     *                ?status=Pending|Granted|Applied|Rejected|RolledBack
+     *                ?feature=<name>  (matches FeatureLookup__r.Name)
+     *                ?pageOffset=N    (LIMIT/OFFSET pagination)
+     */
+    private static void getFeatureToggleRequests() {
+        String statusFilter = RestContext.request.params.get('status');
+        String featureFilter = RestContext.request.params.get('feature');
+        Integer offset = getPageOffset();
+        List<FeatureToggleRequest__c> requests = queryFeatureToggleRequests(
+            statusFilter, featureFilter, offset
+        );
+        List<Map<String, Object>> data = new List<Map<String, Object>>();
+        for (FeatureToggleRequest__c req : requests) {
+            data.add(buildFeatureRequestMap(req));
+        }
+        sendSuccess(data);
+    }
+
+    private static List<FeatureToggleRequest__c> queryFeatureToggleRequests(
+        String statusFilter, String featureFilter, Integer offset
+    ) {
+        Integer maxRows = 50;
+        Integer safeOffset = (offset == null || offset < 0) ? 0 : offset;
+        if (String.isNotBlank(statusFilter) && String.isNotBlank(featureFilter)) {
+            return [
+                SELECT Id, ActionPk__c, StatusPk__c, ReasonTxt__c, RequestedDateTime__c,
+                       FeatureLookup__c, FeatureLookup__r.Name,
+                       FeatureLookup__r.FeatureDefinitionTxt__c
+                FROM FeatureToggleRequest__c
+                WHERE StatusPk__c = :statusFilter
+                  AND FeatureLookup__r.Name = :featureFilter
+                WITH SYSTEM_MODE
+                ORDER BY RequestedDateTime__c DESC NULLS LAST
+                LIMIT :maxRows OFFSET :safeOffset
+            ];
+        }
+        if (String.isNotBlank(statusFilter)) {
+            return [
+                SELECT Id, ActionPk__c, StatusPk__c, ReasonTxt__c, RequestedDateTime__c,
+                       FeatureLookup__c, FeatureLookup__r.Name,
+                       FeatureLookup__r.FeatureDefinitionTxt__c
+                FROM FeatureToggleRequest__c
+                WHERE StatusPk__c = :statusFilter
+                WITH SYSTEM_MODE
+                ORDER BY RequestedDateTime__c DESC NULLS LAST
+                LIMIT :maxRows OFFSET :safeOffset
+            ];
+        }
+        if (String.isNotBlank(featureFilter)) {
+            return [
+                SELECT Id, ActionPk__c, StatusPk__c, ReasonTxt__c, RequestedDateTime__c,
+                       FeatureLookup__c, FeatureLookup__r.Name,
+                       FeatureLookup__r.FeatureDefinitionTxt__c
+                FROM FeatureToggleRequest__c
+                WHERE FeatureLookup__r.Name = :featureFilter
+                WITH SYSTEM_MODE
+                ORDER BY RequestedDateTime__c DESC NULLS LAST
+                LIMIT :maxRows OFFSET :safeOffset
+            ];
+        }
+        return [
+            SELECT Id, ActionPk__c, StatusPk__c, ReasonTxt__c, RequestedDateTime__c,
+                   FeatureLookup__c, FeatureLookup__r.Name,
+                   FeatureLookup__r.FeatureDefinitionTxt__c
+            FROM FeatureToggleRequest__c
+            WITH SYSTEM_MODE
+            ORDER BY RequestedDateTime__c DESC NULLS LAST
+            LIMIT :maxRows OFFSET :safeOffset
+        ];
+    }
+
+    private static Map<String, Object> buildFeatureRequestMap(FeatureToggleRequest__c req) {
+        String featureName = null;
+        if (req.FeatureLookup__r != null) {
+            featureName = String.isNotBlank(req.FeatureLookup__r.FeatureDefinitionTxt__c)
+                ? req.FeatureLookup__r.FeatureDefinitionTxt__c
+                : req.FeatureLookup__r.Name;
+        }
+        return new Map<String, Object>{
+            'id' => req.Id,
+            'featureId' => req.FeatureLookup__c,
+            'featureName' => featureName,
+            'action' => req.ActionPk__c,
+            'status' => req.StatusPk__c,
+            'reason' => req.ReasonTxt__c,
+            'requestedAt' => req.RequestedDateTime__c
+        };
+    }
+
+    /**
+     * @description Looks up a Feature__c by Name OR FeatureDefinitionTxt__c
+     *              (case-insensitive). Returns null if no match.
+     * @param featureName The {name} path segment.
+     * @return Matching Feature__c.Id, or null.
+     */
+    private static Id resolveFeatureIdByName(String featureName) {
+        if (String.isBlank(featureName)) { return null; }
+        List<Feature__c> rows = [
+            SELECT Id FROM Feature__c
+            WHERE Name = :featureName OR FeatureDefinitionTxt__c = :featureName
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        return rows.isEmpty() ? null : rows[0].Id;
     }
 
     private static void postWorkItem(String jsonBody, Id entityId) {

--- a/force-app/main/default/classes/DeliveryPublicApiServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryPublicApiServiceTest.cls
@@ -1223,4 +1223,227 @@ private class DeliveryPublicApiServiceTest {
         String error = (String) body.get('error');
         System.assert(error.contains(expectedMessage), 'Error should contain: ' + expectedMessage + ', got: ' + error);
     }
+
+    // ==========================================
+    // FEATURE COCKPIT — PR 8 ROUTES
+    // ==========================================
+
+    /**
+     * @description POST /features/{name}/toggle creates a Pending request +
+     *              at least the root approval row.
+     */
+    @IsTest
+    static void testPostFeatureToggleSubmitsRequest() {
+        System.runAs(testUser) {
+            Feature__c feat = TestDataFactory.createFeature(new Map<String, Object>{
+                'EnabledDateTime__c' => null,
+                'DisabledDateTime__c' => Datetime.now()
+            });
+
+            Map<String, Object> body = new Map<String, Object>{
+                'action' => 'Enable',
+                'reason' => 'API toggle test'
+            };
+            RestRequest req = buildPostRequest(
+                '/services/apexrest/delivery/deliveryhub/v1/api/features/' + feat.Name + '/toggle',
+                body
+            );
+            req.addHeader('X-Api-Key', TEST_API_KEY);
+            RestResponse res = new RestResponse();
+            RestContext.request = req;
+            RestContext.response = res;
+
+            Test.startTest();
+            DeliveryPublicApiService.handlePost();
+            Test.stopTest();
+
+            System.assertEquals(201, res.statusCode, 'Should return 201 Created');
+            Map<String, Object> responseBody = parseResponse(res);
+            System.assertEquals(true, responseBody.get('success'), 'success=true');
+            Map<String, Object> data = (Map<String, Object>) responseBody.get('data');
+            System.assertNotEquals(null, data.get('requestId'), 'requestId returned');
+            System.assertEquals('Pending', data.get('status'), 'status=Pending');
+
+            Id requestId = (Id) data.get('requestId');
+            FeatureToggleRequest__c persisted = [
+                SELECT StatusPk__c, ActionPk__c, FeatureLookup__c
+                FROM FeatureToggleRequest__c WHERE Id = :requestId
+            ];
+            System.assertEquals('Pending', persisted.StatusPk__c, 'persisted Pending');
+            System.assertEquals('Enable', persisted.ActionPk__c, 'persisted action');
+            System.assertEquals(feat.Id, persisted.FeatureLookup__c, 'feature linked');
+
+            Integer approvalCount = [
+                SELECT COUNT() FROM FeatureToggleApproval__c WHERE RequestLookup__c = :requestId
+            ];
+            System.assertEquals(1, approvalCount, 'root approval row created');
+        }
+    }
+
+    /**
+     * @description POST /features/{name}/toggle rejects an invalid action.
+     */
+    @IsTest
+    static void testPostFeatureToggleInvalidAction() {
+        System.runAs(testUser) {
+            Feature__c feat = TestDataFactory.createFeature(null);
+            Map<String, Object> body = new Map<String, Object>{
+                'action' => 'Bogus'
+            };
+            RestRequest req = buildPostRequest(
+                '/services/apexrest/delivery/deliveryhub/v1/api/features/' + feat.Name + '/toggle',
+                body
+            );
+            req.addHeader('X-Api-Key', TEST_API_KEY);
+            RestResponse res = new RestResponse();
+            RestContext.request = req;
+            RestContext.response = res;
+
+            Test.startTest();
+            DeliveryPublicApiService.handlePost();
+            Test.stopTest();
+
+            System.assertEquals(400, res.statusCode, 'invalid action returns 400');
+        }
+    }
+
+    /**
+     * @description POST /features/{name}/toggle returns 404 when feature
+     *              not found.
+     */
+    @IsTest
+    static void testPostFeatureToggleUnknownFeature() {
+        System.runAs(testUser) {
+            Map<String, Object> body = new Map<String, Object>{ 'action' => 'Enable' };
+            RestRequest req = buildPostRequest(
+                '/services/apexrest/delivery/deliveryhub/v1/api/features/Nonexistent_Feature_xyz/toggle',
+                body
+            );
+            req.addHeader('X-Api-Key', TEST_API_KEY);
+            RestResponse res = new RestResponse();
+            RestContext.request = req;
+            RestContext.response = res;
+
+            Test.startTest();
+            DeliveryPublicApiService.handlePost();
+            Test.stopTest();
+
+            System.assertEquals(404, res.statusCode, 'unknown feature returns 404');
+        }
+    }
+
+    /**
+     * @description GET /feature-toggle-requests returns the seeded request,
+     *              optionally filtered by status.
+     */
+    @IsTest
+    static void testGetFeatureToggleRequests() {
+        System.runAs(testUser) {
+            Feature__c feat = TestDataFactory.createFeature(null);
+            FeatureToggleRequest__c seed = TestDataFactory.newFeatureToggleRequest(feat.Id);
+
+            RestRequest req = buildGetRequest('/services/apexrest/delivery/deliveryhub/v1/api/feature-toggle-requests');
+            req.addHeader('X-Api-Key', TEST_API_KEY);
+            req.addParameter('status', 'Pending');
+            RestResponse res = new RestResponse();
+            RestContext.request = req;
+            RestContext.response = res;
+
+            Test.startTest();
+            DeliveryPublicApiService.handleGet();
+            Test.stopTest();
+
+            System.assertEquals(200, res.statusCode, 'should return 200');
+            Map<String, Object> body = parseResponse(res);
+            List<Object> data = (List<Object>) body.get('data');
+            Boolean foundSeed = false;
+            for (Object entry : data) {
+                Map<String, Object> row = (Map<String, Object>) entry;
+                if (row.get('id') == seed.Id) {
+                    foundSeed = true;
+                    System.assertEquals('Pending', row.get('status'), 'status filter respected');
+                    System.assertEquals('Enable', row.get('action'), 'action surfaced');
+                }
+            }
+            System.assert(foundSeed, 'seeded request should appear in results');
+        }
+    }
+
+    /**
+     * @description POST /feature-toggle-approvals/{id}/grant flips a single
+     *              required approval to Approved + applies the request.
+     */
+    @IsTest
+    static void testPostFeatureApprovalGrant() {
+        System.runAs(testUser) {
+            Feature__c feat = TestDataFactory.createFeature(new Map<String, Object>{
+                'EnabledDateTime__c' => null,
+                'DisabledDateTime__c' => Datetime.now()
+            });
+            Id requestId = DeliveryFeatureApprovalService.submit(feat.Id, 'Enable', null);
+            FeatureToggleApproval__c approval = [
+                SELECT Id FROM FeatureToggleApproval__c WHERE RequestLookup__c = :requestId LIMIT 1
+            ];
+
+            Map<String, Object> body = new Map<String, Object>{ 'note' => 'looks good' };
+            RestRequest req = buildPostRequest(
+                '/services/apexrest/delivery/deliveryhub/v1/api/feature-toggle-approvals/' + approval.Id + '/grant',
+                body
+            );
+            req.addHeader('X-Api-Key', TEST_API_KEY);
+            RestResponse res = new RestResponse();
+            RestContext.request = req;
+            RestContext.response = res;
+
+            Test.startTest();
+            DeliveryPublicApiService.handlePost();
+            Test.stopTest();
+
+            System.assertEquals(200, res.statusCode, 'should return 200');
+            Map<String, Object> responseBody = parseResponse(res);
+            Map<String, Object> data = (Map<String, Object>) responseBody.get('data');
+            System.assertEquals('Approved', data.get('status'), 'approval marked Approved');
+            System.assertEquals('Applied', data.get('requestStatus'),
+                'request applied since only one required row');
+        }
+    }
+
+    /**
+     * @description POST /feature-toggle-approvals/{id}/reject flips the
+     *              approval Rejected and the request Rejected.
+     */
+    @IsTest
+    static void testPostFeatureApprovalReject() {
+        System.runAs(testUser) {
+            Feature__c feat = TestDataFactory.createFeature(new Map<String, Object>{
+                'EnabledDateTime__c' => null,
+                'DisabledDateTime__c' => Datetime.now()
+            });
+            Id requestId = DeliveryFeatureApprovalService.submit(feat.Id, 'Enable', null);
+            FeatureToggleApproval__c approval = [
+                SELECT Id FROM FeatureToggleApproval__c WHERE RequestLookup__c = :requestId LIMIT 1
+            ];
+
+            Map<String, Object> body = new Map<String, Object>{ 'note' => 'risky' };
+            RestRequest req = buildPostRequest(
+                '/services/apexrest/delivery/deliveryhub/v1/api/feature-toggle-approvals/' + approval.Id + '/reject',
+                body
+            );
+            req.addHeader('X-Api-Key', TEST_API_KEY);
+            RestResponse res = new RestResponse();
+            RestContext.request = req;
+            RestContext.response = res;
+
+            Test.startTest();
+            DeliveryPublicApiService.handlePost();
+            Test.stopTest();
+
+            System.assertEquals(200, res.statusCode, 'should return 200');
+            Map<String, Object> responseBody = parseResponse(res);
+            Map<String, Object> data = (Map<String, Object>) responseBody.get('data');
+            System.assertEquals('Rejected', data.get('status'), 'approval rejected');
+            System.assertEquals('Rejected', data.get('requestStatus'),
+                'request marked Rejected on single dissent');
+        }
+    }
 }

--- a/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.html
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.html
@@ -29,7 +29,7 @@
                                     <div class="slds-m-top_xx-small">
                                         <span class={row.actionBadgeClass}>{row.action}</span>
                                         <span class="slds-m-left_x-small slds-text-body_small slds-text-color_weak">
-                                            Step {row.stepNumber} · requested by {row.requestedByName}
+                                            Step {row.stepNumber} &middot; requested by {row.requestedByName}
                                         </span>
                                     </div>
                                 </div>
@@ -74,6 +74,16 @@
                                         onclick={handleReject}>
                                     </lightning-button>
                                 </div>
+                                <div class="slds-col slds-text-align_right">
+                                    <lightning-button
+                                        variant="neutral"
+                                        label="Show chain"
+                                        icon-name="utility:hierarchy"
+                                        data-request-id={row.requestId}
+                                        data-feature-label={row.featureLabel}
+                                        onclick={handleShowChain}>
+                                    </lightning-button>
+                                </div>
                             </div>
                         </li>
                     </template>
@@ -81,4 +91,69 @@
             </template>
         </div>
     </lightning-card>
+
+    <template lwc:if={chainModalOpen}>
+        <section role="dialog" tabindex="-1" aria-modal="true"
+                 aria-labelledby="approval-chain-modal-title"
+                 class="slds-modal slds-fade-in-open">
+            <div class="slds-modal__container">
+                <header class="slds-modal__header">
+                    <button class="slds-button slds-button_icon slds-modal__close slds-button_icon-inverse"
+                            title="Close" onclick={handleCloseChain}>
+                        <lightning-icon icon-name="utility:close" alternative-text="Close" size="small" variant="inverse"></lightning-icon>
+                        <span class="slds-assistive-text">Close</span>
+                    </button>
+                    <h2 id="approval-chain-modal-title" class="slds-modal__title slds-hyphenate">
+                        Approval chain &middot; {chainRequestLabel}
+                    </h2>
+                </header>
+                <div class="slds-modal__content slds-p-around_medium">
+                    <template lwc:if={chainLoading}>
+                        <div class="slds-text-color_weak">Loading chain&hellip;</div>
+                    </template>
+                    <template lwc:if={chainHasError}>
+                        <div class="slds-text-color_error">{chainError}</div>
+                    </template>
+                    <template lwc:if={hasChainRows}>
+                        <ul class="slds-has-dividers_around-space">
+                            <template for:each={chainRows} for:item="node">
+                                <li key={node.key} class="slds-item slds-p-around_small">
+                                    <div class="slds-grid slds-grid_align-spread">
+                                        <div class="slds-col">
+                                            <div class="slds-text-heading_small">
+                                                {node.stepLabel} &middot; {node.featureLabel}
+                                            </div>
+                                            <div class="slds-m-top_xx-small slds-text-body_small slds-text-color_weak">
+                                                <span class={node.statusBadgeClass}>{node.status}</span>
+                                                <span class="slds-m-left_x-small">{node.requiredLabel}</span>
+                                                <span class="slds-m-left_x-small">Approver: {node.approverUserName}</span>
+                                            </div>
+                                        </div>
+                                        <div class="slds-col slds-text-align_right slds-text-body_small slds-text-color_weak">
+                                            <template lwc:if={node.decisionDateTime}>
+                                                <lightning-formatted-date-time
+                                                    value={node.decisionDateTime}
+                                                    year="numeric" month="short" day="2-digit"
+                                                    hour="2-digit" minute="2-digit">
+                                                </lightning-formatted-date-time>
+                                            </template>
+                                        </div>
+                                    </div>
+                                    <template lwc:if={node.hasDecisionNote}>
+                                        <div class="slds-m-top_x-small slds-text-body_small">
+                                            <strong>Note:</strong> {node.decisionNote}
+                                        </div>
+                                    </template>
+                                </li>
+                            </template>
+                        </ul>
+                    </template>
+                </div>
+                <footer class="slds-modal__footer">
+                    <lightning-button label="Close" onclick={handleCloseChain}></lightning-button>
+                </footer>
+            </div>
+        </section>
+        <div class="slds-backdrop slds-backdrop_open"></div>
+    </template>
 </template>

--- a/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.js
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.js
@@ -4,8 +4,9 @@
  * @description  Approval inbox card for the Feature Cockpit (Layer 5).
  *               Lists Pending FeatureToggleApproval__c rows assigned to the
  *               running user, with inline Approve / Reject buttons + an
- *               optional decision-note field. PR 7 — single-step only.
- *               PR 8 will widen to multi-step chains + REST.
+ *               optional decision-note field. PR 8 added the multi-step
+ *               cascade approval chain — each row exposes a "Show chain"
+ *               button that opens a modal listing every step on the request.
  * @author Cloud Nimbus LLC
  */
 import { LightningElement, wire, track } from 'lwc';
@@ -14,16 +15,29 @@ import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import getInbox from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.getInbox';
 import grantApex from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.grant';
 import rejectApex from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.reject';
+import getApprovalChain from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.getApprovalChain';
 
 const REASON_TRUNCATE_AT = 160,
     ELLIPSIS = '…',
     EMPTY = 0;
+
+const STATUS_BADGE_CLASS = {
+    Approved: 'slds-badge slds-theme_success',
+    Auto: 'slds-badge slds-theme_success',
+    Rejected: 'slds-badge slds-theme_error',
+    Pending: 'slds-badge slds-theme_warning'
+};
 
 export default class DeliveryFeatureApprovalInbox extends LightningElement {
     @track rows = [];
     @track errorMessage = '';
     @track isLoaded = false;
     @track noteByApproval = {};
+    @track chainModalOpen = false;
+    @track chainRows = [];
+    @track chainError = '';
+    @track chainLoading = false;
+    @track chainRequestLabel = '';
 
     wiredResult;
 
@@ -82,6 +96,14 @@ export default class DeliveryFeatureApprovalInbox extends LightningElement {
         return this.errorMessage.length > EMPTY;
     }
 
+    get hasChainRows() {
+        return this.chainRows.length > EMPTY;
+    }
+
+    get chainHasError() {
+        return this.chainError.length > EMPTY;
+    }
+
     handleRefresh() {
         if (this.wiredResult) {
             refreshApex(this.wiredResult);
@@ -119,6 +141,59 @@ export default class DeliveryFeatureApprovalInbox extends LightningElement {
         rejectApex({ approvalId, note })
             .then(() => this.onDecisionSuccess('Rejected', approvalId))
             .catch(err => this.onDecisionError('reject', err));
+    }
+
+    handleShowChain(event) {
+        const requestId = event.currentTarget.dataset.requestId;
+        const featureLabel = event.currentTarget.dataset.featureLabel || '';
+        if (!requestId) {
+            return;
+        }
+        this.chainModalOpen = true;
+        this.chainRows = [];
+        this.chainError = '';
+        this.chainLoading = true;
+        this.chainRequestLabel = featureLabel;
+        getApprovalChain({ requestId })
+            .then(data => {
+                this.chainRows = (data || []).map((n, idx) => this.shapeChainNode(n, idx));
+                this.chainLoading = false;
+            })
+            .catch(err => {
+                this.chainError = (err && err.body && err.body.message)
+                    ? err.body.message
+                    : 'Unable to load approval chain.';
+                this.chainLoading = false;
+            });
+    }
+
+    shapeChainNode(n, idx) {
+        const status = n.status || 'Pending';
+        const stepNumber = n.stepNumber === undefined || n.stepNumber === null
+            ? idx
+            : n.stepNumber;
+        return {
+            key: n.approvalId || `chain-${idx}`,
+            approvalId: n.approvalId,
+            featureLabel: n.featureLabel || '(unnamed)',
+            stepNumber,
+            stepLabel: stepNumber === 0 ? 'Root' : `Step ${stepNumber}`,
+            status,
+            statusBadgeClass: STATUS_BADGE_CLASS[status] || 'slds-badge',
+            requiredBoolean: n.requiredBoolean === true,
+            requiredLabel: n.requiredBoolean === true ? 'Required' : 'Optional',
+            approverUserName: n.approverUserName || '—',
+            decisionDateTime: n.decisionDateTime,
+            decisionNote: n.decisionNote || '',
+            hasDecisionNote: !!(n.decisionNote && n.decisionNote.length)
+        };
+    }
+
+    handleCloseChain() {
+        this.chainModalOpen = false;
+        this.chainRows = [];
+        this.chainError = '';
+        this.chainRequestLabel = '';
     }
 
     onDecisionSuccess(label, approvalId) {


### PR DESCRIPTION
## Summary

PR 8 of the Delivery Hub Cockpit plan (~6h scope). Builds on PR 7's single-step approval framework to make the chain cascade-aware, and exposes the surface via REST for the external onboarding portal.

- **Multi-step approval generation**: ``DeliveryFeatureApprovalService.submit()`` now walks the cascade graph (BFS via ``DeliveryFeatureGraphService.computeCascade``) and inserts one ``FeatureToggleApproval__c`` per non-Optional cascade node, plus a Step=0 root sign-off row. Hard edges get ``RequiredDateTime__c=now`` (blocking); Soft edges leave it null (auto-marked ``Status='Auto'`` at apply time).
- **Apply gating**: ``applyIfFullyGranted()`` now considers only required rows. When all required rows are Approved or Auto, it flips the feature, sweeps non-required rows to ``Auto``, stamps the request ``Applied``, and writes an ``ActivityLog__c`` row. The existing ``DeliveryActivityLogTrigger`` contributes the SHA-256 hash chain via ``DeliveryAuditChainService.setHashOnInsert``.
- **Chain introspection**: new ``@AuraEnabled(cacheable=true) getApprovalChain(requestId)`` returns ordered ``ApprovalChainNodeDTO`` entries (StepNumber + DecisionDateTime sort) for LWC + REST surfaces.
- **REST routes** (X-Api-Key authenticated, org-wide not entity-scoped):
  - ``POST /features/{name}/toggle`` — body ``{action, reason}``
  - ``GET /feature-toggle-requests?status=&feature=&pageOffset=``
  - ``POST /feature-toggle-approvals/{id}/grant`` — body ``{note}``
  - ``POST /feature-toggle-approvals/{id}/reject`` — body ``{note}``
- **LWC**: ``deliveryFeatureApprovalInbox`` grows a "Show chain" button per row that opens a modal listing every step with status badges, required/optional flag, approver name, decision time, and decision note.

## What's NOT in this PR (deferred)

- Automatic approver resolution (``ApproverUserLookup__c`` left null at submit; admins assign out-of-band).
- Cross-org cascade.
- No schema changes — ``FeatureToggleRequest__c``, ``FeatureToggleApproval__c``, and the supporting GVS all shipped in PR 7.
- ``DeliveryFeatureCatalogController.toggleFeature()`` (admin-direct path) is untouched.

## Test plan

- [ ] Apex tests pass: ``DeliveryFeatureApprovalServiceTest`` (4 new tests for multi-step shape, required gating, Soft auto-mark, getApprovalChain ordering, + Optional skip) and ``DeliveryPublicApiServiceTest`` (5 new tests covering 4 REST routes).
- [ ] PMD ``apex-scan`` clean (class-level ``@SuppressWarnings`` covers ApexCRUDViolation + cyclomatic + ExcessivePublicCount).
- [ ] LWC scan clean (no template ternaries; uses getters + JS-side shape).
- [ ] ``upload-beta`` green.
- [ ] Manual smoke (post-promote): seed a Feature__c with a 2-level Hard dependency chain, ``curl POST /features/{name}/toggle`` with API key → returns 201 + requestId → assign approvers via record page → grant the leaf → request stays Pending → grant root → flips Applied + audit row visible. Verify ``DeliveryAuditChainService.validateChainForRecord(featureId)`` returns ``passed=true``.

## Key files

- ``force-app/main/default/classes/DeliveryFeatureApprovalService.cls`` (refactored — flatten BFS, cascade row builder, required-gate, getApprovalChain)
- ``force-app/main/default/classes/DeliveryFeatureApprovalServiceTest.cls`` (+5 tests)
- ``force-app/main/default/classes/DeliveryPublicApiService.cls`` (+4 routes via ``routePostFeatureCockpit`` + GET extended)
- ``force-app/main/default/classes/DeliveryPublicApiServiceTest.cls`` (+5 tests)
- ``force-app/main/default/lwc/deliveryFeatureApprovalInbox/*`` (Show chain modal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)