### PR TITLE
feat(watcher): PR-A — WatcherDigest__c schema + DeliveryHubSettings__c fields (Phase 2 Watcher v1)

### DIFF
--- a/force-app/main/default/globalValueSets/WatcherDigestRunMode.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/WatcherDigestRunMode.globalValueSet-meta.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Run-mode classification for WatcherDigest__c rows. Scheduled = produced by the daily cron tick. Manual = invoked ad-hoc by an admin (Glen-triggered replay or smoke test). Test = produced inside an @IsTest context so reporting can filter it out of production trend data.</description>
+    <masterLabel>Watcher Digest Run Mode</masterLabel>
+    <sorted>false</sorted>
+    <customValue>
+        <fullName>Scheduled</fullName>
+        <default>true</default>
+        <label>Scheduled</label>
+    </customValue>
+    <customValue>
+        <fullName>Manual</fullName>
+        <default>false</default>
+        <label>Manual</label>
+    </customValue>
+    <customValue>
+        <fullName>Test</fullName>
+        <default>false</default>
+        <label>Test</label>
+    </customValue>
+</GlobalValueSet>

--- a/force-app/main/default/globalValueSets/WatcherDigestStatus.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/WatcherDigestStatus.globalValueSet-meta.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Outcome status for a WatcherDigest__c run. Success = every enabled signal returned cleanly. Partial = at least one signal threw but the orchestrator caught and continued. Failed = the orchestrator itself errored before any signal ran.</description>
+    <masterLabel>Watcher Digest Status</masterLabel>
+    <sorted>false</sorted>
+    <customValue>
+        <fullName>Success</fullName>
+        <default>true</default>
+        <label>Success</label>
+    </customValue>
+    <customValue>
+        <fullName>Partial</fullName>
+        <default>false</default>
+        <label>Partial</label>
+    </customValue>
+    <customValue>
+        <fullName>Failed</fullName>
+        <default>false</default>
+        <label>Failed</label>
+    </customValue>
+</GlobalValueSet>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherARAgingDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherARAgingDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnableWatcherARAgingDateTime__c</fullName>
+    <description>Per-signal gate for Signal 3 (overdue invoices aged past WatcherARAgingMinDaysOverdueNumber__c, grouped by 1-7/8-14/15-30/30+ aging bands). When non-null AND master gate is non-null, WatcherARAgingQueryService runs on each digest tick. PR-B's install handler sets this on install for top-3 implemented signals.</description>
+    <externalId>false</externalId>
+    <label>Enable Watcher AR Aging Signal</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherDigestDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherDigestDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnableWatcherDigestDateTime__c</fullName>
+    <description>Master opt-in for the Phase 2 Watcher digest. When non-null, the daily DeliveryHubScheduler.enqueueWatcherDigestIfDue tick is active. Null = entire Watcher silent (no DML, no callout, no WatcherDigest__c row). Defaults to null on install — Glen flips it on his org to activate. Subscriber orgs see Watcher silent until they set this field.</description>
+    <externalId>false</externalId>
+    <label>Enable Watcher Digest</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherPaymentOpsDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherPaymentOpsDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnableWatcherPaymentOpsDateTime__c</fullName>
+    <description>Per-signal gate for Stub C (payment-ops edge cases the AR-aging signal does not cover — DeliveryTransaction__c dispute reasons, refund windows opening, Stripe webhook anomalies). Defaults to null — stub returns empty list until the DeliveryTransaction__c surface is fully wired across all orgs.</description>
+    <externalId>false</externalId>
+    <label>Enable Watcher Payment Ops Signal (Stub)</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherSLABreachDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherSLABreachDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnableWatcherSLABreachDateTime__c</fullName>
+    <description>Per-signal gate for Signal 1 (SLA breach + at-risk WIs). When non-null AND the master EnableWatcherDigestDateTime__c is non-null, WatcherSLABreachQueryService runs on each digest tick. PR-B's install handler sets this on install for top-3 implemented signals.</description>
+    <externalId>false</externalId>
+    <label>Enable Watcher SLA Breach Signal</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherSignoffDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherSignoffDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnableWatcherSignoffDateTime__c</fullName>
+    <description>Per-signal gate for Stub B (DeliveryDocuments awaiting signatures past RequireSigningDateTime__c without ViewedDateTime__c; or WIs entering signoff-required stages). Defaults to null — stub returns empty list until the signoff workflow data shape stabilizes.</description>
+    <externalId>false</externalId>
+    <label>Enable Watcher Signoff Signal (Stub)</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherStuckStageDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherStuckStageDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnableWatcherStuckStageDateTime__c</fullName>
+    <description>Per-signal gate for Signal 2 (WIs idle in current stage past WorkflowEscalationRule__mdt threshold, with WatcherStuckStageDefaultDaysNumber__c fallback). When non-null AND master gate is non-null, WatcherStuckStageQueryService runs on each digest tick. PR-B's install handler sets this on install for top-3 implemented signals.</description>
+    <externalId>false</externalId>
+    <label>Enable Watcher Stuck Stage Signal</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherSyncTrendDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherSyncTrendDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnableWatcherSyncTrendDateTime__c</fullName>
+    <description>Per-signal gate for Stub D (rolling 7-day trend of SyncItem__c.StatusPk__c=Failed rows that did NOT auto-recover, compared against prior 7 days). Defaults to null — stub returns empty list until 14-21 days of reconciler data exist to baseline what normal failure rate looks like.</description>
+    <externalId>false</externalId>
+    <label>Enable Watcher Sync Trend Signal (Stub)</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherUnhappySignalDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableWatcherUnhappySignalDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnableWatcherUnhappySignalDateTime__c</fullName>
+    <description>Per-signal gate for Stub A (WIs whose WorkItemComment__c sentiment trend has tipped negative). Defaults to null — stub returns empty list until NLP classifier is built and baselined. Flip to non-null only after the stub class is replaced with a real implementation.</description>
+    <externalId>false</externalId>
+    <label>Enable Watcher Unhappy Signal (Stub)</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/LastWatcherHeartbeatDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/LastWatcherHeartbeatDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>LastWatcherHeartbeatDateTime__c</fullName>
+    <description>Stamped on each successful Watcher run (including quiet days). Mirrors the LastForecastAlertScanDate__c heartbeat pattern. Lets the 14-day stabilization gate verify the cron actually ran every day — independent of whether there was anything to say. Empty until PR-B's orchestrator is wired and the first run completes.</description>
+    <externalId>false</externalId>
+    <label>Last Watcher Heartbeat</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/WatcherARAgingMinDaysOverdueNumber__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/WatcherARAgingMinDaysOverdueNumber__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>WatcherARAgingMinDaysOverdueNumber__c</fullName>
+    <description>Minimum days-overdue before an invoice is included in the Watcher AR-aging signal. Default 7. Avoids overlap with the client-facing OverdueReminderScheduleTxt__c reminder #1 (which fires at 1 day overdue). Glen's digest only surfaces invoices that have already had at least one client-side reminder.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Days. Default 7. Invoices less than this many days overdue do not appear in the Watcher digest.</inlineHelpText>
+    <label>Watcher AR Aging Min Days Overdue</label>
+    <precision>3</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/WatcherDigestRecipientUserIdsTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/WatcherDigestRecipientUserIdsTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>WatcherDigestRecipientUserIdsTxt__c</fullName>
+    <description>Comma-separated User IDs who receive the Watcher digest. v1 = Glen's User ID only. v2 = settings-change-only to add Mahi or other recipients. Defaults to null on install. PR-B's install handler populates Glen's User ID only when running in his org (Org ID match against a known-Glen-orgs check). Subscriber orgs see Watcher silent until this is set.</description>
+    <inlineHelpText>Comma-separated Salesforce User IDs. Blank = Watcher writes its audit record but does not Slack-post.</inlineHelpText>
+    <label>Watcher Digest Recipient User IDs</label>
+    <length>1300</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/WatcherDigestRecipientUserIdsTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/WatcherDigestRecipientUserIdsTxt__c.field-meta.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>WatcherDigestRecipientUserIdsTxt__c</fullName>
-    <description>Comma-separated User IDs who receive the Watcher digest. v1 = Glen's User ID only. v2 = settings-change-only to add Mahi or other recipients. Defaults to null on install. PR-B's install handler populates Glen's User ID only when running in his org (Org ID match against a known-Glen-orgs check). Subscriber orgs see Watcher silent until this is set.</description>
+    <description>Comma-separated User IDs who receive the Watcher digest. v1 = Glen's User ID only. v2 = settings-change-only to add Mahi or other recipients. Defaults to null on install. PR-B's install handler populates Glen's User ID only when running in his org. Custom Settings only support primitive types — Text(255) holds ~13 18-char User IDs, more than enough for v1+v2.</description>
     <inlineHelpText>Comma-separated Salesforce User IDs. Blank = Watcher writes its audit record but does not Slack-post.</inlineHelpText>
     <label>Watcher Digest Recipient User IDs</label>
-    <length>1300</length>
+    <length>255</length>
     <required>false</required>
     <trackTrending>false</trackTrending>
-    <type>LongTextArea</type>
-    <visibleLines>3</visibleLines>
+    <type>Text</type>
+    <unique>false</unique>
 </CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/WatcherDigestRunHourGmtNumber__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/WatcherDigestRunHourGmtNumber__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>WatcherDigestRunHourGmtNumber__c</fullName>
+    <description>GMT hour at which the daily Watcher digest tick fires. Default 12 GMT = 8am ET / 5am PT / 1pm UTC+1 — brackets Glen's morning standup window. PR-B's enqueueWatcherDigestIfDue gates on this value. Tunable per org.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>0-23. Default 12 GMT = 8am ET.</inlineHelpText>
+    <label>Watcher Digest Run Hour (GMT)</label>
+    <precision>2</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/WatcherDigestSlackChannelTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/WatcherDigestSlackChannelTxt__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>WatcherDigestSlackChannelTxt__c</fullName>
+    <description>Optional Slack channel override for the Watcher digest (Block Kit channel field). When blank, defaults to the channel the configured SlackWebhookUrlTxt__c webhook lands in. Avoids forcing operators to configure a second webhook just to redirect Watcher output.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Slack channel name (with or without leading #). Blank = use the default channel of SlackWebhookUrlTxt__c.</inlineHelpText>
+    <label>Watcher Digest Slack Channel</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/WatcherStuckStageDefaultDaysNumber__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/WatcherStuckStageDefaultDaysNumber__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>WatcherStuckStageDefaultDaysNumber__c</fullName>
+    <description>Fallback days-in-stage threshold for the Watcher stuck-stage signal when no WorkflowEscalationRule__mdt row covers a given stage. Default 5. PR-C's WatcherStuckStageQueryService reads CMT rules first, then applies this fallback to stages with no rule.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Days. Default 5. Used only when WorkflowEscalationRule__mdt has no rule for the WI's current stage.</inlineHelpText>
+    <label>Watcher Stuck Stage Default (Days)</label>
+    <precision>3</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/WatcherDigest__c/WatcherDigest__c.object-meta.xml
+++ b/force-app/main/default/objects/WatcherDigest__c/WatcherDigest__c.object-meta.xml
@@ -9,7 +9,7 @@
     <enableReports>true</enableReports>
     <enableSearch>false</enableSearch>
     <enableSharing>true</enableSharing>
-    <enableStreamingApi>false</enableStreamingApi>
+    <enableStreamingApi>true</enableStreamingApi>
     <externalSharingModel>Private</externalSharingModel>
     <label>Watcher Digest</label>
     <nameField>

--- a/force-app/main/default/objects/WatcherDigest__c/WatcherDigest__c.object-meta.xml
+++ b/force-app/main/default/objects/WatcherDigest__c/WatcherDigest__c.object-meta.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <deploymentStatus>Deployed</deploymentStatus>
+    <description>Phase 2 Watcher v1 audit trail. One record per scheduled (or manual) Watcher run. Captures what signals fired, who was notified, and how long the run took. Trend-analysis source for the 14-day stabilization gate that precedes Phase 3 auto-digest. PR-A is pure scaffold (no Apex writes yet); PR-B wires DeliveryWatcherService to persist these rows.</description>
+    <enableActivities>false</enableActivities>
+    <enableBulkApi>true</enableBulkApi>
+    <enableFeeds>false</enableFeeds>
+    <enableHistory>false</enableHistory>
+    <enableReports>true</enableReports>
+    <enableSearch>false</enableSearch>
+    <enableSharing>true</enableSharing>
+    <enableStreamingApi>false</enableStreamingApi>
+    <externalSharingModel>Private</externalSharingModel>
+    <label>Watcher Digest</label>
+    <nameField>
+        <displayFormat>WD-{0000}</displayFormat>
+        <label>Watcher Digest Number</label>
+        <type>AutoNumber</type>
+    </nameField>
+    <pluralLabel>Watcher Digests</pluralLabel>
+    <sharingModel>ReadWrite</sharingModel>
+</CustomObject>

--- a/force-app/main/default/objects/WatcherDigest__c/fields/DigestBodyTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/WatcherDigest__c/fields/DigestBodyTxt__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DigestBodyTxt__c</fullName>
+    <description>The full markdown/plaintext body of the digest that was (or would have been) posted to Slack. Stored for audit replay — lets us reconstruct exactly what Glen saw on a given day even if Slack history rolls off. NOTE: design memo proposed DigestTextLong__c; renamed to DigestBodyTxt__c per docs/FIELD_NAMING.md (LongTextArea uses the Txt suffix, not Long).</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Plaintext fallback of the Slack Block Kit message posted for this run. Empty on quiet days.</inlineHelpText>
+    <label>Digest Body</label>
+    <length>32768</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>10</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/WatcherDigest__c/fields/ErrorMessageTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/WatcherDigest__c/fields/ErrorMessageTxt__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ErrorMessageTxt__c</fullName>
+    <description>Populated when StatusPk__c is Partial or Failed. Holds the exception message + stack trace from the failing signal(s) or orchestrator. Same shape as SyncItem__c.ErrorLogTxt__c. Empty on Success runs.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Exception details when a signal failed or the orchestrator errored.</inlineHelpText>
+    <label>Error Message</label>
+    <length>4096</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/WatcherDigest__c/fields/FlaggedDocumentIdsTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/WatcherDigest__c/fields/FlaggedDocumentIdsTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>FlaggedDocumentIdsTxt__c</fullName>
+    <description>Comma-separated DeliveryDocument__c IDs flagged by the AR-aging signal (or any future doc-centric signal). Mirrors FlaggedWorkItemIdsTxt__c shape for trend joins. A/R history at a glance: which invoices showed up day-over-day in the digest.</description>
+    <externalId>false</externalId>
+    <label>Flagged Document IDs</label>
+    <length>4096</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/WatcherDigest__c/fields/FlaggedWorkItemIdsTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/WatcherDigest__c/fields/FlaggedWorkItemIdsTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>FlaggedWorkItemIdsTxt__c</fullName>
+    <description>Comma-separated WorkItem__c IDs that any signal flagged in this run. Lets us answer "the WI Glen flagged 7 days ago — has it moved?" by joining WatcherDigest history to current WorkItem state. Capped at 4096 chars (LongTextArea) which accommodates ~220 IDs — well above the per-run signal caps.</description>
+    <externalId>false</externalId>
+    <label>Flagged Work Item IDs</label>
+    <length>4096</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/WatcherDigest__c/fields/RecipientUserIdsTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/WatcherDigest__c/fields/RecipientUserIdsTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RecipientUserIdsTxt__c</fullName>
+    <description>Snapshot of who was on the recipient list at this run (mirrors DeliveryHubSettings__c.WatcherDigestRecipientUserIdsTxt__c at run time). Comma-separated User IDs. Lets us audit Glen-to-Mahi expansion: when did Mahi start receiving the digest?</description>
+    <externalId>false</externalId>
+    <label>Recipient User IDs</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/WatcherDigest__c/fields/RunDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/WatcherDigest__c/fields/RunDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RunDateTime__c</fullName>
+    <description>When the Watcher run started. Required. Used to anchor trend analysis (one row per day expected from the scheduled cron). PR-B's orchestrator stamps this at run start before the first signal query fires.</description>
+    <externalId>false</externalId>
+    <label>Run Date Time</label>
+    <required>true</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/WatcherDigest__c/fields/RunDurationMsNumber__c.field-meta.xml
+++ b/force-app/main/default/objects/WatcherDigest__c/fields/RunDurationMsNumber__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RunDurationMsNumber__c</fullName>
+    <description>How long the Watcher run took in milliseconds. Trend metric — when this climbs steadily, query inefficiency is creeping in (a signal class is fanning out per-WI or pulling too wide a window). Captured by PR-B's orchestrator via System.currentTimeMillis() delta.</description>
+    <externalId>false</externalId>
+    <label>Run Duration (ms)</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/WatcherDigest__c/fields/RunModePk__c.field-meta.xml
+++ b/force-app/main/default/objects/WatcherDigest__c/fields/RunModePk__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RunModePk__c</fullName>
+    <description>Distinguishes scheduled cron runs from Glen-triggered ad-hoc runs and test-context runs. Backed by the WatcherDigestRunMode global value set. Lets reporting filter out Test rows from production trend data.</description>
+    <inlineHelpText>Scheduled = daily cron. Manual = ad-hoc invocation. Test = inside an @IsTest context.</inlineHelpText>
+    <label>Run Mode</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetName>WatcherDigestRunMode</valueSetName>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/WatcherDigest__c/fields/SignalCountsTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/WatcherDigest__c/fields/SignalCountsTxt__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>SignalCountsTxt__c</fullName>
+    <description>Compact per-signal hit summary, e.g. SLA:3,Stuck:1,AR:2,UnhappyStub:0,SignoffStub:0,PaymentStub:0,SyncTrendStub:0. Lets reports + dashboards trend signal volume over time without parsing DigestBodyTxt__c.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Compact per-signal hit counts, comma-separated.</inlineHelpText>
+    <label>Signal Counts</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/WatcherDigest__c/fields/StatusPk__c.field-meta.xml
+++ b/force-app/main/default/objects/WatcherDigest__c/fields/StatusPk__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>StatusPk__c</fullName>
+    <description>Outcome of the run. Success = every enabled signal returned cleanly. Partial = at least one signal raised an exception but the run continued (details in ErrorMessageTxt__c). Failed = the orchestrator itself failed before any signal could run. Backed by the WatcherDigestStatus global value set per the CLAUDE.md GVS-from-day-one rule.</description>
+    <inlineHelpText>Success / Partial / Failed. Partial means at least one signal raised an exception; the run completed and other signals fired.</inlineHelpText>
+    <label>Status</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetName>WatcherDigestStatus</valueSetName>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
@@ -1101,6 +1101,51 @@
         <field>DeliveryHubSettings__c.DefaultRetentionDaysNumber__c</field>
         <readable>true</readable>
     </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>WatcherDigest__c.DigestBodyTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>WatcherDigest__c.ErrorMessageTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>WatcherDigest__c.FlaggedDocumentIdsTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>WatcherDigest__c.FlaggedWorkItemIdsTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>WatcherDigest__c.RecipientUserIdsTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>WatcherDigest__c.RunDurationMsNumber__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>WatcherDigest__c.RunModePk__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>WatcherDigest__c.SignalCountsTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>WatcherDigest__c.StatusPk__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
     <label>Delivery Hub Admin App</label>
     <objectPermissions>
@@ -1308,6 +1353,15 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>true</modifyAllRecords>
         <object>PortalAccess__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>true</allowCreate>
+        <allowDelete>true</allowDelete>
+        <allowEdit>true</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>true</modifyAllRecords>
+        <object>WatcherDigest__c</object>
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
     <tabSettings>

--- a/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
@@ -1090,6 +1090,51 @@
         <field>DeliveryHubSettings__c.DefaultRetentionDaysNumber__c</field>
         <readable>true</readable>
     </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>WatcherDigest__c.DigestBodyTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>WatcherDigest__c.ErrorMessageTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>WatcherDigest__c.FlaggedDocumentIdsTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>WatcherDigest__c.FlaggedWorkItemIdsTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>WatcherDigest__c.RecipientUserIdsTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>WatcherDigest__c.RunDurationMsNumber__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>WatcherDigest__c.RunModePk__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>WatcherDigest__c.SignalCountsTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>WatcherDigest__c.StatusPk__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
     <label>Delivery Hub App</label>
     <objectPermissions>
@@ -1315,6 +1360,15 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>PortalAccess__c</object>
+        <viewAllRecords>false</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>false</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>WatcherDigest__c</object>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>
     <tabSettings>


### PR DESCRIPTION
## Summary

Pure metadata scaffold for the [Phase 2 Watcher v1](../blob/feat/watcher-v1-schema/docs/plans/phase-2-watcher-design.md) — the daily Slack digest that aggregates SLA-breach + stuck-stage + AR-aging signals into a Glen-only DM. **Zero Apex, zero behavior change** in subscriber orgs until PR-B wires the orchestrator.

First of three Watcher PRs:
- **PR-A (this PR, ~2.5h)** — Schema scaffold only.
- PR-B (~7h) — `DeliveryWatcherService` orchestrator + `WatcherSLABreachQueryService` + 4 stub classes + Slack post + scheduler tick.
- PR-C (~4.5h) — Signals 2 (stuck-stage) + 3 (AR-aging).

## Scope checklist

### New custom object
- [x] `WatcherDigest__c` (AutoNumber `WD-{0000}`, Private external sharing, ReadWrite internal, reports enabled, history/feeds/search off)

### 10 fields on `WatcherDigest__c`
- [x] `RunDateTime__c` (DateTime, required)
- [x] `RunDurationMsNumber__c` (Number 18,0)
- [x] `StatusPk__c` (Picklist, GVS `WatcherDigestStatus`)
- [x] `DigestBodyTxt__c` (LongTextArea 32768) — **renamed from `DigestTextLong__c` per [FIELD_NAMING.md](../blob/feat/watcher-v1-schema/docs/FIELD_NAMING.md)** — LongTextArea uses the `Txt__c` suffix, not `Long__c`
- [x] `SignalCountsTxt__c` (Text 255)
- [x] `FlaggedWorkItemIdsTxt__c` (LongTextArea 4096)
- [x] `FlaggedDocumentIdsTxt__c` (LongTextArea 4096)
- [x] `ErrorMessageTxt__c` (LongTextArea 4096)
- [x] `RecipientUserIdsTxt__c` (Text 255)
- [x] `RunModePk__c` (Picklist, GVS `WatcherDigestRunMode`)

### 2 new GlobalValueSets
- [x] `WatcherDigestStatus` (Success default, Partial, Failed)
- [x] `WatcherDigestRunMode` (Scheduled default, Manual, Test)

### 14 fields on `DeliveryHubSettings__c`
- [x] `EnableWatcherDigestDateTime__c` (master gate)
- [x] `EnableWatcherSLABreachDateTime__c` (Signal 1 gate)
- [x] `EnableWatcherStuckStageDateTime__c` (Signal 2 gate)
- [x] `EnableWatcherARAgingDateTime__c` (Signal 3 gate)
- [x] `EnableWatcherUnhappySignalDateTime__c` (Stub A gate)
- [x] `EnableWatcherSignoffDateTime__c` (Stub B gate)
- [x] `EnableWatcherPaymentOpsDateTime__c` (Stub C gate)
- [x] `EnableWatcherSyncTrendDateTime__c` (Stub D gate)
- [x] `WatcherDigestSlackChannelTxt__c` (Text 255)
- [x] `WatcherDigestRecipientUserIdsTxt__c` (LongTextArea 1300)
- [x] `WatcherDigestRunHourGmtNumber__c` (Number 2,0 — default 12 GMT set by PR-B install handler)
- [x] `LastWatcherHeartbeatDateTime__c` (DateTime)
- [x] `WatcherStuckStageDefaultDaysNumber__c` (Number 3,0 — default 5 set by PR-B install handler)
- [x] `WatcherARAgingMinDaysOverdueNumber__c` (Number 3,0 — default 7 set by PR-B install handler)

All Enable* gates are DateTime per the `[[no-booleans]]` rule; tuning fields are Number-typed (integers, not feature flags). No defaults wired in PR-A — PR-B's install handler sets the top-3 Enable* gates on install for orgs running in admin mode.

### Permset updates
- [x] `DeliveryHubApp.permissionset-meta.xml`: read-only on `WatcherDigest__c` object + 9 non-required fields (skipped `RunDateTime__c` which is `<required>true</required>`)
- [x] `DeliveryHubAdmin_App.permissionset-meta.xml`: full CRUD on `WatcherDigest__c` + edit on 9 non-required fields

`DeliveryHubSettings__c` fields intentionally have no permset entries — the existing `Enable*DateTime__c` fields (`EnableForecastAlertsDateTime__c`, `EnableWeeklyDigestDateTime__c`, etc.) have no permset entries either; SF treats Custom Settings as global-readable.

## Deviations from the design memo

1. **`DigestTextLong__c` → `DigestBodyTxt__c`** — design memo proposed `DigestTextLong__c`; renamed per `docs/FIELD_NAMING.md` which mandates `Txt__c` for LongTextArea, not `Long__c`. Capacity unchanged (32768 chars). PR-B's formatter writes the plaintext fallback to this field.
2. **GVS-from-day-one preserved** — both new picklist fields (`StatusPk__c`, `RunModePk__c`) reference the new global value sets per the CLAUDE.md rule. No inline `<valueSetDefinition>`.
3. **No install handler changes in PR-A** — design memo said per-signal toggles default to set-on-install for the top 3, but PR-A is metadata-only. PR-B's install handler will stamp `EnableWatcherSLABreachDateTime__c` / `EnableWatcherStuckStageDateTime__c` / `EnableWatcherARAgingDateTime__c` + the tuning fields with their defaults at first run.

## Pre-push validation

- [x] Python `xml.etree.ElementTree.parse()` on all 27 new XML files + both modified permsets: 29/29 OK
- [x] No unescaped `<` inside `<description>` / `<inlineHelpText>` content
- [x] No `Txt`/etc. suffix on URL/Email/Phone fields (none in this PR but checked)
- [x] Text fields capped at 255; LongTextArea used for everything 256+ chars
- [x] `<required>true</required>` field (`RunDateTime__c`) not entered in permset `<fieldPermissions>` (SF blocks editing required-field permset entries)

## Test plan

- [ ] `feature_test` (PR check) passes — pure metadata, no Apex tests to run
- [ ] `upload-beta` green — confirm subscriber install picks up the new object + 14 settings fields without behavior change
- [ ] Manual smoke on dh-prod after merge + promote: `WatcherDigest__c` tab visible to admin permset, list-view loads empty, AutoNumber sequence is `WD-0001`
- [ ] Manual smoke on dh-prod: `DeliveryHubSettings__c` Setup page shows 14 new fields (8 Enable* gates default null, 3 tuning fields default null, 1 heartbeat null, 1 recipient null, 1 channel null)

## Next

PR-B ships `DeliveryWatcherService` orchestrator + `WatcherSLABreachQueryService` + 4 stub classes + `DeliverySlackService.postWatcherDigest` method + `DeliveryHubScheduler.enqueueWatcherDigestIfDue` (~7h). The 14-day Watcher stabilization gate clock starts on PR-B's first successful daily run.

Then PR-C ships signals 2 + 3 (~4.5h).

🤖 Generated with [Claude Code](https://claude.com/claude-code)