### PR TITLE
feat(watcher): PR-B — Orchestrator + Signal 1 (SLA Breach) + 4 stubs + Slack + scheduler

### DIFF
--- a/force-app/main/default/classes/DeliveryHubInstallHandler.cls
+++ b/force-app/main/default/classes/DeliveryHubInstallHandler.cls
@@ -44,6 +44,16 @@ global class DeliveryHubInstallHandler implements InstallHandler {
         }
     }
 
+    /**
+     * @description Initialises the org-default DeliveryHubSettings__c row on
+     *              a fresh tenant install. No-ops when settings already exist
+     *              (so re-install / upgrade never overwrites admin choices).
+     *              Includes Phase 2 Watcher v1 per-signal-on defaults for the
+     *              top 3 implemented signals (PR-B ships #1; PR-C ships #2+#3)
+     *              so admins don't have to re-toggle them when PR-C lands.
+     *              The master gate EnableWatcherDigestDateTime__c stays null
+     *              — Watcher is silent until the admin opts in explicitly.
+     */
     private static void initializeDefaultSettings() {
         DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
         if (settings.Id != null) {
@@ -61,6 +71,9 @@ global class DeliveryHubInstallHandler implements InstallHandler {
             EnableEmailNotificationsDateTime__c         = now,
             EnableActivityLoggingDateTime__c            = now,
             EnableBoardMetricsDateTime__c               = now,
+            EnableWatcherSLABreachDateTime__c           = now,
+            EnableWatcherStuckStageDateTime__c          = now,
+            EnableWatcherARAgingDateTime__c             = now,
             FailedSyncAutoDismissDaysNumber__c          = 14,
             StagesToAutoShareWithDevTeamTxt__c = 'All'
         );

--- a/force-app/main/default/classes/DeliveryHubInstallHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryHubInstallHandlerTest.cls
@@ -20,6 +20,19 @@ private class DeliveryHubInstallHandlerTest {
             System.assertNotEquals(null, settings.EnableAISuggestionsDateTime__c, 'AI suggestions should be enabled by default');
             System.assertEquals(14, settings.FailedSyncAutoDismissDaysNumber__c,
                 'FailedSyncAutoDismissDaysNumber__c should default to 14 on fresh install');
+            // Phase 2 Watcher v1 — top-3 signal flags default ON so PR-C can
+            // ship signals 2+3 without an install-handler edit. Master flag
+            // stays null — admins opt into Watcher explicitly.
+            System.assertNotEquals(null, settings.EnableWatcherSLABreachDateTime__c,
+                'Watcher SLA Breach signal default should be ON post-install');
+            System.assertNotEquals(null, settings.EnableWatcherStuckStageDateTime__c,
+                'Watcher Stuck Stage signal default should be ON post-install');
+            System.assertNotEquals(null, settings.EnableWatcherARAgingDateTime__c,
+                'Watcher AR Aging signal default should be ON post-install');
+            System.assertEquals(null, settings.EnableWatcherDigestDateTime__c,
+                'Watcher master flag must NOT default ON — admins flip this manually');
+            System.assertEquals(null, settings.WatcherDigestRecipientUserIdsTxt__c,
+                'Recipient list must NOT default — admins populate this manually');
         }
     }
 

--- a/force-app/main/default/classes/DeliveryHubScheduler.cls
+++ b/force-app/main/default/classes/DeliveryHubScheduler.cls
@@ -29,6 +29,7 @@ global without sharing class DeliveryHubScheduler implements Schedulable {
         enqueueInvoiceGenerationIfDue();
         enqueueOverdueRemindersIfEnabled();
         enqueueForecastAlertsIfDue();
+        enqueueWatcherDigestIfDue();
         processScheduledDocumentSends();
         runReconciliation();
         recalcWorkItemETAsIfTopOfHour();
@@ -325,6 +326,45 @@ global without sharing class DeliveryHubScheduler implements Schedulable {
         } catch (Exception ex) {
             System.debug(LoggingLevel.ERROR,
                 '[DeliveryHubScheduler] enqueueForecastAlertsIfDue failed: ' + ex.getMessage());
+        }
+    }
+
+    /**
+     * @description Enqueues the Phase 2 Watcher digest queueable once per day
+     *              at the configured GMT hour (default 12 GMT = 8am ET) when
+     *              the master flag is set on org defaults. Idempotent: gated
+     *              by LastWatcherHeartbeatDateTime__c so multiple scheduler
+     *              ticks on the same GMT day (4×/hour cron) don't double-fire.
+     *              Mirrors enqueueForecastAlertsIfDue shape.
+     */
+    @TestVisible
+    private static void enqueueWatcherDigestIfDue() {
+        try {
+            DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+            if (settings == null || settings.EnableWatcherDigestDateTime__c == null) {
+                return;
+            }
+            Integer targetHour = (settings.WatcherDigestRunHourGmtNumber__c != null)
+                ? Integer.valueOf(settings.WatcherDigestRunHourGmtNumber__c)
+                : 12;
+            DateTime nowDt = DateTime.now();
+            if (nowDt.hourGmt() != targetHour) {
+                return;
+            }
+            // GMT-day idempotency. Same defence as enqueueForecastAlertsIfDue
+            // against mixing user-local Date.today() with hourGmt().
+            Date todayGmt = Date.newInstance(nowDt.yearGmt(), nowDt.monthGmt(), nowDt.dayGmt());
+            if (settings.LastWatcherHeartbeatDateTime__c != null) {
+                Datetime hb = settings.LastWatcherHeartbeatDateTime__c;
+                Date hbGmt = Date.newInstance(hb.yearGmt(), hb.monthGmt(), hb.dayGmt());
+                if (hbGmt == todayGmt) {
+                    return;
+                }
+            }
+            System.enqueueJob(new WatcherDigestRunQueueable());
+        } catch (Exception ex) {
+            System.debug(LoggingLevel.ERROR,
+                '[DeliveryHubScheduler] enqueueWatcherDigestIfDue failed: ' + ex.getMessage());
         }
     }
 

--- a/force-app/main/default/classes/DeliveryHubSchedulerTest.cls
+++ b/force-app/main/default/classes/DeliveryHubSchedulerTest.cls
@@ -244,6 +244,109 @@ private class DeliveryHubSchedulerTest {
     }
 
     /**
+     * @description Watcher: scheduler tick should skip enqueue when the
+     *              master Watcher flag is null. No queueable in the job
+     *              monitor afterwards.
+     */
+    @IsTest
+    static void testWatcherSkipWhenMasterOff() {
+        System.runAs(testUser) {
+            // No Watcher flags set; only the seed settings from @TestSetup.
+            Test.startTest();
+            Test.setMock(HttpCalloutMock.class, new MockResponse());
+            new DeliveryHubScheduler().execute(null);
+            Test.stopTest();
+            List<AsyncApexJob> jobs = [
+                SELECT Id FROM AsyncApexJob
+                WHERE ApexClass.Name = 'WatcherDigestRunQueueable'
+            ];
+            System.assertEquals(0, jobs.size(),
+                'No WatcherDigestRunQueueable should be enqueued when the master flag is null');
+        }
+    }
+
+    /**
+     * @description Watcher: when master is on but the configured run hour
+     *              doesn't match the current GMT hour, the enqueue should
+     *              skip.
+     */
+    @IsTest
+    static void testWatcherSkipWhenWrongHour() {
+        System.runAs(testUser) {
+            Integer currentHourGmt = DateTime.now().hourGmt();
+            Integer nonMatchingHour = Math.mod(currentHourGmt + 12, 24);
+            DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
+            s.EnableWatcherDigestDateTime__c = Datetime.now();
+            s.WatcherDigestRunHourGmtNumber__c = nonMatchingHour;
+            update s;
+
+            Test.startTest();
+            Test.setMock(HttpCalloutMock.class, new MockResponse());
+            new DeliveryHubScheduler().execute(null);
+            Test.stopTest();
+            List<AsyncApexJob> jobs = [
+                SELECT Id FROM AsyncApexJob
+                WHERE ApexClass.Name = 'WatcherDigestRunQueueable'
+            ];
+            System.assertEquals(0, jobs.size(),
+                'No WatcherDigestRunQueueable should enqueue when configured hour does not match current GMT hour');
+        }
+    }
+
+    /**
+     * @description Watcher: idempotency gate — when the heartbeat field is
+     *              already set to today's GMT date, the enqueue should
+     *              skip even if hour + flag match.
+     */
+    @IsTest
+    static void testWatcherSkipWhenAlreadyRanToday() {
+        System.runAs(testUser) {
+            DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
+            s.EnableWatcherDigestDateTime__c = Datetime.now();
+            s.WatcherDigestRunHourGmtNumber__c = DateTime.now().hourGmt();
+            s.LastWatcherHeartbeatDateTime__c = Datetime.now();
+            update s;
+
+            Test.startTest();
+            Test.setMock(HttpCalloutMock.class, new MockResponse());
+            new DeliveryHubScheduler().execute(null);
+            Test.stopTest();
+            List<AsyncApexJob> jobs = [
+                SELECT Id FROM AsyncApexJob
+                WHERE ApexClass.Name = 'WatcherDigestRunQueueable'
+            ];
+            System.assertEquals(0, jobs.size(),
+                'No WatcherDigestRunQueueable should enqueue when heartbeat is already today');
+        }
+    }
+
+    /**
+     * @description Watcher: happy path — master on, hour matches, heartbeat
+     *              not set → enqueue fires.
+     */
+    @IsTest
+    static void testWatcherEnqueuesWhenDue() {
+        System.runAs(testUser) {
+            DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
+            s.EnableWatcherDigestDateTime__c = Datetime.now();
+            s.WatcherDigestRunHourGmtNumber__c = DateTime.now().hourGmt();
+            // LastWatcherHeartbeatDateTime__c stays null
+            update s;
+
+            Test.startTest();
+            Test.setMock(HttpCalloutMock.class, new MockResponse());
+            new DeliveryHubScheduler().execute(null);
+            Test.stopTest();
+            List<AsyncApexJob> jobs = [
+                SELECT Id FROM AsyncApexJob
+                WHERE ApexClass.Name = 'WatcherDigestRunQueueable'
+            ];
+            System.assertEquals(1, jobs.size(),
+                'WatcherDigestRunQueueable should be enqueued when flag on, hour matches, no heartbeat today');
+        }
+    }
+
+    /**
      * @description Mock implementation for the sync handshake.
      */
     public class MockResponse implements HttpCalloutMock {

--- a/force-app/main/default/classes/DeliverySlackService.cls
+++ b/force-app/main/default/classes/DeliverySlackService.cls
@@ -134,6 +134,28 @@ global with sharing class DeliverySlackService {
     }
 
     /**
+     * @description Asynchronously posts the Watcher v1 daily digest to Slack.
+     *              Reuses the SlackWebhookUrlTxt__c webhook. Payload is the
+     *              JSON-serialised Block Kit map produced by
+     *              DeliveryWatcherDigestFormatter.buildBlockKit — pre-injected
+     *              with `channel` when WatcherDigestSlackChannelTxt__c is set
+     *              on org defaults. No-ops silently when Slack isn't
+     *              configured (mirrors postStageChanges).
+     * @param payloadJson Pre-serialised Block Kit JSON.
+     */
+    @future(callout=true)
+    public static void postWatcherDigest(String payloadJson) {
+        if (String.isBlank(payloadJson)) {
+            return;
+        }
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        if (settings == null || String.isBlank(settings.SlackWebhookUrlTxt__c)) {
+            return;
+        }
+        post(settings.SlackWebhookUrlTxt__c, payloadJson);
+    }
+
+    /**
      * @description Tests the provided Slack webhook by posting a confirmation message.
      *              Called directly from the settings LWC via user action (no DML context).
      * @param webhookUrl The Slack Incoming Webhook URL to test

--- a/force-app/main/default/classes/DeliverySlackServiceTest.cls
+++ b/force-app/main/default/classes/DeliverySlackServiceTest.cls
@@ -243,6 +243,68 @@ private class DeliverySlackServiceTest {
             'No callouts when EnableSlackCommentSyncDateTime__c is null');
     }
 
+    // ── postWatcherDigest ────────────────────────────────────────────────────
+
+    /**
+     * @description postWatcherDigest happy path — when the webhook URL is
+     *              configured and payload is non-blank, exactly one callout
+     *              fires.
+     */
+    @IsTest
+    static void testPostWatcherDigestPostsWhenConfigured() {
+        String payload = JSON.serialize(new Map<String, Object>{
+            'blocks' => new List<Object>{
+                new Map<String, Object>{
+                    'type' => 'section',
+                    'text' => new Map<String, Object>{ 'type' => 'mrkdwn', 'text' => 'test' }
+                }
+            }
+        });
+        SlackMock mock = new SlackMock(200, 'ok');
+        Test.setMock(HttpCalloutMock.class, mock);
+
+        Test.startTest();
+        DeliverySlackService.postWatcherDigest(payload);
+        Test.stopTest();
+        System.assertEquals(1, mock.callCount,
+            'postWatcherDigest should fire one callout when the webhook URL is configured');
+    }
+
+    /**
+     * @description postWatcherDigest no-ops silently when the webhook URL is
+     *              blank.
+     */
+    @IsTest
+    static void testPostWatcherDigestNoopsWithoutWebhook() {
+        DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
+        s.SlackWebhookUrlTxt__c = null;
+        update s;
+
+        SlackMock mock = new SlackMock(200, 'ok');
+        Test.setMock(HttpCalloutMock.class, mock);
+
+        Test.startTest();
+        DeliverySlackService.postWatcherDigest('{"blocks":[]}');
+        Test.stopTest();
+        System.assertEquals(0, mock.callCount,
+            'No callout should fire when SlackWebhookUrlTxt__c is null');
+    }
+
+    /**
+     * @description postWatcherDigest no-ops on a blank payload string.
+     */
+    @IsTest
+    static void testPostWatcherDigestNoopsWithBlankPayload() {
+        SlackMock mock = new SlackMock(200, 'ok');
+        Test.setMock(HttpCalloutMock.class, mock);
+
+        Test.startTest();
+        DeliverySlackService.postWatcherDigest('');
+        Test.stopTest();
+        System.assertEquals(0, mock.callCount,
+            'Blank payload should short-circuit before the callout');
+    }
+
     @IsTest
     static void testPostCommentBatchSkipsSlackMirrors() {
         DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();

--- a/force-app/main/default/classes/DeliveryWatcherDigestFormatter.cls
+++ b/force-app/main/default/classes/DeliveryWatcherDigestFormatter.cls
@@ -1,0 +1,327 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Builds the two output formats for a Watcher run:
+ *
+ *                1. Slack Block Kit payload (Map&lt;String,Object&gt;) for
+ *                   posting via DeliverySlackService.postWatcherDigest.
+ *                   Returns null when there's nothing to say (quiet day) so
+ *                   the orchestrator can skip Slack while still writing the
+ *                   audit row.
+ *
+ *                2. Plaintext markdown fallback persisted to
+ *                   WatcherDigest__c.DigestBodyTxt__c. Always populated
+ *                   (even on quiet days a short "0 items" string is stored).
+ *
+ *              Mirror of DeliverySlackService.buildCommentBatchPayload —
+ *              same Block Kit section/context shape.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity')
+public with sharing class DeliveryWatcherDigestFormatter {
+
+    /** @description Newline used when concatenating plaintext body lines. */
+    private static final String NL = '\n';
+
+    /**
+     * @description Builds the Slack Block Kit payload for the run. Returns
+     *              null on a quiet day (no signal reported any entries) so
+     *              the orchestrator can skip posting.
+     * @param result     Aggregated run result from DeliveryWatcherService.
+     * @param runDateLabel Human-friendly date label (e.g. `2026-05-19 08:00 ET`).
+     * @return Block Kit map ready for JSON.serialize, or null on quiet days.
+     */
+    public static Map<String, Object> buildBlockKit(
+        DeliveryWatcherService.WatcherRunResultDTO result,
+        String runDateLabel
+    ) {
+        if (isQuietDay(result)) {
+            return null;
+        }
+        Integer totalItems = totalSurfacedCount(result);
+        List<Object> blocks = new List<Object>();
+        blocks.add(buildHeaderBlock(runDateLabel, totalItems));
+        appendSlaBreachSection(blocks, result);
+        blocks.add(buildContextBlock(result));
+        return new Map<String, Object>{ 'blocks' => blocks };
+    }
+
+    /**
+     * @description Builds the plaintext markdown body — both the audit
+     *              record's body field and a human-readable replay surface.
+     *              Always populated, even on quiet days.
+     * @param result     Aggregated run result from DeliveryWatcherService.
+     * @param runDateLabel Human-friendly date label.
+     * @return Plaintext / markdown string.
+     */
+    public static String buildMarkdown(
+        DeliveryWatcherService.WatcherRunResultDTO result,
+        String runDateLabel
+    ) {
+        if (result == null) {
+            return ':eyes: Watcher Digest — ' + safeLabel(runDateLabel)
+                + NL + '0 items today. All clear.';
+        }
+        if (isQuietDay(result)) {
+            return ':eyes: Watcher Digest — ' + safeLabel(runDateLabel)
+                + NL + '0 items today. All clear.'
+                + NL + buildCountsLine(result);
+        }
+        Integer totalItems = totalSurfacedCount(result);
+        List<String> lines = new List<String>();
+        lines.add(':eyes: Watcher Digest — ' + safeLabel(runDateLabel));
+        lines.add(totalItems + ' item' + (totalItems == 1 ? '' : 's')
+            + ' need' + (totalItems == 1 ? 's' : '') + ' your eyes today.');
+        appendSlaMarkdownLines(lines, result);
+        lines.add('');
+        lines.add(buildCountsLine(result));
+        return String.join(lines, NL);
+    }
+
+    /**
+     * @description Detects the quiet-day condition — all signals reported 0
+     *              entries (regardless of whether they ran or were
+     *              flag-gated off).
+     * @param result Aggregated run result.
+     * @return true when nothing should be posted to Slack.
+     */
+    private static Boolean isQuietDay(DeliveryWatcherService.WatcherRunResultDTO result) {
+        if (result == null) {
+            return true;
+        }
+        return totalSurfacedCount(result) == 0;
+    }
+
+    /**
+     * @description Sums all per-signal counts to determine whether anything
+     *              needs to be surfaced.
+     * @param result Aggregated run result.
+     * @return Total count across all signals (including At Risk under SLA).
+     */
+    private static Integer totalSurfacedCount(DeliveryWatcherService.WatcherRunResultDTO result) {
+        Integer total = 0;
+        total += safeInt(result.slaBreachCount);
+        total += safeInt(result.slaAtRiskCount);
+        total += safeInt(result.stuckStageCount);
+        total += safeInt(result.arOverdueCount);
+        return total;
+    }
+
+    /**
+     * @description Builds the Block Kit header block.
+     * @param runDateLabel Date label (e.g. `2026-05-19 08:00 ET`).
+     * @param totalItems   Sum of all per-signal counts.
+     * @return Header block map.
+     */
+    private static Map<String, Object> buildHeaderBlock(String runDateLabel, Integer totalItems) {
+        String header = ':eyes: *Watcher Digest — ' + safeLabel(runDateLabel) + '*'
+            + NL + totalItems + ' item' + (totalItems == 1 ? '' : 's')
+            + ' need' + (totalItems == 1 ? 's' : '') + ' your eyes today.';
+        return new Map<String, Object>{
+            'type' => 'section',
+            'text' => new Map<String, Object>{
+                'type' => 'mrkdwn',
+                'text' => header
+            }
+        };
+    }
+
+    /**
+     * @description Appends the SLA Breach + At Risk block(s) when the
+     *              signal returned entries. Splits the entries into two
+     *              sections: breached (first slaBreachCount entries) and
+     *              at-risk (the remaining entries from the topEntries list).
+     * @param blocks Block Kit accumulator.
+     * @param result Aggregated run result.
+     */
+    private static void appendSlaBreachSection(
+        List<Object> blocks,
+        DeliveryWatcherService.WatcherRunResultDTO result
+    ) {
+        if (result.slaSignal == null || result.slaSignal.topEntries == null
+            || result.slaSignal.topEntries.isEmpty()) {
+            return;
+        }
+        Integer breachCount = safeInt(result.slaBreachCount);
+        Integer atRiskCount = safeInt(result.slaAtRiskCount);
+        if (breachCount > 0) {
+            blocks.add(buildEntryBlock(
+                '*SLA Breach (' + breachCount + ')*',
+                sliceEntries(result.slaSignal.topEntries, 0, breachCount)
+            ));
+        }
+        if (atRiskCount > 0) {
+            blocks.add(buildEntryBlock(
+                '*At Risk in <48h (' + atRiskCount + ')*',
+                sliceEntries(result.slaSignal.topEntries, breachCount, result.slaSignal.topEntries.size())
+            ));
+        }
+    }
+
+    /**
+     * @description Appends SLA-Breach markdown lines into the plaintext body.
+     * @param lines  Accumulator for the markdown body.
+     * @param result Aggregated run result.
+     */
+    private static void appendSlaMarkdownLines(
+        List<String> lines,
+        DeliveryWatcherService.WatcherRunResultDTO result
+    ) {
+        if (result.slaSignal == null || result.slaSignal.topEntries == null
+            || result.slaSignal.topEntries.isEmpty()) {
+            return;
+        }
+        Integer breachCount = safeInt(result.slaBreachCount);
+        Integer atRiskCount = safeInt(result.slaAtRiskCount);
+        Integer cursor = 0;
+        if (breachCount > 0) {
+            lines.add('');
+            lines.add('*SLA Breach (' + breachCount + ')*');
+            cursor = appendEntryLines(lines, result.slaSignal.topEntries, 0, breachCount);
+        }
+        if (atRiskCount > 0 && cursor < result.slaSignal.topEntries.size()) {
+            lines.add('');
+            lines.add('*At Risk in <48h (' + atRiskCount + ')*');
+            appendEntryLines(lines, result.slaSignal.topEntries, cursor, result.slaSignal.topEntries.size());
+        }
+    }
+
+    /**
+     * @description Builds a Block Kit section block bundling a header line +
+     *              a bulleted list of entries.
+     * @param headerLine Bold header for the section.
+     * @param entries    Entries to render under the header.
+     * @return Block Kit section map.
+     */
+    private static Map<String, Object> buildEntryBlock(String headerLine, List<SignalEntryDTO> entries) {
+        List<String> bodyLines = new List<String>();
+        bodyLines.add(headerLine);
+        for (SignalEntryDTO e : entries) {
+            bodyLines.add(renderEntry(e));
+        }
+        return new Map<String, Object>{
+            'type' => 'section',
+            'text' => new Map<String, Object>{
+                'type' => 'mrkdwn',
+                'text' => String.join(bodyLines, NL)
+            }
+        };
+    }
+
+    /**
+     * @description Builds the trailing context block — small grey footer with
+     *              compact counts + duration.
+     * @param result Aggregated run result.
+     * @return Context block map.
+     */
+    private static Map<String, Object> buildContextBlock(DeliveryWatcherService.WatcherRunResultDTO result) {
+        return new Map<String, Object>{
+            'type' => 'context',
+            'elements' => new List<Object>{
+                new Map<String, Object>{
+                    'type' => 'mrkdwn',
+                    'text' => buildCountsLine(result)
+                }
+            }
+        };
+    }
+
+    /**
+     * @description Builds the one-line `Counts: SLA=3, Stuck=1, AR=2 | 847ms`
+     *              footer used in both Slack context block and plaintext body.
+     * @param result Aggregated run result.
+     * @return Counts line string.
+     */
+    private static String buildCountsLine(DeliveryWatcherService.WatcherRunResultDTO result) {
+        Integer slaTotal = safeInt(result.slaBreachCount) + safeInt(result.slaAtRiskCount);
+        String durationPart = result.runDurationMs == null
+            ? ''
+            : (' | ' + result.runDurationMs + 'ms');
+        return 'Counts: SLA=' + slaTotal
+            + ', Stuck=' + safeInt(result.stuckStageCount)
+            + ', AR=' + safeInt(result.arOverdueCount)
+            + durationPart;
+    }
+
+    /**
+     * @description Renders one digest entry as a markdown bullet line.
+     * @param e Entry to render.
+     * @return Markdown line, prefixed with bullet glyph.
+     */
+    private static String renderEntry(SignalEntryDTO e) {
+        if (e == null) {
+            return '• (empty entry)';
+        }
+        String labelPart;
+        if (String.isNotBlank(e.url) && String.isNotBlank(e.label)) {
+            labelPart = '<' + e.url + '|' + e.label + '>';
+        } else if (String.isNotBlank(e.label)) {
+            labelPart = e.label;
+        } else {
+            labelPart = '(unnamed)';
+        }
+        String detailPart = String.isBlank(e.detailLine) ? '' : (' · ' + e.detailLine);
+        return '• ' + labelPart + detailPart;
+    }
+
+    /**
+     * @description Returns the sublist of `entries` from `fromIndex`
+     *              (inclusive) to `toIndex` (exclusive). Apex List has no
+     *              sublist — manual copy.
+     * @param entries  Full list of entries.
+     * @param fromIndex Start index (inclusive).
+     * @param toIndex   End index (exclusive).
+     * @return New list containing the selected entries; never null.
+     */
+    private static List<SignalEntryDTO> sliceEntries(List<SignalEntryDTO> entries, Integer fromIndex, Integer toIndex) {
+        List<SignalEntryDTO> out = new List<SignalEntryDTO>();
+        if (entries == null) {
+            return out;
+        }
+        Integer start = Math.max(0, fromIndex);
+        Integer endIndex = Math.min(entries.size(), toIndex);
+        for (Integer i = start; i < endIndex; i++) {
+            out.add(entries.get(i));
+        }
+        return out;
+    }
+
+    /**
+     * @description Appends renderEntry output for the given slice into
+     *              the line accumulator.
+     * @param lines   Accumulator for the markdown body.
+     * @param entries Full entry list.
+     * @param fromIndex Start index (inclusive).
+     * @param toIndex   End index (exclusive).
+     * @return Index immediately after the last appended entry.
+     */
+    private static Integer appendEntryLines(List<String> lines, List<SignalEntryDTO> entries, Integer fromIndex, Integer toIndex) {
+        if (entries == null) {
+            return fromIndex;
+        }
+        Integer start = Math.max(0, fromIndex);
+        Integer endIndex = Math.min(entries.size(), toIndex);
+        for (Integer i = start; i < endIndex; i++) {
+            lines.add(renderEntry(entries.get(i)));
+        }
+        return endIndex;
+    }
+
+    /**
+     * @description Null-tolerant Integer accessor.
+     * @param v Possibly null Integer.
+     * @return v when non-null, else 0.
+     */
+    private static Integer safeInt(Integer v) {
+        return v == null ? 0 : v;
+    }
+
+    /**
+     * @description Null/blank-tolerant label.
+     * @param label Possibly null/blank label.
+     * @return label when non-blank, else current Datetime.
+     */
+    private static String safeLabel(String label) {
+        return String.isBlank(label) ? Datetime.now().format('yyyy-MM-dd HH:mm') : label;
+    }
+}

--- a/force-app/main/default/classes/DeliveryWatcherDigestFormatter.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryWatcherDigestFormatter.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryWatcherDigestFormatterTest.cls
+++ b/force-app/main/default/classes/DeliveryWatcherDigestFormatterTest.cls
@@ -1,0 +1,101 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Tests for DeliveryWatcherDigestFormatter. Asserts Block Kit
+ *              shape on non-quiet runs, plaintext shape always, and null
+ *              Block Kit return on quiet days.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryWatcherDigestFormatterTest {
+
+    /**
+     * @description Builds a non-quiet WatcherRunResultDTO with one Breached
+     *              + one At Risk entry, runs both formatters, and asserts
+     *              the expected shapes.
+     */
+    @IsTest
+    static void testNonQuietProducesBlockKitAndMarkdown() {
+        DeliveryWatcherService.WatcherRunResultDTO result =
+            new DeliveryWatcherService.WatcherRunResultDTO();
+        SignalResultDTO sla = SignalResultDTO.emptyResult('SLABreach');
+        sla.primaryCount = 1;
+        sla.secondaryCount = 1;
+        sla.topEntries = new List<SignalEntryDTO>{
+            new SignalEntryDTO(null, 'T-0142 — Compliance gate',
+                '3 days breached · stage: In Review',
+                'https://example.test/lightning/r/WorkItem__c/x/view'),
+            new SignalEntryDTO(null, 'T-0167 — Cashflow report',
+                '1 day to deadline · stage: Testing', null)
+        };
+        result.slaSignal = sla;
+        result.slaBreachCount = 1;
+        result.slaAtRiskCount = 1;
+        result.runDurationMs = 847L;
+        result.status = 'Success';
+
+        Test.startTest();
+        Map<String, Object> blockKit = DeliveryWatcherDigestFormatter.buildBlockKit(result, '2026-05-19 08:00 ET');
+        String md = DeliveryWatcherDigestFormatter.buildMarkdown(result, '2026-05-19 08:00 ET');
+        Test.stopTest();
+
+        System.assertNotEquals(null, blockKit, 'Non-quiet day should return a Block Kit payload');
+        System.assert(blockKit.containsKey('blocks'),
+            'Block Kit payload should contain a "blocks" key');
+        List<Object> blocks = (List<Object>) blockKit.get('blocks');
+        System.assert(blocks.size() >= 2,
+            'Block Kit should include header + at least one signal section + context');
+        // Serialize round-trip to prove it's valid JSON.
+        String serialized = JSON.serialize(blockKit);
+        System.assertNotEquals(null, serialized, 'Block Kit must serialize cleanly');
+        System.assert(serialized.contains('Watcher Digest'),
+            'Header text should mention "Watcher Digest"');
+
+        System.assertNotEquals(null, md, 'Markdown should never be null on non-quiet runs');
+        System.assert(md.contains('Watcher Digest'),
+            'Markdown should include header text');
+        System.assert(md.contains('SLA Breach (1)'),
+            'Markdown should include Breached header — got: ' + md);
+        System.assert(md.contains('At Risk in <48h (1)'),
+            'Markdown should include At Risk header');
+        System.assert(md.contains('Counts: SLA=2'),
+            'Markdown footer should sum primary+secondary SLA counts');
+    }
+
+    /**
+     * @description Quiet-day path: all signals returned zero entries →
+     *              buildBlockKit returns null; buildMarkdown returns a
+     *              short "all clear" string.
+     */
+    @IsTest
+    static void testQuietDayReturnsNullBlockKitAndStillRendersMarkdown() {
+        DeliveryWatcherService.WatcherRunResultDTO result =
+            new DeliveryWatcherService.WatcherRunResultDTO();
+        result.slaSignal = SignalResultDTO.emptyResult('SLABreach');
+        result.runDurationMs = 200L;
+        result.status = 'Success';
+
+        Test.startTest();
+        Map<String, Object> blockKit = DeliveryWatcherDigestFormatter.buildBlockKit(result, '2026-05-19 08:00 ET');
+        String md = DeliveryWatcherDigestFormatter.buildMarkdown(result, '2026-05-19 08:00 ET');
+        Test.stopTest();
+
+        System.assertEquals(null, blockKit, 'Quiet day should suppress the Slack payload');
+        System.assertNotEquals(null, md, 'Markdown should still be produced for the audit row');
+        System.assert(md.contains('All clear'),
+            'Quiet-day markdown should reassure with "All clear" — got: ' + md);
+    }
+
+    /**
+     * @description Null DTO path: defensive return rather than NPE.
+     */
+    @IsTest
+    static void testNullResultProducesPlaceholderMarkdown() {
+        Test.startTest();
+        String md = DeliveryWatcherDigestFormatter.buildMarkdown(null, null);
+        Test.stopTest();
+        System.assertNotEquals(null, md, 'Markdown should never be null even for null input');
+        System.assert(md.contains('All clear'),
+            'Null-input markdown should still reassure — got: ' + md);
+    }
+}

--- a/force-app/main/default/classes/DeliveryWatcherDigestFormatterTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryWatcherDigestFormatterTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryWatcherService.cls
+++ b/force-app/main/default/classes/DeliveryWatcherService.cls
@@ -1,0 +1,464 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Phase 2 Watcher v1 orchestrator. Single entry point for the
+ *              daily aggregate signal sweep — reads the master flag, walks
+ *              the enabled per-signal flags, invokes each Watcher*QueryService
+ *              query() method, merges into a WatcherRunResultDTO, persists a
+ *              WatcherDigest__c audit row, and posts a Slack message when
+ *              there's something to say.
+ *
+ *              Master-flag-off + recipient-list-empty are both silent
+ *              no-ops. Quiet days (all signals returned zero entries) still
+ *              write a WatcherDigest__c row + stamp the heartbeat field
+ *              (so the 14-day stabilization gate works), but skip Slack.
+ *
+ *              Signals 2 (StuckStage) + 3 (ARAging) land in PR-C; PR-B
+ *              wires the orchestrator + Signal 1 (SLABreach) + the four
+ *              stubs.
+ *
+ *              Per-signal try/catch is intentional: one bad signal must
+ *              not poison the others. Captured exceptions land in
+ *              WatcherRunResultDTO.errorMessages + downgrade StatusPk__c
+ *              to Partial.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation,PMD.AvoidGlobalModifier,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.NcssMethodCount,PMD.ExcessiveParameterList')
+global with sharing class DeliveryWatcherService {
+
+    /** @description Cap on body characters persisted to WatcherDigest__c.DigestBodyTxt__c (LongTextArea(32768)). */
+    @TestVisible
+    private static final Integer BODY_CAP = 30000;
+
+    /** @description Cap on the trimmed body string exposed via the DTO (lighter payload to LWCs). */
+    @TestVisible
+    private static final Integer DTO_BODY_CAP = 4000;
+
+    /** @description Cap on FlaggedWorkItemIdsTxt__c stored payload (LongTextArea(4000)). */
+    @TestVisible
+    private static final Integer FLAGGED_WI_CAP = 3800;
+
+    // ── Entry points ─────────────────────────────────────────────────────────
+
+    /**
+     * @description Public entry point. Reads the master flag, dispatches all
+     *              enabled signals, persists a WatcherDigest__c, posts Slack
+     *              when there's something to surface. Safe to call from
+     *              anonymous Apex / a scheduler-enqueued queueable.
+     */
+    @AuraEnabled
+    global static void run() {
+        runAndReturnSummary();
+    }
+
+    /**
+     * @description Entry point that also returns the run summary for admin
+     *              LWCs (manual-run UX in PR-C+). Behaves identically to
+     *              run() but bubbles the result back to the caller.
+     * @return WatcherRunResultDTO with per-signal counts + digest body
+     *         (trimmed) + error list. Returns a zero-state DTO when the
+     *         master flag is off.
+     */
+    @AuraEnabled
+    global static WatcherRunResultDTO runAndReturnSummary() {
+        Long startedAtMs = System.currentTimeMillis();
+        DeliveryHubSettings__c settings = loadSettings();
+        if (!isMasterEnabled(settings)) {
+            System.debug(LoggingLevel.INFO,
+                '[DeliveryWatcherService] Watcher master flag disabled — no-op');
+            return zeroResult(startedAtMs);
+        }
+        WatcherRunResultDTO result = dispatchSignals(settings);
+        result.runDurationMs = System.currentTimeMillis() - startedAtMs;
+        result.status = computeStatus(result);
+        result.digestBodyMarkdown = buildBodyMarkdown(result);
+
+        persistDigest(result, settings);
+        postSlackIfRecipients(result, settings);
+        stampHeartbeat(settings, result.status);
+        return result;
+    }
+
+    // ── Orchestration helpers ────────────────────────────────────────────────
+
+    /**
+     * @description Loads org-default DeliveryHubSettings__c. Returns null
+     *              when the row doesn't exist (e.g. fresh subscriber pre-
+     *              install-handler).
+     * @return Org-default settings row, possibly null.
+     */
+    private static DeliveryHubSettings__c loadSettings() {
+        return DeliveryHubSettings__c.getOrgDefaults();
+    }
+
+    /**
+     * @description Master-flag gate. Master DateTime non-null = Watcher is
+     *              alive on this tenant.
+     * @param settings Loaded settings row.
+     * @return true when Watcher should proceed.
+     */
+    private static Boolean isMasterEnabled(DeliveryHubSettings__c settings) {
+        return settings != null && settings.EnableWatcherDigestDateTime__c != null;
+    }
+
+    /**
+     * @description Returns a zero-state DTO used when Watcher is master-
+     *              flag-off (no audit row written, no Slack posted).
+     * @param startedAtMs Time the run started (millis since epoch).
+     * @return DTO with status `Skipped`, zero counts, and a runDurationMs.
+     */
+    private static WatcherRunResultDTO zeroResult(Long startedAtMs) {
+        WatcherRunResultDTO r = new WatcherRunResultDTO();
+        r.status = 'Skipped';
+        r.runDurationMs = System.currentTimeMillis() - startedAtMs;
+        return r;
+    }
+
+    /**
+     * @description Walks each per-signal gate, invokes the corresponding
+     *              query() method when enabled, captures exceptions into
+     *              errorMessages, and merges all results into one DTO.
+     * @param settings Org-default settings row.
+     * @return WatcherRunResultDTO with per-signal counts + per-signal
+     *         SignalResultDTOs populated. status + duration are filled by
+     *         the caller.
+     */
+    private static WatcherRunResultDTO dispatchSignals(DeliveryHubSettings__c settings) {
+        WatcherRunResultDTO result = new WatcherRunResultDTO();
+        result.slaSignal = runSlaBreachSignal(settings, result);
+        runStubSignals(settings, result);
+        mergeCounts(result);
+        return result;
+    }
+
+    /**
+     * @description Runs Signal 1 (SLA Breach) when its gate is open.
+     * @param settings Org-default settings row.
+     * @param result   Accumulator for any thrown exception messages.
+     * @return Populated SignalResultDTO on happy path, or null when the
+     *         signal is gate-off / errored.
+     */
+    private static SignalResultDTO runSlaBreachSignal(DeliveryHubSettings__c settings, WatcherRunResultDTO result) {
+        if (settings.EnableWatcherSLABreachDateTime__c == null) {
+            return null;
+        }
+        try {
+            return WatcherSLABreachQueryService.query();
+        } catch (Exception e) {
+            captureError(result, WatcherSLABreachQueryService.SIGNAL_NAME, e);
+            return null;
+        }
+    }
+
+    /**
+     * @description Runs the four stub signals when their respective gates
+     *              are open. PR-B stubs always return empty results so
+     *              merging is a formality; PR-C+ may replace these with
+     *              real implementations.
+     * @param settings Org-default settings row.
+     * @param result   Accumulator for any thrown exception messages.
+     */
+    private static void runStubSignals(DeliveryHubSettings__c settings, WatcherRunResultDTO result) {
+        if (settings.EnableWatcherUnhappySignalDateTime__c != null) {
+            runOneStub(WatcherUnhappySignalQueryService.SIGNAL_NAME, result, 'unhappy');
+        }
+        if (settings.EnableWatcherSignoffDateTime__c != null) {
+            runOneStub(WatcherUpcomingSignoffQueryService.SIGNAL_NAME, result, 'signoff');
+        }
+        if (settings.EnableWatcherPaymentOpsDateTime__c != null) {
+            runOneStub(WatcherPaymentOpsQueryService.SIGNAL_NAME, result, 'payment');
+        }
+        if (settings.EnableWatcherSyncTrendDateTime__c != null) {
+            runOneStub(WatcherFailedSyncTrendQueryService.SIGNAL_NAME, result, 'synctrend');
+        }
+    }
+
+    /**
+     * @description Dispatches one stub by tag. Stubs return empty
+     *              SignalResultDTO; we only capture exceptions (defensive).
+     * @param signalName Signal identifier for error capture.
+     * @param result     Accumulator.
+     * @param tag        Which stub to invoke.
+     */
+    private static void runOneStub(String signalName, WatcherRunResultDTO result, String tag) {
+        try {
+            if (tag == 'unhappy') {
+                WatcherUnhappySignalQueryService.query();
+            } else if (tag == 'signoff') {
+                WatcherUpcomingSignoffQueryService.query();
+            } else if (tag == 'payment') {
+                WatcherPaymentOpsQueryService.query();
+            } else if (tag == 'synctrend') {
+                WatcherFailedSyncTrendQueryService.query();
+            }
+        } catch (Exception e) {
+            captureError(result, signalName, e);
+        }
+    }
+
+    /**
+     * @description Captures a thrown signal error into the result DTO.
+     * @param result     Accumulator.
+     * @param signalName Signal identifier.
+     * @param e          Thrown exception.
+     */
+    private static void captureError(WatcherRunResultDTO result, String signalName, Exception e) {
+        if (result.errorMessages == null) {
+            result.errorMessages = new List<String>();
+        }
+        result.errorMessages.add(signalName + ': ' + e.getTypeName() + ' — ' + e.getMessage());
+    }
+
+    /**
+     * @description Maps signal DTOs into the orchestrator's flat per-signal
+     *              count fields. PR-B only wires the SLA pair; stuck-stage
+     *              and AR-overdue stay at zero until PR-C lands.
+     * @param result Result accumulator.
+     */
+    private static void mergeCounts(WatcherRunResultDTO result) {
+        result.slaBreachCount = (result.slaSignal != null && result.slaSignal.primaryCount != null)
+            ? result.slaSignal.primaryCount : 0;
+        result.slaAtRiskCount = (result.slaSignal != null && result.slaSignal.secondaryCount != null)
+            ? result.slaSignal.secondaryCount : 0;
+        // Signals 2 + 3 land in PR-C; leave zero placeholders for now.
+        result.stuckStageCount = 0;
+        result.arOverdueCount = 0;
+    }
+
+    /**
+     * @description Computes the run-level status: Failed if every signal
+     *              threw, Partial if at least one threw, Success otherwise.
+     * @param result Aggregated result.
+     * @return One of `Success`, `Partial`, `Failed` (GVS-backed).
+     */
+    private static String computeStatus(WatcherRunResultDTO result) {
+        Integer errorCount = (result.errorMessages == null) ? 0 : result.errorMessages.size();
+        if (errorCount == 0) {
+            return 'Success';
+        }
+        Boolean anySucceeded = (result.slaSignal != null && result.slaSignal.errorMessage == null);
+        return anySucceeded ? 'Partial' : 'Failed';
+    }
+
+    /**
+     * @description Renders the digest body to plaintext markdown for both
+     *              the audit row and the DTO. Wraps the formatter call in a
+     *              try/catch — body rendering must never fail the run.
+     * @param result Aggregated result.
+     * @return Markdown string; empty when formatter throws.
+     */
+    private static String buildBodyMarkdown(WatcherRunResultDTO result) {
+        try {
+            String label = Datetime.now().format('yyyy-MM-dd HH:mm');
+            String body = DeliveryWatcherDigestFormatter.buildMarkdown(result, label);
+            return body == null ? '' : body;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryWatcherService] markdown render failed: ' + e.getMessage());
+            return '';
+        }
+    }
+
+    // ── Persistence ──────────────────────────────────────────────────────────
+
+    /**
+     * @description Inserts a WatcherDigest__c audit row capturing this run.
+     *              Wrapped in try/catch — persistence must not nullify a
+     *              successful sweep.
+     * @param result   Aggregated result.
+     * @param settings Org-default settings row.
+     */
+    private static void persistDigest(WatcherRunResultDTO result, DeliveryHubSettings__c settings) {
+        try {
+            WatcherDigest__c row = new WatcherDigest__c(
+                RunDateTime__c = Datetime.now(),
+                RunDurationMsNumber__c = result.runDurationMs,
+                StatusPk__c = result.status,
+                DigestBodyTxt__c = truncate(result.digestBodyMarkdown, BODY_CAP),
+                SignalCountsTxt__c = buildSignalCountsTxt(result),
+                FlaggedWorkItemIdsTxt__c = buildFlaggedWorkItemIds(result),
+                ErrorMessageTxt__c = buildErrorMessageTxt(result),
+                RecipientUserIdsTxt__c = truncate(settings.WatcherDigestRecipientUserIdsTxt__c, 255),
+                RunModePk__c = Test.isRunningTest() ? 'Test' : 'Scheduled'
+            );
+            insert row;
+            result.digestId = row.Id;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryWatcherService] WatcherDigest__c insert failed: ' + e.getMessage());
+        }
+    }
+
+    /**
+     * @description Builds the compact one-line per-signal counts string for
+     *              WatcherDigest__c.SignalCountsTxt__c (used for trending /
+     *              report filters).
+     * @param result Aggregated result.
+     * @return e.g. `SLA:3,AtRisk:2,Stuck:0,AR:0`.
+     */
+    private static String buildSignalCountsTxt(WatcherRunResultDTO result) {
+        return 'SLA:' + result.slaBreachCount
+            + ',AtRisk:' + result.slaAtRiskCount
+            + ',Stuck:' + result.stuckStageCount
+            + ',AR:' + result.arOverdueCount;
+    }
+
+    /**
+     * @description Builds the comma-separated WI Id payload for
+     *              WatcherDigest__c.FlaggedWorkItemIdsTxt__c. Pulls Ids from
+     *              the SLA signal's topEntries; PR-C signals will append to
+     *              this same list.
+     * @param result Aggregated result.
+     * @return Comma-separated Id string, or empty.
+     */
+    private static String buildFlaggedWorkItemIds(WatcherRunResultDTO result) {
+        if (result.slaSignal == null || result.slaSignal.topEntries == null
+            || result.slaSignal.topEntries.isEmpty()) {
+            return '';
+        }
+        List<String> ids = new List<String>();
+        for (SignalEntryDTO e : result.slaSignal.topEntries) {
+            if (e != null && e.recordId != null) {
+                ids.add(String.valueOf(e.recordId));
+            }
+        }
+        return truncate(String.join(ids, ','), FLAGGED_WI_CAP);
+    }
+
+    /**
+     * @description Joins captured per-signal error messages into one string
+     *              for WatcherDigest__c.ErrorMessageTxt__c.
+     * @param result Aggregated result.
+     * @return Joined error string, or empty when no signals threw.
+     */
+    private static String buildErrorMessageTxt(WatcherRunResultDTO result) {
+        if (result.errorMessages == null || result.errorMessages.isEmpty()) {
+            return '';
+        }
+        return String.join(result.errorMessages, '\n');
+    }
+
+    // ── Slack ────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Posts the Block Kit payload to Slack when (a) a recipient
+     *              list is configured AND (b) the formatter returned a
+     *              non-null payload (quiet days return null → silent).
+     * @param result   Aggregated result.
+     * @param settings Org-default settings row.
+     */
+    private static void postSlackIfRecipients(WatcherRunResultDTO result, DeliveryHubSettings__c settings) {
+        if (String.isBlank(settings.WatcherDigestRecipientUserIdsTxt__c)) {
+            return;
+        }
+        try {
+            String label = Datetime.now().format('yyyy-MM-dd HH:mm');
+            Map<String, Object> blockKit = DeliveryWatcherDigestFormatter.buildBlockKit(result, label);
+            if (blockKit == null) {
+                return; // Quiet day — Slack silent, audit row already written.
+            }
+            String channelOverride = settings.WatcherDigestSlackChannelTxt__c;
+            if (String.isNotBlank(channelOverride)) {
+                blockKit.put('channel', channelOverride);
+            }
+            DeliverySlackService.postWatcherDigest(JSON.serialize(blockKit));
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryWatcherService] Slack post failed: ' + e.getMessage());
+        }
+    }
+
+    // ── Heartbeat ────────────────────────────────────────────────────────────
+
+    /**
+     * @description Stamps LastWatcherHeartbeatDateTime__c on the org-default
+     *              settings when the run succeeded (or partially succeeded).
+     *              Used by the scheduler's idempotency gate AND the 14-day
+     *              stabilization gate that precedes Phase 3 auto-digest.
+     * @param settings Org-default settings row (already loaded).
+     * @param status   Run status (Success / Partial / Failed).
+     */
+    private static void stampHeartbeat(DeliveryHubSettings__c settings, String status) {
+        if (status == 'Failed') {
+            return; // Heartbeat tracks successful runs only.
+        }
+        try {
+            settings.LastWatcherHeartbeatDateTime__c = Datetime.now();
+            upsert settings;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryWatcherService] heartbeat stamp failed: ' + e.getMessage());
+        }
+    }
+
+    // ── Utilities ────────────────────────────────────────────────────────────
+
+    /**
+     * @description Null-tolerant string truncation.
+     * @param value    Value to truncate.
+     * @param maxLen   Max length (inclusive).
+     * @return Trimmed value, or empty when input is null.
+     */
+    private static String truncate(String value, Integer maxLen) {
+        if (value == null) {
+            return '';
+        }
+        if (maxLen == null || value.length() <= maxLen) {
+            return value;
+        }
+        return value.substring(0, maxLen);
+    }
+
+    // ── Inner DTOs ───────────────────────────────────────────────────────────
+
+    /**
+     * @description Aggregated run result bubbled back to admin UIs +
+     *              persisted into WatcherDigest__c. Designed to be JSON-
+     *              serialisable for cross-namespace Aura calls.
+     */
+    global virtual class WatcherRunResultDTO {
+
+        /** @description Id of the persisted WatcherDigest__c row, or null when persistence skipped. */
+        @AuraEnabled public Id digestId;
+
+        /** @description Outcome: `Success` / `Partial` / `Failed` / `Skipped`. */
+        @AuraEnabled public String status;
+
+        /** @description Count of WIs in Breached state (SLA signal). */
+        @AuraEnabled public Integer slaBreachCount;
+
+        /** @description Count of WIs in At Risk state (SLA signal). */
+        @AuraEnabled public Integer slaAtRiskCount;
+
+        /** @description Stuck-stage WI count. Zero in PR-B (signal lands in PR-C). */
+        @AuraEnabled public Integer stuckStageCount;
+
+        /** @description AR-aging document count. Zero in PR-B (signal lands in PR-C). */
+        @AuraEnabled public Integer arOverdueCount;
+
+        /** @description Wall-clock duration of the run in milliseconds. */
+        @AuraEnabled public Long runDurationMs;
+
+        /** @description Trimmed digest body markdown (full body persisted to WatcherDigest__c.DigestBodyTxt__c). */
+        @AuraEnabled public String digestBodyMarkdown;
+
+        /** @description Per-signal error captures (signal name + exception message). */
+        @AuraEnabled public List<String> errorMessages;
+
+        /** @description SLA signal raw payload. Internal — used by the formatter; not surfaced to LWC. */
+        public SignalResultDTO slaSignal;
+
+        /**
+         * @description Default constructor. Initialises counts to zero +
+         *              errorMessages to an empty list so callers never NPE.
+         */
+        global WatcherRunResultDTO() {
+            this.slaBreachCount = 0;
+            this.slaAtRiskCount = 0;
+            this.stuckStageCount = 0;
+            this.arOverdueCount = 0;
+            this.runDurationMs = 0L;
+            this.errorMessages = new List<String>();
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryWatcherService.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryWatcherService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryWatcherServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryWatcherServiceTest.cls
@@ -1,0 +1,167 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Tests for DeliveryWatcherService orchestrator. Covers:
+ *
+ *                - master-flag-off → Skipped status + no audit row
+ *                - happy path → Success status + WatcherDigest__c written
+ *                  + heartbeat stamped + per-signal counts populated
+ *                - quiet-day → Success status + audit row written but
+ *                  no Slack callout (recipient list empty path)
+ *                - signal-throw → captured into errorMessages (validated
+ *                  via tampered settings shape would be too invasive;
+ *                  rely on stub flag-gate to keep coverage tractable)
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryWatcherServiceTest {
+
+    private static User testUser = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+
+    /**
+     * @description Mock that always returns 200 OK for the Slack callout.
+     */
+    private class SlackMock implements HttpCalloutMock {
+        public Integer callCount = 0;
+        public HttpResponse respond(HttpRequest req) {
+            this.callCount++;
+            HttpResponse res = new HttpResponse();
+            res.setStatusCode(200);
+            res.setBody('ok');
+            return res;
+        }
+    }
+
+    /**
+     * @description Master flag off → run() is a silent no-op. No
+     *              WatcherDigest__c row is inserted.
+     */
+    @IsTest
+    static void testMasterFlagOffSkips() {
+        System.runAs(testUser) {
+            insert new DeliveryHubSettings__c(
+                SetupOwnerId = UserInfo.getOrganizationId()
+                // EnableWatcherDigestDateTime__c left null → master off
+            );
+
+            Test.startTest();
+            DeliveryWatcherService.WatcherRunResultDTO result =
+                DeliveryWatcherService.runAndReturnSummary();
+            Test.stopTest();
+
+            System.assertEquals('Skipped', result.status, 'Status should be Skipped when master off');
+            System.assertEquals(0, [SELECT COUNT() FROM WatcherDigest__c],
+                'Master-flag-off path must not write a WatcherDigest__c row');
+        }
+    }
+
+    /**
+     * @description Quiet-day happy path: master + SLA signal enabled but no
+     *              alertable WIs in the org → Success status, audit row
+     *              written, heartbeat stamped, no Slack callout because
+     *              recipient list is empty.
+     */
+    @IsTest
+    static void testQuietDayWritesDigestNoSlack() {
+        System.runAs(testUser) {
+            insertWatcherEnabledSettings(null);
+            SlackMock mock = new SlackMock();
+            Test.setMock(HttpCalloutMock.class, mock);
+
+            Test.startTest();
+            DeliveryWatcherService.WatcherRunResultDTO result =
+                DeliveryWatcherService.runAndReturnSummary();
+            Test.stopTest();
+
+            System.assertEquals('Success', result.status, 'Status should be Success on quiet day');
+            System.assertEquals(0, result.slaBreachCount, 'No seeded WIs → zero breach count');
+            System.assertEquals(0, result.slaAtRiskCount, 'No seeded WIs → zero at-risk count');
+            System.assertEquals(0, mock.callCount,
+                'Empty recipient list → no Slack callout, even on Success');
+            List<WatcherDigest__c> rows = [SELECT Id, StatusPk__c, RunModePk__c FROM WatcherDigest__c];
+            System.assertEquals(1, rows.size(), 'One audit row should have been written');
+            System.assertEquals('Success', rows.get(0).StatusPk__c, 'Persisted status should match');
+            System.assertEquals('Test', rows.get(0).RunModePk__c,
+                'Test-context runs should be tagged Test in RunModePk__c');
+
+            DeliveryHubSettings__c after = DeliveryHubSettings__c.getOrgDefaults();
+            System.assertNotEquals(null, after.LastWatcherHeartbeatDateTime__c,
+                'Heartbeat should be stamped after a Success run');
+        }
+    }
+
+    /**
+     * @description Happy path with seeded alertable WIs + recipient list
+     *              configured → Success status, audit row written, Slack
+     *              callout fires.
+     */
+    @IsTest
+    static void testHappyPathPostsToSlack() {
+        System.runAs(testUser) {
+            insertWatcherEnabledSettings(String.valueOf(UserInfo.getUserId()));
+            seedAlertableWorkItem();
+            SlackMock mock = new SlackMock();
+            Test.setMock(HttpCalloutMock.class, mock);
+
+            Test.startTest();
+            DeliveryWatcherService.WatcherRunResultDTO result =
+                DeliveryWatcherService.runAndReturnSummary();
+            Test.stopTest();
+
+            System.assertEquals('Success', result.status, 'Happy path should be Success');
+            System.assert(result.slaBreachCount >= 1,
+                'Seeded breached WI should be counted, got ' + result.slaBreachCount);
+            System.assertEquals(1, mock.callCount,
+                'Recipient list configured + non-quiet → 1 Slack callout');
+            System.assertEquals(1, [SELECT COUNT() FROM WatcherDigest__c],
+                'One audit row written for the run');
+        }
+    }
+
+    /**
+     * @description run() is the void wrapper; calling it should not throw
+     *              when the master flag is off (entire run is a no-op).
+     */
+    @IsTest
+    static void testRunVoidEntryPointNoThrow() {
+        System.runAs(testUser) {
+            insert new DeliveryHubSettings__c(SetupOwnerId = UserInfo.getOrganizationId());
+            Test.startTest();
+            DeliveryWatcherService.run();
+            Test.stopTest();
+            System.assertEquals(0, [SELECT COUNT() FROM WatcherDigest__c],
+                'run() with master off should still write nothing');
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * @description Inserts a DeliveryHubSettings__c row with Watcher
+     *              master + SLA signal enabled. Optionally configures the
+     *              recipient list (non-blank → Slack post path active).
+     * @param recipientIds Optional recipient string; null = quiet path.
+     */
+    private static void insertWatcherEnabledSettings(String recipientIds) {
+        Datetime now = Datetime.now();
+        DeliveryHubSettings__c s = new DeliveryHubSettings__c(
+            SetupOwnerId = UserInfo.getOrganizationId(),
+            EnableWatcherDigestDateTime__c = now,
+            EnableWatcherSLABreachDateTime__c = now,
+            SlackWebhookUrlTxt__c = 'https://hooks.slack.com/services/test',
+            WatcherDigestRecipientUserIdsTxt__c = recipientIds
+        );
+        insert s;
+    }
+
+    /**
+     * @description Seeds a single Breached WI via TestDataFactory.
+     */
+    private static void seedAlertableWorkItem() {
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'Breached WI for orchestrator test',
+            'StageNamePk__c' => 'In Development',
+            'SLATargetDate__c' => Date.today().addDays(-3)
+        });
+    }
+}

--- a/force-app/main/default/classes/DeliveryWatcherServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryWatcherServiceTest.cls
@@ -23,6 +23,12 @@ private class DeliveryWatcherServiceTest {
      */
     private class SlackMock implements HttpCalloutMock {
         public Integer callCount = 0;
+        /**
+         * @description Records each invocation + returns a canned 200 OK so the
+         *              @future callout path executes end-to-end in test context.
+         * @param req Inbound HttpRequest from DeliverySlackService.postWatcherDigest.
+         * @return Canned HttpResponse (status 200, body "ok").
+         */
         public HttpResponse respond(HttpRequest req) {
             this.callCount++;
             HttpResponse res = new HttpResponse();

--- a/force-app/main/default/classes/DeliveryWatcherServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryWatcherServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/SignalEntryDTO.cls
+++ b/force-app/main/default/classes/SignalEntryDTO.cls
@@ -1,0 +1,49 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Single row of a Watcher signal — one WorkItem / Document /
+ *              SyncItem etc. surfaced into the digest body. Up to 5 entries
+ *              per signal go into both the Slack Block Kit message and the
+ *              persisted WatcherDigest__c.DigestBodyTxt__c plaintext.
+ *
+ *              Held as a top-level class so individual signal services don't
+ *              have to import each other's inner types. All fields
+ *              @AuraEnabled because they bubble through the orchestrator's
+ *              return DTO into PR-C+ admin LWCs.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
+global virtual class SignalEntryDTO {
+
+    /** @description Salesforce Id of the surfaced record (WorkItem, Document, etc.). Null when the entry is synthetic (e.g. roll-up aggregate). */
+    @AuraEnabled public Id recordId;
+
+    /** @description Human-readable title — typically `Name — BriefDescription`. */
+    @AuraEnabled public String label;
+
+    /** @description One-line detail string (e.g. `3 days breached · stage: In Review · owner Jose`). */
+    @AuraEnabled public String detailLine;
+
+    /** @description Optional record-page URL for the Slack action button. May be null. */
+    @AuraEnabled public String url;
+
+    /**
+     * @description Default constructor. All fields null on construction.
+     */
+    global SignalEntryDTO() {
+    }
+
+    /**
+     * @description Convenience constructor.
+     * @param recordId  Surfaced record Id.
+     * @param label     Human-readable title.
+     * @param detailLine Detail string.
+     * @param url       Optional record-page URL.
+     */
+    global SignalEntryDTO(Id recordId, String label, String detailLine, String url) {
+        this.recordId = recordId;
+        this.label = label;
+        this.detailLine = detailLine;
+        this.url = url;
+    }
+}

--- a/force-app/main/default/classes/SignalEntryDTO.cls
+++ b/force-app/main/default/classes/SignalEntryDTO.cls
@@ -28,12 +28,6 @@ global virtual class SignalEntryDTO {
     @AuraEnabled public String url;
 
     /**
-     * @description Default constructor. All fields null on construction.
-     */
-    global SignalEntryDTO() {
-    }
-
-    /**
      * @description Convenience constructor.
      * @param recordId  Surfaced record Id.
      * @param label     Human-readable title.

--- a/force-app/main/default/classes/SignalEntryDTO.cls-meta.xml
+++ b/force-app/main/default/classes/SignalEntryDTO.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/SignalResultDTO.cls
+++ b/force-app/main/default/classes/SignalResultDTO.cls
@@ -1,0 +1,53 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Shared payload returned by every Watcher *QueryService.query()
+ *              method. The orchestrator (DeliveryWatcherService) merges these
+ *              into a WatcherRunResultDTO and persists a WatcherDigest__c row
+ *              + posts to Slack. Held as a top-level class so individual
+ *              signal services don't have to import each other's inner types.
+ *
+ *              All fields are @AuraEnabled — they bubble through the
+ *              orchestrator's WatcherRunResultDTO into LWC manual-run UX
+ *              that PR-C+ may add.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
+global virtual class SignalResultDTO {
+
+    /** @description Stable identifier of the signal that produced this result (e.g. 'SLABreach', 'StuckStage'). */
+    @AuraEnabled public String signalName;
+
+    /** @description Primary headline count (e.g. Breached WI count for SLA, Stuck WI count for stuck-stage). */
+    @AuraEnabled public Integer primaryCount;
+
+    /** @description Secondary count (e.g. AtRisk for SLA). Nullable — signals that have no secondary leave this null. */
+    @AuraEnabled public Integer secondaryCount;
+
+    /** @description Up to 5 representative entries for the digest body. May be empty even when counts are non-zero (signal opted out of body lines). */
+    @AuraEnabled public List<SignalEntryDTO> topEntries;
+
+    /** @description Populated when the query method threw; the orchestrator captures it into WatcherDigest__c.ErrorMessageTxt__c and downgrades StatusPk__c to Partial. */
+    @AuraEnabled public String errorMessage;
+
+    /**
+     * @description Default constructor. Initialises topEntries to an empty
+     *              list so callers never NPE when iterating.
+     */
+    global SignalResultDTO() {
+        this.primaryCount = 0;
+        this.secondaryCount = 0;
+        this.topEntries = new List<SignalEntryDTO>();
+    }
+
+    /**
+     * @description Convenience factory for an empty / no-op result.
+     * @param name Stable signal identifier.
+     * @return Empty SignalResultDTO with signalName set + counts at 0.
+     */
+    global static SignalResultDTO emptyResult(String name) {
+        SignalResultDTO r = new SignalResultDTO();
+        r.signalName = name;
+        return r;
+    }
+}

--- a/force-app/main/default/classes/SignalResultDTO.cls-meta.xml
+++ b/force-app/main/default/classes/SignalResultDTO.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/WatcherDigestRunQueueable.cls
+++ b/force-app/main/default/classes/WatcherDigestRunQueueable.cls
@@ -1,0 +1,31 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Thin queueable wrapper around DeliveryWatcherService.run().
+ *              Enqueued by DeliveryHubScheduler.enqueueWatcherDigestIfDue at
+ *              the configured GMT hour once per day. Implements
+ *              Database.AllowsCallouts so the orchestrator's downstream
+ *              DeliverySlackService.postWatcherDigest @future callout chain
+ *              is permitted in the same job. Mirrors
+ *              DeliveryForecastAlertQueueable shape.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexDoc')
+public with sharing class WatcherDigestRunQueueable implements Queueable, Database.AllowsCallouts {
+
+    /**
+     * @description Queueable entry point. Delegates to the orchestrator and
+     *              swallows any exception so the queueable doesn't crash
+     *              loudly in the org's job monitor — failures are already
+     *              captured in WatcherDigest__c.ErrorMessageTxt__c.
+     * @param qc Queueable context (unused).
+     */
+    public void execute(QueueableContext qc) {
+        try {
+            DeliveryWatcherService.run();
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[WatcherDigestRunQueueable] run failed: ' + e.getMessage());
+        }
+    }
+}

--- a/force-app/main/default/classes/WatcherDigestRunQueueable.cls-meta.xml
+++ b/force-app/main/default/classes/WatcherDigestRunQueueable.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/WatcherDigestRunQueueableTest.cls
+++ b/force-app/main/default/classes/WatcherDigestRunQueueableTest.cls
@@ -1,0 +1,51 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Test for WatcherDigestRunQueueable. Asserts the queueable
+ *              calls DeliveryWatcherService.run() — verified indirectly via
+ *              the digest row insertion path.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class WatcherDigestRunQueueableTest {
+
+    private static User testUser = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+
+    /**
+     * @description Master-flag-off run via the queueable should not insert
+     *              a WatcherDigest__c row and must not throw. Proves the
+     *              queueable hands control to the service.
+     */
+    @IsTest
+    static void testQueueableMasterOffNoOps() {
+        System.runAs(testUser) {
+            insert new DeliveryHubSettings__c(SetupOwnerId = UserInfo.getOrganizationId());
+            Test.startTest();
+            System.enqueueJob(new WatcherDigestRunQueueable());
+            Test.stopTest();
+            System.assertEquals(0, [SELECT COUNT() FROM WatcherDigest__c],
+                'Master-off queueable run should not write an audit row');
+        }
+    }
+
+    /**
+     * @description Happy-path queueable run with master + SLA flags on
+     *              should produce exactly one WatcherDigest__c row.
+     */
+    @IsTest
+    static void testQueueableWritesDigestWhenEnabled() {
+        System.runAs(testUser) {
+            Datetime now = Datetime.now();
+            insert new DeliveryHubSettings__c(
+                SetupOwnerId = UserInfo.getOrganizationId(),
+                EnableWatcherDigestDateTime__c = now,
+                EnableWatcherSLABreachDateTime__c = now
+            );
+            Test.startTest();
+            System.enqueueJob(new WatcherDigestRunQueueable());
+            Test.stopTest();
+            System.assertEquals(1, [SELECT COUNT() FROM WatcherDigest__c],
+                'Enabled queueable run should write exactly one audit row');
+        }
+    }
+}

--- a/force-app/main/default/classes/WatcherDigestRunQueueableTest.cls-meta.xml
+++ b/force-app/main/default/classes/WatcherDigestRunQueueableTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/WatcherFailedSyncTrendQueryService.cls
+++ b/force-app/main/default/classes/WatcherFailedSyncTrendQueryService.cls
@@ -1,0 +1,38 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Stub D — Watcher signal that will eventually detect a
+ *              rolling 7-day count of SyncItem__c.StatusPk__c='Failed' rows
+ *              that did NOT auto-recover (i.e. survived
+ *              FailedSyncAutoDismissDaysNumber__c window or were dismissed
+ *              manually) — trended against the prior 7 days. Alerts on
+ *              delta, not on Failed count itself (the existing self-healers
+ *              handle individual failures fine).
+ *
+ *              Deferred because: needs 14-21 days of post-Watcher-install
+ *              reconciler data to baseline what "normal" failure rate looks
+ *              like per org. Without a baseline this is a noise generator.
+ *              This is the strongest stub — it pairs with the 14-day Watcher
+ *              stabilization gate that already gates Phase 3.
+ *
+ *              v1 shim: empty class + EnableWatcherSyncTrendDateTime__c
+ *              flag. Returns empty SignalResultDTO.
+ * @author Cloud Nimbus LLC
+ */
+public with sharing class WatcherFailedSyncTrendQueryService {
+
+    /** @description Stable signal identifier surfaced into WatcherDigest__c.SignalCountsTxt__c. */
+    public static final String SIGNAL_NAME = 'FailedSyncTrend';
+
+    /**
+     * @description Stub implementation. Always returns an empty result.
+     *              Real implementation lands once Watcher has 14+ days of
+     *              baseline data to compute deltas against.
+     * @return Empty SignalResultDTO with signalName populated.
+     */
+    public static SignalResultDTO query() {
+        System.debug(LoggingLevel.INFO,
+            '[WatcherFailedSyncTrendQueryService] stub — empty result');
+        return SignalResultDTO.emptyResult(SIGNAL_NAME);
+    }
+}

--- a/force-app/main/default/classes/WatcherFailedSyncTrendQueryService.cls-meta.xml
+++ b/force-app/main/default/classes/WatcherFailedSyncTrendQueryService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/WatcherFailedSyncTrendQueryServiceTest.cls
+++ b/force-app/main/default/classes/WatcherFailedSyncTrendQueryServiceTest.cls
@@ -1,0 +1,24 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Smoke test for WatcherFailedSyncTrendQueryService stub.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class WatcherFailedSyncTrendQueryServiceTest {
+
+    /**
+     * @description Verifies the stub returns an empty SignalResultDTO.
+     */
+    @IsTest
+    static void testStubReturnsEmpty() {
+        Test.startTest();
+        SignalResultDTO result = WatcherFailedSyncTrendQueryService.query();
+        Test.stopTest();
+
+        System.assertNotEquals(null, result, 'Stub should return a non-null DTO');
+        System.assertEquals(WatcherFailedSyncTrendQueryService.SIGNAL_NAME, result.signalName,
+            'signalName should be populated');
+        System.assertEquals(0, result.primaryCount, 'Stub should report zero primary count');
+    }
+}

--- a/force-app/main/default/classes/WatcherFailedSyncTrendQueryServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/WatcherFailedSyncTrendQueryServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/WatcherPaymentOpsQueryService.cls
+++ b/force-app/main/default/classes/WatcherPaymentOpsQueryService.cls
@@ -1,0 +1,35 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Stub C — Watcher signal that will eventually detect edge
+ *              cases the AR-aging signal doesn't cover — payment-in-progress
+ *              states (e.g. DeliveryTransaction__c for Stripe webhook,
+ *              dispute reasons surfacing, refund windows opening). Cross-
+ *              references DeliveryTransaction__c (which already exists)
+ *              with invoice status.
+ *
+ *              Deferred because: Stripe-style transaction object isn't fully
+ *              wired across all orgs yet (per memory the CN portal side is
+ *              mid-build).
+ *
+ *              v1 shim: empty class + EnableWatcherPaymentOpsDateTime__c
+ *              flag. Returns empty SignalResultDTO.
+ * @author Cloud Nimbus LLC
+ */
+public with sharing class WatcherPaymentOpsQueryService {
+
+    /** @description Stable signal identifier surfaced into WatcherDigest__c.SignalCountsTxt__c. */
+    public static final String SIGNAL_NAME = 'PaymentOps';
+
+    /**
+     * @description Stub implementation. Always returns an empty result.
+     *              Real implementation lands once DeliveryTransaction__c
+     *              ingest is fully cross-org.
+     * @return Empty SignalResultDTO with signalName populated.
+     */
+    public static SignalResultDTO query() {
+        System.debug(LoggingLevel.INFO,
+            '[WatcherPaymentOpsQueryService] stub — empty result');
+        return SignalResultDTO.emptyResult(SIGNAL_NAME);
+    }
+}

--- a/force-app/main/default/classes/WatcherPaymentOpsQueryService.cls-meta.xml
+++ b/force-app/main/default/classes/WatcherPaymentOpsQueryService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/WatcherPaymentOpsQueryServiceTest.cls
+++ b/force-app/main/default/classes/WatcherPaymentOpsQueryServiceTest.cls
@@ -1,0 +1,24 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Smoke test for WatcherPaymentOpsQueryService stub.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class WatcherPaymentOpsQueryServiceTest {
+
+    /**
+     * @description Verifies the stub returns an empty SignalResultDTO.
+     */
+    @IsTest
+    static void testStubReturnsEmpty() {
+        Test.startTest();
+        SignalResultDTO result = WatcherPaymentOpsQueryService.query();
+        Test.stopTest();
+
+        System.assertNotEquals(null, result, 'Stub should return a non-null DTO');
+        System.assertEquals(WatcherPaymentOpsQueryService.SIGNAL_NAME, result.signalName,
+            'signalName should be populated');
+        System.assertEquals(0, result.primaryCount, 'Stub should report zero primary count');
+    }
+}

--- a/force-app/main/default/classes/WatcherPaymentOpsQueryServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/WatcherPaymentOpsQueryServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/WatcherSLABreachQueryService.cls
+++ b/force-app/main/default/classes/WatcherSLABreachQueryService.cls
@@ -1,0 +1,158 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Signal 1 — surfaces root-level WorkItems whose SLA formula
+ *              field has tipped past `Breached` or `At Risk`. Reuses the
+ *              existing WorkItem__c.SLAStatusTxt__c formula — no
+ *              re-derivation. Single bulk SOQL, capped at 50, excludes
+ *              templates / archived / terminal-stage / parent-WI rows.
+ *
+ *              Returns a SignalResultDTO with:
+ *                primaryCount   = count of `Breached` WIs in the result set
+ *                secondaryCount = count of `At Risk` WIs in the result set
+ *                topEntries     = up to 5 by (breached first, then at-risk),
+ *                                 ordered by SLATargetDate__c ASC (most
+ *                                 overdue first).
+ *
+ *              Errors thrown by query() bubble up to the orchestrator's
+ *              try/catch — this class deliberately does NOT catch internally.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation')
+public with sharing class WatcherSLABreachQueryService {
+
+    /** @description Stable signal identifier surfaced into WatcherDigest__c.SignalCountsTxt__c + the digest body. */
+    public static final String SIGNAL_NAME = 'SLABreach';
+
+    /** @description Max rows pulled in a single sweep. Single SOQL, no fan-out per row. */
+    @TestVisible
+    private static final Integer ROW_CAP = 50;
+
+    /** @description Max body entries surfaced into the digest message. */
+    @TestVisible
+    private static final Integer TOP_ENTRY_CAP = 5;
+
+    /** @description Terminal stages excluded from sweep (matches the SLA formula's `Met` carve-out + adds a couple more). */
+    private static final Set<String> EXCLUDED_STAGES = new Set<String>{
+        'Done', 'Cancelled', 'Closed', 'Rejected', 'Deployed to Prod'
+    };
+
+    /**
+     * @description Run the signal. Single SOQL over WorkItem__c, filtered by
+     *              SLAStatusTxt__c IN ('Breached','At Risk'), root WIs only,
+     *              non-template / non-archived / non-terminal.
+     * @return SignalResultDTO with counts + up to 5 entries.
+     */
+    public static SignalResultDTO query() {
+        List<WorkItem__c> rows = fetchAlertableWorkItems();
+        return assembleResult(rows);
+    }
+
+    /**
+     * @description Pulls the SLA-alertable WorkItems in a single bulk SOQL.
+     *              Ordered breached-first, then At Risk; within each bucket
+     *              the most overdue (smallest SLATargetDate__c) lands first.
+     * @return List of WorkItem__c rows, max ROW_CAP entries.
+     */
+    private static List<WorkItem__c> fetchAlertableWorkItems() {
+        return [
+            SELECT Id, Name, BriefDescriptionTxt__c, StageNamePk__c,
+                   SLAStatusTxt__c, SLATargetDate__c, OwnerId
+            FROM WorkItem__c
+            WHERE SLAStatusTxt__c IN ('Breached', 'At Risk')
+              AND ParentWorkItemLookup__c = NULL
+              AND ActivatedDateTime__c != NULL
+              AND ArchivedDateTime__c = NULL
+              AND TemplateMarkedDateTime__c = NULL
+              AND StageNamePk__c NOT IN :EXCLUDED_STAGES
+            WITH SYSTEM_MODE
+            ORDER BY SLAStatusTxt__c ASC, SLATargetDate__c ASC NULLS LAST
+            LIMIT :ROW_CAP
+        ];
+    }
+
+    /**
+     * @description Walks the queried rows, tallies counts per bucket, and
+     *              builds up to TOP_ENTRY_CAP entries for the digest body.
+     * @param rows Result rows from fetchAlertableWorkItems.
+     * @return Fully-populated SignalResultDTO ready for orchestrator merge.
+     */
+    private static SignalResultDTO assembleResult(List<WorkItem__c> rows) {
+        SignalResultDTO result = SignalResultDTO.emptyResult(SIGNAL_NAME);
+        if (rows == null || rows.isEmpty()) {
+            return result;
+        }
+        Integer breachedCount = 0;
+        Integer atRiskCount = 0;
+        String orgUrl = safeOrgUrl();
+        for (WorkItem__c wi : rows) {
+            if (wi.SLAStatusTxt__c == 'Breached') {
+                breachedCount++;
+            } else if (wi.SLAStatusTxt__c == 'At Risk') {
+                atRiskCount++;
+            }
+            if (result.topEntries.size() < TOP_ENTRY_CAP) {
+                result.topEntries.add(buildEntry(wi, orgUrl));
+            }
+        }
+        result.primaryCount = breachedCount;
+        result.secondaryCount = atRiskCount;
+        return result;
+    }
+
+    /**
+     * @description Builds one digest entry from a WorkItem row.
+     * @param wi     The WorkItem to render.
+     * @param orgUrl Cached org URL (or empty string if unavailable).
+     * @return SignalEntryDTO with label + detail + record-page URL.
+     */
+    private static SignalEntryDTO buildEntry(WorkItem__c wi, String orgUrl) {
+        String briefDesc = String.isBlank(wi.BriefDescriptionTxt__c)
+            ? 'Untitled' : wi.BriefDescriptionTxt__c;
+        String label = wi.Name + ' — ' + briefDesc;
+        String detail = buildDetailLine(wi);
+        String recordUrl = String.isBlank(orgUrl)
+            ? null
+            : (orgUrl + '/lightning/r/WorkItem__c/' + wi.Id + '/view');
+        return new SignalEntryDTO(wi.Id, label, detail, recordUrl);
+    }
+
+    /**
+     * @description Builds the one-line detail string for a digest entry —
+     *              e.g. `3 days breached · stage: In Review` or
+     *              `2 days to deadline · stage: Awaiting Signoff`.
+     * @param wi The WorkItem to summarise.
+     * @return Detail string for the digest body.
+     */
+    private static String buildDetailLine(WorkItem__c wi) {
+        String stagePart = String.isBlank(wi.StageNamePk__c)
+            ? '' : (' · stage: ' + wi.StageNamePk__c);
+        if (wi.SLATargetDate__c == null) {
+            return wi.SLAStatusTxt__c + stagePart;
+        }
+        Integer daysDelta = wi.SLATargetDate__c.daysBetween(Date.today());
+        if (wi.SLAStatusTxt__c == 'Breached') {
+            Integer absDays = Math.abs(daysDelta);
+            String unit = absDays == 1 ? 'day' : 'days';
+            return absDays + ' ' + unit + ' breached' + stagePart;
+        }
+        Integer daysToTarget = -daysDelta;
+        String unit2 = daysToTarget == 1 ? 'day' : 'days';
+        return daysToTarget + ' ' + unit2 + ' to deadline' + stagePart;
+    }
+
+    /**
+     * @description Returns the org domain URL or empty string when unavailable
+     *              (e.g. some scratch contexts return null). We never want to
+     *              produce a URL like `null/lightning/...`.
+     * @return Org domain URL or empty string.
+     */
+    private static String safeOrgUrl() {
+        try {
+            Url u = Url.getOrgDomainUrl();
+            return (u == null) ? '' : u.toExternalForm();
+        } catch (Exception e) {
+            return '';
+        }
+    }
+}

--- a/force-app/main/default/classes/WatcherSLABreachQueryService.cls-meta.xml
+++ b/force-app/main/default/classes/WatcherSLABreachQueryService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/WatcherSLABreachQueryServiceTest.cls
+++ b/force-app/main/default/classes/WatcherSLABreachQueryServiceTest.cls
@@ -1,0 +1,177 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Unit tests for WatcherSLABreachQueryService. SLAStatusTxt__c
+ *              is a formula derived from SLATargetDate__c + StageNamePk__c,
+ *              so tests seed WIs with explicit SLATargetDate__c values that
+ *              place them in the Breached or At Risk buckets per the
+ *              formula in objects/WorkItem__c/fields/SLAStatusTxt__c.
+ *
+ *              Formula recap:
+ *                target blank          → ''
+ *                stage terminal        → 'Met'
+ *                target < TODAY        → 'Breached'
+ *                target - TODAY ≤ 2    → 'At Risk'
+ *                otherwise             → 'On Track'
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class WatcherSLABreachQueryServiceTest {
+
+    /**
+     * @description Happy path: 2 Breached + 1 At Risk → counts 2/1, 3 entries.
+     */
+    @IsTest
+    static void testHappyPathReturnsCountsAndEntries() {
+        seedAlertableWorkItems(2, 1);
+
+        Test.startTest();
+        SignalResultDTO result = WatcherSLABreachQueryService.query();
+        Test.stopTest();
+
+        System.assertNotEquals(null, result, 'Query should never return null on the happy path');
+        System.assertEquals('SLABreach', result.signalName, 'signalName should be SLABreach');
+        System.assertEquals(2, result.primaryCount,
+            'primaryCount should reflect the seeded Breached count');
+        System.assertEquals(1, result.secondaryCount,
+            'secondaryCount should reflect the seeded At Risk count');
+        System.assertEquals(3, result.topEntries.size(),
+            'topEntries should surface all 3 seeded alertable WIs');
+        // Spot-check entry shape.
+        SignalEntryDTO first = result.topEntries.get(0);
+        System.assertNotEquals(null, first.recordId, 'Entry should carry the WI Id');
+        System.assertNotEquals(null, first.label, 'Entry should carry a label');
+        System.assertNotEquals(null, first.detailLine, 'Entry should carry a detail line');
+    }
+
+    /**
+     * @description Empty path: no alertable WIs → counts zero, no entries,
+     *              no error.
+     */
+    @IsTest
+    static void testEmptyReturnsZeroCounts() {
+        // Seed nothing alertable. Insert one On-Track WI to prove the
+        // filter excludes it.
+        WorkItem__c onTrack = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'On track WI',
+            'StageNamePk__c' => 'In Development',
+            'SLATargetDate__c' => Date.today().addDays(30)
+        });
+        System.assertNotEquals(null, onTrack.Id, 'Seed insert should have succeeded');
+
+        Test.startTest();
+        SignalResultDTO result = WatcherSLABreachQueryService.query();
+        Test.stopTest();
+
+        System.assertEquals(0, result.primaryCount, 'No alertable WIs → primaryCount=0');
+        System.assertEquals(0, result.secondaryCount, 'No alertable WIs → secondaryCount=0');
+        System.assertEquals(0, result.topEntries.size(), 'No alertable WIs → empty entries');
+    }
+
+    /**
+     * @description Bulk: 60 alertable WIs → respects LIMIT 50 + caps
+     *              topEntries at 5.
+     */
+    @IsTest
+    static void testBulkRespectsLimit() {
+        seedAlertableWorkItems(60, 0);
+
+        Test.startTest();
+        SignalResultDTO result = WatcherSLABreachQueryService.query();
+        Test.stopTest();
+
+        // The SOQL is LIMIT 50; primaryCount is computed from query rows so it
+        // reflects up to 50, not the seeded 60.
+        System.assert(result.primaryCount <= 50,
+            'primaryCount should be capped at LIMIT 50, got ' + result.primaryCount);
+        System.assert(result.primaryCount >= 49,
+            'primaryCount should pull at or near the LIMIT, got ' + result.primaryCount);
+        System.assertEquals(5, result.topEntries.size(),
+            'topEntries should be capped at TOP_ENTRY_CAP (5)');
+    }
+
+    /**
+     * @description Templates, archived, terminal-stage, and child WIs must
+     *              be excluded from the result set even when their SLA dates
+     *              would otherwise alert.
+     */
+    @IsTest
+    static void testExcludedRecordsNotSurfaced() {
+        Date breachedDate = Date.today().addDays(-3);
+        // Template — should be excluded by TemplateMarkedDateTime__c filter.
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'Template WI',
+            'StageNamePk__c' => 'In Development',
+            'SLATargetDate__c' => breachedDate,
+            'TemplateMarkedDateTime__c' => Datetime.now()
+        });
+        // Archived — should be excluded by ArchivedDateTime__c filter.
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'Archived WI',
+            'StageNamePk__c' => 'In Development',
+            'SLATargetDate__c' => breachedDate,
+            'ArchivedDateTime__c' => Datetime.now()
+        });
+        // Terminal stage 'Done' → SLA formula returns Met, excluded by IN clause too.
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'Done WI',
+            'StageNamePk__c' => 'Done',
+            'SLATargetDate__c' => breachedDate
+        });
+        // Deactivated WI — should be excluded by ActivatedDateTime__c filter.
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'Deactivated WI',
+            'StageNamePk__c' => 'In Development',
+            'SLATargetDate__c' => breachedDate,
+            'ActivatedDateTime__c' => null
+        });
+        // Child WI — should be excluded by ParentWorkItemLookup__c filter.
+        WorkItem__c parent = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'Parent WI for child exclusion test',
+            'StageNamePk__c' => 'In Development',
+            'SLATargetDate__c' => Date.today().addDays(30)
+        });
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'Child WI',
+            'StageNamePk__c' => 'In Development',
+            'SLATargetDate__c' => breachedDate,
+            'ParentWorkItemLookup__c' => parent.Id
+        });
+
+        Test.startTest();
+        SignalResultDTO result = WatcherSLABreachQueryService.query();
+        Test.stopTest();
+
+        System.assertEquals(0, result.primaryCount,
+            'All excluded records should not be surfaced — got ' + result.primaryCount + ' breached');
+        System.assertEquals(0, result.secondaryCount,
+            'No at-risk records should surface — got ' + result.secondaryCount);
+    }
+
+    /**
+     * @description Seeds N Breached + M At-Risk WIs using TestDataFactory.
+     *              Breached WIs have SLATargetDate__c in the past (the
+     *              formula returns 'Breached' when target < TODAY).
+     *              At-Risk WIs have SLATargetDate__c within 2 days of today.
+     * @param breachedCount Number of breached WIs to insert.
+     * @param atRiskCount   Number of at-risk WIs to insert.
+     */
+    private static void seedAlertableWorkItems(Integer breachedCount, Integer atRiskCount) {
+        Date breachedDate = Date.today().addDays(-3);
+        Date atRiskDate = Date.today().addDays(1);
+        for (Integer i = 0; i < breachedCount; i++) {
+            TestDataFactory.createWorkItem(new Map<String, Object>{
+                'BriefDescriptionTxt__c' => 'Breached WI ' + i,
+                'StageNamePk__c' => 'In Development',
+                'SLATargetDate__c' => breachedDate
+            });
+        }
+        for (Integer i = 0; i < atRiskCount; i++) {
+            TestDataFactory.createWorkItem(new Map<String, Object>{
+                'BriefDescriptionTxt__c' => 'At Risk WI ' + i,
+                'StageNamePk__c' => 'In Development',
+                'SLATargetDate__c' => atRiskDate
+            });
+        }
+    }
+}

--- a/force-app/main/default/classes/WatcherSLABreachQueryServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/WatcherSLABreachQueryServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/WatcherUnhappySignalQueryService.cls
+++ b/force-app/main/default/classes/WatcherUnhappySignalQueryService.cls
@@ -1,0 +1,35 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Stub A — Watcher signal that will eventually detect WIs whose
+ *              sentiment trend on WorkItemComment__c.BodyTxt__c has tipped
+ *              negative (frustrated reply patterns, repeated "still broken",
+ *              customer escalation language). Likely OpenAI-classified.
+ *
+ *              Deferred because: requires NLP / signal-design + customer-
+ *              language baseline. Easy to get wrong (false-positive flags
+ *              Glen ignores → erodes signal-to-noise). Wait until we've
+ *              baselined what an "unhappy" comment looks like.
+ *
+ *              v1 shim: empty class + EnableWatcherUnhappySignalDateTime__c
+ *              flag. Returns empty SignalResultDTO so the orchestrator can
+ *              merge cleanly without special-casing stubs.
+ * @author Cloud Nimbus LLC
+ */
+public with sharing class WatcherUnhappySignalQueryService {
+
+    /** @description Stable signal identifier surfaced into WatcherDigest__c.SignalCountsTxt__c. */
+    public static final String SIGNAL_NAME = 'UnhappySignal';
+
+    /**
+     * @description Stub implementation. Always returns an empty result.
+     *              Real implementation lands once we have a comment-sentiment
+     *              baseline and OpenAI classifier wired.
+     * @return Empty SignalResultDTO with signalName populated.
+     */
+    public static SignalResultDTO query() {
+        System.debug(LoggingLevel.INFO,
+            '[WatcherUnhappySignalQueryService] stub — empty result');
+        return SignalResultDTO.emptyResult(SIGNAL_NAME);
+    }
+}

--- a/force-app/main/default/classes/WatcherUnhappySignalQueryService.cls-meta.xml
+++ b/force-app/main/default/classes/WatcherUnhappySignalQueryService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/WatcherUnhappySignalQueryServiceTest.cls
+++ b/force-app/main/default/classes/WatcherUnhappySignalQueryServiceTest.cls
@@ -1,0 +1,30 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Smoke test for WatcherUnhappySignalQueryService stub. PR-B
+ *              ships this signal as a flag-gated empty result; the test
+ *              just asserts the stub responds with an empty SignalResultDTO.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class WatcherUnhappySignalQueryServiceTest {
+
+    /**
+     * @description Verifies the stub returns a non-null result with empty
+     *              entries and zero counts.
+     */
+    @IsTest
+    static void testStubReturnsEmpty() {
+        Test.startTest();
+        SignalResultDTO result = WatcherUnhappySignalQueryService.query();
+        Test.stopTest();
+
+        System.assertNotEquals(null, result, 'Stub should return a non-null DTO');
+        System.assertEquals(WatcherUnhappySignalQueryService.SIGNAL_NAME, result.signalName,
+            'signalName should be populated even for an empty result');
+        System.assertEquals(0, result.primaryCount, 'Stub should report zero primary count');
+        System.assertEquals(0, result.secondaryCount, 'Stub should report zero secondary count');
+        System.assertEquals(0, result.topEntries.size(), 'Stub should not surface entries');
+        System.assertEquals(null, result.errorMessage, 'Stub should not populate an error');
+    }
+}

--- a/force-app/main/default/classes/WatcherUnhappySignalQueryServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/WatcherUnhappySignalQueryServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/WatcherUpcomingSignoffQueryService.cls
+++ b/force-app/main/default/classes/WatcherUpcomingSignoffQueryService.cls
@@ -1,0 +1,34 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Stub B — Watcher signal that will eventually detect
+ *              DeliveryDocuments in Awaiting_Signatures status whose
+ *              RequireSigningDateTime__c is past + signer hasn't viewed
+ *              (ViewedDateTime__c=null) in N days; OR WIs entering a stage
+ *              that requires signoff per a CMT-defined gate.
+ *
+ *              Deferred because: the signoff workflow
+ *              (DeliveryAdminSigningController etc.) is mid-feature — the
+ *              data shape isn't stable yet.
+ *
+ *              v1 shim: empty class + EnableWatcherSignoffDateTime__c flag.
+ *              Returns empty SignalResultDTO.
+ * @author Cloud Nimbus LLC
+ */
+public with sharing class WatcherUpcomingSignoffQueryService {
+
+    /** @description Stable signal identifier surfaced into WatcherDigest__c.SignalCountsTxt__c. */
+    public static final String SIGNAL_NAME = 'UpcomingSignoff';
+
+    /**
+     * @description Stub implementation. Always returns an empty result.
+     *              Real implementation lands after the Awaiting_Signatures /
+     *              gated-stage signoff workflow stabilises.
+     * @return Empty SignalResultDTO with signalName populated.
+     */
+    public static SignalResultDTO query() {
+        System.debug(LoggingLevel.INFO,
+            '[WatcherUpcomingSignoffQueryService] stub — empty result');
+        return SignalResultDTO.emptyResult(SIGNAL_NAME);
+    }
+}

--- a/force-app/main/default/classes/WatcherUpcomingSignoffQueryService.cls-meta.xml
+++ b/force-app/main/default/classes/WatcherUpcomingSignoffQueryService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/WatcherUpcomingSignoffQueryServiceTest.cls
+++ b/force-app/main/default/classes/WatcherUpcomingSignoffQueryServiceTest.cls
@@ -1,0 +1,25 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Smoke test for WatcherUpcomingSignoffQueryService stub.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class WatcherUpcomingSignoffQueryServiceTest {
+
+    /**
+     * @description Verifies the stub returns an empty SignalResultDTO.
+     */
+    @IsTest
+    static void testStubReturnsEmpty() {
+        Test.startTest();
+        SignalResultDTO result = WatcherUpcomingSignoffQueryService.query();
+        Test.stopTest();
+
+        System.assertNotEquals(null, result, 'Stub should return a non-null DTO');
+        System.assertEquals(WatcherUpcomingSignoffQueryService.SIGNAL_NAME, result.signalName,
+            'signalName should be populated');
+        System.assertEquals(0, result.primaryCount, 'Stub should report zero primary count');
+        System.assertEquals(0, result.topEntries.size(), 'Stub should not surface entries');
+    }
+}

--- a/force-app/main/default/classes/WatcherUpcomingSignoffQueryServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/WatcherUpcomingSignoffQueryServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
@@ -221,7 +221,39 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryWatcherDigestFormatter</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DeliveryWatcherService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryWorkloadController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>WatcherDigestRunQueueable</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>WatcherFailedSyncTrendQueryService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>WatcherPaymentOpsQueryService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>WatcherSLABreachQueryService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>WatcherUnhappySignalQueryService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>WatcherUpcomingSignoffQueryService</apexClass>
         <enabled>true</enabled>
     </classAccesses>
     <description>This permission set provides access to the &quot;Delivery Hub Admin&quot; Lightning App</description>

--- a/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
@@ -221,7 +221,39 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryWatcherDigestFormatter</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DeliveryWatcherService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryWorkloadController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>WatcherDigestRunQueueable</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>WatcherFailedSyncTrendQueryService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>WatcherPaymentOpsQueryService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>WatcherSLABreachQueryService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>WatcherUnhappySignalQueryService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>WatcherUpcomingSignoffQueryService</apexClass>
         <enabled>true</enabled>
     </classAccesses>
     <description>This permission set provides access to the &quot;Delivery Hub&quot; Lightning App</description>

--- a/unpackaged/post/testSuites/DH.testSuite-meta.xml
+++ b/unpackaged/post/testSuites/DH.testSuite-meta.xml
@@ -111,4 +111,12 @@
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryOnboardingServiceTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryDevLoopControllerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryDatasetControllerTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryWatcherDigestFormatterTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryWatcherServiceTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%WatcherDigestRunQueueableTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%WatcherFailedSyncTrendQueryServiceTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%WatcherPaymentOpsQueryServiceTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%WatcherSLABreachQueryServiceTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%WatcherUnhappySignalQueryServiceTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%WatcherUpcomingSignoffQueryServiceTest</testClassName>
 </ApexTestSuite>


### PR DESCRIPTION
## Summary

Second of three Watcher PRs (Phase 2). Builds on PR-A's schema scaffold (#807) — adds the orchestrator, the first implemented signal (SLA Breach), four flag-gated stubs, a Slack post path, a daily scheduler tick, and an install-handler default.

After PR-B lands and runs cleanly for 14 days, PR-C adds signals 2 + 3 (StuckStage, ARAging) on the same orchestrator wiring.

## Scope (per docs/plans/phase-2-watcher-design.md § PR-B)

- [x] `DeliveryWatcherService` — global orchestrator + `WatcherRunResultDTO`
- [x] `WatcherSLABreachQueryService` — Signal 1, single bulk SOQL on `WorkItem__c.SLAStatusTxt__c IN ('Breached','At Risk')` with template / archived / terminal / child / inactive exclusions, LIMIT 50
- [x] `SignalResultDTO` + `SignalEntryDTO` — shared payload (top-level, `global virtual`)
- [x] `DeliveryWatcherDigestFormatter` — Block Kit + plaintext markdown; null Block Kit on quiet days so orchestrator can skip Slack while still writing the audit row
- [x] 4 stub classes (Unhappy / Signoff / PaymentOps / FailedSyncTrend) + flag-gates + 1 test each
- [x] `DeliverySlackService.postWatcherDigest` — `@future(callout=true)` reusing `SlackWebhookUrlTxt__c`
- [x] `DeliveryHubScheduler.enqueueWatcherDigestIfDue` — 12 GMT default + heartbeat idempotency
- [x] `WatcherDigestRunQueueable` — `Database.AllowsCallouts` wrapper
- [x] Install handler — defaults top-3 signal flags ON; master flag + recipient list stay null
- [x] Tests: orchestrator (4) + SLA signal (4) + formatter (3) + queueable (2) + 4 stubs + scheduler (4) + Slack (3) + install-handler additions
- [x] Permset entries on both `DeliveryHubApp` + `DeliveryHubAdmin_App`
- [x] 8 new test classes added to `unpackaged/post/testSuites/DH.testSuite-meta.xml`

## What this is NOT

- No new schema fields, no new objects (PR-A handled).
- No `WatcherStuckStageQueryService` (Signal 2) or `WatcherARAgingQueryService` (Signal 3) — PR-C.
- No admin LWC for manual runs — PR-C+.

## Behavior on subscriber orgs

- Master flag (`EnableWatcherDigestDateTime__c`) is null on install → Watcher is silent.
- Glen flips the master flag + populates `WatcherDigestRecipientUserIdsTxt__c` to activate per-tenant.
- Quiet days (all signals returned 0 entries) write a `WatcherDigest__c` row + stamp heartbeat but skip Slack. 14-day-clean gate measured on the audit row trail, not Slack volume.

## Next

PR-C ships signals 2 (StuckStage) + 3 (ARAging) (~4.5h). Same orchestrator wiring — just two new query services + a couple of install-handler tweaks.

## Test plan

- [ ] CI: feature-test job green (PMD + Apex tests)
- [ ] CI: upload-beta job green (packaging-org Apex compile + namespaced tests)
- [ ] Post-promote: anonymous Apex `delivery.DeliveryWatcherService.run()` writes a `WatcherDigest__c` row
- [ ] Post-promote: with master flag + SLA signal flag + recipient list set, Slack message lands on a non-quiet day
- [ ] Verify scheduler tick: `[SELECT Id, CronJobDetail.Name FROM CronTrigger WHERE CronJobDetail.Name LIKE '%Delivery Hub Sync%']` returns 4 rows; manual scheduler `.execute(null)` invocation in anonymous Apex enqueues `WatcherDigestRunQueueable` when GMT hour matches + heartbeat is null

🤖 Generated with [Claude Code](https://claude.com/claude-code)