### PR TITLE
refactor(slack): extract event-type helpers in DeliverySlackInboundHandler.handle()

### DIFF
--- a/force-app/main/default/classes/DeliverySlackInboundHandler.cls
+++ b/force-app/main/default/classes/DeliverySlackInboundHandler.cls
@@ -23,6 +23,13 @@
  *               v1 implements the simple guard "AuthorTxt__c starts with
  *               'DeliveryHub Bot'" — the bot's own outbound posts are tagged
  *               with that author so we recognize and drop them on the way back.
+ *
+ *               Internal structure: handle() is a thin dispatcher. Per-envelope
+ *               and per-event-type branches live in private helpers
+ *               (handleEventCallback / handleMessageEvent / isBotMessage /
+ *               createCommentFromMessage) so each method's cyclomatic stays
+ *               small and individual flow steps are independently readable
+ *               and testable.
  * @author Cloud Nimbus LLC
  */
 @SuppressWarnings('PMD.ApexCRUDViolation,PMD.AvoidGlobalModifier')
@@ -37,9 +44,12 @@ global with sharing class DeliverySlackInboundHandler implements IWebhookEventHa
     private static final String SLACK_AUTHOR_PREFIX = 'Slack';
 
     /**
-     * @description Process a Slack event_callback envelope. v1 only handles
-     *              event.type='message' — channel_join, file_share, etc. are
-     *              ignored as 200 OK so Slack stops retrying.
+     * @description Process a Slack envelope. Acts as a thin dispatcher — the
+     *              only branch is the envelope-type gate; everything else is
+     *              delegated to per-event-type helpers. v1 only handles
+     *              event.type='message' under an event_callback envelope; all
+     *              other envelopes return 200 OK ignored so Slack stops
+     *              retrying.
      * @param eventType The outer Slack envelope type (expects 'event_callback').
      * @param payload   The full Slack Event API payload as a parsed Map.
      * @return WebhookHandlerResult — ok with the inserted comment Id, ignored
@@ -47,17 +57,90 @@ global with sharing class DeliverySlackInboundHandler implements IWebhookEventHa
      *         retryable when DML fails transiently.
      */
     global WebhookHandlerResult handle(String eventType, Map<String, Object> payload) {
-        WebhookHandlerResult envelopeCheck = validateEnvelope(eventType);
-        if (envelopeCheck != null) { return envelopeCheck; }
+        if (!isEventCallback(eventType)) {
+            return WebhookHandlerResult.ignored('Unsupported envelope type ' + eventType);
+        }
+        return handleEventCallback(payload);
+    }
 
+    /**
+     * @description Predicate: is the outer envelope an event_callback? Slack
+     *              also sends url_verification on initial subscription setup,
+     *              but that's intercepted earlier by DeliveryWebhookReceiverApi
+     *              so this handler only ever sees event_callback envelopes in
+     *              steady state.
+     * @param eventType The outer envelope type from the routing dispatcher.
+     * @return true when the envelope is event_callback (case-insensitive).
+     */
+    private static Boolean isEventCallback(String eventType) {
+        return String.isNotBlank(eventType) && eventType.equalsIgnoreCase('event_callback');
+    }
+
+    /**
+     * @description Handle a Slack event_callback envelope. Validates the inner
+     *              event block exists, then delegates to handleMessageEvent for
+     *              actual processing.
+     * @param payload The full Slack Event API payload as a parsed Map.
+     * @return terminal when the envelope is malformed, otherwise whatever
+     *         handleMessageEvent returns.
+     */
+    private static WebhookHandlerResult handleEventCallback(Map<String, Object> payload) {
         Map<String, Object> event = extractMap(payload, 'event');
         if (event == null) {
             return WebhookHandlerResult.terminal('event_callback missing event payload');
         }
-        WebhookHandlerResult messageCheck = validateMessageEvent(event);
-        if (messageCheck != null) { return messageCheck; }
+        return handleMessageEvent(event);
+    }
 
+    /**
+     * @description Process the inner Slack message event. Rejects non-message
+     *              inner types, bot echoes, and empty text up front, then
+     *              delegates to createCommentFromMessage for the actual
+     *              WI-name extraction + comment insert.
+     * @param event The inner event map from the event_callback envelope.
+     * @return ignored when the message should be skipped, otherwise whatever
+     *         createCommentFromMessage returns.
+     */
+    private static WebhookHandlerResult handleMessageEvent(Map<String, Object> event) {
+        String innerType = String.valueOf(event.get('type'));
+        if (!'message'.equalsIgnoreCase(innerType)) {
+            return WebhookHandlerResult.ignored('Slack event.type=' + innerType + ' not yet handled');
+        }
+        if (isBotMessage(event)) {
+            return WebhookHandlerResult.ignored('Skipping bot message — echo-suppression');
+        }
         String text = String.valueOf(event.get('text'));
+        if (String.isBlank(text)) {
+            return WebhookHandlerResult.ignored('Empty message text');
+        }
+        return createCommentFromMessage(event, text);
+    }
+
+    /**
+     * @description Predicate: did this Slack message originate from a bot?
+     *              Slack adds bot_id to messages posted via incoming webhook;
+     *              our outbound poster doesn't go through a Slack App so bot_id
+     *              normally won't be present, but defensively guard anyway so
+     *              we don't loop on our own outbound mirrors when the
+     *              transport changes.
+     * @param event The inner Slack message event.
+     * @return true when the message should be dropped as a bot echo.
+     */
+    private static Boolean isBotMessage(Map<String, Object> event) {
+        return event.containsKey('bot_id');
+    }
+
+    /**
+     * @description Extract the T-NNNN WorkItem name from the message text and
+     *              create the mirrored WorkItemComment__c. Returns ignored
+     *              when no T-NNNN match is found or the WI doesn't exist in
+     *              this org.
+     * @param event The inner Slack message event (used for author + channel).
+     * @param text  The raw Slack message text (pre-validated non-blank).
+     * @return ok with the inserted comment Id on success, ignored when no WI
+     *         is found, retryable on transient DML failure.
+     */
+    private static WebhookHandlerResult createCommentFromMessage(Map<String, Object> event, String text) {
         String wiName = extractWorkItemName(text);
         if (String.isBlank(wiName)) {
             return WebhookHandlerResult.ignored('No WorkItem name (T-NNNN) found in message');
@@ -67,43 +150,6 @@ global with sharing class DeliverySlackInboundHandler implements IWebhookEventHa
             return WebhookHandlerResult.ignored('No WorkItem with Name ' + wiName + ' found in this org');
         }
         return insertSlackComment(wi.Id, buildAuthor(event), buildBody(text, wiName, event));
-    }
-
-    /**
-     * @description Reject non-event_callback envelopes early.
-     * @param eventType The outer envelope type from the routing dispatcher.
-     * @return ignored result when the envelope isn't event_callback, null
-     *         when the envelope is accepted.
-     */
-    private static WebhookHandlerResult validateEnvelope(String eventType) {
-        if (String.isNotBlank(eventType) && eventType.equalsIgnoreCase('event_callback')) {
-            return null;
-        }
-        return WebhookHandlerResult.ignored('Unsupported envelope type ' + eventType);
-    }
-
-    /**
-     * @description Reject non-message inner events, bot echoes, and empty text.
-     *              Slack adds bot_id to messages posted via incoming webhook;
-     *              our outbound poster doesn't go through a Slack App so bot_id
-     *              normally won't be present, but defensively guard anyway.
-     * @param event The inner event map from the event_callback envelope.
-     * @return ignored result when the message should be skipped, null when
-     *         the message should be processed.
-     */
-    private static WebhookHandlerResult validateMessageEvent(Map<String, Object> event) {
-        String innerType = String.valueOf(event.get('type'));
-        if (!'message'.equalsIgnoreCase(innerType)) {
-            return WebhookHandlerResult.ignored('Slack event.type=' + innerType + ' not yet handled');
-        }
-        if (event.containsKey('bot_id')) {
-            return WebhookHandlerResult.ignored('Skipping bot message — echo-suppression');
-        }
-        String text = String.valueOf(event.get('text'));
-        if (String.isBlank(text)) {
-            return WebhookHandlerResult.ignored('Empty message text');
-        }
-        return null;
     }
 
     /**
@@ -168,12 +214,25 @@ global with sharing class DeliverySlackInboundHandler implements IWebhookEventHa
         }
     }
 
+    /**
+     * @description Safely extract a nested Map value by key, returning null
+     *              when the key is missing or the value isn't a Map.
+     * @param source The parent Map.
+     * @param key    The key to look up.
+     * @return The nested Map, or null when absent / wrong type.
+     */
     @TestVisible
     private static Map<String, Object> extractMap(Map<String, Object> source, String key) {
         Object v = source.get(key);
         return v instanceof Map<String, Object> ? (Map<String, Object>) v : null;
     }
 
+    /**
+     * @description Find the first T-NNNN WorkItem Name match in the message
+     *              text. Returns the uppercase form for downstream lookups.
+     * @param text The raw Slack message text.
+     * @return Uppercase T-NNNN string, or null when no match is found.
+     */
     @TestVisible
     private static String extractWorkItemName(String text) {
         if (String.isBlank(text)) { return null; }
@@ -182,6 +241,14 @@ global with sharing class DeliverySlackInboundHandler implements IWebhookEventHa
         return m.group(1).toUpperCase();
     }
 
+    /**
+     * @description Resolve a WorkItem__c by Name. Returns null when no record
+     *              with the given Name exists in this org (e.g. the T-NNNN
+     *              was typed in Slack but the WI lives only on another org in
+     *              the daisy chain).
+     * @param wiName The exact Name to look up (case-sensitive in SOQL).
+     * @return The matching WorkItem__c (Id, Name, OwnerId), or null when not found.
+     */
     @TestVisible
     private static WorkItem__c findWorkItemByName(String wiName) {
         List<WorkItem__c> hits = [


### PR DESCRIPTION
## Scope

Behavior-preserving refactor of `DeliverySlackInboundHandler.handle()`. Splits the dispatcher into per-envelope / per-event-type helpers per the suggested shape in `docs/audits/pmd-baseline-2026-05-21.md` (sweep #2). Same external surface — `global handle(String, Map<String,Object>)` signature unchanged.

## Scope checklist

- [x] `handle()` signature preserved (global, identical params + return)
- [x] No new SOQL / DML / callouts
- [x] No `Schema.getGlobalDescribe()` introduced
- [x] No `WITH USER_MODE` (existing `WITH SYSTEM_MODE` preserved per CLAUDE.md)
- [x] ApexDoc on every new helper (`@description`, `@param`, `@return`)
- [x] All existing `@TestVisible` static helpers kept `@TestVisible` (no test churn)
- [x] Existing `DeliverySlackInboundHandlerTest` left untouched — covers every branch end-to-end via `handle()`
- [x] No new test methods added for private helpers (they are internals, exercised via `handle()`)
- [x] Cyclomatic per method ≤ 10

## New helper shape

| Helper | Purpose | Cyc |
|---|---|---|
| `handle()` | Thin dispatcher: envelope gate then delegate | ~2 |
| `isEventCallback(eventType)` | Predicate — is the outer envelope `event_callback`? | ~2 |
| `handleEventCallback(payload)` | Extract inner event, terminal on malformed envelope, delegate | ~2 |
| `handleMessageEvent(event)` | Inner-type / bot / empty-text guards, then delegate | ~4 |
| `isBotMessage(event)` | Predicate — does the message have `bot_id`? | 1 |
| `createCommentFromMessage(event, text)` | T-NNNN extract + WI lookup + comment insert | ~3 |

Kept from previous shape (unchanged): `buildAuthor`, `buildBody`, `insertSlackComment`, `extractMap`, `extractWorkItemName`, `findWorkItemByName`.

## Before / after cyclomatic

| Method | Before | After |
|---|---|---|
| `handle()` | 13 (per audit baseline) | ~2 |
| Largest helper | n/a | `handleMessageEvent` ~4 |

Kills ~4% of repo PMD baseline debt per `docs/audits/pmd-baseline-2026-05-21.md` (sweep #2, Priority 2, est. 45 min).

## Risk

Low. External surface identical, every existing test branch still exercised end-to-end through `handle()`. No behavior change in:

- Envelope validation (non-`event_callback` envelopes still ignored 200)
- Inner-event validation (non-`message` types still ignored 200)
- Bot echo suppression (still skips on `bot_id` key presence)
- Empty-text skip (still ignored 200)
- T-NNNN extraction + WI lookup (unchanged regex + SOQL)
- Comment insert (unchanged DML + AccessLevel.SYSTEM_MODE + retryable on DmlException)

## Test plan

- [x] All 8 methods in `DeliverySlackInboundHandlerTest` traced against new flow — each branch still reachable, assertions still hold
- [ ] CI apex-scan: PMD cyclomatic violations on this class drop from 6 → expected ≤ 2 (ApexDoc only on the 2 pre-existing helpers — both now also documented in this PR)
- [ ] CI feature-tests: full Apex run, expect green