### PR TITLE
fix(rest): rate-limit PATCH + idempotency on toggle POST + pagination envelope on list GET

### DIFF
--- a/force-app/main/default/classes/DeliveryPublicApiService.cls
+++ b/force-app/main/default/classes/DeliveryPublicApiService.cls
@@ -11,6 +11,9 @@
 @RestResource(urlMapping='/deliveryhub/v1/api/*')
 global without sharing class DeliveryPublicApiService {
 
+    /** @description Page size for paginated list endpoints (LIMIT cap). */
+    private static final Integer FEATURE_TOGGLE_PAGE_SIZE = 50;
+
     /** @description Handles all GET requests. Routes by resource path after authentication. */
     @HttpGet
     global static void handleGet() {
@@ -19,17 +22,7 @@ global without sharing class DeliveryPublicApiService {
             if (entity == null) { return; }
 
             // Rate limiting (opt-in — only active when PublicApiRateLimitNumber__c is set)
-            DeliveryHubSettings__c rlSettings = DeliveryHubSettings__c.getOrgDefaults();
-            if (rlSettings != null && rlSettings.PublicApiRateLimitNumber__c != null) {
-                Integer publicApiLimit = (Integer) rlSettings.PublicApiRateLimitNumber__c;
-                if (DeliveryRateLimitService.isRateLimited(entity.Id, 'PublicAPI', publicApiLimit, 1)) {
-                    RestContext.response.statusCode = 429;
-                    RestContext.response.addHeader('Retry-After', '3600');
-                    RestContext.response.responseBody = Blob.valueOf('{"error":"Rate limit exceeded"}');
-                    return;
-                }
-                DeliveryRateLimitService.recordRequest(entity.Id, 'PublicAPI');
-            }
+            if (!enforceRateLimit(entity.Id)) { return; }
 
             String resource = extractResource(RestContext.request.requestURI);
             if (handlePreEntityRoutes(resource)) { return; }
@@ -53,6 +46,14 @@ global without sharing class DeliveryPublicApiService {
         try {
             NetworkEntity__c entity = authenticateRequest();
             if (entity == null) { return; }
+
+            // Rate limiting (opt-in — only active when PublicApiRateLimitNumber__c is set).
+            // Mirrors the gate in handleGet / handlePost; the PATCH path was previously
+            // ungated, letting an attacker with a valid X-Api-Key issue unlimited state-
+            // mutation calls on /scratch-orgs/{id}. Audit:
+            // docs/audits/rest-api-surface-review-2026-05-21.md §3.
+            if (!enforceRateLimit(entity.Id)) { return; }
+
             String resource = extractResource(RestContext.request.requestURI);
             String jsonBody = RestContext.request.requestBody != null ? RestContext.request.requestBody.toString() : '';
             if (String.isBlank(jsonBody)) { sendError(400, 'Request body is required.'); return; }
@@ -76,17 +77,7 @@ global without sharing class DeliveryPublicApiService {
             if (entity == null) { return; }
 
             // Rate limiting (opt-in — only active when PublicApiRateLimitNumber__c is set)
-            DeliveryHubSettings__c rlSettings2 = DeliveryHubSettings__c.getOrgDefaults();
-            if (rlSettings2 != null && rlSettings2.PublicApiRateLimitNumber__c != null) {
-                Integer publicApiLimit = (Integer) rlSettings2.PublicApiRateLimitNumber__c;
-                if (DeliveryRateLimitService.isRateLimited(entity.Id, 'PublicAPI', publicApiLimit, 1)) {
-                    RestContext.response.statusCode = 429;
-                    RestContext.response.addHeader('Retry-After', '3600');
-                    RestContext.response.responseBody = Blob.valueOf('{"error":"Rate limit exceeded"}');
-                    return;
-                }
-                DeliveryRateLimitService.recordRequest(entity.Id, 'PublicAPI');
-            }
+            if (!enforceRateLimit(entity.Id)) { return; }
 
             String resource = extractResource(RestContext.request.requestURI);
             String jsonBody = RestContext.request.requestBody != null ? RestContext.request.requestBody.toString() : '';
@@ -347,6 +338,27 @@ global without sharing class DeliveryPublicApiService {
         }
         Id featureId = resolveFeatureIdByName(featureName);
         if (featureId == null) { sendError(404, 'Feature not found: ' + featureName); return; }
+
+        // Idempotency guard — if a Pending or Granted request for the same
+        // (feature, action) already exists, return its id rather than inserting
+        // a duplicate row. Closes the duplicate-Pending-on-network-retry hole
+        // noted in the 2026-05-21 REST surface review §6.
+        List<FeatureToggleRequest__c> existing = [
+            SELECT Id FROM FeatureToggleRequest__c
+            WHERE FeatureLookup__c = :featureId
+              AND ActionPk__c = :action
+              AND StatusPk__c IN ('Pending', 'Granted')
+            WITH SYSTEM_MODE LIMIT 1
+        ];
+        if (!existing.isEmpty()) {
+            sendSuccess(new Map<String, Object>{
+                'requestId' => existing[0].Id,
+                'featureId' => featureId,
+                'status' => 'Pending'
+            });
+            return;
+        }
+
         try {
             Id requestId = DeliveryFeatureApprovalService.submit(featureId, action, reason);
             sendSuccess(new Map<String, Object>{
@@ -427,13 +439,23 @@ global without sharing class DeliveryPublicApiService {
         for (FeatureToggleRequest__c req : requests) {
             data.add(buildFeatureRequestMap(req));
         }
-        sendSuccess(data);
+        // Pagination envelope — `hasMore` is a heuristic (true when the LIMIT
+        // was filled); accurate enough for client UX without a second SOQL.
+        // See docs/audits/rest-api-surface-review-2026-05-21.md §8.
+        Integer maxRows = FEATURE_TOGGLE_PAGE_SIZE;
+        Map<String, Object> resp = new Map<String, Object>{
+            'data'     => data,
+            'offset'   => offset,
+            'pageSize' => maxRows,
+            'hasMore'  => data.size() >= maxRows
+        };
+        sendSuccess(resp);
     }
 
     private static List<FeatureToggleRequest__c> queryFeatureToggleRequests(
         String statusFilter, String featureFilter, Integer offset
     ) {
-        Integer maxRows = 50;
+        Integer maxRows = FEATURE_TOGGLE_PAGE_SIZE;
         Integer safeOffset = (offset == null || offset < 0) ? 0 : offset;
         if (String.isNotBlank(statusFilter) && String.isNotBlank(featureFilter)) {
             return [
@@ -720,6 +742,34 @@ global without sharing class DeliveryPublicApiService {
     }
 
     // ── Auth + Resolution ──────────────────────────────────────────────
+
+    /**
+     * @description Applies the public-API rate-limit gate (opt-in via the
+     *              `PublicApiRateLimitNumber__c` org-default setting). Returns
+     *              true when the request should proceed and false when the
+     *              caller has been rate-limited (response already populated
+     *              with 429 + Retry-After). Shared across handleGet,
+     *              handlePost, and handlePatch — closes the PATCH gap noted
+     *              in the 2026-05-21 REST surface review.
+     * @param entityId The authenticated NetworkEntity__c.Id used as the rate-
+     *                 limit bucket key.
+     * @return true if the request may proceed, false if 429 was returned.
+     */
+    private static Boolean enforceRateLimit(Id entityId) {
+        DeliveryHubSettings__c rlSettings = DeliveryHubSettings__c.getOrgDefaults();
+        if (rlSettings == null || rlSettings.PublicApiRateLimitNumber__c == null) {
+            return true;
+        }
+        Integer publicApiLimit = (Integer) rlSettings.PublicApiRateLimitNumber__c;
+        if (DeliveryRateLimitService.isRateLimited(entityId, 'PublicAPI', publicApiLimit, 1)) {
+            RestContext.response.statusCode = 429;
+            RestContext.response.addHeader('Retry-After', '3600');
+            RestContext.response.responseBody = Blob.valueOf('{"error":"Rate limit exceeded"}');
+            return false;
+        }
+        DeliveryRateLimitService.recordRequest(entityId, 'PublicAPI');
+        return true;
+    }
 
     private static NetworkEntity__c authenticateRequest() {
         String apiKey = RestContext.request.headers.get('X-Api-Key');

--- a/force-app/main/default/classes/DeliveryPublicApiServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryPublicApiServiceTest.cls
@@ -1433,7 +1433,9 @@ private class DeliveryPublicApiServiceTest {
 
             System.assertEquals(200, res.statusCode, 'should return 200');
             Map<String, Object> body = parseResponse(res);
-            List<Object> data = (List<Object>) body.get('data');
+            // Pagination envelope (audit fix 3) — list is nested under `data.data`.
+            Map<String, Object> envelope = (Map<String, Object>) body.get('data');
+            List<Object> data = (List<Object>) envelope.get('data');
             Boolean foundSeed = false;
             for (Object entry : data) {
                 Map<String, Object> row = (Map<String, Object>) entry;
@@ -1522,6 +1524,164 @@ private class DeliveryPublicApiServiceTest {
             System.assertEquals('Rejected', data.get('status'), 'approval rejected');
             System.assertEquals('Rejected', data.get('requestStatus'),
                 'request marked Rejected on single dissent');
+        }
+    }
+
+    // ==========================================
+    // REST API HARDENING — 2026-05-21 AUDIT FIXES
+    // ==========================================
+
+    /**
+     * @description Audit fix 1 — PATCH /scratch-orgs/{id} now runs the same
+     *              rate-limit gate as GET/POST. Pre-fix the PATCH path was
+     *              ungated, so a valid X-Api-Key could mutate state
+     *              indefinitely. Setting the limit to 1 + pre-recording a
+     *              request exhausts the bucket, forcing the second PATCH to
+     *              return 429.
+     */
+    @IsTest
+    static void testPatchScratchOrgRateLimited() {
+        System.runAs(testUser) {
+            // Opt-in: configure the limit at 1/hour and pre-record one hit so
+            // the next call trips the gate.
+            DeliveryHubSettings__c rl = DeliveryHubSettings__c.getOrgDefaults();
+            if (rl == null) { rl = new DeliveryHubSettings__c(); }
+            rl.PublicApiRateLimitNumber__c = 1;
+            upsert rl;
+
+            NetworkEntity__c entity = [SELECT Id FROM NetworkEntity__c WHERE Name = 'API Client Corp' LIMIT 1];
+            DeliveryRateLimitService.recordRequest(entity.Id, 'PublicAPI');
+
+            ScratchOrgInstance__c soi = TestDataFactory.createScratchOrgInstance(new Map<String, Object>{
+                'StatePk__c' => 'Active'
+            });
+            Map<String, Object> body = new Map<String, Object>{ 'state' => 'Deleted' };
+            RestRequest req = buildPatchRequest(
+                '/services/apexrest/delivery/deliveryhub/v1/api/scratch-orgs/' + soi.Id, body);
+            req.addHeader('X-Api-Key', TEST_API_KEY);
+            RestResponse res = new RestResponse();
+            RestContext.request = req;
+            RestContext.response = res;
+
+            Test.startTest();
+            DeliveryPublicApiService.handlePatch();
+            Test.stopTest();
+
+            System.assertEquals(429, res.statusCode, 'PATCH should be rate-limited');
+            System.assertEquals('3600', res.headers.get('Retry-After'), 'Retry-After header set');
+
+            // State must not have flipped since the gate fired before patchScratchOrg.
+            ScratchOrgInstance__c reloaded = [SELECT StatePk__c FROM ScratchOrgInstance__c WHERE Id = :soi.Id];
+            System.assertEquals('Active', reloaded.StatePk__c, 'State not mutated when rate-limited');
+        }
+    }
+
+    /**
+     * @description Audit fix 2 — duplicate POST /features/{name}/toggle for
+     *              the same (feature, action) returns the existing Pending
+     *              request id, never a freshly-inserted row. Closes the
+     *              network-retry duplicate-row hole.
+     */
+    @IsTest
+    static void testPostFeatureToggleIdempotent() {
+        System.runAs(testUser) {
+            Feature__c feat = TestDataFactory.createFeature(new Map<String, Object>{
+                'EnabledDateTime__c' => null,
+                'DisabledDateTime__c' => Datetime.now()
+            });
+
+            Map<String, Object> body = new Map<String, Object>{
+                'action' => 'Enable',
+                'reason' => 'first submission'
+            };
+
+            // First submission — creates the Pending row.
+            RestRequest req1 = buildPostRequest(
+                '/services/apexrest/delivery/deliveryhub/v1/api/features/' + feat.Name + '/toggle',
+                body
+            );
+            req1.addHeader('X-Api-Key', TEST_API_KEY);
+            RestResponse res1 = new RestResponse();
+            RestContext.request = req1;
+            RestContext.response = res1;
+
+            Test.startTest();
+            DeliveryPublicApiService.handlePost();
+
+            System.assertEquals(201, res1.statusCode, 'First submission returns 201 Created');
+            Map<String, Object> data1 = (Map<String, Object>) parseResponse(res1).get('data');
+            Id firstRequestId = (Id) data1.get('requestId');
+
+            // Second submission (same feature + action) — must NOT create a new row.
+            RestRequest req2 = buildPostRequest(
+                '/services/apexrest/delivery/deliveryhub/v1/api/features/' + feat.Name + '/toggle',
+                new Map<String, Object>{ 'action' => 'Enable', 'reason' => 'duplicate retry' }
+            );
+            req2.addHeader('X-Api-Key', TEST_API_KEY);
+            RestResponse res2 = new RestResponse();
+            RestContext.request = req2;
+            RestContext.response = res2;
+
+            DeliveryPublicApiService.handlePost();
+            Test.stopTest();
+
+            System.assertEquals(200, res2.statusCode, 'Duplicate returns 200 (not 201)');
+            Map<String, Object> data2 = (Map<String, Object>) parseResponse(res2).get('data');
+            System.assertEquals(firstRequestId, (Id) data2.get('requestId'),
+                'Duplicate must return the same requestId — no new row');
+
+            Integer rowCount = [
+                SELECT COUNT() FROM FeatureToggleRequest__c
+                WHERE FeatureLookup__c = :feat.Id AND ActionPk__c = 'Enable'
+            ];
+            System.assertEquals(1, rowCount, 'Only one FeatureToggleRequest__c row exists');
+        }
+    }
+
+    /**
+     * @description Audit fix 3 — GET /feature-toggle-requests now wraps the
+     *              list in a pagination envelope with `data`, `offset`,
+     *              `pageSize`, and `hasMore` so clients can drive a
+     *              next-page button without a separate count call.
+     */
+    @IsTest
+    static void testGetFeatureToggleRequestsPaginationEnvelope() {
+        System.runAs(testUser) {
+            Feature__c feat = TestDataFactory.createFeature(null);
+            TestDataFactory.newFeatureToggleRequest(feat.Id);
+
+            RestRequest req = buildGetRequest('/services/apexrest/delivery/deliveryhub/v1/api/feature-toggle-requests');
+            req.addHeader('X-Api-Key', TEST_API_KEY);
+            RestResponse res = new RestResponse();
+            RestContext.request = req;
+            RestContext.response = res;
+
+            Test.startTest();
+            DeliveryPublicApiService.handleGet();
+            Test.stopTest();
+
+            System.assertEquals(200, res.statusCode, 'Should return 200');
+            Map<String, Object> body = parseResponse(res);
+            Map<String, Object> envelope = (Map<String, Object>) body.get('data');
+
+            System.assert(envelope.containsKey('data'),
+                'Envelope must include `data`');
+            System.assert(envelope.containsKey('offset'),
+                'Envelope must include `offset`');
+            System.assert(envelope.containsKey('pageSize'),
+                'Envelope must include `pageSize`');
+            System.assert(envelope.containsKey('hasMore'),
+                'Envelope must include `hasMore`');
+
+            System.assertEquals(0, (Integer) envelope.get('offset'),
+                'Offset defaults to 0 when no pageOffset param');
+            System.assertEquals(50, (Integer) envelope.get('pageSize'),
+                'Page size matches LIMIT');
+            System.assertEquals(false, (Boolean) envelope.get('hasMore'),
+                'Single seeded row → hasMore=false');
+
+            List<Object> data = (List<Object>) envelope.get('data');
+            System.assert(data.size() >= 1, 'Seeded request returned in envelope.data');
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes the Top-3 fixes from `docs/audits/rest-api-surface-review-2026-05-21.md`.

- [x] **Fix 1 (High)** — `PATCH /scratch-orgs/{id}` now runs the same rate-limit gate as GET/POST. Pre-fix, a valid `X-Api-Key` could mutate state without bound. Extracted the duplicated gate into `enforceRateLimit(entityId)` so all three verbs share one path.
- [x] **Fix 2 (High)** — `POST /features/{name}/toggle` now query-before-inserts. If an existing `Pending` or `Granted` `FeatureToggleRequest__c` for the same `(feature, action)` is found, the existing id is returned with a `200` (idempotent replay) instead of inserting a duplicate row. GH-Actions / Slack retries on network blips no longer fan duplicate Pending rows.
- [x] **Fix 3 (Medium)** — `GET /feature-toggle-requests` now returns a pagination envelope (`{data, offset, pageSize, hasMore}`) so clients can drive a next-page button without a separate `COUNT()` call. `hasMore` is the same heuristic used by the activity-feed surface (LIMIT-filled = probably more).

Closes Top-3 fixes from `docs/audits/rest-api-surface-review-2026-05-21.md`.

## Test plan

- [ ] CI: `DeliveryPublicApiServiceTest` passes. New tests:
  - `testPatchScratchOrgRateLimited` — sets limit=1, pre-records 1 hit, asserts second PATCH returns `429` + `Retry-After: 3600` and the target row state was NOT mutated.
  - `testPostFeatureToggleIdempotent` — submits the same `Enable` toggle twice for one Feature, asserts both calls return the same `requestId`, second response is `200` (not `201`), and exactly one `FeatureToggleRequest__c` row exists.
  - `testGetFeatureToggleRequestsPaginationEnvelope` — asserts the envelope contains `data` + `offset` + `pageSize` + `hasMore`, with sensible defaults (`offset=0`, `pageSize=50`, `hasMore=false` when under the cap).
- [ ] Existing `testGetFeatureToggleRequests` updated to unwrap the new envelope shape.
- [ ] Smoke read-test webhook + toggle flows after release ships (per audit "Bottom line").

## Notes

- The audit flagged the rate-limit duplication as a "cleanup opportunity, not a blocker" — extracted the shared `enforceRateLimit(entityId)` helper instead of inline copying. Single source of truth for the gate across `handleGet`, `handlePost`, `handlePatch`.
- `FEATURE_TOGGLE_PAGE_SIZE = 50` lifted to a class constant so `queryFeatureToggleRequests` and the envelope agree without drift.

Generated with [Claude Code](https://claude.com/claude-code)
