### PR TITLE
chore(lwc): icon alt-text + DatasetTemplates subscriber flag + modal ESC handler

### DIFF
--- a/force-app/main/default/classes/DeliveryDatasetController.cls
+++ b/force-app/main/default/classes/DeliveryDatasetController.cls
@@ -28,6 +28,37 @@ global with sharing class DeliveryDatasetController {
     /** Max audit rows surfaced on the cockpit "recent loads" panel. */
     private static final Integer RECENT_LIMIT = 10;
 
+    /** Internal hint — the running install's namespace prefix. Blank in dev orgs, "delivery" on subscriber installs. */
+    private static final String PUBLISHER_NAMESPACE = 'delivery';
+
+    /**
+     * @description Detects whether this is a subscriber install by checking
+     *              the running org's namespace prefix against the publisher
+     *              namespace literal "delivery". Mirrors the same probe used
+     *              by DeliveryDevLoopController so the dataset-templates LWC
+     *              can render a consistent "for package developers" badge
+     *              on managed-package installs without relying on the
+     *              empty-state copy fallback alone.
+     *
+     *              Defensive: any failure of the Organization probe degrades
+     *              to `false` so the LWC never blocks rendering of the
+     *              template list over a metadata read.
+     * @return True on subscriber installs, false in unpackaged dev orgs.
+     */
+    @AuraEnabled(cacheable=true)
+    global static Boolean isSubscriberOrg() {
+        try {
+            List<Organization> orgs = [SELECT NamespacePrefix FROM Organization WITH SYSTEM_MODE LIMIT 1];
+            if (orgs.isEmpty()) {
+                return false;
+            }
+            String prefix = orgs.get(0).NamespacePrefix;
+            return String.isNotBlank(prefix) && prefix.equalsIgnoreCase(PUBLISHER_NAMESPACE);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     /**
      * @description Card payload for a single DatasetTemplate__c. Mirrors the
      *              fields the LWC renders without leaking the full SObject.

--- a/force-app/main/default/lwc/deliveryDatasetTemplates/deliveryDatasetTemplates.html
+++ b/force-app/main/default/lwc/deliveryDatasetTemplates/deliveryDatasetTemplates.html
@@ -19,6 +19,14 @@
                 </div>
             </template>
 
+            <template lwc:if={isSubscriberOrg}>
+                <div class="slds-box slds-theme_shade slds-text-body_small slds-m-bottom_small">
+                    Dataset templates are for package developers &mdash;
+                    install scratch org tooling locally (CumulusCI + sfdx)
+                    to load sample data.
+                </div>
+            </template>
+
             <template lwc:if={isEmpty}>
                 <div class="slds-illustration slds-illustration_small slds-p-vertical_medium">
                     <div class="slds-text-longform slds-text-align_center">

--- a/force-app/main/default/lwc/deliveryDatasetTemplates/deliveryDatasetTemplates.js
+++ b/force-app/main/default/lwc/deliveryDatasetTemplates/deliveryDatasetTemplates.js
@@ -22,6 +22,7 @@ import getTemplatesForFeature from '@salesforce/apex/%%%NAMESPACE_DOT%%%Delivery
 import getTemplatesForWorkItem from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDatasetController.getTemplatesForWorkItem';
 import getRecentAssignmentsForTemplate from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDatasetController.getRecentAssignmentsForTemplate';
 import formatCciCommand from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDatasetController.formatCciCommand';
+import isSubscriberOrgApex from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDatasetController.isSubscriberOrg';
 
 const FEATURE_OBJECT = 'Feature__c',
     WORK_ITEM_OBJECT = 'WorkItem__c',
@@ -38,9 +39,19 @@ export default class DeliveryDatasetTemplates extends LightningElement {
     @track errorMessage = '';
     @track isLoaded = false;
     @track selectedTemplateId = null;
+    @track isSubscriberOrg = false;
 
     wiredTemplatesResult;
     wiredRecentResult;
+
+    @wire(isSubscriberOrgApex)
+    wiredIsSubscriberOrg({ data }) {
+        // Failure path intentionally degrades to non-subscriber rendering —
+        // matches the Apex method's defensive `return false` on probe failure.
+        if (data === true || data === false) {
+            this.isSubscriberOrg = data;
+        }
+    }
 
     @wire(getTemplatesForFeature, { featureId: '$featureIdForWire' })
     wiredFeatureTemplates(result) {

--- a/force-app/main/default/lwc/deliveryDevLoopGuide/deliveryDevLoopGuide.html
+++ b/force-app/main/default/lwc/deliveryDevLoopGuide/deliveryDevLoopGuide.html
@@ -3,7 +3,7 @@
         <header class="slds-card__header slds-grid">
             <div class="slds-media slds-media_center slds-has-flexi-truncate">
                 <div class="slds-media__figure">
-                    <lightning-icon icon-name="utility:apex" size="small"></lightning-icon>
+                    <lightning-icon icon-name="utility:apex" size="small" alternative-text="Dev-loop guide"></lightning-icon>
                 </div>
                 <div class="slds-media__body">
                     <h2 class="slds-card__header-title">

--- a/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.html
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.html
@@ -95,7 +95,8 @@
     <template lwc:if={chainModalOpen}>
         <section role="dialog" tabindex="-1" aria-modal="true"
                  aria-labelledby="approval-chain-modal-title"
-                 class="slds-modal slds-fade-in-open">
+                 class="slds-modal slds-fade-in-open"
+                 onkeydown={handleModalKeydown}>
             <div class="slds-modal__container">
                 <header class="slds-modal__header">
                     <button class="slds-button slds-button_icon slds-modal__close slds-button_icon-inverse"

--- a/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.js
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.js
@@ -196,6 +196,15 @@ export default class DeliveryFeatureApprovalInbox extends LightningElement {
         this.chainRequestLabel = '';
     }
 
+    handleModalKeydown(event) {
+        // Explicit ESC handler — SLDS modals typically dismiss via backdrop
+        // interaction, but wiring `Escape` directly is more robust and
+        // matches WCAG 2.1 keyboard-trap expectations for dialogs.
+        if (event && event.key === 'Escape') {
+            this.handleCloseChain();
+        }
+    }
+
     onDecisionSuccess(label, approvalId) {
         this.dispatchEvent(new ShowToastEvent({
             title: `${label}`,

--- a/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.html
+++ b/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.html
@@ -37,7 +37,7 @@
 
                                 <header class="slds-grid slds-grid_vertical-align-center slds-m-bottom_x-small">
                                     <div class="slds-media__figure slds-m-right_small">
-                                        <lightning-icon icon-name={feature.icon} size="medium"></lightning-icon>
+                                        <lightning-icon icon-name={feature.icon} size="medium" alternative-text={feature.label}></lightning-icon>
                                     </div>
                                     <div class="slds-media__body">
                                         <h3 class="slds-text-heading_small slds-truncate" title={feature.label}>


### PR DESCRIPTION
## Summary

Closes Top-3 polish fixes from `docs/audits/lwc-quality-review-2026-05-21.md`.

- **Fix 1 — icon `alternative-text`:** added on the per-feature card icon in `deliveryFeatureCockpit` (bound to `{feature.label}` for context) and on the header icon in `deliveryDevLoopGuide`. Closes the WCAG 2.1 AA polish gap flagged in the audit.
- **Fix 2 — DatasetTemplates subscriber-org consistency:** `DeliveryDatasetController` gains an `@AuraEnabled(cacheable=true) global static Boolean isSubscriberOrg()` probe (namespace-prefix check, mirrors the same defensive pattern from `DeliveryDevLoopController`). `deliveryDatasetTemplates` LWC wires it and renders a "for package developers" badge on managed-package installs. Closes the UX-consistency gap with DevLoopGuide.
- **Fix 3 — modal ESC handler:** added `onkeydown={handleModalKeydown}` on the approval-chain modal in `deliveryFeatureApprovalInbox`. New handler closes the modal on `Escape` via the existing `handleCloseChain` method.

## Files

- `force-app/main/default/classes/DeliveryDatasetController.cls` (+31)
- `force-app/main/default/lwc/deliveryDatasetTemplates/deliveryDatasetTemplates.html` (+8)
- `force-app/main/default/lwc/deliveryDatasetTemplates/deliveryDatasetTemplates.js` (+11)
- `force-app/main/default/lwc/deliveryDevLoopGuide/deliveryDevLoopGuide.html` (+1/-1)
- `force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.html` (+2/-1)
- `force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.js` (+9)
- `force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.html` (+1/-1)

7 files, +63 / -3.

## CLAUDE.md compliance

- No template ternaries — `isSubscriberOrg` is rendered via `lwc:if` on the @track-backed flag.
- No `@api` boolean defaulting to true — the new `isSubscriberOrg` is `@track`, defaulted to `false`.
- `%%%NAMESPACE_DOT%%%` namespace token used on the new Apex import.
- New Apex method is `global static` with no inner-class return type (returns `Boolean`).

## Test plan

- [ ] Open a Feature__c record page on a non-namespaced dev org → `deliveryDatasetTemplates` renders the template list, no subscriber badge.
- [ ] Install the package on a subscriber org → the `deliveryDatasetTemplates` card shows the "for package developers" badge above the template list (parallel to DevLoopGuide).
- [ ] Inspect `deliveryFeatureCockpit` card icons in the browser a11y tree → each icon exposes the feature label as the accessible name.
- [ ] Open the approval-chain modal from `deliveryFeatureApprovalInbox` → press `Escape` → modal closes; verify mouse Close button still works.
- [ ] CI: PMD + lint clean (no new violations expected, only additive Apex + tiny LWC tweaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
