### PR TITLE
chore(audits): commit 8 untracked 2026-05-21 audit reports + pmd-baseline correction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,12 @@ MORNING_GAPS_REPORT.md
 /GAPS_*.md
 /REPORT_*.md
 
+# Windows-path-mangled audit scripts (audit agents occasionally write
+# "C:\temp\foo.ps1" from a Linux-path context, which Git for Windows
+# encodes as `C<U+E03A>temp...` and surfaces at repo root).
+/C?temp*.ps1
+/C?temp*.sh
+
 # Temp dump directories from CLI tooling
 /mfp-dump/
 /scripts/mfp-check/

--- a/docs/audits/admin-ux-audit-2026-05-21.md
+++ b/docs/audits/admin-ux-audit-2026-05-21.md
@@ -1,0 +1,136 @@
+# Admin/Setup UX Audit — 2026-05-21
+
+## Headline
+
+**Significant subscriber-blocking gaps.** Cockpit + Watcher objects shipped with Apex controllers + field perms but **no tabs, no page layouts, no record pages**. They're discoverable only via LWC cards on home pages — admins can't navigate by tab, can't edit records via standard record pages, and `WatcherDigest__c` has **0 field perms granted** so subscribers literally can't read it.
+
+This is the most serious gap surfaced in the post-cycle audit sweep. Most of these are 30min-2h fixes; bundling them as PRs is straightforward.
+
+---
+
+## 1. Tabs
+
+| Object | Tab? | Finding |
+|---|---|---|
+| `Feature__c` | ❌ | Only via `deliveryFeatureCockpit` LWC on home page |
+| `FeatureDependency__c` | ❌ | Nested in cockpit only |
+| `FeatureToggleRequest__c` | ❌ | REST + Apex; no admin visibility |
+| `FeatureToggleApproval__c` | ❌ | No audit interface |
+| `OnboardingProgress__c` | ❌ | Via LWC only |
+| `ScratchOrgInstance__c` | ❌ | No admin list view |
+| `DatasetTemplate__c` | ❌ | LWC only |
+| `DatasetTemplateAssignment__c` | ❌ | No direct access |
+| `WatcherDigest__c` | ❌ | No tab or inbox UI |
+
+## 2. App Menu Inclusion
+
+`DeliveryHub.app-meta.xml` and `DeliveryHubAdmin.app-meta.xml`: **no new objects' tabs included** (would need to be created first).
+
+## 3. Page Layouts
+
+**0 of 9 new objects have a layout.** Record detail pages fall back to system defaults — fields are read-only / unordered regardless of permset access. Admins cannot edit records via UI.
+
+## 4. FlexiPages
+
+**What's there:**
+- `DeliveryFeatureCockpit.flexipage-meta.xml` (App Page hosting `deliveryFeatureCockpit`) ✅
+- `DeliveryHubHome.flexipage-meta.xml` has `deliveryFeatureCockpit` + `deliveryFeatureApprovalInbox` cards ✅
+
+**What's missing — 0/9 record pages:**
+No FlexiPage for any new object. Approval inbox is only on the user-facing home page; **not** on the admin home (`DeliveryHubAdminHome.flexipage`).
+
+## 5. Permission Set Coverage
+
+`DeliveryHubAdmin_App.permissionset-meta.xml` grants **most** new-object field perms:
+- ✅ Feature__c, FeatureDependency__c, FeatureToggleRequest__c, FeatureToggleApproval__c
+- ✅ OnboardingProgress__c, ScratchOrgInstance__c
+- ✅ DatasetTemplate__c, DatasetTemplateAssignment__c
+- ✅ ~~`WatcherDigest__c` has 0 field perms~~ — **stale claim.** Verified during PR #816 retry: all readable WatcherDigest__c fields + `<objectPermissions>` were shipped in PR-A #807. Audit snapshot was wrong on this row.
+
+**Object-level CRUD note:** all 9 new objects have `<objectPermissions>` in both permsets (verified during PR #816). The original "search-confirmed" caveat was an audit gap, not a code gap.
+
+## 6. Custom Settings Configuration UX
+
+`DeliveryHubSettings__c` got 14 new Watcher fields in PR-A. Currently configurable only via Setup → Custom Settings (UX-hostile native UI) OR via `deliveryHubSetup` LWC card (which may or may not surface the Watcher fields — verify).
+
+If `deliveryHubSetup` doesn't expose `EnableWatcherDigestDateTime__c` + `WatcherDigestRecipientUserIdsTxt__c`, the master flag and recipient list are essentially unreachable for non-developers.
+
+## 7. Site Guest / Public Perms — OK
+
+No new public/guest endpoints. New REST routes are X-Api-Key gated. No new ConnectedApp / Auth Provider needed.
+
+## 8. CustomNotificationType — Major gap
+
+**Directory `customNotificationTypes/` does not exist in the repo.**
+
+No Watcher_Digest, Feature_Toggle, or ApprovalRequest notification types defined. This means:
+- Approval requests cannot trigger in-app bell notifications (mobile-unfriendly)
+- Watcher digest is Slack-only (no Salesforce alternative)
+- Toggle decisions don't notify requesters in-platform
+
+The Slack flow from PR 7 leans entirely on Slack outbound; a Salesforce-native fallback was never wired.
+
+## 9. Quick Actions / Buttons — none for new objects
+
+No "Request Toggle", "Approve/Reject", "Complete Onboarding", "Provision Scratch Org" quick actions. Everything goes through LWCs.
+
+## 10. Reports + Report Types — none for new objects
+
+No report types for `WatcherDigest__c` (30-day trends), `FeatureToggleRequest__c` (audit), `OnboardingProgress__c` (completion rates). Rich data, zero out-of-the-box reporting.
+
+## 11. Email Templates — none for new flows
+
+No completion / approval / digest email templates. Onboarding-complete and Watcher both async-only.
+
+---
+
+## Recommended PRs
+
+### Subscriber-blocking (ship before GA)
+
+| # | PR | Effort | Impact |
+|---|---|---|---|
+| 1 | **Add page layouts for 9 new objects** | ~2h | Without these, record-detail pages are broken — admins can't view/edit records via UI |
+| 2 | **Grant `WatcherDigest__c` field perms in `DeliveryHubAdmin_App`** | ~5min | 0 fields visible today; subscribers see empty record pages |
+| 3 | **Verify object-level CRUD grants for all 9 new objects in both permsets** | ~15min audit + however many fixes surface | Object perms may be missing entirely |
+| 4 | **Add tabs for `Feature__c`, `FeatureToggleRequest__c`, `WatcherDigest__c`, `ScratchOrgInstance__c`** + add to `DeliveryHubAdmin` app menu | ~1h | Non-dev admins can't navigate to these objects today |
+
+**Subtotal: ~3.5h, ships as one bundled PR. All low-risk metadata-only.**
+
+### Polish (strongly recommended within 30 days)
+
+| # | PR | Effort | Impact |
+|---|---|---|---|
+| 5 | Add record-page FlexiPages for Feature, ToggleRequest, WatcherDigest | ~2h | Embed dependency-graph, approval-chain, signal-summary LWCs in context |
+| 6 | Add CustomNotificationTypes for Watcher_Digest + ApprovalRequest | ~1h + wire in Apex | In-app bell notifications; mobile parity with Slack |
+| 7 | Verify `deliveryHubSetup` LWC surfaces the 14 new Watcher settings (extend it if not) | ~1h | Master flag + recipient list become reachable via friendly UI |
+
+### Post-GA polish
+
+| # | PR | Effort |
+|---|---|---|
+| 8 | Report types for WatcherDigest / FeatureToggleRequest / OnboardingProgress | ~1.5h |
+
+---
+
+## Verdict
+
+### Works end-to-end today
+- Feature cockpit (read + admin toggle via LWC)
+- Approval workflow (via LWC inbox)
+- Onboarding stepper (via LWC on Feature record page)
+- Dev-loop guide + Dataset templates (LWC-only displays)
+
+### Apex/REST-only (no admin UI)
+- Feature toggle requests via REST — no audit UI for admins
+- Watcher digest — runs in batch, no human-visible inbox
+- FeatureDependency cascades — graph logic invisible to admins
+
+### Broken in the UI right now
+1. **No tabs** for any new object — Salesforce-navigator-only discovery
+2. **No layouts** for any new object — record detail pages broken even when found
+3. **`WatcherDigest__c` 0 field perms** — unreadable even by admin permset holders
+4. **No approval audit trail** visible to admins
+5. **No in-app notifications** — Slack-or-nothing on approvals
+
+**Recommendation:** **ship PRs 1-4 (subscriber-blocking bundle, ~3.5h) before any external GA announcement.** PR 4 (tabs) and PR 1 (layouts) are the most embarrassing gaps — they make the package look unfinished even though the Apex/LWC is solid.

--- a/docs/audits/architecture-governor-review-2026-05-21.md
+++ b/docs/audits/architecture-governor-review-2026-05-21.md
@@ -1,0 +1,90 @@
+# Architecture + Governor Review — 2026-05-21
+
+## Headline
+
+The cockpit + Watcher ship cycle landed 20+ new Apex classes with **strong trigger discipline, correct governance patterns, and appropriate complexity suppression**. The architecture is clean and event-driven, with **no critical governor violations**. One minor code-path redundancy in `DeliveryPublicApiService` and a few low-priority polish items. **Production-ready.**
+
+---
+
+## 1. Trigger Architecture — PASS
+
+| File:Line | Concern | Finding |
+|---|---|---|
+| `FeatureTrigger.trigger:9` | After-insert/update delegation | Fires after DML so sync service sees final state. Handler receives `Trigger.new`/`oldMap` as params — proper decoupling |
+| `FeatureToggleRequestTrigger.trigger:10` | Same pattern | Delegates to handler; no `Trigger.X` static refs in handler logic |
+| `DeliveryFeatureTriggerHandler:33-43` | Recursion guard | Checks `DeliveryFeatureSyncService.isInSyncContext()` before processing. Guard set/cleared via try/finally in `commitSettingsInSyncContext()` (L188). No re-entry risk |
+| `DeliveryFeatureApprovalService:403-418` | Apply-context guard | `inApplyContext` checked at entry, set in try/finally (L479-492). Prevents re-entry from the request trigger when service flips features |
+| All handlers | Bulk-safety | All handlers iterate `newRows` as lists, never assume size 1. No SOQL inside loops processing trigger rows |
+
+## 2. Governor Exposure — PASS
+
+| File:Line | Pattern | Finding |
+|---|---|---|
+| `DeliveryFeatureSyncService:60-81` | Bulk SOQL upfront | Single SOQL loads all FeatureDefinition__mdt rows; in-memory map iteration. No per-row SOQL |
+| `DeliveryFeatureGraphService:68-74` | BFS upfront load | One SOQL loads all FeatureDependency__c rows (LIMIT 2000). BFS in memory with depth cap 10 + visited guard |
+| `DeliveryFeatureCatalogController:53-79` | Catalog + runtime join | Two bulk SOQLs (defs + features) then in-memory DTO build |
+| `DeliveryFeatureApprovalService:150-158` | Approval cascade insert | Single bulk `insert approvals` after in-memory build |
+| `DeliveryHubInstallHandler:80-108` | Idempotent seed | Two SOQLs upfront, in-memory list build, single bulk insert. Re-running install won't duplicate |
+
+**No DML inside loops anywhere.** All bulk patterns hold.
+
+## 3. Coupling Smells — minor
+
+| File:Line | Concern | Severity |
+|---|---|---|
+| `DeliveryPublicApiService:22-32, 79-89` | Rate-limit block duplicated between `handleGet()` + `handlePost()` (identical logic, different var names `rlSettings` / `rlSettings2`) | Low — extract `checkRateLimit(entity)` helper |
+| `DeliveryFeatureApprovalService:110-121` vs `DeliveryFeatureCatalogController:147-165` | Both interpret hard/soft edges from `FeatureGraphNodeDTO` independently | Low — document edge semantics in the DTO's `@description` so both consumers reference the same contract |
+
+## 4. Cyclomatic Post-Cleanup — ACCEPTABLE
+
+All complex classes carry justified class-level `@SuppressWarnings`. Top 5 highest-cyclomatic methods all under 10:
+
+1. `DeliveryFeatureApprovalService.applyIfFullyGranted()` — cyc ~6
+2. `DeliveryFeatureApprovalService.flattenCascadeWithDepth()` — cyc ~5
+3. `DeliveryFeatureGraphService.expandLayer()` — cyc ~7
+4. `DeliveryFeatureSyncService.applyTimestampsToSettings()` — cyc ~5
+5. `DeliveryFeatureCatalogController.toggleFeature()` — cyc ~4
+
+No cleanup needed.
+
+## 5. Naming Consistency — PASS
+
+`*Service` for business logic; `*Controller` for LWC/REST entry points; `*TriggerHandler` for thin trigger wrappers; `*DTO` for inner-class payloads. Tight discipline across all 20+ new classes.
+
+## 6. Install Handler Discipline — PASS
+
+| Step | Method | Idempotent? |
+|---|---|---|
+| 1 | `initializeDefaultSettings()` (L47) | YES — `settings.Id != null` early-return (L49) |
+| 2 | `seedFeaturesFromDefinitions()` (L80) | YES — `existingDefNames` set-check before insert (L98) |
+| 3 | `syncLegacySettingsToFeatures()` (L37) | YES — service-level idempotent (only updates differing rows) |
+| 4 | `scheduleSyncJobs()` (L125) | YES — `scheduleAll()` aborts matching jobs before re-scheduling |
+| 5 | `backfillUserPermissionSets()` (L141) | YES |
+
+Order-of-ops correct: seed (step 2) before sync (step 3).
+
+## 7. Test Coverage + Quality — GOOD
+
+Paired test classes present for every new service/controller/handler. No shared state between test classes. Recursion-guard state is `@TestVisible` to allow guard-behavior assertions. No SMT issues.
+
+---
+
+## Top 3 Surgical Cleanup PRs
+
+| # | PR | Effort | Risk |
+|---|---|---|---|
+| 1 | Extract `checkRateLimit(entity)` helper in `DeliveryPublicApiService` (kills the duplicated block between handleGet + handlePost) | 15 min | Low — pure refactor + 1 helper test |
+| 2 | Add `@see` ApexDoc in `FeatureGraphNodeDTO` linking to the hard/soft semantic used by both ApprovalService + CatalogController. Documentation-only | 30 min | None |
+| 3 | (Stretch) Extract `DeliveryFeatureInstallService` from `DeliveryHubInstallHandler` to isolate feature-seed reusability for the future Watcher install path | 1h | Medium — touches install-on-upgrade path, needs smoke test |
+
+## Architectural recommendations (next cycle)
+
+1. **Event-driven approval notifications** — grant/reject decisions persist synchronously today. Consider enqueuing a `FeatureApprovalNotificationQueueable` so Slack/email side-effects don't block the approval transaction. Scales better when cascades exceed ~50 approval rows.
+2. **Cascade depth UI pagination** — graph service caps depth at 10 but the cockpit UI renders the full tree. For deep cascades, lazy-load children in the approval-chain modal.
+3. **Settings → Feature sync deprecation roadmap** — `DeliveryFeatureSyncService` is a temporary mirror. Document a PR timeline to retire the legacy `DeliveryHubSettings__c.Enable*DateTime__c` fields once all internal readers pivot to `Feature__c`. That removes the recursion-guard complexity.
+
+---
+
+## Bottom line
+
+**Code quality is production-ready.** The three-layer service model (catalog → approval → graph) cleanly separates concerns, the recursion guard pattern prevents trigger feedback loops, and bulk-safe SOQL patterns pass all governor checks. Ship with high confidence. Cleanup PRs above are polish, not blockers.

--- a/docs/audits/documentation-gap-audit-2026-05-21.md
+++ b/docs/audits/documentation-gap-audit-2026-05-21.md
@@ -1,0 +1,107 @@
+# Documentation Gap Audit — 2026-05-21
+
+## Headline
+
+The 21+ PRs shipped **functional systems** (cockpit feature lifecycle, Watcher v1, onboarding tracks with structured content, REST API surface) but **documentation is fragmented across audit files + design memos, not user-facing guides**. Subscribers lack setup instructions for 5 major new sObjects, can't find REST API definitions for 4 new routes, and have no template guide for the onboarding-track content pattern.
+
+---
+
+## 1. README / Top-Level — High severity
+
+**Missing from `README.md`:**
+- Feature Catalog (`Feature__c`, `FeatureDefinition__mdt`, `FeatureToggleRequest__c`, `FeatureToggleApproval__c`) — cockpit UI + toggle/approval workflow absent.
+- Watcher v1 (`WatcherDigest__c`, signal queries, daily digest). README still mentions only the weekly digest.
+- Onboarding Tracks (5 new `__mdt` types + `OnboardingProgress__c`).
+- Version pinned at `release/0.239`; 0.243-0.246 (and pending 0.247) shipped in 36 hours.
+
+## 2. Object-Level User-Facing Docs — High severity
+
+| Object | User-facing doc? | Recommendation |
+|---|---|---|
+| `Feature__c` | No | Add "Feature Catalog Setup" section to GETTING_STARTED.md |
+| `FeatureDefinition__mdt` | No | Part of Feature__c section (metadata registry) |
+| `FeatureDependency__c` | No | Part of Feature__c section (dependency rules) |
+| `FeatureToggleRequest__c` | No | REST API guide + admin UI workaround if any |
+| `FeatureToggleApproval__c` | No | Approval workflow section |
+| `WatcherDigest__c` | No | "Watcher Digest — Daily Operations Summary" — signals, Slack config, recipient setup |
+| `OnboardingTrack__mdt` + Lesson/Quiz/ChecklistItem | No | "Onboarding Tracks — Self-Service Training" — show Invoice_Generation_Track sample + cloning steps |
+| `OnboardingProgress__c` | No | Part of Onboarding Tracks docs |
+| `ScratchOrgInstance__c` | No | REST API + Developer Setup |
+| `DevLoopGuide__mdt` | No | Developer Guide |
+| `DatasetTemplate__c` / `DatasetTemplateAssignment__c` | No | Clarify dev-vs-subscriber scope |
+
+## 3. REST API Documentation — High severity
+
+Four new routes shipped with **zero public docs**:
+- `POST /features/{name}/toggle`
+- `GET /feature-toggle-requests`
+- `POST /feature-toggle-approvals/{id}/grant|reject`
+- `POST /scratch-orgs` + `PATCH /scratch-orgs/{id}`
+
+The 3 hardening fixes from `rest-api-surface-review-2026-05-21.md` (rate-limit PATCH, idempotency on toggle POST, pagination metadata) should ship together with the public docs.
+
+## 4. CCI Task Docs — Medium severity
+
+`load_feature_data` task exists in `cumulusci.yml` but no description/docstring; not mentioned in `GETTING_STARTED.md` or README.
+
+## 5. Onboarding-Track Template Guide — High severity
+
+`Invoice_Generation_Track` sample ships (3 lessons + 1 quiz + 3 checklist items) but no docs explaining:
+- How to view the sample in an org
+- How to clone it for a custom feature
+- What the `__mdt` field names mean
+- How `OnboardingProgress__c` tracks completion
+
+Without this, subscribers can't reuse the pattern even though all four `__mdt` types are designed for it.
+
+## 6. Migration / Upgrade Guide — Medium severity
+
+No `docs/UPGRADE_GUIDE.md` covering:
+- v0.243-0.247 release notes (feature summary, deprecations)
+- Opt-in feature flags (Watcher master `EnableWatcherDigestDateTime__c` is null on install; subscribers must enable)
+- New permission set assignments
+- REST API stability notice (3 routes have known issues being fixed)
+
+## 7. Architecture Diagrams — Medium severity
+
+No Mermaid/flow diagrams for:
+- Feature Catalog state machine (definition → request → approval → enabled/disabled, with dependency blocking)
+- Watcher signal aggregation (cron → 7 signals → merge → Slack + WatcherDigest__c row)
+- Onboarding track content structure (Track → Lesson/Quiz/Checklist → Progress)
+
+Complex state machines without visuals are harder to grok for a new admin or contributor.
+
+## 8. Stale Docs — none critical
+
+`docs/SUBTRACT_GLEN_ROADMAP_2026-04-24.md` is still useful context; no contradictions with current state. No `*-RESOLVED.md` markers needed.
+
+---
+
+## Recommended doc-PR bundle
+
+### PR-D1: REST API Completeness (~3h)
+- Fix 3 issues in 4 new routes (rate-limit PATCH, idempotency guard on toggle POST, pagination metadata on list GET)
+- Document all 4 routes in `PUBLIC_API_GUIDE.md` (or create the file) with request/response examples + error codes
+- 1.5h code + 1.5h docs
+
+### PR-D2: Feature Catalog + Watcher Setup Guide (~2h)
+- Add "Feature Catalog — Toggle Management" and "Watcher Digest — Daily Operations Summary" sections to `GETTING_STARTED.md`
+- Cover: how to find the cockpit, how to toggle, how to enable Watcher's master flag + recipient list
+
+### PR-D3: Onboarding Tracks Template + Architecture (~2.5h)
+- "Onboarding Tracks — Self-Service Learning Paths" section in `GETTING_STARTED.md`
+- Create `docs/COCKPIT_ARCHITECTURE.md` with 3 Mermaid diagrams (Feature state machine, Watcher signal flow, Onboarding track content)
+
+**Total: ~7.5h** across 3 PRs.
+
+---
+
+## Verdict
+
+What ships now is **functional but undiscoverable**. Subscribers who install 0.247 will get:
+- A working Feature Catalog with no UI/API guidance
+- A daily Watcher digest that they don't know how to enable
+- An onboarding-track sample they can't clone without reverse-engineering metadata field names
+- Four REST routes with documented bugs (per `rest-api-surface-review`) and no public reference
+
+**Recommendation:** ship the 3 doc PRs as a single "Documentation Completeness" release before declaring General Availability. Code can ship today; docs can ship tomorrow as `0.247.1` (docs-only) or bundled into `0.248`.

--- a/docs/audits/e2e-walkthrough-2026-05-21.md
+++ b/docs/audits/e2e-walkthrough-2026-05-21.md
@@ -1,8 +1,9 @@
 # E2E Business-Logic Walkthrough — 2026-05-21
 
-> Two factual corrections to the original walkthrough are inline below:
+> Three factual corrections to the original walkthrough are inline below:
 > 1. **Watcher v1 IS merged to main** (PRs #807 / #809 / #810). The agent claimed it was on unmerged feature branches; it's in `release/0.246.0.4` LIVE.
 > 2. **`POST /scratch-orgs` and `PATCH /scratch-orgs/{id}` REST routes DO exist** (PR #804). The agent claimed they were unshipped. Verified in `DeliveryPublicApiService.cls`.
+> 3. **Flow 3 #2 quiz-retry-gate claim is wrong** (verified 2026-05-22 during follow-on UX-gap fan-out). `AllowRetryDateTime__c` lives on `OnboardingQuiz__mdt` (a static catalog flag, populated = retries allowed), NOT on `OnboardingProgress__c` as a runtime cooldown. The service does not "set" it; it only reads it. The LWC at `deliveryFeatureOnboarding.js:169` (`quizSubmitButtonDisabled` getter) already honors this flag: `if (this.quizSubmitted && !this.quizAllowsRetry) { return true; }`. The retry gate IS honored. No-op PR.
 >
 > All other findings hold and are serious.
 
@@ -38,7 +39,7 @@ Lessons → 4/5 quiz pass → Manual checklist → toggle works.
 
 **Gaps:**
 1. **Error toast doesn't link to the feature record page.** User must navigate manually.
-2. **Quiz retry gate not honored in UI.** `AllowRetryDateTime__c` is set by the service but `deliveryFeatureOnboarding.js` doesn't check it before showing the retake button.
+2. ~~**Quiz retry gate not honored in UI.** `AllowRetryDateTime__c` is set by the service but `deliveryFeatureOnboarding.js` doesn't check it before showing the retake button.~~ **STALE (verified 2026-05-22).** `AllowRetryDateTime__c` is on `OnboardingQuiz__mdt` (catalog config, not runtime state). `deliveryFeatureOnboarding.js:169` already honors `quizAllowsRetry` (derived from `AllowRetryDateTime__c != null`) in `quizSubmitButtonDisabled`. Audit got both location and semantics wrong. **Adjacent polish opportunity** (deferred — not load-bearing): show explanatory message under the disabled Submit button when retries are blocked, and change button label "Submit Quiz" → "Retry Quiz" when `quizSubmitted && quizAllowsRetry`.
 3. **External checklist evaluators (SoqlQuery / RestCall / WebhookReceived) are PR 4 stubs** — only `Manual` attestation actually verifies. Items render but always fail eval.
 4. **No completion notification.** User has to manually navigate back to the cockpit to discover the gate has lifted.
 

--- a/docs/audits/e2e-walkthrough-2026-05-21.md
+++ b/docs/audits/e2e-walkthrough-2026-05-21.md
@@ -1,0 +1,139 @@
+# E2E Business-Logic Walkthrough — 2026-05-21
+
+> Two factual corrections to the original walkthrough are inline below:
+> 1. **Watcher v1 IS merged to main** (PRs #807 / #809 / #810). The agent claimed it was on unmerged feature branches; it's in `release/0.246.0.4` LIVE.
+> 2. **`POST /scratch-orgs` and `PATCH /scratch-orgs/{id}` REST routes DO exist** (PR #804). The agent claimed they were unshipped. Verified in `DeliveryPublicApiService.cls`.
+>
+> All other findings hold and are serious.
+
+## Headline
+
+**Critical paths are incomplete end-to-end.** Feature toggle + onboarding happy path works. But:
+- **No approval submission UI** (service exists, no LWC form to call it)
+- **No approver auto-assignment** (admins must open each row to set `ApproverUserLookup__c`)
+- **No audit-trail viewer** for `ActivityLog__c`, `WatcherDigest__c`, or `OnboardingProgress__c`
+- **No notification on approval grant** (requester polls manually)
+- **External onboarding checklist evaluators are stubs** (SoqlQuery / RestCall / WebhookReceived)
+- **No Watcher-digest viewing UI** even though the data is being written
+
+---
+
+## Flow 1 — Feature Catalog browse — ✅ WORKS
+
+Install handler seeds Feature__c rows; `deliveryFeatureCockpit` LWC renders the catalog with admin-only Enable/Disable + "Show dependencies" buttons.
+
+**Gap:** card has no link to a feature record page or docs — discovery dead-ends at the catalog.
+
+## Flow 2 — Admin toggles a feature — ⚠ MOSTLY WORKS
+
+End-to-end happy path: LWC → toggleFeature() → onboarding gate → cascade enforce → Feature__c update → trigger → ActivityLog + settings mirror. Cascade refusal opens preview modal automatically.
+
+**Gaps:**
+1. ActivityLog__c audit row is written but no admin LWC surfaces it. Reachable only via SOQL or a report (and no report type ships).
+2. The cascade enforcement path (`DeliveryFeatureCatalogController.enforceCascadeOrThrow`) and the preview path (`DeliveryFeatureGraphService.computeCascade`) are independent — patching one risks visible divergence (toggle allowed but preview warns, or vice versa). Architecture review flagged the same.
+
+## Flow 3 — Non-admin onboarding — ⚠ PARTIAL
+
+Lessons → 4/5 quiz pass → Manual checklist → toggle works.
+
+**Gaps:**
+1. **Error toast doesn't link to the feature record page.** User must navigate manually.
+2. **Quiz retry gate not honored in UI.** `AllowRetryDateTime__c` is set by the service but `deliveryFeatureOnboarding.js` doesn't check it before showing the retake button.
+3. **External checklist evaluators (SoqlQuery / RestCall / WebhookReceived) are PR 4 stubs** — only `Manual` attestation actually verifies. Items render but always fail eval.
+4. **No completion notification.** User has to manually navigate back to the cockpit to discover the gate has lifted.
+
+## Flow 4 — Approval workflow — ❌ NOT END-TO-END
+
+**No submission UI exists.** `DeliveryFeatureApprovalService.submit()` is `@AuraEnabled global static` — callable from REST and an LWC — but no LWC form was built. The `deliveryFeatureApprovalInbox` LWC only displays pending approvals.
+
+After submit:
+- **`ApproverUserLookup__c` is null at create.** No admin UI to assign approvers; admin must open each `FeatureToggleApproval__c` row directly. The security review flagged that the grant/reject methods don't even verify caller-is-approver, so a non-approver could call them via REST.
+- **No notification to the requester on grant.** Apply happens, ActivityLog row writes, requester has no idea.
+
+## Flow 5 — Dependency cascade preview — ⚠ PARTIAL
+
+Preview renders correctly IF dependencies exist.
+
+**Gap:** **no UI to create FeatureDependency__c records.** Admins must use Data Loader / DML / direct record-page creation (and per the Admin UX audit, **no record page or layout exists for FeatureDependency__c**, so even that fallback is broken).
+
+## Flow 6 — Dev-loop mirror — ⚠ PARTIAL (correction below)
+
+**Correction to original audit:** the REST endpoint exists. `POST /scratch-orgs` + `PATCH /scratch-orgs/{id}` are implemented in `DeliveryPublicApiService.cls` (shipped in PR #804, in `release/0.246.0.4`).
+
+**Real gaps:**
+1. **No example GitHub Action workflow shipped** in `.github/workflows/` that actually calls the endpoint. Subscriber devs would need to write their own.
+2. **No auto-create of WorkItem__c** when a branch name doesn't match an existing WI — the LWC only shows scratch orgs linked to an existing WI.
+3. **No record page or layout for `ScratchOrgInstance__c`** per the Admin UX audit, so even when rows exist they're hard to inspect.
+
+## Flow 7 — Dataset loading — ⚠ PARTIAL
+
+`DatasetTemplate__c` and the `load_feature_data` CCI task ship. LWC shows the template list + copies the command.
+
+**Gaps:**
+1. **No execution-context guidance** — the LWC just copies a CLI command with no note about local-CCI vs scratch-org.
+2. **Nothing writes `DatasetTemplateAssignment__c` rows** after a successful load. The audit-trail object is shipped empty.
+3. **`load_feature_data` task body** in `cumulusci.yml` is a parameterized wrapper — confirm it actually invokes the per-feature `scripts/feature-data/<name>.apex` file. Only `invoice_generation.apex` ships; other features have no script.
+
+## Flow 8 — Watcher daily digest — ⚠ PARTIAL (correction below)
+
+**Correction:** Watcher v1 IS shipped to main and is in `release/0.246.0.4`. PRs #807 (PR-A schema), #809 (PR-B orchestrator + Signal 1 + stubs), #810 (PR-C Signals 2+3) all merged.
+
+**Real gaps:**
+1. **No admin setup UI for the master flag + recipient list.** Subscribers must open Setup → Custom Settings → DeliveryHubSettings → edit to flip `EnableWatcherDigestDateTime__c` and populate `WatcherDigestRecipientUserIdsTxt__c`. No friendly form, no user picker, no help text.
+2. **No digest-viewing UI.** `WatcherDigest__c` rows accumulate (audit-of-runs purpose) but no LWC reads them. Per the Admin UX audit, the object also has **0 field perms granted** in the `DeliveryHubAdmin_App` permset, so subscribers literally cannot read them at all.
+3. **Slack post is fire-and-forget.** No fallback if the webhook 4xx/5xx's. The `WatcherDigest__c` row records `StatusPk__c='Success'` even if Slack didn't deliver.
+
+---
+
+## Cross-flow gaps
+
+| Category | Gap |
+|---|---|
+| **Notifications layer** | Feature toggles, approval grants, onboarding completion — none notify anyone. Users poll. |
+| **Admin assignment UIs** | Approver assignment is per-row manual. Feature dependencies are data-loader-only. Watcher recipients are raw text-field. |
+| **Audit-trail surfaces** | `ActivityLog__c`, `WatcherDigest__c`, `FeatureToggleRequest__c` history, `OnboardingProgress__c` history — all data-rich, zero LWC. |
+| **Link nav between surfaces** | Onboarding-gate toast doesn't link to the feature record page. Catalog cards don't link to feature record pages. Approval inbox doesn't link to cascade snapshot. WatcherDigest doesn't link flagged WIs. |
+
+---
+
+## Top 5 "this won't actually work end-to-end without ___" gaps
+
+| # | Gap | Blocks | Effort |
+|---|---|---|---|
+| 1 | **No approval submission UI** — service exists, no LWC to call it | Flow 4 entirely | 1-2d (LWC form + cockpit modal entry point) |
+| 2 | **No approver auto-assignment** — null at create, admin must edit each row | Flow 4 usability | 1-2d (Routing__mdt config + auto-assign on insert, plus security review's caller-is-approver assertion) |
+| 3 | **No audit-trail viewer LWCs** — ActivityLog, WatcherDigest, OnboardingProgress history all invisible | All flows | 2-3d (3 LWCs + record-page placement) |
+| 4 | **Admin UX bundle** (per separate audit) — 9 new objects missing tabs/layouts/record pages | Discoverability of any new feature | ~3.5h metadata-only (see admin-ux-audit) |
+| 5 | **No notification layer** — requesters/users never told their action completed | UX confidence on every async flow | 2-3d (queueable + CustomNotificationType for bell + reuse Slack outbound for chat) |
+
+---
+
+## Verdict
+
+### Works end-to-end today
+- Feature catalog browse (Flow 1)
+- Admin feature toggle with cascade enforcement (Flow 2)
+- Non-admin onboarding happy path: Lessons → Manual quiz pass → Manual checklist → toggle (Flow 3)
+- Cascade preview rendering when dependencies exist (Flow 5)
+- Watcher signal pipeline → digest record written → Slack posted (Flow 8 happy path)
+
+### Code shipped but no UI
+- Approval submission (`submit()` is callable but no form)
+- Activity audit trail (writes happen, no viewer LWC)
+- Watcher digest history (records accumulate, no viewer + can't read fields anyway)
+- Approver assignment (null at create, no admin UI)
+- Dependency definition (no edit UI; layout missing)
+
+### Code or content not yet shipped
+- Onboarding quiz retry gating UI (service sets `AllowRetryDateTime__c`; LWC ignores)
+- Onboarding non-Manual evaluators (Soql/Rest/Webhook checklist verifiers are stubs)
+- Notification side-effects on toggle/approval/completion
+- Example GitHub Action workflow for the `/scratch-orgs` endpoint
+- Per-feature dataset-load scripts beyond `invoice_generation.apex`
+- `DatasetTemplateAssignment__c` row insertion after CCI runs
+
+### Net assessment
+
+The cockpit is **roughly 60% end-to-end** for the happy-path user (admin browsing, toggling, an onboarding learner). The remaining 40% is "code shipped but no UI" or "no notification loop." A subscriber who installs today would see the cockpit, would successfully toggle a feature, would walk a Manual-only onboarding track, would see Watcher's Slack message at 8am ET — but would never figure out how to submit a request for approval, never see the audit trail, never know that a Watcher digest was even written, and never get told when their approval landed.
+
+**Most leveraged next push:** the **Admin UX gap PR bundle** (~3.5h) + a single **approval submission + assignment UI PR** (~2 days). That converts ~25 of the 40% gap to working surfaces.

--- a/docs/audits/lwc-quality-review-2026-05-21.md
+++ b/docs/audits/lwc-quality-review-2026-05-21.md
@@ -1,0 +1,139 @@
+# LWC Quality + Accessibility Review — 2026-05-21
+
+## Headline
+
+All 6 LWCs ship with **strong CLAUDE.md compliance** and **complete loading/error states**. Key accessibility gaps exist around aria-labels on icon-only buttons and modal focus management. Subscriber-org degradation is properly implemented in DevLoopGuide but incomplete in DatasetTemplates.
+
+| Component | State Coverage | A11y | CLAUDE.md | Meta-XML | Critical Issues |
+|---|---|---|---|---|---|
+| `deliveryFeatureCockpit` | ✅ Full | ⚠ Icon labels missing | ✅ | ⚠ description tight | 0 |
+| `deliveryFeatureCascadePreview` | ✅ Full | ✅ Dialog ARIA complete | ✅ | ✅ | 0 |
+| `deliveryFeatureApprovalInbox` | ✅ Full | ⚠ Modal ESC keyboard | ✅ | ✅ | 0 |
+| `deliveryFeatureOnboarding` | ✅ Full | ✅ Tab roles correct | ✅ | ✅ | 0 |
+| `deliveryDevLoopGuide` | ✅ Full | ⚠ Icon labels | ✅ Subscriber badge | ✅ | 0 |
+| `deliveryDatasetTemplates` | ✅ Full | ✅ | ✅ | ✅ | ⚠ subscriber gap |
+
+All 6 LWCs are production-ready. Gaps below are polish items, not blockers.
+
+---
+
+## Per-LWC Findings
+
+### `deliveryFeatureCockpit`
+
+**State coverage:** loading (implicit via wire) ✅; error (`hasError` getter, `role="alert"` line 16) ✅; empty (`isEmpty` getter + illustration lines 23-29) ✅.
+
+**A11y gaps:** line 40 `<lightning-icon icon-name={feature.icon}>` is missing `alternative-text`. Decorative but should be explicit per WCAG 2.1 AA. Modal close-button pattern at line 113 is correct (`<span class="slds-assistive-text">Close</span>`). Modal structure (lines 106-135) has `role="dialog"`, `aria-modal="true"`, `aria-labelledby`.
+
+**CLAUDE.md compliance:** no template ternaries, `@api` booleans default to false, namespace tokens correct.
+
+**Notable:** `refreshApex(this.wiredResult)` after toggle success; all `.catch()` paths land in toast or state mutation; `for:each` with `key={feature.key}`.
+
+### `deliveryFeatureCascadePreview`
+
+**State coverage:** isLoading spinner, hasError state, null-feature graceful path. All three states covered.
+
+**A11y — exemplary:**
+- Line 25: `<ul role="tree">`
+- Line 30: `<li role="treeitem" aria-level={row.ariaLevel}>` (hierarchy depth)
+- Lines 34-40: icons have `alternative-text={row.iconAlt}` + `title`
+- No color-contrast issues (SLDS-native badges)
+
+**CLAUDE.md compliance:** comment on line 11 explicitly notes "No ternaries in the template (LWC v62 limitation per CLAUDE.md)". Line 34: `@api hideFooterButtons = false` — inverted boolean per LWC1503.
+
+**Meta-XML:** `<isExposed>false</isExposed>` correctly hidden (internal-only component).
+
+### `deliveryFeatureApprovalInbox`
+
+**State coverage:** loading, error, empty, plus chain-loading state.
+
+**A11y:** modal at lines 95-158 has `role="dialog"`, `aria-modal="true"`, `aria-labelledby`. Refresh icon-button has `alternative-text="Refresh"`. Close button has icon + assistive text.
+
+**Gap:** keyboard ESC not wired explicitly — relies on SLDS backdrop defaults. SLDS typically handles ESC but explicit `onkeydown` handler is more robust.
+
+**Notable:** toast variants correct (success/error/warning); `refreshApex` after decision; note textareas cleaned on success.
+
+### `deliveryFeatureOnboarding`
+
+**State coverage:** all 4 states (loading, error, empty track, sub-section empty fallbacks via `lwc:elseif`).
+
+**A11y — strong:** stepper tabs with `role="tablist" / role="presentation" / role="tab"`; radio quiz items use standard `<label class="slds-radio">`; checklist buttons have clear text labels. No icon-only elements without labels.
+
+**CLAUDE.md compliance:** no template ternaries (all in getters lines 77-295), `@api trackDeveloperName = ''` defaults to empty string not boolean, namespace tokens.
+
+**Notable:** `completedLessonNames` JSON parsing wrapped in try-catch; quiz answer tracking via immutable object spread; CSS uses `var(--lwc-colorBackgroundAlt, #fafaf9)` (SLDS-aware).
+
+### `deliveryDevLoopGuide`
+
+**State coverage:** loading, error, empty, **subscriber-org degraded** (badge lines 23-29 when `isSubscriberOrg === true`). Exemplary pattern.
+
+**A11y gaps:** line 40 header icon missing `alternative-text` (decorative but should be explicit). Copy icon-buttons at lines 56 + 73 correctly labeled (`alternative-text="Copy command"` / `"Copy step command"`).
+
+**Notable:** `navigator.clipboard.writeText()` with fallback toasts; subscriber detection via Apex return flag.
+
+### `deliveryDatasetTemplates`
+
+**State coverage:** loading, error, empty.
+
+**Subscriber-org gap:** unlike DevLoopGuide, this component has **no Apex-level `isSubscriberOrg` flag** — relies on empty-state message fallback only. Users on a subscriber org see the full template list before reading "for package developers." UX friction, not functional.
+
+**A11y:** copy button has full text label ("Copy Load Command") + icon, not icon-only. All interactive elements labeled.
+
+**Notable:** elegant dual-wire pattern (lines 45-61) — conditional `featureIdForWire`/`workItemIdForWire` return null until parent object matches, leaving the wire inert.
+
+---
+
+## Cross-Cutting Issues
+
+### 1. Icon labels on decorative/utility icons
+
+**Affected:** `deliveryFeatureCockpit:40`, `deliveryDevLoopGuide:40`.
+
+`<lightning-icon>` lacks `alternative-text`. Per SLDS, decorative icons can omit but explicit labels are WCAG 2.1 AA best practice.
+
+**Severity:** Low.
+
+### 2. Subscriber-org degradation inconsistency
+
+**Affected:** `deliveryDatasetTemplates` vs `deliveryDevLoopGuide`.
+
+DevLoopGuide returns `isSubscriberOrg` flag from Apex and renders a clear badge. DatasetTemplates relies on empty-state message fallback.
+
+**Severity:** Low (UX friction, not functional).
+
+### 3. Modal keyboard escape
+
+**Affected:** `deliveryFeatureApprovalInbox` lines 95-158.
+
+Approval chain modal wires close via button onclick but not keyboard `Escape`. SLDS often handles ESC via backdrop interaction; explicit handler is more robust.
+
+**Severity:** Low.
+
+---
+
+## Top 3 Fixes
+
+### Fix 1: Add `alternative-text` to decorative icons
+- Scope: `deliveryFeatureCockpit.html:40`, `deliveryDevLoopGuide.html:40`
+- Effort: 5 min (2 one-line edits)
+- Severity: Low
+
+### Fix 2: Align DatasetTemplates subscriber-org UX with DevLoopGuide
+- Scope: `deliveryDatasetTemplates.js` + `DeliveryDatasetController.cls`
+- Effort: 30 min (Apex returns `isSubscriberOrg`, JS getter, conditional render)
+- Severity: Low (UX consistency)
+
+### Fix 3: Wire ESC handler on the approval-chain modal
+- Scope: `deliveryFeatureApprovalInbox.js` — add `onkeydown` on the modal container
+- Effort: 5 min
+- Severity: Low
+
+---
+
+## Summary
+
+**Strengths:** complete state coverage across all 6 LWCs; strong CLAUDE.md compliance (no ternaries, namespace tokens, boolean handling); robust error handling on imperative Apex calls; exemplary modal ARIA (cockpit + cascade); subscriber-org awareness established in DevLoopGuide.
+
+**Gaps:** decorative-icon labels (WCAG AA polish); DatasetTemplates subscriber-org consistency; explicit modal ESC handlers.
+
+**Bottom line:** all 6 LWCs are production-ready. The three Top Fixes total ~40 minutes and can ship as a single polish PR when convenient — not blocking.

--- a/docs/audits/pmd-baseline-2026-05-21.md
+++ b/docs/audits/pmd-baseline-2026-05-21.md
@@ -40,7 +40,7 @@ The cockpit-plan PRs did **not** regress baseline quality. Every new class passe
 
 | Class | Debt | Dominant rules | Risk | Recommendation |
 |---|---|---|---|---|
-| `DeliveryDocumentController` | 40 | `ApexDoc` only | Low | **Priority 1.** Javadoc sweep on 40 public methods — 1-2h, kills 11% of baseline debt |
+| ~~`DeliveryDocumentController`~~ | ~~40~~ | `ApexDoc` | — | **CLOSED in PR #791 (2026-05-18)** — audit was stale on this row when written 2026-05-21. 88 ApexDoc-tag lines across 25 methods now present. Net 40 findings removed. |
 | `DeliverySlackInboundHandler` | 6 | `StdCyclomaticComplexity` ×2, `ApexDoc` ×2, `CyclomaticComplexity`, `NcssMethodCount` | High (`handle()` cyc=13) | **Priority 2.** Extract event-type branches into 3 helpers — 45min, drops cyc 13→~4 |
 | `DeliveryFeatureApprovalService` | 5 | Cyclomatic ×2 + others | Medium | Monitor; intentional additive-signature design. Defer refactor |
 | `DeliveryOnboardingService` | 5 | Cyclomatic + `ExcessivePublicCount` ×2 | Medium | Monitor; same pattern. Defer |
@@ -66,4 +66,4 @@ Net codebase quality is **the same** as 5/15 plus 10 new well-tested classes wit
 | 5 | `ApexCRUDViolation` triage on `DeliveryWorkItemController` (5 findings) | 2h | 1.4% | Validates security controls |
 | 6 | Suppress monoliths with TODO (`DeliveryGanttController`, `DeliverySyncItemIngestor`) | 30min | Reduces noise | Documentation-only |
 
-**Recommended next-session bundle:** #1 + #2 = ~2.5h, kills 15% of baseline debt, low risk. Ship as a single cleanup PR.
+**Recommended next-session bundle:** #2 + (#5 partial) ≈ 2-3h. Sweep #1 was already closed by PR #791 — the audit referenced it as if pending because the original PMD scan was copy-forwarded from the May-15 baseline without re-verifying this row. **Lesson for future audits:** the agent doing repo-wide PMD baselines must actually run `npx sfdx scanner:run` or grep current ApexDoc state per-class, not paste-forward findings from the prior baseline.

--- a/docs/audits/rest-api-surface-review-2026-05-21.md
+++ b/docs/audits/rest-api-surface-review-2026-05-21.md
@@ -1,0 +1,135 @@
+# REST API Surface Review — 2026-05-21
+
+## Headline
+
+The 6 new feature-cockpit (PR 8) + dev-loop mirror (PR 9) routes follow solid foundational patterns, but **three issues warrant action**:
+
+1. **`PATCH /scratch-orgs/{id}` is not rate-limited** (POST is; PATCH path skipped the gate) — High
+2. **`POST /features/{name}/toggle` has no idempotency guard** — duplicate submissions create duplicate FeatureToggleRequest__c rows — High
+3. **`GET /feature-toggle-requests` lacks pagination metadata** — clients can't tell if more rows exist beyond the LIMIT 50 cap — Medium
+
+Authentication, tenant-scoping, error envelope, response shape, and versioning are all consistent across the surface.
+
+---
+
+## 1. Authentication Consistency — PASS
+
+- All 6 new routes call `authenticateRequest()` before processing.
+- X-Api-Key validates against `NetworkEntity__c.ApiKeyTxt__c` with `ConnectionStatusPk__c = 'Connected'`.
+- Intentionally tenant-less routes (`/scratch-orgs`) skip `resolveEffectiveEntity()` by design (lines 94-100, documented in comments).
+
+**Note:** feature-cockpit routes are org-wide (no per-tenant scope). Any NetworkEntity with a valid X-Api-Key can call ANY feature toggle. Comment at L151-154 acknowledges; if the design intent is per-tenant feature-flag scoping eventually, that's PR 11+ scope.
+
+## 2. Tenant Scoping — PASS by design
+
+Routes that should be tenant-scoped use `resolveEffectiveEntity()`; routes that intentionally bypass (`/scratch-orgs`) are documented.
+
+## 3. Rate Limiting — FAIL (PATCH ungated)
+
+GET (lines 22-32) ✅. POST (lines 78-89) ✅. PATCH (lines 51-69) ❌ — no rate-limit gate.
+
+**Impact:** an attacker with a valid X-Api-Key can submit unlimited `PATCH /scratch-orgs/{id}` requests.
+
+**Fix:** copy lines 78-89 from `handlePost()` into `handlePatch()` after `authenticateRequest()`. ~10 min.
+
+## 4. Error Envelope Shape — PASS
+
+`sendError(code, msg)` → `{success: false, error: ...}` and `sendSuccess(data)` → `{success: true, data: ...}` used consistently. Status codes appropriate (200/201/400/401/404/500). Minor: both grant + reject return 200 — semantically different outcomes, could clarify.
+
+## 5. Response Shape Stability — PASS (minor naming inconsistency)
+
+All POSTs include stable `id`-like field. `POST /features/{name}/toggle` returns `requestId` rather than `id` — minor REST-convention drift but doesn't break clients.
+
+## 6. Idempotency — FAIL
+
+### Issue 1: `POST /features/{name}/toggle` (lines 339-360)
+
+Submitting the same (feature, action) twice creates two `FeatureToggleRequest__c` rows. No deduplication.
+
+**Fix (~15 min):** before insert, query for an existing `Pending` or `Granted` row with the same `FeatureLookup__c + ActionPk__c`; if found, return its ID with status 200 (not 201).
+
+```apex
+List<FeatureToggleRequest__c> existing = [
+    SELECT Id FROM FeatureToggleRequest__c
+    WHERE FeatureLookup__c = :featureId
+      AND ActionPk__c = :action
+      AND StatusPk__c IN ('Pending', 'Granted')
+    WITH SYSTEM_MODE LIMIT 1
+];
+if (!existing.isEmpty()) {
+    sendSuccess(new Map<String, Object>{
+        'requestId' => existing[0].Id,
+        'featureId' => featureId,
+        'status' => 'Pending'
+    });
+    return;
+}
+```
+
+### Issue 2: `POST /scratch-orgs` (lines 640-681)
+
+Submitting the same `OrgIdTxt__c` twice creates two `ScratchOrgInstance__c` rows. GH Actions retry on network blip → duplicate rows.
+
+**Fix (~10 min):** either add a `<unique>true</unique>` constraint on `OrgIdTxt__c.field-meta.xml`, or query-before-insert pattern as above.
+
+## 7. Input Validation — PASS
+
+JSON parsing is wrapped in the outer try/catch (lines 104). Validation after retrieval. DateTime parsing defensive (try/catch with safe fallbacks). URL path-segment decoding handled by the REST framework before `extractResource()` runs.
+
+Minor: PATCH `state` value is not enum-validated against the StatePk__c picklist — the database constraint rejects bad values, but a pre-DML check would give a cleaner 400.
+
+## 8. Pagination — FAIL (no metadata)
+
+`GET /feature-toggle-requests` has LIMIT 50 + optional `?pageOffset`, but the response is a bare list. Clients can't tell if row 51 exists.
+
+**Fix (~20 min):** wrap in pagination envelope:
+```apex
+Map<String, Object> resp = new Map<String, Object>{
+    'data'     => data,
+    'offset'   => offset,
+    'pageSize' => maxRows,
+    'hasMore'  => data.size() >= maxRows
+};
+sendSuccess(resp);
+```
+
+Or fetch `LIMIT maxRows+1` to actually know.
+
+## 9. Versioning — PASS
+
+All new routes are additive to `/v1/`. No breaking changes.
+
+## 10. CORS / Hostname — PASS
+
+Salesforce-internal REST endpoints; CORS handled by platform.
+
+## 11. Webhook Safety (`POST /scratch-orgs`) — PARTIAL
+
+ANY NetworkEntity with a valid API key can submit scratch-org rows that show up org-wide. If GH Actions is the only caller, low risk. If multi-tenant, add a `CreatedByNetworkEntityLookup__c` lookup or an `IsScratchOrgPublisherDateTime__c` permission gate on NetworkEntity.
+
+## Top 3 Fixes (priority order)
+
+| # | Fix | Effort | Severity |
+|---|---|---|---|
+| 1 | Add rate limiting to `handlePatch()` (copy from `handlePost()` lines 78-89) | 10 min | High — unlimited PATCH bypasses the gate |
+| 2 | Idempotency guard on `POST /features/{name}/toggle` (query-before-insert) | 15 min | High — duplicate Pending rows from network-retry |
+| 3 | Pagination envelope on `GET /feature-toggle-requests` (hasMore + offset) | 20 min | Medium — client UX hole |
+
+**Bundle as one cleanup PR:** ~45 min total. Read-test webhook + toggle flows after.
+
+## Recommended next-cycle work
+
+**v2 surface (not for this cycle):**
+- Auto-resolve `ApproverUserLookup__c` at submit (PR 8 leaves null)
+- Per-tenant feature-flag scoping (currently org-wide)
+- Feature-specific approval policies (currently all features share cascade graph)
+- `OrgIdTxt__c` uniqueness constraint on `ScratchOrgInstance__c`
+
+**v1 polish (debt, not blocker):**
+- Refactor `queryFeatureToggleRequests` 4-branch query into a single builder
+- Add `X-RateLimit-Remaining` / `X-RateLimit-Reset` headers on 429s
+- Improve feature-not-found errors with available-names list
+
+## Bottom line
+
+The REST surface is **well-structured and follows consistent patterns**. The 3 fixes above are the only hardening needed before production traffic. The underlying `DeliveryFeatureApprovalService` design is mature; the entry points need ~45 minutes of additional hardening.

--- a/docs/audits/security-review-2026-05-21.md
+++ b/docs/audits/security-review-2026-05-21.md
@@ -1,0 +1,107 @@
+# Security Review — 2026-05-21
+
+## Headline
+
+**Net posture: ACCEPTABLE with one medium remediation.** No PMD-missed CRUD violations, no SOQL injection, no FLS bypass. Authentication + tenant-scoping are solid across the cockpit + Watcher + REST surface.
+
+**One medium-severity finding:** `DeliveryFeatureApprovalService.grant/reject` does not guard against a `null` `ApproverUserLookup__c`. Any authenticated user could grant/reject an approval whose approver was never assigned. Mitigated in practice by PR 9-era auto-assignment plans but should be hardened now.
+
+Two low-severity polish items below (rate-limit opt-in visibility, optional request-body size cap).
+
+---
+
+## 1. FLS / Sharing — PASS
+
+`DeliveryPublicApiService` is `without sharing` (intentional REST gate, all DML uses `AccessLevel.SYSTEM_MODE`). `DeliveryFeatureCatalogController`, `DeliveryFeatureApprovalService`, `DeliveryOnboardingService`, `DeliveryDevLoopController`, `DeliveryDatasetController` all `with sharing`. `DeliveryRateLimitService` and `DeliveryPortalAccessService` are `without sharing` (appropriate for cross-cutting utilities), use `WITH SYSTEM_MODE` on internal reads. No `Security.stripInaccessible()` needed given explicit access-level discipline.
+
+## 2. CRUD — PASS
+
+All DML reviewed. `DeliveryPublicApiService.cls` insert/update sites at lines 608, 672, 711 all `AccessLevel.SYSTEM_MODE`. `DeliveryFeatureApprovalService` DML at lines 143, 364, 382, 485, 516, 528, 578 runs under class-level `@SuppressWarnings('PMD.ApexCRUDViolation')` (line 44) justified by `with sharing` context + multi-step approval workflow + comprehensive test coverage.
+
+## 3. SOQL Injection — PASS
+
+All user-supplied input either cast to known types with try/catch (`Id.valueOf()`, `Integer.valueOf()`, `Decimal`) or used as bind variables (`:featureName`, `:statusFilter`, `:offset` at `DeliveryPublicApiService.cls:438-484`). No string concatenation in SOQL queries. `JSON.deserializeUntyped()` results are accessed via typed `.get(key)` calls — no eval risk.
+
+## 4. REST Authentication + Tenant Scoping — PASS
+
+`authenticateRequest()` fires on every `@HttpGet`/`@HttpPost`/`@HttpPatch` entry (lines 18, 54, 75). X-Api-Key validates against `NetworkEntity__c.ApiKeyTxt__c` with `ConnectionStatusPk__c='Connected'` constraint (lines 727-733). Returns 401 on failure.
+
+`resolveEffectiveEntity()` (lines 736-749) enforces per-entity access via `DeliveryPortalAccessService.validateAccess()`. Pre-entity routes (`my-entities`, `portal-users`) require X-Portal-User header before resolution — correct pattern.
+
+Routes that intentionally bypass entity-scoping (`/scratch-orgs` POST/PATCH, feature-cockpit POSTs) are org-wide tooling and rate-limited on the API-key NetworkEntity ID. Documented at lines 94-96.
+
+## 5. Sensitive Data Exposure — PASS
+
+`ActivityLog__c` writes contain only IDs, hours, optional notes, action types — no secrets / passwords / API keys logged. No `System.debug()` calls with sensitive payloads. Slack webhook URLs / API keys are never in test classes or response bodies. Error responses are generic.
+
+## 6. Cross-Org / Namespace — PASS
+
+PSG check at `DeliveryFeatureCatalogController.isAdmin()` lines 391-398 accepts both `'DeliveryHubAdmin'` (dev) and `'delivery__DeliveryHubAdmin'` (subscriber). No `Schema.getGlobalDescribe().get()` patterns remain after hotfixes #797 + #800. No `getName()` vs `getLocalName()` mismatches.
+
+## 7. Auth Bypass Paths
+
+**`isAdmin()` PSG query:** uses `UserInfo.getUserId()` — platform-supplied, not user-input. Cannot be spoofed.
+
+**Onboarding gate:** `assertCanToggle` → `isAdmin` → `isTrackComplete(trackName, UserInfo.getUserId())`. No spoofable input path.
+
+**Approval grant/reject — FINDING (Medium severity):**
+- `DeliveryFeatureApprovalService.grant(approvalId, note)` and `.reject(approvalId, note)` load the approval row by ID, then call `stampDecision()` and apply.
+- They do **NOT** verify that the calling `UserInfo.getUserId()` equals `row.ApproverUserLookup__c`. They also don't verify `ApproverUserLookup__c` is non-null.
+- `getInbox()` filters its returned rows by `ApproverUserLookup__c = :UserInfo.getUserId()`, so the LWC won't surface approvals not assigned to you. BUT the underlying methods are callable directly (`@AuraEnabled global static`) — any authenticated DH user could call `grant(approvalId, '')` with any approval ID.
+- Particularly risky for approvals with `ApproverUserLookup__c = null` (which PR 9-era auto-assignment was supposed to wire). Until then, those rows are open to any caller.
+
+**Scratch-Org POST:** X-Api-Key only. Comment at lines 94-96 confirms intentional "developer-tooling scoped." Acceptable for GH Actions CI/CD context.
+
+## 8. Webhook + Queueable Safety — PASS
+
+`JSON.deserializeUntyped` wrapped in try-catch with 400-on-malformed (line 104-108). Blank body check at line 93. Salesforce platform enforces 6MB REST body limit globally — no app-level cap needed. Watcher queueables (`WatcherDigestRunQueueable`) reviewed in PR-B; no concerns.
+
+---
+
+## Recommended Remediation PRs
+
+### Fix 1 — `FeatureToggleApproval` grant/reject: assert calling user is the approver
+- **Scope:** `DeliveryFeatureApprovalService.cls` (add a `assertCallerIsApprover(row)` helper before `stampDecision`)
+- **Effort:** ~15 min
+- **Severity:** **Medium**
+
+```apex
+private static void assertCallerIsApprover(FeatureToggleApproval__c row) {
+    if (row.ApproverUserLookup__c == null) {
+        throw new AuraHandledException('Approval has no assigned approver — cannot decide.');
+    }
+    if (row.ApproverUserLookup__c != UserInfo.getUserId()) {
+        throw new AuraHandledException('You are not the assigned approver for this row.');
+    }
+}
+```
+
+Call at the top of both `grant()` and `reject()`. Existing tests need a tiny update to set `ApproverUserLookup__c = UserInfo.getUserId()` on the test approval rows.
+
+### Fix 2 — Rate-limit opt-in visibility
+- **Scope:** `DeliveryPublicApiService.cls` startup log OR a runtime warning if `PublicApiRateLimitNumber__c` is null on the first call of the day
+- **Effort:** ~10 min
+- **Severity:** Low — ops/observability gap
+
+The current opt-in gating at lines 23 + 80 silently disables rate limiting if `PublicApiRateLimitNumber__c` is null. Should at least log a `System.debug(LoggingLevel.WARN, ...)` when un-set so it shows up in audit traces.
+
+### Fix 3 — Optional request-body size cap on POST
+- **Scope:** `DeliveryPublicApiService.handlePost()` — add an early `requestBody.size() > 1_000_000` check
+- **Effort:** ~10 min
+- **Severity:** Low — Salesforce enforces 6MB platform-wide; this is belt-and-suspenders
+
+---
+
+## Net verdict
+
+The cockpit + Watcher ship cycle introduced **20+ new classes with strong security fundamentals**:
+
+- ✅ Authentication present and correct on all REST routes
+- ✅ Sharing/access-level discipline is explicit and intentional
+- ✅ CRUD violations are either zero or class-level suppressed with documented justification
+- ✅ SOQL injection: zero risk (bind vars only)
+- ✅ Multi-tenant boundaries correctly enforced via `resolveEffectiveEntity` + portal-access service
+- ✅ ActivityLog audit writes are safe (no PII/secrets)
+- ⚠ One medium gap: approval grant/reject should verify caller-is-approver before stamping a decision
+
+**Recommendation:** ship Fix 1 in a small PR (~15min) before any production deploy that exposes the REST approval routes to external clients. Fixes 2 + 3 are optional polish.

--- a/docs/audits/wiring-gap-audit-2026-05-21.md
+++ b/docs/audits/wiring-gap-audit-2026-05-21.md
@@ -1,0 +1,96 @@
+# Wiring Gap Audit — 2026-05-21
+
+> Cross-reference note: this audit is narrower than the Admin UX + E2E walkthrough audits. It looked at **deployment wiring** (triggers active, scheduler called, test classes registered, etc.) and found things mostly clean. The Admin UX audit + E2E walkthrough surfaced **discoverability + UX wiring** gaps that this audit didn't scope. Read all four together for the full picture.
+
+## Headline
+
+**Deployment wiring is clean.** Triggers active, handlers wired, scheduler orchestrated, GVS files present, test suite comprehensive, picklist values externalized. Two polish gaps + cross-references to issues already surfaced in other audits.
+
+---
+
+## 1. Trigger wiring — COMPLETE
+
+- `FeatureTrigger.trigger` → `DeliveryFeatureTriggerHandler.handle()` ✅
+- `FeatureToggleRequestTrigger.trigger` → `FeatureToggleRequestTriggerHandler.handle()` ✅
+- Both `<status>Active</status>` ✅
+- Both `after insert, after update` ✅
+
+## 2. Scheduler wiring — COMPLETE
+
+`DeliveryHubInstallHandler.onInstall()` → `scheduleSyncJobs()` → `DeliveryHubScheduler.scheduleAll()` (idempotent, aborts existing jobs before re-scheduling). All 9 cron-tick branches enqueue cleanly: weekly digest, invoice gen, overdue reminders, forecast alerts, and 5 sync ops.
+
+**Note:** the audit agent claims "no `enqueueWatcherDigestIfDue()` — integrated into general digest framework." That's incorrect — PR-B's brief explicitly added a new dedicated method. Verify by reading `DeliveryHubScheduler.cls` post-merge; this is the one wiring claim that needs eyes-on confirmation.
+
+## 3. Install handler completeness — COMPLETE (audit was wrong on the Watcher gap)
+
+`onInstall()` runs: settings init → feature seed → legacy settings mirror → schedule sync jobs → backfill user permsets → backfill WI status defaults → enqueue reconciliation. Complete + idempotent.
+
+**Original audit claimed the 3 Watcher per-signal flags were missing from `initializeDefaultSettings()`. Verified in actual main: this is INCORRECT.** Lines 74-76 of `DeliveryHubInstallHandler.cls` set all three:
+```apex
+EnableWatcherSLABreachDateTime__c           = now,
+EnableWatcherStuckStageDateTime__c          = now,
+EnableWatcherARAgingDateTime__c             = now,
+```
+Matching test assertions exist in `DeliveryHubInstallHandlerTest.cls` lines 26-31. Shipped in PR #809 commit `39ada64c`.
+
+## 4. CustomNotificationType definitions — gap (per other audit)
+
+No `customNotificationTypes/` directory exists. Bell notifications for approval requests / Watcher digest / onboarding complete don't fire. **Cross-reference: see `admin-ux-audit-2026-05-21.md` §8 for the same finding + remediation PR.**
+
+## 5. Field defaults — COMPLETE
+
+Same as §3 — original "polish gap" claim was incorrect, Watcher signal flags ARE defaulted on install.
+
+## 6. Tab + App definitions — subscriber-blocking (per other audit)
+
+**`Feature__c`, `FeatureToggleRequest__c`, `FeatureToggleApproval__c` have no tabs.** Not in `DeliveryHub` or `DeliveryHubAdmin` app navigation. **Cross-reference: see `admin-ux-audit-2026-05-21.md` §1-2** — the Admin UX audit identified 9 objects (the full new-object set, not just 3) with missing tabs/layouts/record pages.
+
+## 7. Site Guest / Public perms — OK
+
+No new public/guest routes. All new REST routes are X-Api-Key gated. No Site Guest config needed.
+
+## 8. Namespace-prefix tripwires — CLEAN
+
+No `Schema.getGlobalDescribe().get('Foo__c')` patterns in new code (hotfixes #797 + #800 closed the prior surface). All sObject + service references are typed (compile-time, namespace-safe). GVS files for picklists are external `.globalValueSet-meta.xml` so namespace is handled by metadata tooling.
+
+## 9. Tests not in suite — CLEAN
+
+All 6 new feature-cockpit + Watcher test classes registered in `unpackaged/post/testSuites/DH.testSuite-meta.xml` (PR #808 closed the 2 prior gaps).
+
+## 10. TestDataFactory gaps — CLEAN
+
+`buildFeature()` / `createFeature()` / `createFeatures()` / `buildFeatureToggleRequest()` / `createFeatureToggleRequest()` all present with safe picklist defaults + parent auto-mint.
+
+## 11. Cross-tenant blockers (`ScratchOrgInstance__c`) — known gap
+
+No `CreatedByNetworkEntityLookup__c` field. Acknowledged Low-risk in the REST API surface review. Acceptable for single-tenant developer-tooling use; deferred until multi-tenant ingest is wanted.
+
+## 12. Picklist value drift — CLEAN
+
+All new `__c` picklists use external GVS reference (`<valueSetName>`). All GVS files present. `__mdt` picklists correctly use inline `<valueSetDefinition>` per platform requirement (see [[mdt-picklists-must-be-inline]]).
+
+---
+
+## Verdict
+
+**Deployment wiring is ship-ready.** Triggers fire, scheduler runs, picklists deploy, tests execute in CI.
+
+**Cross-audit reconciliation** — this audit's "ship-ready" verdict ONLY covers wiring. The other 3 audits identified real subscriber-facing gaps:
+
+| Wiring view | Admin UX view | E2E walkthrough view | Net |
+|---|---|---|---|
+| Triggers + scheduler + tests = ✅ ship | 9 new objects missing tabs/layouts/record pages, WatcherDigest__c has 0 field perms, no CustomNotificationTypes | 60% of user flows end-to-end; submission UI, approver assignment, audit-trail viewers all missing | **Ship the code; do NOT ship to subscribers without the Admin UX bundle + a submission UI PR** |
+
+**Combined "subscriber-ready bundle"** (across all 4 audits, deduped):
+1. Admin UX metadata (~3.5h) — tabs, layouts, WatcherDigest__c field perms, app menu updates
+2. Approval submission LWC (~1-2d) — service exists, no caller
+3. Approver auto-assignment (~1-2d) — null at create today
+4. Audit-trail viewer LWCs (~2-3d) — ActivityLog, WatcherDigest history, OnboardingProgress
+5. CustomNotificationType definitions + wiring (~1h + Apex callouts) — bell notifications for approval / digest / completion
+6. ~~Watcher install-handler flag defaults~~ — **already shipped in PR #809; audit was wrong.**
+7. Onboarding quiz retry gating + non-Manual evaluators (~2-3d) — UI + Apex evaluators
+8. Documentation bundle (~7.5h) — README, REST API, setup guide, architecture diagrams
+
+**Hard-blocking subset (must ship before any subscriber-facing release):** items #1, #2, #4, #5 — ~6-8 days of work.
+
+**Polish that can ship in a follow-on cycle:** items #3, #6, #7, #8.


### PR DESCRIPTION
## Summary
- Captures 8 untracked audit reports from the 2026-05-21 fan-out (drivers for cheap-wins bundle PRs #813-#816) as durable reference under `docs/audits/`.
- Marks `DeliveryDocumentController` ApexDoc row in `pmd-baseline-2026-05-21.md` as already CLOSED by PR #791 — the audit copy-forwarded the row from 5/15 without re-verifying ([[verify-audit-findings-before-shipping]] applied retroactively).
- Adds defensive `.gitignore` patterns (`/C?temp*.ps1`, `/C?temp*.sh`) for Windows-path-mangled audit-script names. Stray instance deleted from working tree.

These docs are the input for the next UX-gap fan-out (4 parallel PRs closing Top 5 gaps from `e2e-walkthrough-2026-05-21.md`).

## Test plan
- [ ] CI feature-test green (docs-only change, no code touched)
- [ ] Verify `.gitignore` does not over-match real source files (`/C?temp*` only matches repo-root files starting with `C<any>temp`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)