### PR TITLE
feat(approval): submission UI — deliveryFeatureApprovalSubmit + cockpit entry-point (closes Flow 4 gap)

### DIFF
--- a/force-app/main/default/lwc/deliveryFeatureApprovalSubmit/__tests__/deliveryFeatureApprovalSubmit.test.js
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalSubmit/__tests__/deliveryFeatureApprovalSubmit.test.js
@@ -1,0 +1,250 @@
+import { createElement } from 'lwc';
+import DeliveryFeatureApprovalSubmit from 'c/deliveryFeatureApprovalSubmit';
+import getCatalog from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.getCatalog';
+import submitRequest from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.submit';
+
+// Apex methods auto-mocked via force-app/test/jest-mocks/apex/.
+
+const FEATURE_ID_A = 'a0F000000000001',
+    FEATURE_ID_B = 'a0F000000000002',
+    REQUEST_ID = 'a0G000000000999';
+
+const MOCK_CATALOG = [
+    {
+        featureId: FEATURE_ID_A,
+        name: 'FeatureA',
+        label: 'Alpha feature',
+        isActive: false
+    },
+    {
+        featureId: FEATURE_ID_B,
+        name: 'FeatureB',
+        label: 'Bravo feature',
+        isActive: true
+    },
+    {
+        // mdt-only row — no Feature__c yet — should be skipped from picker
+        featureId: null,
+        name: 'CharlieDefinition',
+        label: 'Charlie (unbacked)',
+        isActive: false
+    }
+];
+
+function createComponent() {
+    const element = createElement('c-delivery-feature-approval-submit', {
+        is: DeliveryFeatureApprovalSubmit
+    });
+    document.body.appendChild(element);
+    return element;
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function findButtonByLabelStart(element, prefix) {
+    const buttons = element.shadowRoot.querySelectorAll('lightning-button');
+    return Array.from(buttons).find((b) => (b.label || '').indexOf(prefix) === 0);
+}
+
+function findComboboxByName(element, name) {
+    const combos = element.shadowRoot.querySelectorAll('lightning-combobox');
+    return Array.from(combos).find((c) => c.name === name);
+}
+
+function findTextareaByName(element, name) {
+    const tas = element.shadowRoot.querySelectorAll('lightning-textarea');
+    return Array.from(tas).find((t) => t.name === name);
+}
+
+describe('c-delivery-feature-approval-submit', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('renders without error', () => {
+        const element = createComponent();
+        expect(element).toBeTruthy();
+    });
+
+    it('renders feature combobox, action combobox, justification, and submit button when catalog loads', async () => {
+        const element = createComponent();
+        getCatalog.emit(MOCK_CATALOG);
+        await flushPromises();
+
+        expect(findComboboxByName(element, 'feature')).toBeDefined();
+        expect(findComboboxByName(element, 'action')).toBeDefined();
+        expect(findTextareaByName(element, 'justification')).toBeDefined();
+        expect(findButtonByLabelStart(element, 'Submit')).toBeDefined();
+    });
+
+    it('omits catalog entries with no featureId from the picker', async () => {
+        const element = createComponent();
+        getCatalog.emit(MOCK_CATALOG);
+        await flushPromises();
+
+        const featureCombo = findComboboxByName(element, 'feature');
+        expect(featureCombo.options).toBeDefined();
+        expect(featureCombo.options.length).toBe(2);
+        const values = featureCombo.options.map((o) => o.value);
+        expect(values).toEqual([FEATURE_ID_A, FEATURE_ID_B]);
+        expect(values.indexOf(null)).toBe(-1);
+    });
+
+    it('disables submit until all three fields are valid', async () => {
+        const element = createComponent();
+        getCatalog.emit(MOCK_CATALOG);
+        await flushPromises();
+
+        let submitBtn = findButtonByLabelStart(element, 'Submit');
+        expect(submitBtn.disabled).toBe(true);
+
+        // Set feature
+        findComboboxByName(element, 'feature').dispatchEvent(
+            new CustomEvent('change', { detail: { value: FEATURE_ID_A } })
+        );
+        await flushPromises();
+        submitBtn = findButtonByLabelStart(element, 'Submit');
+        expect(submitBtn.disabled).toBe(true);
+
+        // Set action
+        findComboboxByName(element, 'action').dispatchEvent(
+            new CustomEvent('change', { detail: { value: 'Enable' } })
+        );
+        await flushPromises();
+        submitBtn = findButtonByLabelStart(element, 'Submit');
+        expect(submitBtn.disabled).toBe(true);
+
+        // Set short justification (< 10 chars) — still disabled
+        findTextareaByName(element, 'justification').dispatchEvent(
+            new CustomEvent('change', { detail: { value: 'short' } })
+        );
+        await flushPromises();
+        submitBtn = findButtonByLabelStart(element, 'Submit');
+        expect(submitBtn.disabled).toBe(true);
+
+        // Set valid justification (>= 10 chars)
+        findTextareaByName(element, 'justification').dispatchEvent(
+            new CustomEvent('change', { detail: { value: 'A reasonable explanation of why this is needed.' } })
+        );
+        await flushPromises();
+        submitBtn = findButtonByLabelStart(element, 'Submit');
+        expect(submitBtn.disabled).toBe(false);
+    });
+
+    it('calls submit() with the correct args and dispatches a submitted event on success', async () => {
+        submitRequest.mockResolvedValue(REQUEST_ID);
+        const submittedHandler = jest.fn();
+
+        const element = createComponent();
+        element.addEventListener('submitted', submittedHandler);
+        getCatalog.emit(MOCK_CATALOG);
+        await flushPromises();
+
+        findComboboxByName(element, 'feature').dispatchEvent(
+            new CustomEvent('change', { detail: { value: FEATURE_ID_A } })
+        );
+        findComboboxByName(element, 'action').dispatchEvent(
+            new CustomEvent('change', { detail: { value: 'Enable' } })
+        );
+        findTextareaByName(element, 'justification').dispatchEvent(
+            new CustomEvent('change', { detail: { value: 'We need this to unblock the QuickBooks pilot.' } })
+        );
+        await flushPromises();
+
+        const submitBtn = findButtonByLabelStart(element, 'Submit');
+        submitBtn.click();
+        await flushPromises();
+        await flushPromises();
+
+        expect(submitRequest).toHaveBeenCalledTimes(1);
+        const args = submitRequest.mock.calls[0][0];
+        expect(args.featureId).toBe(FEATURE_ID_A);
+        expect(args.action).toBe('Enable');
+        expect(args.reason).toBe('We need this to unblock the QuickBooks pilot.');
+
+        expect(submittedHandler).toHaveBeenCalledTimes(1);
+        const detail = submittedHandler.mock.calls[0][0].detail;
+        expect(detail.requestId).toBe(REQUEST_ID);
+        expect(detail.featureId).toBe(FEATURE_ID_A);
+        expect(detail.action).toBe('Enable');
+    });
+
+    it('clears the form on successful submit', async () => {
+        submitRequest.mockResolvedValue(REQUEST_ID);
+
+        const element = createComponent();
+        getCatalog.emit(MOCK_CATALOG);
+        await flushPromises();
+
+        findComboboxByName(element, 'feature').dispatchEvent(
+            new CustomEvent('change', { detail: { value: FEATURE_ID_A } })
+        );
+        findComboboxByName(element, 'action').dispatchEvent(
+            new CustomEvent('change', { detail: { value: 'Disable' } })
+        );
+        findTextareaByName(element, 'justification').dispatchEvent(
+            new CustomEvent('change', { detail: { value: 'Cleanup after pilot ended.' } })
+        );
+        await flushPromises();
+
+        findButtonByLabelStart(element, 'Submit').click();
+        await flushPromises();
+        await flushPromises();
+
+        const featureCombo = findComboboxByName(element, 'feature');
+        const actionCombo = findComboboxByName(element, 'action');
+        const justification = findTextareaByName(element, 'justification');
+        expect(featureCombo.value).toBe('');
+        expect(actionCombo.value).toBe('');
+        expect(justification.value).toBe('');
+    });
+
+    it('surfaces the error message and stays enabled when submit rejects', async () => {
+        submitRequest.mockRejectedValue({ body: { message: 'Approver required.' } });
+
+        const element = createComponent();
+        getCatalog.emit(MOCK_CATALOG);
+        await flushPromises();
+
+        findComboboxByName(element, 'feature').dispatchEvent(
+            new CustomEvent('change', { detail: { value: FEATURE_ID_A } })
+        );
+        findComboboxByName(element, 'action').dispatchEvent(
+            new CustomEvent('change', { detail: { value: 'Enable' } })
+        );
+        findTextareaByName(element, 'justification').dispatchEvent(
+            new CustomEvent('change', { detail: { value: 'We need this enabled for the pilot.' } })
+        );
+        await flushPromises();
+
+        findButtonByLabelStart(element, 'Submit').click();
+        await flushPromises();
+        await flushPromises();
+
+        expect(submitRequest).toHaveBeenCalledTimes(1);
+        // Form preserved so user can retry
+        expect(findComboboxByName(element, 'feature').value).toBe(FEATURE_ID_A);
+        // Inline error rendered
+        expect(element.shadowRoot.textContent).toContain('Approver required.');
+        // Submit re-enabled after the error
+        const submitBtn = findButtonByLabelStart(element, 'Submit');
+        expect(submitBtn.disabled).toBe(false);
+    });
+
+    it('renders a load-error message when the catalog wire errors', async () => {
+        const element = createComponent();
+        // createApexTestWireAdapter passes the first arg as `error.body`, so
+        // the body shape is { message } — matches extractErrorMessage().
+        getCatalog.error({ message: 'Catalog unavailable.' });
+        await flushPromises();
+
+        expect(element.shadowRoot.textContent).toContain('Catalog unavailable.');
+        // Form not rendered
+        expect(findComboboxByName(element, 'feature')).toBeUndefined();
+    });
+});

--- a/force-app/main/default/lwc/deliveryFeatureApprovalSubmit/deliveryFeatureApprovalSubmit.css
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalSubmit/deliveryFeatureApprovalSubmit.css
@@ -1,0 +1,7 @@
+.submit-form {
+    max-width: 36rem;
+}
+
+.justification-help {
+    margin-top: 0.25rem;
+}

--- a/force-app/main/default/lwc/deliveryFeatureApprovalSubmit/deliveryFeatureApprovalSubmit.html
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalSubmit/deliveryFeatureApprovalSubmit.html
@@ -1,0 +1,97 @@
+<template>
+    <lightning-card title="Request feature toggle" icon-name="standard:approval">
+        <div slot="actions">
+            <lightning-button-icon
+                icon-name="utility:refresh"
+                variant="border-filled"
+                onclick={handleRefresh}
+                alternative-text="Refresh feature list">
+            </lightning-button-icon>
+        </div>
+
+        <div class="slds-p-horizontal_medium slds-p-bottom_medium submit-form">
+            <template lwc:if={hasLoadError}>
+                <div class="slds-notify slds-notify_alert slds-theme_warning" role="alert">
+                    <h2>{loadErrorMessage}</h2>
+                </div>
+            </template>
+
+            <template lwc:if={isReady}>
+                <p class="slds-text-body_regular slds-m-bottom_small">
+                    Pick a feature, choose Enable or Disable, and explain why.
+                    Your request will route through the approval inbox for an admin to act on.
+                </p>
+
+                <lightning-combobox
+                    name="feature"
+                    label="Feature"
+                    placeholder="Select a feature"
+                    options={featureOptions}
+                    value={selectedFeatureId}
+                    required
+                    onchange={handleFeatureChange}
+                    class="slds-m-bottom_small">
+                </lightning-combobox>
+
+                <lightning-combobox
+                    name="action"
+                    label="Action"
+                    placeholder="Select an action"
+                    options={actionOptions}
+                    value={selectedAction}
+                    required
+                    onchange={handleActionChange}
+                    class="slds-m-bottom_small">
+                </lightning-combobox>
+
+                <lightning-textarea
+                    name="justification"
+                    label="Justification"
+                    placeholder="Why is this toggle needed? (10-2000 characters)"
+                    value={justification}
+                    required
+                    min-length={justificationMin}
+                    max-length={justificationMax}
+                    onchange={handleJustificationChange}
+                    onblur={handleJustificationBlur}
+                    field-level-help="Captured on the audit row. Be specific — the approver may not have context."
+                    class="slds-m-bottom_x-small">
+                </lightning-textarea>
+                <div class="slds-text-body_small slds-text-color_weak justification-help">
+                    {justificationCounter}
+                </div>
+
+                <template lwc:if={hasSubmitError}>
+                    <div class="slds-m-top_small slds-text-color_error" role="alert">
+                        {submitErrorMessage}
+                    </div>
+                </template>
+
+                <div class="slds-m-top_medium slds-grid slds-grid_align-end slds-gutters_x-small">
+                    <div class="slds-col slds-no-flex">
+                        <lightning-button
+                            label="Reset"
+                            variant="neutral"
+                            onclick={handleReset}
+                            disabled={isSubmitting}>
+                        </lightning-button>
+                    </div>
+                    <div class="slds-col slds-no-flex">
+                        <lightning-button
+                            label={submitLabel}
+                            variant="brand"
+                            onclick={handleSubmit}
+                            disabled={submitDisabled}>
+                        </lightning-button>
+                    </div>
+                </div>
+
+                <template lwc:if={isSubmitting}>
+                    <div class="slds-m-top_small slds-text-body_small slds-text-color_weak" aria-live="polite">
+                        Submitting&hellip;
+                    </div>
+                </template>
+            </template>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/deliveryFeatureApprovalSubmit/deliveryFeatureApprovalSubmit.js
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalSubmit/deliveryFeatureApprovalSubmit.js
@@ -1,0 +1,244 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Submission form for Feature__c toggle requests (Layer 5).
+ *               Closes the Flow 4 gap surfaced in
+ *               docs/audits/e2e-walkthrough-2026-05-21.md —
+ *               DeliveryFeatureApprovalService.submit() existed but no LWC
+ *               called it. This form lets any user (admin or otherwise) post
+ *               a request that lands in the approval inbox.
+ *
+ *               Driven by getCatalog() so the feature picker only shows
+ *               Features that actually exist in this tenant (i.e. have a
+ *               Feature__c row, not just an mdt definition — submit needs a
+ *               real Id). FeatureToggleAction GVS is small (Enable/Disable)
+ *               and stable so we hard-code its values; if it ever grows we
+ *               swap in getPicklistValues / a wire to a controller.
+ *
+ *               Modal-host friendly: dispatches `submitted` (success) and
+ *               `cancel` events so deliveryFeatureCockpit can close the
+ *               modal it opens us in.
+ *
+ *               No ternaries in the template (LWC v62 limitation per
+ *               CLAUDE.md). No @api boolean defaulting to true (LWC1503).
+ * @author Cloud Nimbus LLC
+ */
+import { LightningElement, wire, track } from 'lwc';
+import { refreshApex } from '@salesforce/apex';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import getCatalog from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.getCatalog';
+import submitRequest from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.submit';
+
+const ACTION_ENABLE = 'Enable',
+    ACTION_DISABLE = 'Disable',
+    JUSTIFICATION_MIN = 10,
+    JUSTIFICATION_MAX = 2000,
+    EMPTY = 0;
+
+export default class DeliveryFeatureApprovalSubmit extends LightningElement {
+    @track featureOptions = [];
+    @track featuresById = {};
+    @track selectedFeatureId = '';
+    @track selectedAction = '';
+    @track justification = '';
+    @track justificationTouched = false;
+    @track isSubmitting = false;
+    @track submitErrorMessage = '';
+    @track loadErrorMessage = '';
+    @track isLoaded = false;
+
+    wiredCatalogResult;
+
+    /** Hard-coded mirror of the FeatureToggleAction GVS (Enable / Disable).
+     *  Kept in sync with force-app/main/default/globalValueSets/FeatureToggleAction.globalValueSet-meta.xml.
+     *  If the GVS ever grows beyond these two values, swap to getPicklistValues
+     *  off FeatureToggleRequest__c.ActionPk__c. */
+    actionOptions = [
+        { label: 'Enable', value: ACTION_ENABLE },
+        { label: 'Disable', value: ACTION_DISABLE }
+    ];
+
+    justificationMin = JUSTIFICATION_MIN;
+    justificationMax = JUSTIFICATION_MAX;
+
+    @wire(getCatalog)
+    wiredCatalog(result) {
+        this.wiredCatalogResult = result;
+        if (result.data) {
+            const rows = result.data || [];
+            const options = [];
+            const byId = {};
+            for (let i = 0; i < rows.length; i++) {
+                const f = rows[i];
+                // submit() needs an actual Feature__c Id — skip mdt-only rows
+                // that haven't been backfilled yet.
+                if (!f.featureId) {
+                    continue;
+                }
+                const label = f.label || f.name || f.featureId;
+                const status = f.isActive === true ? 'Active' : 'Inactive';
+                options.push({
+                    label: `${label} (${status})`,
+                    value: f.featureId
+                });
+                byId[f.featureId] = {
+                    label,
+                    isActive: f.isActive === true
+                };
+            }
+            this.featureOptions = options;
+            this.featuresById = byId;
+            this.loadErrorMessage = '';
+            this.isLoaded = true;
+        } else if (result.error) {
+            this.loadErrorMessage = this.extractErrorMessage(result.error)
+                || 'Unable to load feature catalog.';
+            this.featureOptions = [];
+            this.featuresById = {};
+            this.isLoaded = true;
+        }
+    }
+
+    // ── Derived state ──────────────────────────────────────────────────
+
+    get hasLoadError() {
+        return this.loadErrorMessage.length > EMPTY;
+    }
+
+    get hasSubmitError() {
+        return this.submitErrorMessage.length > EMPTY;
+    }
+
+    get isReady() {
+        return this.isLoaded && !this.hasLoadError;
+    }
+
+    get justificationLength() {
+        return (this.justification || '').length;
+    }
+
+    get justificationCounter() {
+        return `${this.justificationLength} / ${this.justificationMax} characters (minimum ${this.justificationMin})`;
+    }
+
+    get isFeatureValid() {
+        return !!this.selectedFeatureId;
+    }
+
+    get isActionValid() {
+        return this.selectedAction === ACTION_ENABLE
+            || this.selectedAction === ACTION_DISABLE;
+    }
+
+    get isJustificationValid() {
+        const len = this.justificationLength;
+        return len >= this.justificationMin && len <= this.justificationMax;
+    }
+
+    get isFormValid() {
+        return this.isFeatureValid
+            && this.isActionValid
+            && this.isJustificationValid;
+    }
+
+    get submitDisabled() {
+        return this.isSubmitting || !this.isFormValid;
+    }
+
+    get submitLabel() {
+        if (this.isSubmitting) {
+            return 'Submitting...';
+        }
+        return 'Submit request';
+    }
+
+    // ── Handlers ───────────────────────────────────────────────────────
+
+    handleFeatureChange(event) {
+        this.selectedFeatureId = event.detail.value || '';
+        this.submitErrorMessage = '';
+    }
+
+    handleActionChange(event) {
+        this.selectedAction = event.detail.value || '';
+        this.submitErrorMessage = '';
+    }
+
+    handleJustificationChange(event) {
+        this.justification = event.detail.value || '';
+        this.submitErrorMessage = '';
+    }
+
+    handleJustificationBlur() {
+        this.justificationTouched = true;
+    }
+
+    handleRefresh() {
+        if (this.wiredCatalogResult) {
+            refreshApex(this.wiredCatalogResult);
+        }
+    }
+
+    handleReset() {
+        this.resetForm();
+    }
+
+    handleSubmit() {
+        if (!this.isFormValid || this.isSubmitting) {
+            return;
+        }
+        this.isSubmitting = true;
+        this.submitErrorMessage = '';
+        const featureId = this.selectedFeatureId,
+            action = this.selectedAction,
+            reason = this.justification;
+        submitRequest({ featureId, action, reason })
+            .then(requestId => {
+                this.isSubmitting = false;
+                const feature = this.featuresById[featureId] || { label: 'feature' };
+                this.dispatchEvent(new ShowToastEvent({
+                    title: 'Request submitted',
+                    message: `${action} request for "${feature.label}" sent for approval.`,
+                    variant: 'success'
+                }));
+                this.dispatchEvent(new CustomEvent('submitted', {
+                    detail: { requestId, featureId, action }
+                }));
+                this.resetForm();
+                if (this.wiredCatalogResult) {
+                    refreshApex(this.wiredCatalogResult);
+                }
+            })
+            .catch(err => {
+                this.isSubmitting = false;
+                const msg = this.extractErrorMessage(err)
+                    || 'Unable to submit the request. Please try again.';
+                this.submitErrorMessage = msg;
+                this.dispatchEvent(new ShowToastEvent({
+                    title: 'Submission failed',
+                    message: msg,
+                    variant: 'error'
+                }));
+            });
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    resetForm() {
+        this.selectedFeatureId = '';
+        this.selectedAction = '';
+        this.justification = '';
+        this.justificationTouched = false;
+        this.submitErrorMessage = '';
+    }
+
+    extractErrorMessage(error) {
+        if (error && error.body && error.body.message) {
+            return error.body.message;
+        }
+        if (error && error.message) {
+            return error.message;
+        }
+        return '';
+    }
+}

--- a/force-app/main/default/lwc/deliveryFeatureApprovalSubmit/deliveryFeatureApprovalSubmit.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalSubmit/deliveryFeatureApprovalSubmit.js-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <masterLabel>Delivery Feature Approval Submit</masterLabel>
+    <description>Form for non-admin users to request an Enable/Disable on a Feature__c. Wraps DeliveryFeatureApprovalService.submit(). Closes the Flow 4 submission-UI gap surfaced in the 2026-05-21 e2e walkthrough audit.</description>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <target>lightning__RecordPage</target>
+    </targets>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.html
+++ b/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.html
@@ -2,6 +2,13 @@
     <lightning-card title="Feature Cockpit" icon-name="standard:apps">
 
         <div slot="actions">
+            <lightning-button
+                label="Request approval to toggle"
+                icon-name="utility:approval"
+                variant="neutral"
+                onclick={handleOpenApprovalSubmit}
+                class="slds-m-right_x-small">
+            </lightning-button>
             <lightning-button-icon
                 icon-name="utility:refresh"
                 variant="border-filled"
@@ -102,6 +109,35 @@
 
         </div>
     </lightning-card>
+
+    <template lwc:if={isApprovalSubmitModalOpen}>
+        <section role="dialog" tabindex="-1" aria-modal="true"
+                 aria-labelledby="approval-submit-modal-title"
+                 class="slds-modal slds-fade-in-open">
+            <div class="slds-modal__container">
+                <header class="slds-modal__header">
+                    <button class="slds-button slds-button_icon slds-modal__close slds-button_icon-inverse"
+                            title="Close" onclick={handleCloseApprovalSubmit}>
+                        <lightning-icon icon-name="utility:close" alternative-text="Close" size="small" variant="inverse"></lightning-icon>
+                        <span class="slds-assistive-text">Close</span>
+                    </button>
+                    <h2 id="approval-submit-modal-title" class="slds-modal__title slds-hyphenate">
+                        Request feature toggle
+                    </h2>
+                </header>
+                <div class="slds-modal__content slds-p-around_medium">
+                    <c-delivery-feature-approval-submit
+                        onsubmitted={handleApprovalSubmitted}
+                        oncancel={handleCloseApprovalSubmit}>
+                    </c-delivery-feature-approval-submit>
+                </div>
+                <footer class="slds-modal__footer">
+                    <lightning-button label="Close" onclick={handleCloseApprovalSubmit}></lightning-button>
+                </footer>
+            </div>
+        </section>
+        <div class="slds-backdrop slds-backdrop_open"></div>
+    </template>
 
     <template lwc:if={isCascadeModalOpen}>
         <section role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="cascade-modal-title" class="slds-modal slds-fade-in-open">

--- a/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.js
+++ b/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.js
@@ -32,6 +32,11 @@ export default class DeliveryFeatureCockpit extends LightningElement {
     @track cascadeFeatureId = null;
     @track cascadeFeatureLabel = '';
 
+    // PR closing Flow 4 gap (audit 2026-05-21): a submission-UI modal
+    // hosting deliveryFeatureApprovalSubmit. Open via "Request approval"
+    // on any card; closes on submit success or cancel.
+    @track isApprovalSubmitModalOpen = false;
+
     wiredResult;
 
     @wire(isAdminApex)
@@ -209,5 +214,24 @@ export default class DeliveryFeatureCockpit extends LightningElement {
         this.isCascadeModalOpen = false;
         this.cascadeFeatureId = null;
         this.cascadeFeatureLabel = '';
+    }
+
+    // ── Approval-submit modal (closes Flow 4 audit gap) ─────────────────
+
+    handleOpenApprovalSubmit() {
+        this.isApprovalSubmitModalOpen = true;
+    }
+
+    handleCloseApprovalSubmit() {
+        this.isApprovalSubmitModalOpen = false;
+    }
+
+    handleApprovalSubmitted() {
+        // Submission service refreshes its own state — refresh the catalog
+        // so the user sees the latest status badges, then close the modal.
+        this.isApprovalSubmitModalOpen = false;
+        if (this.wiredResult) {
+            refreshApex(this.wiredResult);
+        }
     }
 }

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.submit.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.submit.js
@@ -1,0 +1,4 @@
+/**
+ * Mock for DeliveryFeatureApprovalService.submit (imperative).
+ */
+module.exports = { default: jest.fn() };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.getCatalog.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.getCatalog.js
@@ -1,0 +1,7 @@
+/**
+ * Mock for DeliveryFeatureCatalogController.getCatalog (wire).
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+
+const getCatalog = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getCatalog };


### PR DESCRIPTION
## Summary

- Closes the Flow 4 gap from `docs/audits/e2e-walkthrough-2026-05-21.md`: `DeliveryFeatureApprovalService.submit()` was `@AuraEnabled global static` but no LWC called it, so non-admins had no way to request a feature toggle.
- New `deliveryFeatureApprovalSubmit` LWC: feature picker (driven by `getCatalog` wire, filtered to features that actually have a `Feature__c` Id), Enable/Disable combobox (hard-coded mirror of the `FeatureToggleAction` GVS), justification textarea (required, 10-2000 chars), Submit button gated on validity. Calls `submit()` imperatively; success/error toasts; fires `submitted` event with the new request id.
- Wired into `deliveryFeatureCockpit` as an SLDS modal launched from a new "Request approval to toggle" button in the card actions slot (matches the existing cascade-modal pattern). Visible to admins too so they have the same submission path the REST surface uses.

## Implementation notes

- No new fields, no permset changes. `DeliveryFeatureApprovalService` class access + `FeatureToggleRequest__c` `allowCreate=true` were already granted in both `DeliveryHubApp.permissionset-meta.xml` and `DeliveryHubAdmin_App.permissionset-meta.xml` from PR #799 (Approval framework single-step). Verified by grep against both permsets.
- LWC respects CLAUDE.md rules: no template ternaries (getters only), no `@api` boolean defaulting to true, no `getGlobalDescribe`, namespace tokens use `%%%NAMESPACE_DOT%%%` everywhere.
- mdt-only catalog entries (rows without a backing `Feature__c` Id) are dropped from the picker — `submit()` requires a real Id, so showing them would just produce a confusing validation error.

## Test plan

- [x] `npx jest force-app/main/default/lwc/deliveryFeatureApprovalSubmit/` — 8/8 pass (render, picker filter, validation gating, success path with arg + event assertion, form reset, error toast, wire error)
- [x] `npx jest` (whole repo) — 25/25 pass across 3 suites
- [ ] Manual cockpit click-through after install on a scratch / subscriber org: open Feature Cockpit, click "Request approval to toggle", pick a feature + action, write 10+ char justification, Submit, verify success toast + modal closes + a row appears in the approval inbox for the admin.
- [x] Both permsets contain `DeliveryFeatureApprovalService` `<classAccesses>` and `FeatureToggleRequest__c` `<objectPermissions allowCreate=true>` (verified via grep; no diff needed).

## Reference

- Audit doc: `docs/audits/e2e-walkthrough-2026-05-21.md` (Flow 4 — Approval submission UI missing)
- Underlying service: `DeliveryFeatureApprovalService.submit(Id featureId, String action, String reason)` returns `Id` of the new `FeatureToggleRequest__c`. Shipped in PR #799 (single-step) and extended in PR #802 (multi-step + REST).