### PR TITLE
fix(deps): call Test.calculatePermissionSetGroup before PSG assignment (unblocks upload-beta for 0.248.x)

### DIFF
--- a/force-app/main/default/classes/DeliveryFeatureDepEditorControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryFeatureDepEditorControllerTest.cls
@@ -82,6 +82,12 @@ private class DeliveryFeatureDepEditorControllerTest {
         System.runAs(new User(Id = UserInfo.getUserId())) {
             insert u;
             if (!psgs.isEmpty()) {
+                // PSGs land in "Outdated" status after package install — the
+                // packaging-org test context REQUIRES recalculation before a
+                // PermissionSetAssignment can target the group. The non-namespaced
+                // PR-level scratch happens to leave PSGs Updated already, which
+                // is why this only fails on upload-beta.
+                Test.calculatePermissionSetGroup(psgs[0].Id);
                 insert new PermissionSetAssignment(
                     AssigneeId = u.Id,
                     PermissionSetGroupId = psgs[0].Id


### PR DESCRIPTION
## Summary
- `upload-beta` for 0.248.0.3 (the cumulative Wave 1 beta with PR #818 + #820 + #819) failed all 9 admin-gated tests in `DeliveryFeatureDepEditorControllerTest` with `INVALID_CROSS_REFERENCE_KEY, You can only assign users to permission set groups that have the "Updated" status`.
- Packaging-org test context leaves freshly-installed PSGs in `Outdated` status. `PermissionSetAssignment` against an Outdated PSG is refused. The non-namespaced PR-level scratch's PSG calculation persists across the install, which is why PR #819's `feature-test` passed but `upload-beta` blew up.
- Fix: call `Test.calculatePermissionSetGroup(psgId)` inside `buildAdminUser()` before inserting the assignment — synchronously recalculates the group inside the test transaction so the subsequent assignment is accepted.

## Test plan
- [ ] feature-test green (sanity — already passes pre-fix on non-namespaced scratch)
- [ ] upload-beta green (the actual blocker — should now pass and publish 0.248.0.4)
- [ ] Wave 1 cumulative install on a scratch / subscriber org once the new beta lands

## Reference
- PR #819 (merged) shipped the editor + the buildAdminUser helper without the recalc call
- Lessons feeding into [[upload-beta-gotchas-consolidated]] memory: PSG status divergence is a new class to add to the pre-merge checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)