### PR TITLE
docs: refresh README + architecture + setup + REST API reference (closes Glen's audit ask)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,223 +13,151 @@
     <a href="https://cloudnimbusllc.com"><img src="https://img.shields.io/badge/docs-cloudnimbusllc.com-0070d2" alt="Docs"></a>
   </p>
   <p align="center">
-    <a href="#install">Install</a> &middot; <a href="https://cloudnimbusllc.com/examples">Examples</a> &middot; <a href="https://cloudnimbusllc.com/docs">Docs</a> &middot; <a href="#contributing">Contributing</a>
+    <a href="#install">Install</a> &middot; <a href="#architecture-the-8-layer-cockpit">Architecture</a> &middot; <a href="docs/ARCHITECTURE.md">Docs</a> &middot; <a href="docs/PUBLIC_API_GUIDE.md">REST API</a> &middot; <a href="#contributing">Contributing</a>
   </p>
 </p>
 
 ---
 
-## Why Delivery Hub?
+## What is Delivery Hub?
 
-Most Salesforce teams track work in Jira, Slack threads, or shared spreadsheets. None of those tools know your clients, your pipeline, or your data. Every status update is a manual handoff. Every estimate lives in a comment nobody can find six weeks later.
+Delivery Hub is a Salesforce-native delivery operations platform. It gives teams a Kanban board, cross-org sync, time tracking, document generation, AI-powered estimates, a public REST API, and an **admin cockpit** for feature lifecycle management (toggle, approve, onboard, observe) — all running inside Salesforce, tied to the accounts and contacts they belong to.
 
-Meanwhile your CRM &mdash; the system that already knows every account, contact, and deal &mdash; sits right there, completely disconnected from the delivery work you're doing.
-
-**Delivery Hub closes that loop.** Work items, comments, files, stage changes, and estimates all live inside Salesforce, tied to the accounts and contacts they belong to.
-
-| Before | After |
-|--------|-------|
-| Client emails a change request, gets forwarded 3 times | Client submits directly &mdash; team sees it instantly on the board |
-| Small bug fix needs 3 meetings before anyone writes code | Fast Track skips the queue &mdash; developer picks it up same day |
-| Vendor work tracked in a separate spreadsheet | Cross-org sync sends it to their Salesforce org automatically |
-| VP asks for status &mdash; you open 4 spreadsheets | System Pulse shows everything live, right now |
-| Developer guesses hours at end of week | Time Logger captures it on the work item as they go |
-| Hours logged but no approval trail | WorkLog approval workflow with Draft &rarr; Approved &rarr; Sync pipeline |
-| "We need a portal" = 5 days writing requirements | AI generates description, acceptance criteria, and estimate from one line |
-| Blocked item sits for days before anyone notices | Escalation engine auto-alerts when SLA targets are missed |
-| Weekly status email takes an hour to write | AI digest compiles and sends it automatically |
-| Re-baselining a 50-WI project means hand-shifting every downstream date | **Auto-Schedule** modal runs CPM + capacity leveling client-side, previews every change, applies as one audit-pass batch |
+It is open source under the [BSL 1.1 license](LICENSE.md) and ships as an unlocked 2GP package in the `delivery` namespace.
 
 ---
 
 ## Install
 
-**Current version**: `release/0.239` &mdash; see the [Changelog](docs/CHANGELOG.md) for the full history.
+**Current release**: [`release/0.248.0.3`](https://github.com/Nimba-Solutions/Delivery-Hub/releases) (production-promoted 2026-05-25). See [GitHub Releases](https://github.com/Nimba-Solutions/Delivery-Hub/releases) for the full version history.
 
 | Environment | Link |
 |---|---|
 | **Production** | [![Install in Production](https://img.shields.io/badge/Install-Production-0070d2?logo=salesforce&style=for-the-badge)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000T0SrIAK) |
 | **Sandbox** | [![Install in Sandbox](https://img.shields.io/badge/Install-Sandbox-3e8b3e?logo=salesforce&style=for-the-badge)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000T0SrIAK) |
 
-**Setup takes about 3 minutes:**
+**Quickstart (≈5 minutes):**
 
-1. Install the package
-2. Open the **Delivery Hub** app
-3. Click **Quickstart Connection** on the Home tab &mdash; it configures scheduled jobs, connection handshake, and default settings automatically
-4. Create your first work item on the board
+1. Install the package (select **Install for All Users**)
+2. Assign permsets — see [Permission Sets](#permission-sets) below
+3. Open the **Delivery Hub Admin** app
+4. Run **Quickstart Connection** on the Home tab (configures scheduler, settings, handshake)
+5. Open the **Feature Catalog** card on the home page to see what's available
 
-No consultants. No manual REST endpoint configuration. No Apex scripts to run.
+Full step-by-step is in [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).
 
 ---
 
-## What You Get
+## Permission Sets
 
-### Kanban Board
+| Permset | Audience | What it grants |
+|---|---|---|
+| `DeliveryHubApp` | End users | Read/write on work items, time logging, board access, portal user access |
+| `DeliveryHubAdmin_App` | Admins | Everything in `DeliveryHubApp` plus settings, cockpit, Watcher digest, REST keys, audit-trail viewers |
+| `DeliveryHubGuestUser` | Salesforce Site guest profile | Minimal access for the public REST API + portal signing |
+| `Delivery_Hub_Gantt_Fullscreen` | Optional | Full-screen Gantt experience |
 
-Drag-and-drop board with 40+ configurable stages from **Backlog** to **Deployed to Production**. Stage gate enforcement blocks bad transitions until required fields are filled. Persona-based views show clients, developers, and managers exactly what they need to see &mdash; nothing more. The slide-out detail panel shows Created By alongside Assignee, Developer, and Epic so you always know who submitted each work item.
+Assign via Setup → Permission Sets → click the permset → **Manage Assignments**.
 
-### Cross-Org Sync
+Or via Apex (one-shot for the current user):
 
-Bidirectional REST sync between any two Salesforce orgs. Work items created in one org appear in the other within seconds. Stage changes, comments, and files replicate in both directions with echo suppression to prevent loops. Every sync event is logged for full audit visibility.
-
-### AI-Powered Work Management
-
-OpenAI integration that estimates hours, generates descriptions, and drafts acceptance criteria from a one-line summary. ETA engine projects delivery dates from queue depth, developer velocity, and team calendar. Weekly AI digest emails summarize delivery status and send to configurable recipients on a schedule. One click to accept, easy to override.
-
-### Escalation Engine
-
-Rule-based automated escalations defined through Custom Metadata. Configure conditions like "stuck in QA for 3+ days" or "high priority with no assignee" &mdash; the engine evaluates on every scheduler run and fires email notifications automatically. No-response detection flags work items where the submitter hasn't received a reply: set `RequireNoResponseDateTime__c` on any escalation rule and the engine checks whether anyone other than the creator has commented before firing. No manual follow-up needed.
-
-### Board Metrics and Analytics
-
-Burndown chart tracks sprint progress against ideal pace. Developer Workload dashboard shows capacity distribution across the team. Cycle Time analytics measure how long items spend in each stage, identifying bottlenecks before they become blockers.
-
-### Project Timeline (Nimbus Gantt)
-
-High-performance canvas-based Gantt chart built from scratch as a standalone MIT library ([nimbus-gantt](https://github.com/glen-bradford-nimba/nimbus-gantt)). **Five visualization modes** for the same data: Gantt timeline, Treemap (effort concentration), Bubble chart (timeline galaxy), Calendar heatmap (daily workload density), and Stage Flow (workflow distribution). Drag-to-reschedule and drag-to-resize with lock/unlock editing. Dependency arrows with critical path highlighting. 27 plugins including undo/redo, keyboard navigation, dark mode, Monte Carlo simulation, risk analysis, and export to PNG/SVG. **Phone remote control** via Platform Events &mdash; tilt your phone to scroll, swipe to zoom, tap to select tasks. QR code connection in the Remote modal. **40-step demo mode** showcases every feature with health-aware sonification that plays the project schedule as music (consonant = on track, dissonant = overdue). 259KB static resource, zero external dependencies.
-
-### Auto-Schedule Modal (release/0.239)
-
-One-click CPM + capacity leveling for the whole timeline. Click **Auto-Schedule** in the Gantt title bar — Stage 1 collects scope (all visible / project subtree), anchor date, direction (forward/backward), lock policy (treat manually-edited starts as Must Start On), working calendar (7-day vs M-F), hours/day, and leveling algorithm (Serial priority / Parallel forward-pack / None). **Run Preview** computes the schedule client-side via `window.NimbusGantt.computeSchedule` + `serialLevel`/`parallelLevel` — no server call. Stage 2 renders a per-task delta checklist tagged Schedule / Leveling / Both, with critical-path flags, violations, and resource conflict panels. All deltas are checked by default; uncheck anything you don't want. **Apply Selected** pushes each row into the gantt's audit-pass `pendingBuffer` (the same pipeline used by drag-to-reschedule since release/0.223), and the existing **Submit** button commits the batch atomically through `commitGanttPatches`. v1 ships uniform per-resource capacity and the M-F calendar bridge; per-User capacity overrides, full holiday calendars, and "what-if engineer" temporary capacity adds are on the v1.5 roadmap. Walkthrough with a worked example: [cloudnimbusllc.com/mf/auto-schedule-walkthrough](https://cloudnimbusllc.com/mf/auto-schedule-walkthrough).
-
-### Voice Notes
-
-Mobile-first voice-to-work-item creation. Tap the microphone, speak about a customer visit or task, and the transcript becomes a structured work item. Uses the Web Speech API (browser-native, no external APIs). Supports single-item and batch mode (splits by sentence boundaries). Natural language date detection parses "next Monday" or "in two weeks" into `EstimatedStartDevDate__c`. Designed for field reps who need to capture notes hands-free at job sites.
-
-### Real-Time Collaboration
-
-Polling-based chat on every work item. File rollup panel that aggregates every file from the work item, its comments, and related requests into a single view. Ghost Recorder &mdash; a floating form available anywhere in the app for instant issue submission without leaving your current screen, with built-in **voice dictation** via the Web Speech API for hands-free feedback capture. Activity timeline provides a full audit trail of every change on a work item.
-
-### Client Transparency
-
-Home page dashboard showing everything in flight, broken down by phase. Attention Required surfacing calls out anything waiting on the client immediately. System Pulse gives live counts of active work items, hours booked, and sync health at a glance. Public status page provides a shareable Visualforce view without requiring a Salesforce login.
-
-### Operational Automation
-
-Recurring items auto-create work items on configurable schedules &mdash; daily standups, weekly deploys, monthly reviews. Email notifications fire on stage changes. SLA tracking monitors response and resolution times against configurable targets with visual status indicators.
-
-### Bulk Operations
-
-CSV import wizard maps spreadsheet columns to work item fields and creates items in bulk. Dependency graph visualizes blocking relationships so you can see the critical path. Release notes generator compiles completed items into formatted summaries.
-
-### Billing & Approval
-
-WorkLog approval workflow gates logged hours behind a Draft &rarr; Approved &rarr; Synced pipeline. Enable the `RequireWorkLogApprovalDateTime__c` setting and all new hours save as Draft until a manager approves them. Batch approve or reject directly from the Activity Feed. When the setting is null, existing behavior is unchanged &mdash; hours sync immediately. Invoices only include **Approved** work logs &mdash; Draft and unapproved hours are excluded from all generated documents.
-
-The Activity Feed provides a unified, cross-item timeline of comments, hours, and stage/field changes. Date-grouped entries, conversation threads with inline reply, batch WorkLog approval actions, and 30-second polling keep the entire team on the same page without switching between records.
-
-### Invoice Automation
-
-Scheduled invoice generation runs on the DeliveryHubScheduler and produces documents automatically based on each NetworkEntity's billing frequency. Four frequencies are supported: **Daily** (hours summary only), **Weekly**, **Monthly** (full dollar invoice), and **Quarterly**. Enable billing on any entity by setting `EnableBillingDateTime__c` and `BillingFrequencyPk__c` on the NetworkEntity record. The `EnableInvoiceGenerationDateTime__c` setting on DeliveryHubSettings__c activates the scheduler-level invoice generation service.
-
-The engine generates Draft invoices that can be reviewed before sending. Overdue invoice detection automatically marks past-due invoices as Overdue. A pending invoices banner in the Document Viewer alerts users to documents awaiting review. The `LastInvoiceGenerationDate__c` setting tracks when the last generation run completed to prevent duplicate processing.
-
-### Native Document Actioning & Signatures
-
-Multi-party document signing built into the package — no DocuSign integration required. Templates that `RequiresSigningCheckbox__c = true` (Client Agreement, Contractor Agreement, and any custom template you configure) auto-generate one `DocumentAction__c` record per signer slot from `DocumentTemplateSlot__mdt`. Each slot gets a unique signer token, a dedicated public URL (`/portal/documents/<token>`), and captures the signer's IP address (via `X-Forwarded-For` / `X-Salesforce-SIP`), user agent, electronic consent timestamp, and either a text stamp (`Name (digitally signed MMM DD, YYYY)`) or a drawn canvas signature persisted as a ContentVersion. Signatures ride the existing `ActivityLog__c` SHA-256 hash chain for tamper-evident audit — `DocumentAction__c.PriorHashTxt__c` materializes the chain parent at sign time. Documents flow `Draft → Ready → Sent → Awaiting_Signatures → Approved` once every slot is Completed, and a `Certificate_Of_Completion` template can auto-render a full audit trail listing every signer, IP, timestamp, and hash. Admin-side has a "Copy Signer Link" button per slot and `FOR UPDATE` locking so two simultaneous signers cannot double-sign the same slot. Details: [DOCUMENT_ACTIONING_FEATURE.md](docs/DOCUMENT_ACTIONING_FEATURE.md).
-
-### Document Engine
-
-Generate professional invoices, status reports, client agreements, contractor agreements, certificates of completion, and security audit reports directly from Delivery Hub data. Each document captures an immutable JSON snapshot of hours, rates, and work items for the billing period. Zero-hour work items are automatically filtered from invoices so only billable items appear. PDF rendering via Visualforce produces print-ready output with clickable hyperlinks to the source Salesforce records. The VF URL builder detects the namespace at runtime, so PDF and web preview links work correctly in both managed and unmanaged installations. Issuer branding (company name, address, URL) is sourced from the configured vendor `NetworkEntity__c` — no hardcoded strings.
-
-**Email Preview & Scheduled Send:** The "Prepare Email" button opens a full preview modal showing the rendered email body, subject line, recipient (editable), CC addresses, and a clickable PDF attachment link &mdash; all before anything is sent. Send immediately or toggle "Schedule for later" with a datetime picker and a "Next business day at 8 AM" shortcut. The DeliveryHubScheduler checks every 15 minutes for scheduled sends and delivers them automatically. Multiple CC addresses are supported via comma-separated values in `DocumentCcEmailTxt__c`. The email body includes This Invoice, Prior Balance (if outstanding), and Amount Due breakdowns.
-
-Payment tracking through `DeliveryTransaction__c` records supports multiple transaction types (payment, credit, refund, adjustment, write-off) per document. The A/R summary on each invoice shows outstanding prior balances. White-label vendor branding pulls the issuing entity's name, address, email, and phone from the vendor NetworkEntity record. Every invoice footer links to cloudnimbusllc.com. Document versioning preserves history when regenerating &mdash; superseded documents link back via version chain. Client-facing invoice approval flow lets clients approve or dispute invoices from the portal with full audit trail.
-
-### Configurable Workflows
-
-Not just software delivery &mdash; the workflow engine supports any stage-based process. Ships with seven workflow types out of the box: Software Delivery (40+ stages), Loan Approval (8 stages), Customer Onboarding, HR Recruiting, Marketing Campaign, Change Management (12 stages, 3 personas: Requester/CAB/Implementer), and Operations (9 stages, 3 personas: Technician/Supervisor/Customer). Define your own workflow types, stages, personas, and transitions through Custom Metadata. The Workflow Builder admin tab provides a visual editor for creating and modifying workflows without touching metadata files.
-
-### Workspace
-
-A unified tabbed interface combining Board, Timeline, Activity Feed, Documents, Guide, Templates, Analytics, Velocity, Settings, and Workflow Builder. Admin-only tabs are conditionally shown based on user permissions. The workspace replaces the need for multiple app pages and keeps all delivery tools in one screen.
-
-### Activity Dashboard
-
-Tracks user adoption and engagement across the platform. Shows weekly and monthly activity counts, top users, most-used components, and page navigation patterns. All data comes from the Ghost Recorder's background activity logging, providing actionable insights into how the team uses Delivery Hub. The Ghost Recorder now tracks page duration (seconds on each page) and exit method (navigation vs tab close), stored in the existing `ContextDataTxt__c` JSON &mdash; no additional fields required.
-
-### Permission Analyzer
-
-Analyzes 30 days of activity log data to produce permission recommendations based on actual user behavior. The summary view shows active user count, total page views, objects accessed, a per-user activity table (with profile, view count, unique objects, top objects, and risk level), and an object usage table. Click any user row to drill into their detailed breakdown: object frequency, top pages, daily activity bar chart (30-day trend), session count, and average pages per session. Plain-English recommendations flag overprivileged users who have admin access but only touch a small number of objects. Output can be rendered as a Security Audit document via the Document Engine for PDF/email delivery to executives. Available as a dedicated tab in the Delivery Hub Admin app.
-
-### Report Navigation
-
-Dashboard tiles and metrics link directly to pre-deployed Salesforce reports (Attention Items, In-Flight Work Items, Blocked, Recently Completed, Monthly Hours, and per-phase breakdowns). When a report isn't found in the org, navigation falls back gracefully to the corresponding list view.
-
-### Self-Service Onboarding (Phase 3)
-
-Getting Started wizard handles full org setup in 4 steps &mdash; configures scheduled jobs, connection handshake, default settings, and entity registration. No Apex scripts or manual configuration required. Global classes (`DeliveryHubScheduler`, `SyncItemProcessor`, `DeliveryActivityLogCleanup`) ensure subscriber orgs can schedule managed package jobs.
-
-### Velocity and Capacity Planning (Phase 4)
-
-Velocity tracking service calculates team and developer completion rates over configurable time windows. Projected completion dates extrapolate from current velocity and remaining backlog. Capacity utilization reads from `DeveloperCapacity__mdt` configuration to show allocated vs. available hours per developer. What-if analysis lets admins model the impact of adding items to the backlog.
-
-### Enterprise Security & Compliance
-
-A suite of opt-in enterprise features for organizations that need formal governance, compliance controls, and audit-grade data integrity.
-
-**API Rate Limiting:** Configurable per-entity request throttles for both the Public API and the Sync API. Set `PublicApiRateLimitNumber__c` (default: 100 requests/hour) or `SyncApiRateLimitNumber__c` (default: 60 requests/hour) on `DeliveryHubSettings__c` to activate. Excess requests receive HTTP 429 with a `Retry-After: 3600` header. Disabled by default &mdash; leave the fields null to allow unlimited throughput.
-
-**Immutable Audit Chain:** Every auditable event (stage changes, approvals, document lifecycle actions, sync completions) is hashed into a SHA-256 chain via `DeliveryAuditChainService`. Each `ActivityLog__c` record stores its hash and its parent hash, creating a tamper-evident ledger. Legal hold mode (`LegalHoldEnabledDateTime__c` on `DeliveryHubSettings__c`) prevents deletion of any audit chain records. The chain can be verified programmatically at any time.
-
-**HMAC Request Signing:** Outbound sync payloads are signed with an HMAC-SHA256 signature when `HmacSecretTxt__c` is configured on the target `NetworkEntity__c`. The receiving org validates the `X-Signature` header against the request body and shared secret. Backward compatible &mdash; if no secret is set, signature validation is skipped.
-
-**Inbound Webhook Receiver:** `IntegrationProvider__mdt`-driven webhook ingest framework. Stripe payment webhook ships out of the box (PR #724) — HMAC-verified, idempotent, returns 401 on every call until admin sets `SignatureSecretTxt__c` AND `EnabledDateTime__c`. The framework is generic; add new providers by creating a CMT row and an Apex handler.
-
-**Business-Hours SLAs:** `DeliverySLAService` now supports business-hours calculations via `BusinessHoursId` on `SLARule__mdt`. SLA clocks pause outside configured business hours, weekends, and holidays. Response and resolution targets are evaluated against business time, not wall-clock time.
-
-**Notification Preferences:** `DeliveryNotificationPreferenceService` lets users configure per-event notification channels (email, platform event, both, or none) through `DeliveryHubSettings__c`. Preferences are respected by the escalation engine, digest service, and stage-change alerts.
-
-### Admin Settings
-
-Central settings page with DateTime activation toggles that record who enabled each feature and when. Four operational settings control runtime behavior across the platform:
-
-| Setting | Field | Default | What It Controls |
-|---------|-------|---------|-----------------|
-| Reconciliation Hour | `ReconciliationHourNumber__c` | 6 (AM UTC) | Hour when the scheduler runs the daily sync reconciliation |
-| Sync Retry Limit | `SyncRetryLimitNumber__c` | 3 | Max retry attempts before a failed sync item stops requeueing |
-| Activity Log Retention | `ActivityLogRetentionDaysNumber__c` | 90 days | How long activity log records are kept before batch purge |
-| Escalation Cooldown | `EscalationCooldownHoursNumber__c` | 24 hours | Minimum interval before re-escalating the same work item |
-
-All four settings are wired into the Apex runtime &mdash; the DeliveryHubScheduler, DeliveryActivityLogCleanup, and DeliveryEscalationService read from `DeliveryHubSettings__c` on every execution. The admin page uses dynamic forms for field-level layout control.
-
-**DateTime toggles (zero Boolean fields):** The codebase contains **zero Checkbox/Boolean custom fields**. Every toggle uses a DateTime stamp that records **when** the flag was set (e.g., `ActivatedDateTime__c = 2026-03-27T14:30:00Z`). This tells you both **if** and **when**. Examples: `ActivatedDateTime__c`, `BountyEnabledDateTime__c`, `RecurringEnabledDateTime__c`, `TemplateMarkedDateTime__c` (all on WorkItem\_\_c), `EnableVendorPushDateTime__c` (NetworkEntity\_\_c), `DefaultSetDateTime__c` (DeliverySavedFilter\_\_c), and all enterprise feature flags (`LegalHoldEnabledDateTime__c`, `TeamVisibilityEnabledDateTime__c`, etc.). DateTime stamps provide richer audit data at zero extra cost.
-
----
-
-## How It Works
-
-```text
-Your Org (Client)                        Delivery Team's Org (Vendor)
-
-Work item created        ---- sync ---->  Request ingested
-  Stage updated          <--- sync ----   Developer assigned
-  Comment posted         ---- sync ---->  Comment synced back
-  File attached          ---- sync ---->  Status progressed
-  Client approval        ---- sync ---->  Deployed to Prod
+```apex
+PermissionSet ps = [SELECT Id FROM PermissionSet WHERE Name = 'DeliveryHubAdmin_App'];
+insert new PermissionSetAssignment(AssigneeId = UserInfo.getUserId(), PermissionSetId = ps.Id);
 ```
 
-1. A work item is created on the board. A sync record queues automatically.
-2. The sync engine POSTs to the vendor's REST endpoint &mdash; in real time or on the 15-minute scheduler, whichever fires first.
-3. The vendor org ingests the payload, creates or updates the matching work item, and syncs back.
-4. Both orgs stay in lock-step. Echo suppression ensures changes don't bounce back as duplicates.
+---
 
-The engine is retry-aware (configurable limit, default 3 attempts), handles namespace translation for managed packages, and supports multi-vendor routing to multiple external orgs simultaneously.
+## Apps and Tabs
+
+Delivery Hub ships **two Lightning apps**:
+
+- **Delivery Hub** — end-user app: Home, Workspace, Board, Timeline, Activity Feed, Voice Notes, Guide
+- **Delivery Hub Admin** — admin/superuser app: everything above plus all object tabs, cockpit objects, Permission Analyzer, Settings
+
+### Admin app tabs (current as of `release/0.248.0.3`)
+
+`Home` · `Workspace` · `WorkItem` · `Board` · `Timeline` · `Activity` · `Activity Dashboard` · `NetworkEntity` · `WorkRequest` · `WorkItemComment` · `SyncItem` · `ActivityLog` · **`Feature`** · **`FeatureToggleRequest`** · **`WatcherDigest`** · **`ScratchOrgInstance`** · `Permission Analyzer` · `Settings` · `Guide` · `Reports`
+
+The four bolded tabs are the cockpit additions from the 50-hour cockpit plan + Watcher v1 (shipped in `release/0.245.0.4` and `release/0.246.0.4`).
 
 ---
 
-## Architecture
+## Architecture: the 8-layer cockpit
 
-| Layer | Count | Key Components |
-|-------|-------|----------------|
-| **Apex Classes** | ~270 (production + test, roughly 50/50 split) | Core: SyncEngine, SyncItemProcessor, SyncItemIngestor, SyncItemPendingResolver, HubPoller, HubSyncService, InboundEmailHandler, EmailService, InvoiceGenerationService, DepthProbeService. Controllers: WorkItemController, DocumentController, DocumentPdfController, GuideController, PortalController, AiController, SettingsController, TimelineController, SavedFilterController, WorkflowConfigService, PermissionAnalyzerController, GhostController, GanttController, GanttRemoteController, VoiceNotesController, ExecutiveDashboardController, DashboardCardController. Services (enterprise): RateLimitService, AuditChainService, CryptoService, ApprovalChainService, TeamPermissionService, ArchivalService, NotificationPreferenceService, SLAService, WorkItemQueryService, VelocityService, WeeklyDigestService, WorkItemETAService, EscalationService, EscalationRuleEvaluator, EscalationActionExecutor, EscalationNotifService. Document engine: DocQueryService, DocApprovalService, DocEmailService, DocGenerationService, DocPaymentService, DocActionService, DocActionController, DocActionRestApi, DocCertificateService, DocDeferralService. |
-| **LWC Components** | 71 | deliveryHubBoard, deliveryClientDashboard, deliveryGuide, deliveryDocumentViewer, deliveryDocumentSignatureBlock, deliveryDocumentSignPortal, deliverySignaturePad, deliveryVelocityDashboard, deliveryBurndownChart, deliveryCycleTimeChart, deliveryDeveloperWorkload, deliveryDependencyGraph, deliveryCsvImport, deliveryStatusPage, deliveryActivityTimeline, deliveryActivityFeed, deliveryDataLineage, deliveryGhostRecorder, deliveryScore, deliverySettingsContainer, deliveryNimbusGantt, deliveryProFormaTimeline, deliveryGanttAutoScheduleModal, deliveryVoiceNotes, deliveryPermissionAnalyzer, deliveryHubWorkspace, deliveryWorkflowBuilder, deliveryExecutiveDashboard, deliveryHubHealthDashboard, deliveryInvoicePreviewDeferPanel |
-| **Custom Objects** | 16 | WorkItem\_\_c, WorkRequest\_\_c, SyncItem\_\_c, NetworkEntity\_\_c, WorkItemComment\_\_c, WorkItemDependency\_\_c, WorkLog\_\_c, ActivityLog\_\_c, DeliveryDocument\_\_c, DeliveryTransaction\_\_c, DocumentAction\_\_c, PortalAccess\_\_c, DeliveryHubSettings\_\_c, BountyClaim\_\_c, DeliverySavedFilter\_\_c, NotificationPreference\_\_c |
-| **Custom Metadata** | 14 | WorkflowType\_\_mdt, WorkflowStage\_\_mdt, WorkflowPersonaView\_\_mdt, WorkflowEscalationRule\_\_mdt, WorkflowStageRequirement\_\_mdt, CloudNimbusGlobalSettings\_\_mdt, DocumentTemplate\_\_mdt, DocumentTemplateSlot\_\_mdt, SLARule\_\_mdt, TrackedField\_\_mdt, DeveloperCapacity\_\_mdt, DashboardCard\_\_mdt, IntegrationProvider\_\_mdt, UserAutoAssignConfig\_\_mdt. (DeliveryTeam\_\_mdt + ApprovalStep\_\_mdt deleted in PR #727 as part of the custom-object cap recovery — Apex code paths and tests are gone with them.) |
-| **Platform Events** | 5 | DeliveryWorkItemChange\_\_e, DeliverySync\_\_e, DeliveryEscalation\_\_e, DeliveryDocEvent\_\_e, GanttRemoteEvent\_\_e |
-| **Triggers** | 16 | WorkItem, WorkItemComment, WorkItemDependency, WorkLog, ContentDocumentLink, BountyClaim, DeliveryDocument, DocumentAction (via DeliveryDocumentTrigger), NetworkEntity, DeliveryTransaction, WorkRequest, ActivityLog, NotificationPreference, User, plus platform-event subscribers (SyncEvent, DocEvent) |
-| **FlexiPages** | 15+ | Record pages, admin home, and workspace pages for all major objects |
-| **Reports** | 25 | Attention Items, In-Flight, Blocked, Recently Completed, Monthly Hours, phase breakdowns, activity tracking, budget health |
+Delivery Hub is organized into 8 layers. Layers 1–3 are the original delivery platform; Layers 4–8 were added in the cockpit plan (`release/0.243.x` → `0.246.x`) and hardened in `release/0.247.x` → `0.248.x`.
+
+| Layer | Name | Purpose |
+|---|---|---|
+| **1** | Core domain | `WorkItem__c`, `WorkRequest__c`, `WorkLog__c`, `WorkItemComment__c`, `WorkItemDependency__c` |
+| **2** | Sync & integration | `SyncItem__c`, `NetworkEntity__c`, Slack inbound/outbound, inbound email, IntegrationProvider webhooks |
+| **3** | Observability | `ActivityLog__c` (hash-chained), `WatcherDigest__c`, daily Watcher digest (Signals 1-3) |
+| **4** | Feature Catalog | `Feature__c` + `FeatureDefinition__mdt` + `FeatureDependency__c` + `deliveryFeatureCockpit` LWC |
+| **5** | Onboarding gates | `OnboardingTrack__mdt` + `OnboardingLesson/Quiz/ChecklistItem__mdt` + `OnboardingProgress__c` |
+| **6** | Dev-loop mirror | `ScratchOrgInstance__c` + `DevLoopGuide__mdt` + REST `POST/PATCH /scratch-orgs` |
+| **7** | Dataset templates | `DatasetTemplate__c` + `DatasetTemplateAssignment__c` + `load_feature_data` CCI task |
+| **8** | Approval framework | `FeatureToggleRequest__c` + `FeatureToggleApproval__c` + multi-step cascading approvals + in-app notifications |
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the deep object/class/trigger reference, [docs/COCKPIT.md](docs/COCKPIT.md) for the per-layer cockpit detail, and [docs/SETUP.md](docs/SETUP.md) for the install/smoke-test runbook.
+
+---
+
+## REST API
+
+Three REST surfaces ship with the package, all under `/services/apexrest/delivery/`:
+
+| Surface | Base path | Use case | Auth |
+|---|---|---|---|
+| **Public API** | `/deliveryhub/v1/api/*` | Websites, mobile apps, portal, cockpit clients | `X-Api-Key` header |
+| **Sync API** | `/deliveryhub/v1/sync/*` | Org-to-org bidirectional sync | `X-Api-Key` + HMAC (opt-in) |
+| **Task API** | `/deliveryhub/v1/tasks/*` | CI/CD agents, AI agents | `X-Api-Key` |
+
+The Public API covers dashboard reads, work items, comments, work logs, activity feed, documents, document signing, feature toggle requests, and scratch-org mirror writes.
+
+Highlights from the recent hardening pass (`release/0.247.x` PR #813):
+
+- **Rate limiting** on GET / POST / PATCH (opt-in via `PublicApiRateLimitNumber__c` on `DeliveryHubSettings__c`; HTTP 429 + `Retry-After: 3600` on breach)
+- **Idempotency** on `POST /features/{name}/toggle` (deduplicates Pending/Granted rows on retry)
+- **Pagination envelope** (`{data, offset, pageSize, hasMore}`) on `GET /feature-toggle-requests`
+
+Full endpoint reference: [docs/PUBLIC_API_GUIDE.md](docs/PUBLIC_API_GUIDE.md). For org-to-org sync: [docs/SYNC_API_GUIDE.md](docs/SYNC_API_GUIDE.md). For the bounty marketplace surface: [docs/BOUNTY_API_GUIDE.md](docs/BOUNTY_API_GUIDE.md).
+
+---
+
+## What's in the box
+
+A short cross-reference. The deep narrative is in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) and [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).
+
+**Delivery platform** — Kanban board (40+ stages, persona views, stage gates), Nimbus Gantt timeline (5 visualization modes, Auto-Schedule modal, phone remote), cross-org sync (bidirectional REST with echo suppression, HMAC signing, retry, pending queue for child-before-parent races), inbound email handler, Slack bidirectional comment sync.
+
+**Time tracking & billing** — WorkLog approval pipeline (Draft → Approved → Synced), invoice automation (Daily/Weekly/Monthly/Quarterly per NetworkEntity), document engine (invoices, status reports, agreements, certificates of completion), native multi-party signing (no DocuSign integration, ESIGN/UETA-compliant via SHA-256 hash chain), client-portal approval/dispute flow.
+
+**AI & escalation** — OpenAI-backed work-item drafting (description + acceptance criteria + estimate), weekly digest, ETA engine, rule-based escalation engine (`WorkflowEscalationRule__mdt`), no-response detection, business-hours SLAs.
+
+**Observability** — `ActivityLog__c` audit trail with SHA-256 hash chain (legal-hold mode), `WatcherDigest__c` daily ops digest (Signals 1-3 active: SLA Breach / Stuck Stage / A/R Aging; 4 stubs ready for activation), Permission Analyzer (30-day usage → permset recommendations), Activity Dashboard, audit-trail viewer LWCs.
+
+**Cockpit (Layers 4-8)** — Feature Catalog with toggle/approve/cascade workflow, gated onboarding tracks (Checkr-style), FeatureDependency editor on record page, dev-loop mirror (scratch org provenance), dataset templates, multi-step approvals with caller-is-approver assertion + in-app notifications.
+
+**Configurable workflows** — 7 workflow types ship (Software Delivery, Loan Approval, Customer Onboarding, HR Recruiting, Marketing Campaign, Change Management, Operations); all stages/personas/transitions are CMT-driven.
+
+**Operational** — Quickstart Connection wizard, Ghost Recorder (floating capture form with voice dictation), Voice Notes, CSV Import, 25 pre-built reports, Saved Filters, Email Preview & Scheduled Send.
+
+---
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [Getting Started](docs/GETTING_STARTED.md) | Installation, permset assignment, first work item, optional cross-org sync, document signing, AI |
+| [Setup Guide](docs/SETUP.md) | Pre-install checklist, install/upgrade commands, smoke test, common gotchas |
+| [Architecture](docs/ARCHITECTURE.md) | Object model, sync engine, API layer, LWC catalogue, enterprise services, permission model |
+| [Cockpit Architecture](docs/COCKPIT.md) | 8-layer cockpit: per-layer objects, classes, LWCs, UI pointers |
+| [REST API Reference](docs/PUBLIC_API_GUIDE.md) | Public API — endpoints, auth, request/response shapes, rate-limiting, pagination |
+| [Sync API Guide](docs/SYNC_API_GUIDE.md) | Org-to-org sync — push/pull flows, echo suppression, HMAC, setup |
+| [Bounty API Guide](docs/BOUNTY_API_GUIDE.md) | Bounty marketplace — public discovery, authenticated claim lifecycle |
+| [Document Actioning](docs/DOCUMENT_ACTIONING_FEATURE.md) | Multi-party signing — slots, signer tokens, hash chain, certificate of completion |
+| [Field Naming](docs/FIELD_NAMING.md) | Type-suffix convention enforced by PMD (`*Txt__c`, `*Number__c`, etc.) |
+| [Changelog](docs/CHANGELOG.md) | Version history (pre-0.200 PR-by-PR; later releases tagged in GitHub Releases) |
 
 ---
 
@@ -237,11 +165,12 @@ The engine is retry-aware (configurable limit, default 3 attempts), handles name
 
 ### Prerequisites
 
-- [CumulusCI](https://cumulusci.readthedocs.io/)
-- A Salesforce Dev Hub org
+- [CumulusCI](https://cumulusci.readthedocs.io/) (`pip install cumulusci`)
+- A Salesforce Dev Hub org with scratch-org allocations available
+- Salesforce CLI (`sf` or `sfdx`)
 - Git
 
-### Local Setup
+### Local setup
 
 ```bash
 git clone https://github.com/Nimba-Solutions/Delivery-Hub
@@ -250,191 +179,53 @@ cci flow run dev_org --org dev
 cci org browser dev
 ```
 
-### Day-to-Day
+### Day-to-day
 
 ```bash
-# Retrieve changes from scratch org
+# Retrieve changes from your scratch org
 cci task run retrieve_changes --org dev
 
-# Push your branch
+# Push a feature branch — CI spins a fresh namespaced scratch org per PR
 git push origin feature/your-feature
 ```
 
-Every pull request automatically spins up a namespaced scratch org, deploys the package, runs 1,000+ Apex tests (90%+ coverage enforced on new services), and runs PMD static analysis (zero violations enforced, priority 1-4 blocking).
-
-### Reconciliation
-
-Run a full sync reconciliation to detect and repair drift:
-
-```bash
-# In subscriber org Dev Console:
-delivery.DeliverySyncReconciler.reconcileAll();
-```
-
-### Billing Entity Setup
-
-Configure the default billing entity for invoice generation:
-
-```apex
-delivery__DeliveryHubSettings__c s = delivery__DeliveryHubSettings__c.getOrgDefaults();
-s.delivery__DefaultBillingEntityIdTxt__c = '<NetworkEntity ID>';
-upsert s;
-```
+Every pull request runs feature tests in a namespaced scratch org. PMD static analysis blocks priority 1-4 violations. Apex coverage is enforced at 75% globally, 90% on new enterprise services.
 
 ### Releasing
 
 ```bash
-cci flow run release_unlocked_beta --org dev
-cci flow run release_unlocked_production --org dev
+# Beta — auto-runs on merge to main via beta_create.yml
+cci flow run release_unlocked_beta --org packaging
+
+# Production
+cci flow run release_unlocked_production --org packaging
 ```
 
----
-
-## Public API
-
-Delivery Hub exposes a REST API for non-Salesforce clients (websites, mobile apps, external platforms) to read and write delivery data.
-
-**Base URL**: `/services/apexrest/delivery/deliveryhub/v1/api/`
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/dashboard` | Dashboard with active counts, phase distribution, recent activity |
-| GET | `/api/work-items` | List work items (filter: `?status=active`, `completed`, `attention`) |
-| GET | `/api/work-items/{id}` | Full work item detail with comments and file count |
-| POST | `/api/work-items` | Submit a new work item request |
-| POST | `/api/work-items/{id}/comments` | Add a comment to a work item |
-| GET | `/api/activity-feed` | Unified timeline of comments, hours, and changes |
-| GET | `/api/work-logs` | List work logs for the authenticated entity |
-| POST | `/api/log-hours` | Create a new work log entry |
-| POST | `/api/approve-worklogs` | Batch approve draft work logs |
-| POST | `/api/reject-worklogs` | Batch reject draft work logs |
-| GET | `/api/board-summary` | AI-generated board summary |
-| GET | `/api/files` | Files attached to entity work items |
-| GET | `/api/documents` | Documents generated for the entity |
-| GET | `/api/documents/{token}` | Document detail by public token (now includes `signingRequired`, `signingComplete`, `signingSlots[]`, `hashChainVerified`) |
-| POST | `/api/document-approve` | Approve a document by public token |
-| POST | `/api/document-dispute` | Dispute a document with reason by public token |
-| POST | `/sign/{signerToken}` | Public signing endpoint — accepts `signatureType: "Text"` or `"Image"` (base64 PNG via `signatureData`/`drawnSignature`), captures `X-Forwarded-For` IP and User-Agent |
-| GET | `/sync/health` | Org-level sync health &mdash; record counts, hours, status breakdown (no auth required) |
-
-All requests require an `X-Api-Key` header matched against a NetworkEntity record. **Rate limiting** is available: set `PublicApiRateLimitNumber__c` on `DeliveryHubSettings__c` to cap requests per entity per hour (default off; returns HTTP 429 when exceeded). See the [Public API Guide](docs/PUBLIC_API_GUIDE.md) for complete documentation.
-
-### Bounty Marketplace API
-
-**Base URL**: `/services/apexrest/delivery/deliveryhub/v1/bounties/`
-
-| Method | Endpoint | Auth | Description |
-|--------|----------|------|-------------|
-| GET | `/bounties` | Public | List open bounties (filter: `?difficulty=X&skill=Y`) |
-| GET | `/bounties/{token}` | Public | Bounty detail with acceptance criteria and active claims |
-| POST | `/bounties/{token}/claim` | X-Api-Key | Claim a bounty |
-| POST | `/bounties/{token}/submit` | X-Api-Key | Submit completed work with proof URL |
-| POST | `/bounties/{token}/withdraw` | X-Api-Key | Withdraw an active claim |
-
-Any WorkItem with `BountyEnabledDateTime__c` set (non-null) is published to the marketplace. Claims are tracked via `BountyClaim__c` and synced to origin orgs automatically. See the [Bounty API Guide](docs/BOUNTY_API_GUIDE.md) for details.
-
-For org-to-org synchronization (with opt-in HMAC request signing and rate limiting), see the [Sync API Guide](docs/SYNC_API_GUIDE.md).
+See [CLAUDE.md](CLAUDE.md) for the full Salesforce/CI/CD/workflow rule reference.
 
 ---
 
-## Documentation
+## Help & support
 
-| Document | Description |
-|----------|-------------|
-| [Getting Started](docs/GETTING_STARTED.md) | Installation, setup wizard, first work item, and optional sync configuration |
-| [Architecture](docs/ARCHITECTURE.md) | Object model, sync engine, API layer, LWC components, enterprise services, and permission model |
-| [Changelog](docs/CHANGELOG.md) | Version history grouped by unlocked package release |
-| [Field Naming](docs/FIELD_NAMING.md) | Type-suffix convention enforced by PMD (`*Txt__c`, `*Number__c`, etc.) |
-| [Document Actioning](docs/DOCUMENT_ACTIONING_FEATURE.md) | Native multi-party signing with hash chain audit |
-| [Public API Guide](docs/PUBLIC_API_GUIDE.md) | REST API for websites and external apps &mdash; endpoints, auth, response schemas |
-| [Sync API Guide](docs/SYNC_API_GUIDE.md) | Org-to-org synchronization &mdash; push/pull flows, echo suppression, setup steps |
-| [Bounty API Guide](docs/BOUNTY_API_GUIDE.md) | Bounty marketplace &mdash; publishing bounties, claim lifecycle, sync to origin orgs |
+- **Bug reports / feature requests**: [open an issue](https://github.com/Nimba-Solutions/Delivery-Hub/issues)
+- **Docs**: the [docs/](docs/) folder in this repo
+- **Recent changes**: [GitHub Releases](https://github.com/Nimba-Solutions/Delivery-Hub/releases)
 
 ---
 
 ## Contributing
 
-Delivery Hub is open source under the [BSL 1.1 license](LICENSE.md) (converts to Apache 2.0 after 4 years per release).
+Delivery Hub is open source under the [BSL 1.1 license](LICENSE.md) (converts to Apache 2.0 four years after each release).
 
 1. Fork the repo
 2. Create a feature branch (`git checkout -b feature/your-idea`)
 3. Make your changes
-4. Push and open a PR &mdash; CI will validate everything automatically
-
-If you're not sure where to start, check [open issues](https://github.com/Nimba-Solutions/Delivery-Hub/issues) or reach out.
-
----
-
-## Feature Summary
-
-| Feature | What It Does |
-|---|---|
-| **Kanban Board** | Drag-and-drop, 40+ stages, persona views, column color coding, Created By in detail panel |
-| **Stage Gates** | Block transitions when required fields are missing |
-| **Fast Track** | Skip approval queue when estimate fits pre-approved budget |
-| **Cross-Org Sync** | Bidirectional REST with retry, echo suppression, audit ledger |
-| **Multi-Vendor Routing** | Send to multiple external orgs, each independently tracked |
-| **AI Estimation** | Hours estimate, description, acceptance criteria from one line |
-| **AI Weekly Digest** | Scheduled email summarizing delivery status across all active work |
-| **ETA Engine** | Projected dates from velocity, queue depth, and dependencies |
-| **Escalation Engine** | Rule-based auto-escalations with email alerts on SLA breaches, no-response detection for unacknowledged submissions |
-| **Burndown Chart** | Sprint progress tracking against ideal pace |
-| **Developer Workload** | Team capacity distribution dashboard |
-| **Cycle Time Analytics** | Stage duration measurement to identify bottlenecks |
-| **Real-Time Chat** | Polling-based comments with file attachment indicators |
-| **File Rollup** | All files from work item + comments + requests in one panel |
-| **Activity Timeline** | Full audit trail of every change on a work item |
-| **Time Logger** | Quick hour logging with date picker, creates WorkLog entries |
-| **WorkLog Approval** | Draft &rarr; Approved &rarr; Synced pipeline, gated by org setting |
-| **Activity Feed** | Cross-item unified timeline of comments, hours, and changes with inline reply |
-| **Data Lineage** | Visual sync chain with per-entity health metrics on admin home |
-| **Document Engine** | Generate invoices, status reports, proposals with AI narratives, PDF rendering with hyperlinks to SF records, zero-hour filtering, runtime namespace detection for VF URLs, email delivery with CC, payment tracking, A/R balance, white-label vendor branding (sourced from NetworkEntity, no hardcoded strings), and cloudnimbusllc.com footer. Document versioning tracks regeneration history with version numbers and superseded-document chains. |
-| **Native Document Actioning & Signatures** | Multi-party document signing without a DocuSign integration. Auto-generates one `DocumentAction__c` record per signer slot from `DocumentTemplateSlot__mdt`. Each slot has a unique signer token, public `/portal/documents/<token>` URL, captured IP (`X-Forwarded-For` / `X-Salesforce-SIP`), user-agent, electronic consent timestamp, and either text-stamp or drawn-canvas signature (persisted as a ContentVersion). SHA-256 hash chain rides the existing ActivityLog audit chain for tamper evidence. `FOR UPDATE` locking prevents double-sign races. Certificate_Of_Completion template auto-renders the full audit trail. |
-| **Invoice Automation** | Scheduled invoice generation via DeliveryInvoiceGenerationService. Supports Daily (hours summary), Weekly, Monthly (full dollar invoice), and Quarterly frequencies per NetworkEntity. Auto-generates Draft invoices on schedule, detects overdue invoices and marks them past-due, and shows a pending invoices banner in the Document Viewer. Invoices only include Approved work logs. |
-| **Invoice Approval Flow** | Client-facing approve/dispute workflow via portal. Clients review invoices by public token and either approve or dispute with a reason. Dispute details stored in DisputeReasonTxt__c. All actions logged to ActivityLog for audit trail. |
-| **Timeline View** | Gantt-style horizontal timeline showing active work items grouped by NetworkEntity. CSS Grid-based bars with zoom (week/month/quarter), scroll controls, today-line marker, stage-based colors from workflow config, and click-to-navigate to work item records. Available as the Delivery Timeline tab. |
-| **Auto-Schedule Modal** | One-click CPM + capacity leveling. Two-stage flow: Stage 1 collects scope / anchor / direction / lock policy / working calendar / hours-per-day / leveling algorithm; Stage 2 renders a per-task delta checklist (Schedule / Leveling / Both, critical-path flagged, violations + resource conflicts surfaced). **Apply Selected** dispatches into the audit-pass `pendingBuffer` — the existing **Submit** button commits the batch atomically. Pure client-side preview, no new Apex endpoint. |
-| **Saved Filters** | Save and recall board filter configurations. Per-user filters (Private sharing model) with default filter auto-applied on board load. Stored as JSON in DeliverySavedFilter__c. Accessible from a dropdown in the board toolbar. |
-| **Email Preview & Scheduled Send** | Full email preview before sending (subject, HTML body, recipient, CC, PDF link). Schedule sends for a future date/time with "Next business day at 8 AM" shortcut. Multi-CC support via comma-separated addresses. |
-| **Permission Analyzer** | Analyzes activity logs to recommend permission sets based on actual user behavior. User heatmaps, object usage, risk flags, drill-down per user with daily activity chart, Security Audit document template. Dedicated admin tab. |
-| **Ghost Recorder** | Floating submission form with keyboard shortcut, background navigation tracking, page duration logging (seconds on page, exit method), and **voice dictation** via Web Speech API &mdash; click the mic, speak, and transcribed text auto-appends to the description as `[Voice]` entries |
-| **Delivery Guide** | In-app documentation with Ghost Recorder utility bar detection across all Lightning apps |
-| **Client Dashboard** | Phase counts, attention items, recent activity |
-| **Public Status Page** | Shareable delivery status view &mdash; no Salesforce login required |
-| **System Pulse** | Live work items, hours, sync health |
-| **Dependency Graph** | Visual blocking relationships between work items |
-| **SLA Tracking** | Response and resolution time targets with visual indicators, business-hours support via BusinessHoursId on SLARule__mdt |
-| **Recurring Items** | Auto-create work items on configurable schedules |
-| **Email Notifications** | Stage-change alerts to keep stakeholders informed |
-| **CSV Import** | Bulk import work items from spreadsheets |
-| **Release Notes** | Auto-generate formatted release summaries from completed items |
-| **Configurable Workflows** | Custom stages, personas, and transitions via metadata |
-| **Setup Wizard** | One-click connection with automatic scheduler provisioning and real-time prerequisites checklist |
-| **Bounty Marketplace** | Publish work items as bounties with fixed payouts, skill tags, difficulty ratings, and deadlines. Developers claim, submit work, and get approved through a structured lifecycle. Public API for marketplace browsing, authenticated API for claims. Claims auto-sync to origin orgs. |
-| **Sync Reconciler** | Self-healing sync engine that detects drift between orgs and auto-repairs missing records. Runs daily at a configurable hour (default 6 AM UTC) or on-demand. Health endpoint for monitoring. |
-| **Dynamic Record Pages** | Every object has a production-quality record page with dynamic forms, smart field sections, readonly enforcement on rollup fields, and compact layouts for lookup previews. LWC placements put the right component on the right page: deliveryScore on WorkItem, deliveryDocumentViewer on Document and NetworkEntity, deliverySyncRetryPanel on NetworkEntity. All 10 record pages are assigned as app defaults for both Delivery Hub apps. |
-| **Default Billing Entity** | Configurable billing entity override for pass-through invoicing patterns (e.g., Cloud Nimbus &rarr; At Large &rarr; MF). |
-| **Configurable Settings** | Admin settings page with DateTime activation toggles (shows who enabled what and when) and 4 operational knobs: reconciliation hour (default 6 AM UTC), sync retry limit (default 3), activity log retention days (default 90), and escalation cooldown hours (default 24). All settings are wired into the Apex runtime &mdash; the scheduler, cleanup job, and escalation service read from `DeliveryHubSettings__c` on every run. |
-| **Document Versioning** | Regenerating a document for the same entity, period, and template creates a new version. The old document is marked Superseded, the new one gets an incremented VersionNumber__c and links back via PreviousVersionId__c. Superseded documents are excluded from A/R prior balance calculations. |
-| **Inbound Email Handler** | Reply to work item notification emails to create comments directly. DeliveryInboundEmailHandler parses work item numbers (T-0039, WI-0039) from the To address or Subject, strips reply quotes, and inserts a WorkItemComment__c. Gated by EnableEmailNotificationsDateTime__c. DeliveryEmailService sends outbound comment notifications with reply-to routing for seamless email-based collaboration. |
-| **Platform Events** | Three HighVolume platform events (DeliverySync__e, DeliveryEscalation__e, DeliveryDocEvent__e) enable external systems to subscribe to sync completions, escalation firings, and document lifecycle changes without polling. |
-| **Portal Time Entry** | Enhanced portal time logging with entity scoping, workItemId filtering on GET /work-logs, cross-entity validation on POST /log-hours (403 if work item belongs to another entity), and activity log auditing for portal hour submissions. |
-| **Demo Org Flow** | One-command demo org setup via `cci flow run demo_org --org dev`. Creates a scratch org, deploys the package, loads realistic sample data (2 entities, 10 work items, 21 work logs, comments, a draft invoice), configures org defaults, and schedules all background jobs. |
-| **Task API (Versioned)** | CI/CD and AI agent endpoints moved to `/deliveryhub/v1/tasks/*` to match the URL convention used by all other REST endpoints. |
-| **Field Change Tracking** | Automatic audit trail of field changes on all DH objects via triggers. Configured declaratively through TrackedField\_\_mdt &mdash; add a metadata record to track any field. Captures old/new values, delta for numeric fields, and stores as ActivityLog entries. Enabled by default on new installs. |
-| **Native Reports** | Full Salesforce reporting on all delivery data &mdash; 25 pre-built reports ship with the package |
-| **API Rate Limiting** | Opt-in per-entity throttle for both Public API (default 100 req/hr) and Sync API (default 60 req/hr). HTTP 429 with Retry-After header when exceeded. Disabled by default. |
-| **Immutable Audit Chain** | SHA-256 hash chain on ActivityLog records creates a tamper-evident audit trail. Legal hold mode prevents deletion. Chain verifiable programmatically. |
-| **HMAC Request Signing** | Outbound sync payloads signed with HMAC-SHA256 via shared secret on NetworkEntity. Receiving org validates X-Signature header. Backward compatible &mdash; no secret means no signature required. |
-| **Inbound Webhook Receiver** | Generic `IntegrationProvider__mdt`-driven receiver. Stripe payment webhook ships out of the box (PR #724); add new providers by creating a CMT row + handler class. HMAC-verified, idempotent, returns 401 until admin enables. |
-| **Data Archival** | Automated archival of completed work items and related records after configurable retention period (default 365 days). Archived records excluded from board/API but queryable for compliance. |
-| **Business-Hours SLAs** | SLA clocks pause outside configured business hours, weekends, and holidays. BusinessHoursId on SLARule__mdt controls the calendar. |
-| **Notification Preferences** | Per-event notification channel configuration (email, platform event, both, or none). Respected by escalation engine, digest service, and stage-change alerts. |
+4. Push and open a PR — CI validates everything automatically
 
 ---
 
 <p align="center">
   <strong>Built by <a href="https://cloudnimbusllc.com">Cloud Nimbus LLC</a></strong><br>
   We build Salesforce delivery infrastructure so you can focus on your actual product.<br><br>
-  <a href="https://cloudnimbusllc.com">Website</a> &middot; <a href="https://cloudnimbusllc.com/docs">Documentation</a> &middot; <a href="https://cloudnimbusllc.com/examples">Examples</a> &middot; <a href="https://github.com/Nimba-Solutions/Delivery-Hub/issues">Issues</a>
+  <a href="https://cloudnimbusllc.com">Website</a> &middot; <a href="https://cloudnimbusllc.com/docs">Documentation</a> &middot; <a href="https://github.com/Nimba-Solutions/Delivery-Hub/issues">Issues</a>
 </p>

--- a/docs/COCKPIT.md
+++ b/docs/COCKPIT.md
@@ -1,0 +1,155 @@
+# Delivery Hub Cockpit — 8-Layer Architecture
+
+This document describes the **cockpit-era architecture** of Delivery Hub: 8 logical layers covering domain, sync, observability, feature lifecycle, onboarding, dev-loop tooling, dataset provisioning, and approvals.
+
+Layers 1-3 are the original delivery platform. Layers 4-8 were added by the cockpit plan (10 PRs, ~50h, shipped in `release/0.243.x` → `release/0.246.x`) and hardened in `release/0.247.x` → `release/0.248.x`.
+
+For the deep object / Apex class / trigger reference, see [ARCHITECTURE.md](ARCHITECTURE.md). For install + smoke-test, see [SETUP.md](SETUP.md).
+
+---
+
+## Layer 1 — Core domain objects
+
+The original work-item model. Everything Delivery Hub does ties back to a `WorkItem__c`.
+
+- **Objects**: `WorkItem__c`, `WorkRequest__c` (vendor bridge), `WorkLog__c` (time entries), `WorkItemComment__c`, `WorkItemDependency__c`
+- **Key classes**: `DeliveryWorkItemController`, `DeliveryTimeLoggerController`, `DeliveryWorkflowConfigService`, `DeliveryWorkItemETAService`, `DeliveryWorkItemQueryService`
+- **Where to look in the UI**: Delivery Hub → **Board**, **Timeline**, **WorkItem** tab, **Workspace** tab
+- **Triggers**: `DeliveryWorkItemTrigger`, `DeliveryWorkLogTrigger`, `DeliveryWorkItemCommentTrigger`, `DeliveryDependencyTrigger`, `DeliveryWorkRequestTrigger`
+
+---
+
+## Layer 2 — Sync & integration
+
+Bidirectional REST sync between Salesforce orgs plus inbound channels (email, Slack, webhooks).
+
+- **Objects**: `SyncItem__c` (audit ledger; `StatusPk__c` = Queued / Staged / Synced / Failed / Pending), `NetworkEntity__c` (connected org or external system)
+- **Key classes**: `DeliverySyncEngine`, `DeliverySyncItemProcessor`, `DeliverySyncItemIngestor`, `DeliverySyncItemPendingResolver`, `DeliveryHubSyncService` (REST gateway), `DeliveryHubPoller`, `DeliveryInboundEmailHandler`, `DeliverySlackInboundHandler`, `DeliverySlackOutboundService`, `DeliveryWebhookReceiver`
+- **REST surfaces**: `/deliveryhub/v1/sync/*` (org-to-org), inbound webhook handlers for `IntegrationProvider__mdt` (Stripe ships out of box), Slack Event API at `/services/apexrest/slack/events`
+- **Where to look in the UI**: **NetworkEntity** tab (connection management), **SyncItem** tab (audit ledger), admin Home → **Sync Retry Panel**, **WorkRequest** tab
+
+Echo suppression is three-layered (X-Global-Source-Id gateway check, in-memory `blockedOrigins`, kill-switch in `captureChanges`). The pending queue (PR #758 added dual-FK support for WorkItemDependency) self-heals via the 15-minute scheduler.
+
+---
+
+## Layer 3 — Observability
+
+Audit trail + daily operations digest.
+
+- **Objects**: `ActivityLog__c` (with SHA-256 hash chain via `DeliveryAuditChainService`), `WatcherDigest__c` (per-run digest snapshot)
+- **Key classes**: `DeliveryAuditChainService`, `DeliveryActivityLogCleanup`, `DeliveryWatcherService` (orchestrator), `WatcherDigestRunQueueable`, signal query services (`WatcherARAgingQueryService`, `WatcherFailedSyncTrendQueryService`, etc.), `DeliveryWatcherDigestFormatter`, `deliveryWatcherDigestHistory` (LWC), `deliveryAuditChainViewer` (LWC), `deliveryOnboardingHistory` (LWC)
+- **CMT**: `TrackedField__mdt` (declarative field-change tracking — add a row to track any field)
+- **Where to look in the UI**: **WatcherDigest** tab (history), **ActivityLog** tab, admin Home → activity dashboard, Permission Analyzer tab
+- **Watcher v1 signals shipped**: Signal 1 (SLA Breach), Signal 2 (Stuck Stage), Signal 3 (A/R Aging). 4 additional signal slots are stubbed for activation.
+
+Master flag: `EnableWatcherDigestDateTime__c` on `DeliveryHubSettings__c`. Recipient list: `WatcherDigestRecipientUserIdsTxt__c`. Per-signal toggles: `EnableWatcherSLABreachDateTime__c`, `EnableWatcherStuckStageDateTime__c`, `EnableWatcherARAgingDateTime__c` (all defaulted on install).
+
+---
+
+## Layer 4 — Feature Catalog
+
+Self-describing registry of all toggleable features in the package. Driven by `FeatureDefinition__mdt` (static catalog) + `Feature__c` (runtime state).
+
+- **Objects**: `Feature__c` (runtime — one per shipped feature, install handler seeds), `FeatureDependency__c` (Hard/Soft dependencies, optional CascadeDirection)
+- **CMT**: `FeatureDefinition__mdt` (catalog entries; each Feature__c links back via `FeatureDefinitionTxt__c`)
+- **Key classes**: `DeliveryFeatureCatalogController` (LWC controller), `DeliveryFeatureGraphService` (BFS cascade computation), `DeliveryFeatureSyncService` (bidirectional Feature__c ↔ DeliveryHubSettings__c.Enable*DateTime__c mirror), `DeliveryFeatureTriggerHandler`, `DeliveryFeatureDepEditorController`
+- **LWCs**: `deliveryFeatureCockpit` (catalog browse + admin toggle), `deliveryFeatureCascadePreview` (modal — shows what else would flip), `deliveryFeatureDependencyEditor` (inline dependency edit on Feature__c record page from PR #819)
+- **Where to look in the UI**: **Feature** tab, admin Home → **Feature Catalog** card, Feature record page → Dependencies inline editor
+
+When an admin toggles a feature, `toggleFeature` → onboarding gate check → cascade enforcement (refuses Hard violations and auto-opens the preview modal) → `Feature__c` update → trigger → `ActivityLog__c` row + Settings mirror.
+
+---
+
+## Layer 5 — Onboarding gates
+
+Checkr-style gated onboarding tracks. A non-admin cannot enable a feature until they've walked the linked track.
+
+- **Objects**: `OnboardingProgress__c` (per-user per-track runtime state — lessons completed, quiz score + attempts, checklist state JSON, completion stamp)
+- **CMTs**: `OnboardingTrack__mdt` (the track itself, links to a FeatureDefinition), `OnboardingLesson__mdt`, `OnboardingQuiz__mdt` (with `AllowRetryDateTime__c` catalog flag), `OnboardingChecklistItem__mdt` (Manual / SoqlQuery / RestCall / WebhookReceived types)
+- **Key classes**: `DeliveryOnboardingService` (Manual evaluator + completion stamp), `DeliveryClientOnboardingController` (LWC controller)
+- **LWCs**: `deliveryFeatureOnboarding` (lessons → quiz → checklist), `deliveryClientOnboarding`
+- **Where to look in the UI**: Feature card → "Start onboarding" when the user lacks the gate; **Feature** record page side panel
+- **Sample track shipped**: `Invoice_Generation_Track` (3 lessons + 1 quiz + 3 checklist items). Clone this as a template for custom tracks.
+- **Status**: Manual evaluator is fully implemented. SoqlQuery / RestCall / WebhookReceived evaluators are PR 4 stubs (items render and gate, but always fail eval) — see [e2e-walkthrough audit](audits/e2e-walkthrough-2026-05-21.md) Flow 3.
+
+---
+
+## Layer 6 — Dev-loop mirror
+
+DH is the **mirror**, not the orchestrator. Scratch-org provisioning happens in CumulusCI / GitHub Actions; DH records the result.
+
+- **Objects**: `ScratchOrgInstance__c` (per-scratch-org record — orgId, branch, login URL, CCI flow, state, expiry, optional WorkItem link)
+- **CMT**: `DevLoopGuide__mdt` (named workflow guides — 4 seed records ship)
+- **Key classes**: REST endpoints in `DeliveryPublicApiService.cls` (`postScratchOrg`, `patchScratchOrg`)
+- **LWCs**: `deliveryDevLoopGuide`
+- **REST routes**: `POST /deliveryhub/v1/api/scratch-orgs` (create on provision), `PATCH /deliveryhub/v1/api/scratch-orgs/{id}` (update state on teardown)
+- **Where to look in the UI**: **ScratchOrgInstance** tab, **DevLoopGuide** card
+- **Status**: REST endpoints exist and ship; an example `.github/workflows/` file calling them is **not yet shipped** (subscriber devs must write their own).
+
+---
+
+## Layer 7 — Dataset templates
+
+Per-feature sample-data loading via the `load_feature_data` CCI task.
+
+- **Objects**: `DatasetTemplate__c` (catalog entry — feature, NetworkEntity scope, mapping YAML path, Apex script path, estimated record count), `DatasetTemplateAssignment__c` (audit trail of which org loaded which template — currently no writer)
+- **Key classes**: `DeliveryDatasetController`
+- **LWC**: `deliveryDatasetTemplates` (lists available templates + copies the CLI command)
+- **CCI task**: `load_feature_data` in `cumulusci.yml` (parameterized wrapper around `scripts/feature-data/<name>.apex`)
+- **Where to look in the UI**: cockpit → **Dataset Templates** card
+- **Status**: `invoice_generation.apex` ships as the only per-feature dataset script. Other features will need their own scripts. `DatasetTemplateAssignment__c` rows are not auto-inserted after a successful load — manual provenance only.
+
+---
+
+## Layer 8 — Approval framework
+
+Multi-step cascading approvals for feature toggle requests, with caller-is-approver enforcement and in-app notifications.
+
+- **Objects**: `FeatureToggleRequest__c` (the request — feature, Enable/Disable action, reason, status), `FeatureToggleApproval__c` (one per step in the BFS-derived approval chain — assigned approver, required-by date, decision, note, StepNumber)
+- **Key classes**: `DeliveryFeatureApprovalService` (`submit` / `grant` / `reject` / `apply` — caller-is-approver enforced from PR #815), `DeliveryFeatureGraphService` (BFS cascade graph that determines the approval chain depth)
+- **LWCs**: `deliveryFeatureApprovalInbox` (admin inbox — pending approvals for the current user), `deliveryFeatureApprovalSubmit` (submission modal from cockpit entry point — PR #818)
+- **Notification layer (PR #822)**: `DeliveryNotificationService` + `DeliveryNotificationQueueable` fire on submit / grant / reject / onboarding-completion via the `Delivery_Hub_Alert` CustomNotificationType. Bell notifications + mobile push.
+- **REST**: `POST /features/{name}/toggle` (submit), `POST /feature-toggle-approvals/{id}/grant`, `POST /feature-toggle-approvals/{id}/reject`, `GET /feature-toggle-requests` (paginated)
+- **Where to look in the UI**: admin Home → **Approval Inbox** card, cockpit → **Submit Request** button on any feature with `RequiresApprovalCheckbox__c` semantics, **FeatureToggleRequest** tab (audit)
+- **Gaps**: `ApproverUserLookup__c` is null at create — admin must edit each row to assign the approver (auto-routing via `ApprovalRouting__mdt` is on the v2 roadmap).
+
+---
+
+## Cross-layer integration
+
+The layers are independently testable but compose at runtime:
+
+```
+admin clicks Enable in deliveryFeatureCockpit (Layer 4)
+  ↓
+toggleFeature(featureId)
+  ↓
+Layer 5: onboarding gate check (DeliveryOnboardingService — refuses non-admins without complete track)
+  ↓
+Layer 4: cascade enforcement (DeliveryFeatureGraphService — refuses Hard violations, opens preview modal)
+  ↓
+Layer 8: if RequiresApproval, submit FeatureToggleRequest instead of flipping (deliveryFeatureApprovalSubmit)
+  ↓
+Layer 4: Feature__c.EnabledDateTime__c stamped
+  ↓
+Layer 2/3: DeliveryFeatureTriggerHandler → ActivityLog__c row (Layer 3 hash chain) + Settings mirror (Layer 4 sync)
+  ↓
+Layer 8 notification: DeliveryNotificationService.notifyFeatureToggled (in-app bell)
+```
+
+Watcher (Layer 3) reads from all layers (sync drift, SLA-breached WorkItems, A/R aging from DeliveryDocument__c / DeliveryTransaction__c) and publishes the daily digest to `WatcherDigest__c` + Slack.
+
+---
+
+## What's *not* in the cockpit (yet)
+
+Documented for transparency in [docs/audits/e2e-walkthrough-2026-05-21.md](audits/e2e-walkthrough-2026-05-21.md):
+
+- Approver **auto-assignment** (currently null at create — admin opens row to set)
+- Non-Manual onboarding **checklist evaluators** (SoqlQuery / RestCall / WebhookReceived stubs)
+- **Example GitHub Action** workflow for the `/scratch-orgs` endpoint
+- Per-feature **dataset scripts** beyond `invoice_generation.apex`
+- `DatasetTemplateAssignment__c` **auto-write** after a successful load
+- Approval **chain auto-routing** via `ApprovalRouting__mdt`
+
+These are tracked as follow-on cycles; the cockpit is **roughly 60% end-to-end** for the happy-path user as of `release/0.248.0.3`.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 This guide walks you through installing Delivery Hub, running the setup wizard, creating your first work item, and optionally configuring cross-org sync, document signing, and external API access.
 
-**Current release**: `0.239` — see the [Changelog](CHANGELOG.md) for the full history. (CHANGELOG entries through 0.200 are PR-by-PR; later releases ship as a stream of named PRs — see the GitHub release tags `release/0.201.x` … `release/0.239.x` for the per-version manifests.)
+**Current release**: `release/0.248.0.3` (production-promoted 2026-05-25). See [GitHub Releases](https://github.com/Nimba-Solutions/Delivery-Hub/releases) for the full version history (CHANGELOG entries through 0.200 are PR-by-PR; later releases ship as named PRs tagged in GitHub Releases). For the install + smoke-test runbook, see [SETUP.md](SETUP.md). For the cockpit-era 8-layer architecture, see [COCKPIT.md](COCKPIT.md).
 
 ---
 

--- a/docs/PUBLIC_API_GUIDE.md
+++ b/docs/PUBLIC_API_GUIDE.md
@@ -68,6 +68,8 @@ Error responses:
 
 ## Endpoints
 
+### Portal & work items
+
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/api/dashboard` | Portal dashboard with counts and phase distribution |
@@ -76,18 +78,56 @@ Error responses:
 | POST | `/api/work-items` | Create a new work item request |
 | POST | `/api/work-items/{id}/comments` | Add a comment to a work item |
 | GET | `/api/activity-feed` | Unified timeline of comments, work logs, and changes |
-| GET | `/api/work-logs` | All work logs for the authenticated entity |
+| GET | `/api/conversations` | Comment threads for entity work items |
+| GET | `/api/work-logs` | All work logs for the authenticated entity (filter: `?workItemId=`) |
 | POST | `/api/log-hours` | Create a new work log entry |
 | GET | `/api/pending-approvals` | Draft work logs awaiting approval |
 | POST | `/api/approve-worklogs` | Batch approve draft work logs |
 | POST | `/api/reject-worklogs` | Batch reject draft work logs |
-| GET | `/api/board-summary` | AI-generated board summary |
+| GET | `/api/board-summary` | AI-generated board summary (returns `summary: null` when AI is not configured or no data) |
 | GET | `/api/files` | Files attached to the entity's work items |
+
+### Portal-user (multi-entity) headers
+
+| Header | Description |
+|--------|-------------|
+| `X-Portal-User` | Email of the portal user (validated against `PortalAccess__c`) |
+| `?entityId=<id>` query param | When `X-Portal-User` is present, selects which of the user's entities the request is scoped to |
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/my-entities` | Entities accessible by the portal user (requires `X-Portal-User`) |
+| GET | `/api/portal-users` | Portal users for the active entity (requires `X-Portal-User`) |
+
+### Documents & signing
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
 | GET | `/api/documents` | Generated documents (invoices, statements) for the entity |
 | GET | `/api/documents/{token}` | Document detail by public token — includes `signingRequired`, `signingComplete`, `signingSlots[]`, `hashChainVerified` for signing-required templates |
 | POST | `/api/document-approve` | Approve a document by public token |
 | POST | `/api/document-dispute` | Dispute a document with reason by public token |
-| POST | `/sign/{signerToken}` | Public signing endpoint — accepts `Text` or `Image` (base64 PNG) signatures. No `X-Api-Key` required; signer token is the credential. |
+| POST | `/sign/{signerToken}` | Public signing endpoint — accepts `Text` or `Image` (base64 PNG) signatures. No `X-Api-Key` required; signer token is the credential. See [DOCUMENT_ACTIONING_FEATURE.md](DOCUMENT_ACTIONING_FEATURE.md). |
+
+### Feature cockpit (Layer 8 — approvals)
+
+These routes are **org-wide, not entity-scoped**. Any caller with a valid `X-Api-Key` can read/submit feature requests; entity-scoping is not currently applied. Per-tenant feature scoping is on the v2 roadmap.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/features/{name}/toggle` | Submit a `FeatureToggleRequest__c`. Body: `{ "action": "Enable" \| "Disable", "reason": "..." }`. **Idempotent** (PR #813) — submitting the same `(feature, action)` while a Pending or Granted row exists returns the existing requestId rather than inserting a duplicate. |
+| GET | `/api/feature-toggle-requests` | Paginated list. Filters: `?status=Pending\|Granted\|Applied\|Rejected\|RolledBack`, `?feature=<name>`, `?pageOffset=<n>`. Returns `{data, offset, pageSize, hasMore}` envelope (PR #813). |
+| POST | `/api/feature-toggle-approvals/{id}/grant` | Approver grants an approval step. Body: `{ "note": "..." }`. Caller is asserted to be the assigned approver (PR #815). |
+| POST | `/api/feature-toggle-approvals/{id}/reject` | Approver rejects an approval step. Body: `{ "note": "..." }`. Caller-is-approver enforced. |
+
+### Dev-loop mirror (Layer 6)
+
+These routes are intentionally **tenant-less** (no portal-entity scoping). They're invoked by CI / GitHub Actions to record scratch-org provenance. The X-Api-Key check still authenticates the caller.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/scratch-orgs` | Insert a `ScratchOrgInstance__c` row. Body: `{branch, orgId, loginUrl, cciFlow, workItemName (opt), expiresAt (opt ISO-8601)}`. Returns `{id, state: "Active"}`. |
+| PATCH | `/api/scratch-orgs/{id}` | Update state on teardown. Body: `{state, lastSyncAt (opt)}`. State must match a `ScratchOrgState` GVS value. **Rate-limited** since PR #813 (previously bypassed the gate). |
 
 ---
 
@@ -1205,6 +1245,250 @@ On dispute:
 
 ---
 
+### POST /api/features/{name}/toggle
+
+Submits a `FeatureToggleRequest__c` requesting that a feature be enabled or disabled. The `{name}` segment matches `Feature__c.Name` or `FeatureDefinitionTxt__c` (case-insensitive). Org-wide route — no per-tenant scoping.
+
+**Idempotent (PR #813):** if a Pending or Granted request for the same `(feature, action)` already exists, the existing request is returned with HTTP 200 rather than inserting a duplicate. New requests return HTTP 201.
+
+**Request**:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -H "X-Api-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "action": "Enable",
+    "reason": "Need invoice generation for the May billing cycle."
+  }' \
+  "YOUR_INSTANCE_URL/services/apexrest/delivery/deliveryhub/v1/api/features/Invoice_Generation/toggle"
+```
+
+**Request body**:
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `action` | Yes | String | `Enable` or `Disable` |
+| `reason` | No | String | Free-text rationale, surfaced in approval UI |
+
+**Response** (201 — new request, or 200 — idempotent return):
+
+```json
+{
+    "success": true,
+    "data": {
+        "requestId": "a0bxx0000000001AAA",
+        "featureId": "a0axx0000000001AAA",
+        "status": "Pending"
+    }
+}
+```
+
+**Errors**:
+
+| Code | Condition |
+|------|-----------|
+| 400 | Missing/blank `action`, or value not in {Enable, Disable} |
+| 400 | Service-side validation failure (e.g., cascade Hard-dependency violation) |
+| 404 | No feature found matching `{name}` |
+
+---
+
+### GET /api/feature-toggle-requests
+
+Paginated list of `FeatureToggleRequest__c` rows. Returns an envelope (PR #813) with `hasMore` so clients can page through.
+
+**Query parameters**:
+
+| Parameter | Required | Values | Description |
+|-----------|----------|--------|-------------|
+| `status` | No | `Pending`, `Granted`, `Applied`, `Rejected`, `RolledBack` | Filter by request status |
+| `feature` | No | Feature name | Filter by `Feature__c.Name` |
+| `pageOffset` | No | Integer ≥ 0 | LIMIT/OFFSET pagination cursor (page size = 50) |
+
+**Request**:
+
+```bash
+curl -s \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -H "X-Api-Key: YOUR_API_KEY" \
+  "YOUR_INSTANCE_URL/services/apexrest/delivery/deliveryhub/v1/api/feature-toggle-requests?status=Pending&pageOffset=0"
+```
+
+**Response** (200):
+
+```json
+{
+    "success": true,
+    "data": {
+        "data": [
+            {
+                "id": "a0bxx0000000001AAA",
+                "featureId": "a0axx0000000001AAA",
+                "featureName": "Invoice_Generation",
+                "action": "Enable",
+                "status": "Pending",
+                "reason": "Need invoice generation for the May billing cycle.",
+                "requestedAt": "2026-05-26T12:34:56.000Z"
+            }
+        ],
+        "offset": 0,
+        "pageSize": 50,
+        "hasMore": false
+    }
+}
+```
+
+The `hasMore` field is a heuristic (true when the LIMIT was filled). To page through, increment `pageOffset` by `pageSize` until `hasMore` is false.
+
+---
+
+### POST /api/feature-toggle-approvals/{id}/grant
+
+Grants an individual approval step in the multi-step cascading chain. The `{id}` is the `FeatureToggleApproval__c.Id`. **Caller is asserted to be the assigned approver** (`ApproverUserLookup__c`) since PR #815 — non-approvers receive a 400.
+
+**Request**:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -H "X-Api-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "note": "Approved — billing window is locked." }' \
+  "YOUR_INSTANCE_URL/services/apexrest/delivery/deliveryhub/v1/api/feature-toggle-approvals/a0cxx0000000001AAA/grant"
+```
+
+**Response** (200):
+
+```json
+{
+    "success": true,
+    "data": {
+        "approvalId": "a0cxx0000000001AAA",
+        "status": "Granted",
+        "requestId": "a0bxx0000000001AAA",
+        "requestStatus": "Granted"
+    }
+}
+```
+
+When the final approval step in the chain grants, the parent `FeatureToggleRequest__c.StatusPk__c` advances to `Granted` (then `Applied` once the toggle apply queueable runs).
+
+---
+
+### POST /api/feature-toggle-approvals/{id}/reject
+
+Rejects an approval step. Same caller-is-approver enforcement as `grant`. Rejecting any step in the chain rolls the parent request to `Rejected`.
+
+**Request**:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -H "X-Api-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "note": "Wait for the security review before enabling this." }' \
+  "YOUR_INSTANCE_URL/services/apexrest/delivery/deliveryhub/v1/api/feature-toggle-approvals/a0cxx0000000001AAA/reject"
+```
+
+**Response** (200): same shape as `/grant` with `status: "Rejected"`.
+
+---
+
+### POST /api/scratch-orgs
+
+**Dev-loop mirror — Layer 6.** Invoked by CumulusCI / GitHub Actions after a scratch org is provisioned, to record provenance in `ScratchOrgInstance__c`. Tenant-less by design (no per-portal-entity scoping) — auth is the X-Api-Key check only.
+
+**Request**:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -H "X-Api-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "orgId": "00DSB000005xY1z",
+    "branch": "feature/cockpit-pr8",
+    "loginUrl": "https://scratch-org-12345.my.salesforce.com",
+    "cciFlow": "ci_feature",
+    "workItemName": "WI-0123",
+    "expiresAt": "2026-06-05T00:00:00Z"
+  }' \
+  "YOUR_INSTANCE_URL/services/apexrest/delivery/deliveryhub/v1/api/scratch-orgs"
+```
+
+**Request body**:
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `orgId` | Yes | String | The 15- or 18-char Salesforce Org ID. Also used as `Name` for the inserted row. |
+| `branch` | No | String | Source-control branch the scratch was built from |
+| `loginUrl` | No | URL | Scratch org's login URL |
+| `cciFlow` | No | String | CCI flow used to build (e.g., `ci_feature`, `dev_org`) |
+| `workItemName` | No | String | If matches an existing `WorkItem__c.Name`, links the scratch to that WI |
+| `expiresAt` | No | ISO-8601 DateTime | Scratch expiry; malformed values fall back to null |
+
+**Response** (201):
+
+```json
+{
+    "success": true,
+    "data": {
+        "id": "a0dxx0000000001AAA",
+        "state": "Active"
+    }
+}
+```
+
+**Note:** `OrgIdTxt__c` is not unique-constrained — submitting the same orgId twice creates two rows. On-retry idempotency is on the v2 roadmap. If GitHub Actions is the only caller, the network-retry surface is small.
+
+---
+
+### PATCH /api/scratch-orgs/{id}
+
+Updates a `ScratchOrgInstance__c` row's state (typically on teardown). **Rate-limited since PR #813** (previously the PATCH path bypassed the rate-limit gate).
+
+**Request**:
+
+```bash
+curl -s -X PATCH \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -H "X-Api-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "state": "Deleted", "lastSyncAt": "2026-05-26T15:00:00Z" }' \
+  "YOUR_INSTANCE_URL/services/apexrest/delivery/deliveryhub/v1/api/scratch-orgs/a0dxx0000000001AAA"
+```
+
+**Request body**:
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `state` | Yes | String | Must match a `ScratchOrgState` GVS value (`Active`, `Deleted`, `Expired`, etc.) |
+| `lastSyncAt` | No | ISO-8601 DateTime | When the state transition was observed. Defaults to `Datetime.now()` when blank. |
+
+**Response** (200):
+
+```json
+{
+    "success": true,
+    "data": {
+        "id": "a0dxx0000000001AAA",
+        "state": "Deleted"
+    }
+}
+```
+
+**Errors**:
+
+| Code | Condition |
+|------|-----------|
+| 400 | Missing/blank `state` or unparseable `lastSyncAt` |
+| 404 | No scratch-org row with the given id |
+| 500 | DML failure |
+
+---
+
 ## Authentication
 
 ### How It Works
@@ -1275,6 +1559,8 @@ All data is scoped to the authenticated NetworkEntity. The API key determines wh
 ## Rate Limiting
 
 The Public API supports opt-in rate limiting to protect org resources. When enabled, each NetworkEntity is limited to a configurable number of requests per hour.
+
+**Coverage:** GET, POST, **and PATCH** all run through the rate-limit gate. The PATCH gap was closed in PR #813 (previously `PATCH /api/scratch-orgs/{id}` bypassed throttling — a caller with a valid X-Api-Key could submit unlimited PATCH calls). See [docs/audits/rest-api-surface-review-2026-05-21.md](audits/rest-api-surface-review-2026-05-21.md) §3 for the audit finding.
 
 ### Configuration
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,229 @@
+# Delivery Hub Setup Guide
+
+Step-by-step install + smoke test for `release/0.248.0.3` (current production-promoted release as of 2026-05-25). The newest beta on top is `release/0.249.x` carrying the in-app notification layer (PR #822).
+
+For deep architecture, see [ARCHITECTURE.md](ARCHITECTURE.md). For per-layer cockpit reference, see [COCKPIT.md](COCKPIT.md). For end-user walkthroughs (first work item, document signing, AI), see [GETTING_STARTED.md](GETTING_STARTED.md).
+
+---
+
+## 1. Pre-install checklist
+
+You need:
+
+- A Salesforce org with **My Domain enabled** (required for the LWC bundles)
+- **System Administrator** profile or equivalent for the installing user
+- Outbound network access from your org to your Slack workspace (optional, only if you'll use Watcher's Slack post)
+- For developer / contributor work only:
+  - [CumulusCI](https://cumulusci.readthedocs.io/) installed (`pip install cumulusci`)
+  - A Salesforce **Dev Hub** org with scratch-org allocations available
+  - The Salesforce CLI (`sf` or `sfdx`)
+
+Subscribers do **not** need CCI or a Dev Hub to install — only contributors and CI do.
+
+---
+
+## 2. Install the package
+
+### Production org
+
+[![Install in Production](https://img.shields.io/badge/Install-Production-0070d2?logo=salesforce&style=for-the-badge)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000T0SrIAK)
+
+### Sandbox / scratch / pre-prod
+
+[![Install in Sandbox](https://img.shields.io/badge/Install-Sandbox-3e8b3e?logo=salesforce&style=for-the-badge)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000T0SrIAK)
+
+The install links point at the latest **promoted** release. To install a specific version, browse [GitHub Releases](https://github.com/Nimba-Solutions/Delivery-Hub/releases) and use that tag's install URL.
+
+**At the install prompt**: select **Install for All Users** (recommended). The package install handler (`DeliveryHubInstallHandler.onInstall`) runs automatically and:
+
+- Seeds default `DeliveryHubSettings__c` values (including the 14 Watcher settings — master flag stays off; 3 per-signal flags default on)
+- Seeds `Feature__c` rows from `FeatureDefinition__mdt` (Layer 4)
+- Schedules all background jobs via `DeliveryHubScheduler.scheduleAll()` (idempotent)
+- Backfills permset assignments for existing users via `UserAutoAssignConfig__mdt`
+- Backfills stale `Status='New'` WorkItems
+
+### Known CI quirk
+
+- `install-beta` job in CI is **known to fail** on a DeliveryHubSite error — this does NOT block promotion. Safe to promote when `upload-beta` is green. (Documented in `CLAUDE.md`.)
+
+---
+
+## 3. Assign permission sets
+
+| Permset | Who gets it | Apex name |
+|---|---|---|
+| `DeliveryHubApp` | All end users | `DeliveryHubApp` |
+| `DeliveryHubAdmin_App` | Admins, superusers | `DeliveryHubAdmin_App` |
+| `DeliveryHubGuestUser` | Site Guest profile (only if exposing public API) | `DeliveryHubGuestUser` |
+| `Delivery_Hub_Gantt_Fullscreen` | Optional, anyone using full-screen Gantt | `Delivery_Hub_Gantt_Fullscreen` |
+
+### Quickest assignment (current user — admin)
+
+```apex
+PermissionSet ps = [SELECT Id FROM PermissionSet WHERE Name = 'DeliveryHubAdmin_App'];
+insert new PermissionSetAssignment(
+    AssigneeId      = UserInfo.getUserId(),
+    PermissionSetId = ps.Id
+);
+```
+
+### Bulk assignment via SF CLI
+
+```bash
+sf org assign permset --name DeliveryHubAdmin_App --target-org YOUR_ALIAS
+```
+
+### From Setup UI
+
+Setup → **Permission Sets** → click the permset → **Manage Assignments** → **Add Assignments** → pick users → **Assign**.
+
+---
+
+## 4. Initial smoke test
+
+After install + permset assignment, walk this checklist to verify the install came up clean:
+
+### 4.1 Apps and tabs visible
+
+1. **App Launcher** → search "Delivery Hub" → both **Delivery Hub** and **Delivery Hub Admin** apps should appear.
+2. Open **Delivery Hub Admin**.
+3. Tabs along the top should include: `Home`, `Workspace`, `WorkItem`, `Board`, `Timeline`, `Activity`, `Activity Dashboard`, `NetworkEntity`, `WorkRequest`, `WorkItemComment`, `SyncItem`, `ActivityLog`, **`Feature`**, **`FeatureToggleRequest`**, **`WatcherDigest`**, **`ScratchOrgInstance`**, `Permission Analyzer`, `Settings`, `Guide`, `Reports`.
+
+The four bolded tabs are the cockpit additions. If they're missing, re-check the `DeliveryHubAdmin_App` permset assignment.
+
+### 4.2 Cockpit visible
+
+1. Open the **Home** tab in **Delivery Hub Admin**.
+2. The **Feature Catalog** card should render with seeded `Feature__c` rows (Layer 4).
+3. The **Approval Inbox** card should render (likely empty on a fresh install — that's correct).
+
+### 4.3 Quickstart Connection wizard
+
+1. On the Home tab, find the **Getting Started** card.
+2. Click **Quickstart Connection** — this configures scheduled jobs, connection handshake, and default settings.
+3. The connection-health indicator should flip to **Connected** within a few seconds.
+
+### 4.4 Scheduled jobs
+
+Setup → **Apex Jobs** → **Scheduled Jobs**. You should see:
+
+- `DeliveryHubScheduler` (15-minute tick)
+- `DeliveryActivityLogCleanup` (daily)
+- Plus a handful of feature-specific jobs (poller, reconciliation, weekly digest, etc.)
+
+If the list is empty, the install handler didn't run. Re-run manually:
+
+```apex
+delivery.DeliveryHubScheduler.scheduleAll();
+```
+
+### 4.5 Toggle a feature (admin context — no approval gate)
+
+1. On the **Feature Catalog** card, find a feature with `EnabledDateTime__c` null.
+2. Click **Enable** (admin context bypasses the onboarding gate).
+3. The card should flip to enabled; an `ActivityLog__c` row should be written; the corresponding `DeliveryHubSettings__c.Enable*DateTime__c` field should be mirrored.
+
+Inspect the audit row in the **ActivityLog** tab or via the `deliveryAuditChainViewer` LWC if added to a flexipage.
+
+---
+
+## 5. Optional setup steps
+
+### 5.1 Enable Watcher daily digest
+
+`WatcherDigest__c` rows accumulate from install (the 3 active signals fire), but **Slack post stays off** until you set:
+
+```apex
+delivery__DeliveryHubSettings__c s = delivery__DeliveryHubSettings__c.getOrgDefaults();
+s.delivery__EnableWatcherDigestDateTime__c        = Datetime.now();
+s.delivery__WatcherDigestRecipientUserIdsTxt__c   = '005...,005...';       // comma-separated User Ids
+s.delivery__WatcherSlackWebhookUrlTxt__c          = 'https://hooks.slack.com/...';
+upsert s;
+```
+
+The per-signal flags (`EnableWatcherSLABreachDateTime__c`, `EnableWatcherStuckStageDateTime__c`, `EnableWatcherARAgingDateTime__c`) default to enabled at install — toggle them off individually if you want to silence a signal without disabling the whole digest.
+
+To view past digest runs, use the **WatcherDigest** tab or the `deliveryWatcherDigestHistory` LWC.
+
+### 5.2 Enable cross-org sync
+
+See [GETTING_STARTED.md §5](GETTING_STARTED.md#5-set-up-cross-org-sync-optional) for the full vendor-org + client-org setup. Summary:
+
+1. Create a `NetworkEntity__c` on each side (one as Client, one as Vendor)
+2. Add Remote Site Settings for the peer's domain
+3. Create a `WorkRequest__c` linking a WorkItem to the vendor NetworkEntity
+4. Optionally set `HmacSecretTxt__c` for HMAC-signed payloads
+5. Optionally set `ApiKeyTxt__c` for API-key auth
+
+### 5.3 Configure billing entity
+
+```apex
+delivery__DeliveryHubSettings__c s = delivery__DeliveryHubSettings__c.getOrgDefaults();
+s.delivery__DefaultBillingEntityIdTxt__c = '<NetworkEntity Id>';
+upsert s;
+```
+
+### 5.4 Configure OpenAI for AI features
+
+Open **Delivery Hub Admin** → **Settings** tab → **AI Settings** → enter your OpenAI API key → Save.
+
+This enables auto-drafting of work-item descriptions + acceptance criteria + weekly digest AI narratives.
+
+---
+
+## 6. Upgrades
+
+The package upgrades cleanly via the install link — `DeliveryHubInstallHandler.onInstall` is idempotent. New settings get defaulted; new Feature__c rows get seeded; no data migration steps are required.
+
+**One CI/CD note** specific to subscribers running the package in a downstream scratch / unlocked install:
+
+- After upgrade, run `delivery.DeliveryHubScheduler.scheduleAll();` from anonymous Apex if you suspect scheduled jobs didn't re-register.
+- For sync-heavy installs, run a reconciliation once after major upgrades: `delivery.DeliverySyncReconciler.reconcileAll();`
+
+---
+
+## 7. Common gotchas
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `install-beta` CI job fails on DeliveryHubSite | Known issue; doesn't block promotion | Ignore; promote when `upload-beta` is green |
+| LWC throws "object not found" at `[WorkItem__c]` | Calling without namespace in subscriber context | Use `[delivery__WorkItem__c]` — fixed broadly in PR #777, but custom code may still hit it |
+| `Schema.getGlobalDescribe().get('Foo__c')` returns null | `delivery__` namespaced packaging context | Use typed `Foo__c.SObjectType.getDescribe()` instead (memory: `namespace-safe-typed-sobject-describe`) |
+| `WITH USER_MODE` SOQL throws in tests | Namespaced package test context breaks USER_MODE | Use `WITH SYSTEM_MODE` |
+| `UNABLE_TO_LOCK_ROW` in CI | Flaky scratch-org contention | Re-run the job |
+| Feature toggle button does nothing for a non-admin | Onboarding gate refusing | The user must complete the linked OnboardingTrack first; admin can bypass |
+| Approval inbox is always empty | `ApproverUserLookup__c` defaults to null on insert | Admin must open each `FeatureToggleApproval__c` row and assign the approver manually (auto-routing is on the roadmap) |
+| `WatcherDigest__c` records exist but Slack never posts | Master `EnableWatcherDigestDateTime__c` flag is null | Set the flag + the webhook URL — see §5.1 |
+| Tabs missing in the Admin app | `DeliveryHubAdmin_App` permset not assigned to the running user | Re-assign the permset |
+
+---
+
+## 8. Anonymous Apex cheat sheet
+
+All of these are safe to run in **Setup → Developer Console → Open Execute Anonymous Window** in a subscriber org (with the `delivery__` namespace prefix). Use without the prefix in the publisher / source org.
+
+```apex
+// Show current settings
+System.debug(delivery__DeliveryHubSettings__c.getOrgDefaults());
+
+// Re-schedule background jobs (idempotent)
+delivery.DeliveryHubScheduler.scheduleAll();
+
+// Force a sync reconciliation (drift detection + repair)
+delivery.DeliverySyncReconciler.reconcileAll();
+
+// Manually run a Watcher digest (independent of cron)
+System.enqueueJob(new delivery.WatcherDigestRunQueueable());
+
+// Generate a fresh API key
+String key = delivery.DeliveryPublicApiService.generateApiKey();
+System.debug('API key: ' + key);
+```
+
+---
+
+## 9. Uninstall
+
+Standard Salesforce package uninstall via Setup → **Installed Packages** → **Uninstall** next to Delivery Hub. All `delivery__` objects, classes, triggers, LWCs, layouts, and tabs are removed.
+
+Custom records created by your team in `WorkItem__c`, `WorkLog__c`, etc. will be **deleted** during uninstall. Export anything you want to retain first.


### PR DESCRIPTION
## Summary

Subscriber-facing docs were pinned at `release/0.239` with no mention of the 50h cockpit plan (Layers 4-8), Watcher v1, REST hardening (PR #813), caller-is-approver guard (PR #815), or notification layer (PR #822). A fresh installer of `release/0.248.0.3` would see the cockpit tabs but have no map for the architecture or how to invoke the REST surface.

This PR closes [`docs/audits/documentation-gap-audit-2026-05-21.md`](docs/audits/documentation-gap-audit-2026-05-21.md). Pure docs — no Apex/LWC/metadata changes.

### Files

- **`README.md`** — rewrite around current state. Pin install link to `release/0.248.0.3`. New 8-layer cockpit overview table. Current Admin-app tab list (incl. Feature / FeatureToggleRequest / WatcherDigest / ScratchOrgInstance). Trim feature-by-feature narrative (still in ARCHITECTURE.md) in favor of a short "What's in the box" cross-reference.
- **`docs/COCKPIT.md`** (new) — per-layer reference for Layers 1-8: objects, classes, LWCs, REST routes, "where to look in the UI", a cross-layer integration sketch (toggle → onboarding gate → cascade → trigger → ActivityLog + Settings mirror → notification), plus an honest "what's not in the cockpit yet" section that cites the e2e-walkthrough audit.
- **`docs/SETUP.md`** (new) — pre-install checklist, install link, permset assignment (Apex + CLI + UI), 5-step smoke test (apps, tabs, cockpit, Quickstart, scheduled jobs), Watcher enablement, common gotchas with the namespace-safe-typed-describe + USER_MODE-in-namespace + getLocalName pitfalls spelled out, anonymous-Apex cheat sheet.
- **`docs/PUBLIC_API_GUIDE.md`** — add endpoint sub-tables (Portal / Cockpit / Dev-loop) and full request/response docs for the 6 previously-undocumented cockpit routes: `POST /features/{name}/toggle` (with idempotency note), `GET /feature-toggle-requests` (pagination envelope), grant/reject, plus `POST/PATCH /scratch-orgs`. Update Rate Limiting section to call out the PATCH gap closed by PR #813.
- **`docs/GETTING_STARTED.md`** — bump pinned version from 0.239 to 0.248.0.3 and add pointers to SETUP.md + COCKPIT.md.

### What I verified against

- Live `force-app/main/default/applications/DeliveryHubAdmin.app-meta.xml` for tabs
- Live `force-app/main/default/classes/DeliveryPublicApiService.cls` for endpoint shapes + status codes + idempotency / rate-limit / pagination behavior
- Live `force-app/main/default/objects/*/fields/` for object field references in COCKPIT.md
- `git log main` for PR-number references (#807-#822)
- `docs/audits/*-2026-05-21.md` audit findings (which fed the "what's not in the cockpit yet" + gotchas)

### What I deliberately did NOT do

- No new endpoints, features, or objects fabricated
- No `docs/audits/` files written (this is README/setup work, not an audit)
- No Apex, LWC, or metadata changes
- Did NOT remove the existing rich feature narrative — that lives on in ARCHITECTURE.md and GETTING_STARTED.md unchanged

## Test plan

- [ ] `cat README.md` — render check, the 8-layer table renders cleanly in GitHub markdown
- [ ] All internal doc links resolve (`docs/COCKPIT.md`, `docs/SETUP.md`, `docs/audits/e2e-walkthrough-2026-05-21.md`, etc.)
- [ ] The install link `https://login.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000T0SrIAK` still points at the current promoted release (unchanged from prior README)
- [ ] Spot-check 2-3 REST endpoint docs against `DeliveryPublicApiService.cls` request/response shape
- [ ] Spot-check the 8-layer table object references against `force-app/main/default/objects/`
- [ ] No prior docs deleted accidentally (`git diff --stat`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)