### PR TITLE
docs(architecture): design principles + contributing guide + flow reference + gap audit refresh

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,152 @@
+# Contributing to Delivery Hub
+
+> Rules of the road for shipping new code, fixes, or docs to the Delivery Hub managed package. Companion to `docs/DESIGN_PRINCIPLES.md` (which explains *what* patterns to follow) — this doc explains *how* to ship them.
+
+Aimed at outside contributors and at internal agent + human authors alike. Where this doc and `CLAUDE.md` conflict, follow `CLAUDE.md` (it captures the internal-tooling rules that govern day-to-day shipping).
+
+---
+
+## 1. Branch + PR workflow
+
+- **Never commit directly to `main`.** Every change ships via branch + PR + CI.
+- Branch naming: `feat/<topic>`, `fix/<topic>`, `chore/<topic>`, `docs/<topic>`, `refactor/<topic>`. Topic is hyphen-cased.
+- PR titles use conventional commits: `feat(cockpit): ...`, `fix(watcher): ...`, etc.
+- One concern per PR. The two-scratch-org cost of each PR (one for feature-test, one for upload-beta) means batching related fixes into fewer PRs is real money — but don't batch unrelated work. Reviewers can't separate it post-hoc.
+- After-merge: every push to `main` triggers `beta_create.yml`. The cumulative beta becomes promoteable when `upload-beta` (not `install-beta`, which has a known flaky DeliveryHubSite failure) reports green.
+
+---
+
+## 2. Apex class naming
+
+- Test class name = production class name + `Test` (no separator). E.g., `DeliveryFeatureApprovalService` → `DeliveryFeatureApprovalServiceTest`.
+- Class name **including namespace prefix** must be ≤ 40 chars (Salesforce hard limit). Because the prefix is `delivery__` (10 chars) + `_Test` suffix (4 chars), production class names should stay **≤ 36 chars** so `*Test` still fits. Above 36 chars and the test class can't deploy.
+- Service class names end in `Service`. Controller class names end in `Controller`. Trigger-handler class names end in `TriggerHandler`. DTO inner classes named `*DTO`. PR review will flag any naming drift.
+- Inner classes used in `global` return / param signatures must themselves be `global`. Forgetting this surfaces as an upload-beta failure with a `Cannot reference non-global class` error.
+
+---
+
+## 3. SOQL + Apex conventions
+
+- `WITH SYSTEM_MODE`, not `WITH USER_MODE`. `WITH USER_MODE` breaks in the namespaced package test context.
+- `getLocalName()`, not `getName()`. The former returns the bare API name; the latter returns the namespace-prefixed name in packaging context.
+- **Typed describe, not `Schema.getGlobalDescribe()`.** Use `<SObject>__c.SObjectType.getDescribe()`. The global-describe form returns null for namespaced custom objects in packaging context. See `docs/DESIGN_PRINCIPLES.md` §4.
+- **PSG admin checks query DeveloperName, accept both forms.** `PermissionSetGroup.DeveloperName IN ('DeliveryHubAdmin', 'delivery__DeliveryHubAdmin')`. See `docs/DESIGN_PRINCIPLES.md` §6.
+- `AuraHandledException.getMessage()` returns a generic string in managed-package context — never write a test that asserts on the message text.
+- LWC boolean `@api` properties cannot default to `true` (LWC1503). Invert the prop name (e.g., `disableX` rather than `enableX` defaulting `true`).
+- LWC templates do not support ternary expressions in API v62 — define a getter on the JS side and reference it from the template.
+
+---
+
+## 4. Custom Settings + Custom Object metadata
+
+- `DeliveryHubSettings__c` is a hierarchy Custom Setting. **Custom Settings only support primitive types** (`Number`, `Text`, `Checkbox`, `DateTime`, `Date`, `Currency`, `Email`, `URL`). `LongTextArea`, `Picklist`, and `Lookup` are platform-forbidden — if your design needs one, convert to `Text(255)` (or move state to a `__c` object).
+- Custom Object `.object-meta.xml` must set the three API-flag triplet consistently:
+  - `enableSharing` (true if Sharing Rules / OWD writeable, false otherwise)
+  - `enableBulkApi` (true unless platform reason to disable)
+  - `enableStreamingApi` (true if record changes drive CDC / platform events)
+  Mismatched values across the triplet are an upload-beta deploy failure.
+- `<fieldManageability>` is only valid on `__mdt` fields. Adding it to a `__c` field is a silent deploy skip + an Apex compile failure at the next service that references the field.
+- Picklist fields on `__c` must use `<valueSetName>` (GVS). Picklist fields on `__mdt` must use inline `<valueSetDefinition>`. The two platforms have opposite rules.
+- **Always grep `docs/FIELD_NAMING.md` before drafting a new field name.** URL/Email/Phone fields drop the typed suffix; Formula fields suffix by return type, not source type; Master-Detail fields use `*Id__c`. Following CLAUDE.md alone is insufficient — the full table is only in `FIELD_NAMING.md`.
+
+---
+
+## 5. Permission set + permset group hygiene
+
+- Every new `__c` object gets explicit field perms in **both** `DeliveryHubAdmin_App` (admin) and `DeliveryHubApp` (user) permsets if user-readable. Admin-only objects (`WatcherDigest__c`, `FeatureToggleApproval__c`, etc.) ship in `DeliveryHubAdmin_App` only.
+- Object-level CRUD goes under `<objectPermissions>` in each permset. Missing object perms is one of the highest-frequency subscriber bug reports (admin can see fields but can't query).
+- `DeliveryHubAdmin` PSG bundles `DeliveryHubAdmin_App`; `DeliveryHubUser` PSG bundles `DeliveryHubApp`. Field/object perms go in the **permsets**, not the PSGs — PSGs are routing only.
+- New CustomTab entries on `__c` objects must appear in both `DeliveryHub.app-meta.xml` and `DeliveryHubAdmin.app-meta.xml` tab lists; otherwise the tab is invisible in the app launcher.
+
+---
+
+## 6. Test helpers + admin context in tests
+
+- **Use `TestDataFactory`.** All new tests should construct test data via the helper class. It defaults to safe values for the high-frequency CI failure classes (Master-Detail FKs, reserved-word fields, picklist allowlist alignment) so individual tests don't have to.
+- **Admin-gated tests must call `Test.calculatePermissionSetGroup()` before querying PSG membership.** A fresh PSG assignment isn't queryable in the same transaction until the platform finishes the asynchronous calculation; `Test.calculatePermissionSetGroup()` forces it synchronously in test context. The canonical helper is `TestDataFactory.makeAdminUser()` (post-PR #821).
+- **`@IsTest`-only classes** for test infrastructure — `TestDataFactory` itself is `@IsTest`. Test infrastructure must not ship as runtime code (no `public` test helpers leaking into production).
+- **Bracket inserts with `triggerDisabled` only when the trigger is the unit under test.** Otherwise let the trigger fire; the integration coverage matters.
+
+---
+
+## 7. PMD ruleset
+
+- CI scanner is **`engine: pmd` only.** The ESLint engine is ignored at the project level — LWC lint runs locally only.
+- **`AvoidDebugStatements` is strictly enforced.** Any `System.debug(...)` call in production code (excluding `@IsTest` classes) fails CI. Use comments or remove.
+- **Severity threshold is 4.** Findings at severity 1-4 break CI; severity 5 is informational. Most ApexDoc / cyclomatic-complexity findings are severity 3-4 and **will** block.
+- ApexDoc `@param` + `@return` are required on every `global` and `@AuraEnabled` method. PR #791 swept `DeliveryDocumentController` for this; new contributions should not regress.
+- Cyclomatic complexity > 10 on a single method must be suppressed with `@SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity')` at the class level, with a comment explaining why (e.g., REST routing tables that fan out by resource).
+
+---
+
+## 8. Pre-merge upload-beta gotcha checklist
+
+The upload-beta job runs in the namespaced `delivery__` packaging context, so it surfaces a different class of failures than the PR-level feature-test job. Before approving a PR for merge, check:
+
+- [ ] **No `Schema.getGlobalDescribe().get('Foo__c')`** anywhere in the diff. Use typed describe.
+- [ ] **PSG admin checks include both forms** (`'DeliveryHubAdmin', 'delivery__DeliveryHubAdmin'`).
+- [ ] **All `global` inner DTOs declared `global`**, not `public`.
+- [ ] **Custom Setting fields are primitive types** (no LongTextArea / Picklist / Lookup on `DeliveryHubSettings__c`).
+- [ ] **Custom Object API-flag triplet aligned** (`enableSharing` / `enableBulkApi` / `enableStreamingApi` consistent for the object's intent).
+- [ ] **`<fieldManageability>` only on `__mdt` fields**, never on `__c`.
+- [ ] **Master-Detail FK populated on test inserts** (PR #770 hotfix — `WorkLog__c.RequestId__c` required).
+- [ ] **Reserved-word fields aren't used as Apex variable names** (`merge`, `share`, `update`, etc.) — Apex parser rejects them as identifiers.
+- [ ] **Picklist fields on `__c` use `<valueSetName>` (GVS)**, not inline `<valueSetDefinition>`.
+- [ ] **Picklist fields on `__mdt` use inline `<valueSetDefinition>`**, not `<valueSetName>` (platform forbids GVS on `__mdt`).
+- [ ] **Rolling-window date assertions anchor on `Date.today()`**, not hardcoded dates — PR #771 hotfix.
+- [ ] **Org-state assertions (e.g., `isSubscriberOrg`, `recommendedCciFlow`) tolerate both namespaced and bare context** — PR #805 / #806 hotfix.
+
+The single most common upload-beta failure shape is "passes feature-test, fails upload-beta with a null deref on `Schema.getGlobalDescribe()` or a typed-describe miss." Grep the diff for `getGlobalDescribe` before approving.
+
+---
+
+## 9. Change log expectation
+
+`docs/CHANGELOG.md` is **not** the source of truth for per-PR detail. Per-PR detail lives in the GitHub PR description. The changelog rolls up themes per release (e.g., "0.243 — 0.247: cockpit feature catalog, Watcher v1, onboarding tracks").
+
+New contributors don't need to edit the changelog as part of a PR. The release-promote step folds the per-PR descriptions into the next changelog section.
+
+---
+
+## 10. Documentation expectation per PR type
+
+| PR type | Doc expectation |
+|---|---|
+| `feat` shipping a new `__c` object | Update `docs/ARCHITECTURE.md` object-model table; add a one-line entry to `docs/FLOW_REFERENCE.md` if it touches a user flow |
+| `feat` shipping a new `__mdt` type | Object-level `<description>` block in the `.object-meta.xml` (admin-readable in Setup) |
+| `feat` shipping a new REST route | Inline ApexDoc on the route method (verb / path / body shape / status codes); `docs/PUBLIC_API_GUIDE.md` entry for external-facing routes |
+| `feat` shipping a new LWC | Top-of-file `/** @description ... */` block in the `.js` file |
+| `feat` shipping a new Custom Setting field | `<description>` AND `<inlineHelpText>` in the `.field-meta.xml`. Both — the description shows in Setup, the help text shows on the field edit page |
+| `fix` resolving an audit finding | If the audit lives under `docs/audits/`, update the audit doc inline (mark the row resolved or correct the stale claim). PR #807-#816 introduced this discipline; honour it. |
+| `docs` | No production code touched. README + setup + REST API guide and architecture-level docs (`DESIGN_PRINCIPLES`, `CONTRIBUTING`, `FLOW_REFERENCE`) are owned by docs PRs only. |
+
+---
+
+## 11. Org aliases
+
+| Alias | Purpose |
+|---|---|
+| `MF-Prod` | Internal production for the cross-org sync partner |
+| `nimba` | Sandbox where invoices are cut |
+| `dh-prod` | Dev hub org (separate from Nimba) |
+
+When running anonymous Apex against a subscriber org, always prefix with `delivery__` — the deploy artefact is namespaced and bare names won't resolve.
+
+---
+
+## 12. Reporting bugs + getting help
+
+- GitHub Issues: https://github.com/Nimba-Solutions/Delivery-Hub/issues
+- Docs hub: https://cloudnimbusllc.com/docs
+- Internal: post in the relevant Fathom-tracked standup or surface to the next architecture review.
+
+---
+
+## Related reading
+
+- `docs/DESIGN_PRINCIPLES.md` — the eight patterns this contributing guide assumes you'll follow
+- `docs/ARCHITECTURE.md` — the object model + service-layer map
+- `docs/FIELD_NAMING.md` — typed-suffix field naming convention
+- `docs/PICKLIST_INTEGRITY.md` — GVS vs inline picklist deep-dive
+- `docs/PUBLIC_API_GUIDE.md` — public REST surface
+- `CLAUDE.md` — internal-tooling rules for the day-to-day shipping cadence

--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -1,0 +1,171 @@
+# Delivery Hub — Design Principles
+
+> The eight patterns that recur across every Apex service, every custom object, every test, and every PR review. New code that conflicts with one of these patterns is a flag for re-review, not an acceptable variation.
+
+These principles were extracted from the project's CLAUDE.md, the recurring upload-beta and PR-feedback incidents documented in `feedback_*.md` memories, and the post-cycle audit reports under `docs/audits/`. Each section names the pattern, explains the failure mode it prevents, and points at a current call site.
+
+---
+
+## 1. DateTime stamps, not Booleans, for feature toggles
+
+**Pattern.** Every feature-flag field on `DeliveryHubSettings__c` and `Feature__c` is a `DateTime` named `Enable*DateTime__c` (master) or `*EnabledDateTime__c` (per-feature runtime row). Truthy = `!= null`; the value is when the flag was last flipped on.
+
+**Why.** Booleans answer "is it on?" but not "when did it go on?" or "who turned it on?". DateTime stamps unify the toggle state with the audit-trail metadata that admins, support, and the `DeliveryActivityChainService` all need. The same field powers the boolean check, the activation timestamp on `ActivityLog__c.ContextDataTxt__c`, and the "stabilization window" gate for follow-on features (e.g., Phase 2 Watcher uses its own `EnableWatcherDigestDateTime__c` to bootstrap the 14-day heartbeat window before Phase 3 auto-digest unlocks).
+
+**Field-naming corollary.** Per `docs/FIELD_NAMING.md`:
+- New flag → `Enable<Capability>DateTime__c`.
+- Inverted boolean (e.g., suppress / disable) is forbidden in new code; use a positive `Enable*DateTime__c` name even when the default behaviour is "off until enabled."
+
+**Anti-pattern.** `Checkbox` fields for new feature flags. The package is allowed to keep historical `Checkbox` fields (no retrofit), but any new flag goes in as DateTime.
+
+**Reference.** `force-app/main/default/objects/DeliveryHubSettings__c/fields/Enable*DateTime__c.field-meta.xml` (40+ fields). Reader pattern: `DeliveryHubSettings__c.EnableWatcherDigestDateTime__c != null`.
+
+---
+
+## 2. GlobalValueSet from day one, no inline picklists
+
+**Pattern.** Every new picklist field on a `__c` object must declare `<valueSetName>` referencing a `GlobalValueSet`. Inline `<valueSetDefinition>` is forbidden.
+
+**Why.** Salesforce Known Issue `a028c00000qPzYUAA0`: unlocked packages do not reliably propagate **new** values added to restricted inline picklists on subscriber upgrades. The retrofit path is blocked too — Salesforce refuses to swap an existing inline-defined picklist over to a GVS reference ("Cannot change which global value set this picklist uses"). GVS from day one is the only durable path.
+
+**Exception — `__mdt` only.** Salesforce platform forbids `<valueSetName>` on `__mdt` picklist fields. `__mdt` picklists must use inline `<valueSetDefinition>`. Reference patterns: `DashboardCard__mdt.CardTypePk__c`, `IntegrationProvider__mdt.HttpMethodPk__c`, `WorkflowEscalationRule__mdt`'s two picklists.
+
+**Existing inline picklists.** Pre-2026 inline-defined picklists on `__c` objects stay `<restricted>false</restricted>` (so any value is accepted at the DML layer; data quality is a service-layer concern). There is **no longer a runtime picklist-allowlist trigger** — `DeliverySyncItemTriggerHandler.onBeforeInsertOrUpdate` is a documented no-op. Apex services that write picklist values should pass safe known values directly; `TestDataFactory` defaults to allowlist-compliant values for the same reason.
+
+**Reference.** `force-app/main/default/globalValueSets/` (40+ GVS definitions). Schema example: `force-app/main/default/objects/FeatureToggleRequest__c/fields/StatusPk__c.field-meta.xml`.
+
+---
+
+## 3. `__c` vs `__mdt` — when each is appropriate
+
+| Use `__c` (Custom Object) when... | Use `__mdt` (Custom Metadata Type) when... |
+|---|---|
+| Data is per-tenant or per-user runtime state | Data is package-shipped catalog or admin config |
+| Records change at runtime via Apex / LWC | Records change at deploy time via metadata DML |
+| Bulk insert / update / delete throughput matters | Tens-to-hundreds of records, mostly read-only |
+| Sharing rules / record types / report types needed | Same record-shape across every subscriber org |
+| Master-Detail / Lookup to other `__c` | Loose `Txt__c` cross-reference (`FeatureDefinitionTxt__c`) |
+
+**Hybrid pattern (cockpit Layer 4).** `FeatureDefinition__mdt` ships the catalog (one record per shippable feature, common across every install). `Feature__c` ships the per-tenant runtime row (one per subscriber per feature, holds `EnabledDateTime__c`). The catalog joins to the runtime row via the `FeatureDefinitionTxt__c` external-id column. New features can be added by shipping a `FeatureDefinition__mdt` record + a single `DeliveryHubInstallHandler` seed entry; no schema change on `Feature__c`.
+
+**Anti-pattern.** Putting per-tenant state on `__mdt` (subscribers can't write to it at runtime — `Metadata.DeployContainer` is async + admin-only). Putting catalog data on `__c` (no metadata propagation; subscriber upgrades won't pick up new entries).
+
+**Reference.** `force-app/main/default/objects/FeatureDefinition__mdt/` + `force-app/main/default/objects/Feature__c/`.
+
+---
+
+## 4. Namespace-safe Apex — typed describe, no `Schema.getGlobalDescribe()`
+
+**Pattern.** Use the typed `<SObject>__c.SObjectType.getDescribe()` pattern for any reference to a Delivery Hub custom object or field.
+
+```apex
+// CORRECT — works in both packaging context (delivery__) and non-namespaced scratch
+Map<String, Schema.SObjectField> fields =
+    DeliveryHubSettings__c.SObjectType.getDescribe().fields.getMap();
+
+// WRONG — returns null in delivery__ packaging context
+SObjectType t = Schema.getGlobalDescribe().get('DeliveryHubSettings__c');
+```
+
+**Why.** `Schema.getGlobalDescribe().get('Foo__c')` returns null when the calling code runs in the namespaced `delivery__` packaging context (publisher packaging org or any subscriber install). PR-level CI uses a non-namespaced scratch org so the bug isn't caught; the upload-beta job *is* namespaced, which is where it fails. This bit twice in PR #797 and PR #800 (production + test code paths separately).
+
+**Corollary — `getLocalName()` not `getName()`.** For field / object API names, `field.getDescribe().getLocalName()` returns `MyField__c`; `getName()` returns `delivery__MyField__c` in packaging context. Use `getLocalName()` whenever the caller compares against an unprefixed string.
+
+**Corollary — PermissionSetGroup DeveloperName queries.** `WHERE PermissionSetGroup.DeveloperName IN ('DeliveryHubAdmin', 'delivery__DeliveryHubAdmin')` — accept BOTH the bare and the namespaced developer name. Subscriber installs see the namespaced form; dev scratch sees the bare form.
+
+**Corollary — `WITH SYSTEM_MODE`, not `WITH USER_MODE`.** `WITH USER_MODE` breaks in namespaced package test context. Use `WITH SYSTEM_MODE` (and rely on the `with sharing` / `without sharing` class declaration for the runtime gate).
+
+**Reference.** `DeliveryHubDashboardController.isAdminUser()` (L582–L595) — canonical PSG-DeveloperName-tolerant query. `DeliveryFeatureSyncService.describeSettingsFields()` (post-PR #797) — typed describe call.
+
+---
+
+## 5. Receiver-side gate pattern (per-record DateTime + per-org opt-in DateTime)
+
+**Pattern.** Any cross-org content class that opts in to receiving signals from another org gates inbound writes behind **two** DateTime stamps:
+
+1. A **per-record** `<Capability>EligibleDateTime__c` (or similar) on the inbound payload — sender stamps this when the record is sender-side eligible.
+2. A **per-org** `Enable<Capability>InboundDateTime__c` on `DeliveryHubSettings__c` — receiver org admin must opt in before any inbound write succeeds.
+
+Both must be `!= null` for the receiver to accept the inbound write. Either one null = silent drop.
+
+**Why.** Cross-org content classes (Slack inbound, depth-probe, sync-from-vendor, etc.) need both sender intent and receiver consent. A boolean on either side erases the audit-trail metadata (when did sender mark it eligible? when did receiver opt in?). Two DateTimes capture both. Glen validated this pattern in PR #747 (predecisional gate) and asked it be used for every future cross-org content class.
+
+**Reference.** Slack inbound (`DeliverySlackInboundHandler` + `EnableSlackCommentSyncDateTime__c` + `SlackInboundEligibleDateTime__c` on `WorkItemComment__c`). Depth-probe (`DeliveryDepthProbeService` + per-org `EnableDepthProbeInboundDateTime__c`).
+
+---
+
+## 6. Admin permission checks via PSG `DeveloperName`
+
+**Pattern.** Server-side admin gates query `PermissionSetAssignment` joined to `PermissionSetGroup.DeveloperName`, accepting both the bare and the namespaced developer name:
+
+```apex
+[
+    SELECT Id FROM PermissionSetAssignment
+    WHERE AssigneeId = :UserInfo.getUserId()
+      AND PermissionSetGroup.DeveloperName
+          IN ('DeliveryHubAdmin', 'delivery__DeliveryHubAdmin')
+    LIMIT 1
+]
+```
+
+**Why.** Two independent issues are fixed by this single pattern:
+1. Subscriber orgs see the namespaced developer name (`delivery__DeliveryHubAdmin`); dev scratches see the bare name (`DeliveryHubAdmin`). Querying for only one form breaks one of the two contexts.
+2. `PermissionSet.Name` (vs `PermissionSetGroup.DeveloperName`) returns the label, which can drift between releases. PSG DeveloperName is package-stable.
+
+**Test-context corollary.** When `@IsTest` code inserts a fresh User and assigns the `DeliveryHubAdmin` PSG, the assignment isn't queryable until `Test.calculatePermissionSetGroup()` runs. The canonical test helper is in `TestDataFactory.makeAdminUser()` (post-PR #821). New admin-gated tests should call this helper, not roll their own.
+
+**Reference.** `DeliveryHubDashboardController.isAdminUser()` (L582) — the canonical pattern. Also used by `DeliveryFeatureCatalogController` (L394), `DeliveryFeatureDepEditorController` (L167), `DeliverySyncDismissalService` (L225).
+
+---
+
+## 7. ActivityLog__c on every meaningful side effect
+
+**Pattern.** Every Apex service that mutates state writes one `ActivityLog__c` row per side effect with:
+
+| Field | Value |
+|---|---|
+| `ActionTypePk__c` | One of the GVS values (`Feature_Toggle`, `Approval_Granted`, `Onboarding_Completed`, `Watcher_Run`, etc.) |
+| `ComponentNameTxt__c` | The calling class.method (`DeliveryFeatureSyncService.syncFeaturesToSettings`) |
+| `RecordIdTxt__c` | The mutated record's Id (e.g., `Feature__c.Id` on a toggle) |
+| `ContextDataTxt__c` | JSON blob: who, when, before/after values, reason |
+| `NetworkEntityId__c` | When the side effect is scoped to a single tenant |
+
+**Why.** Three downstream consumers depend on a complete activity log:
+1. **Audit-chain hash** — `DeliveryAuditChainService.setHashOnInsert` SHA-256s each row in insertion order, creating an immutable tamper-detection chain that `DeliveryComplianceExportService` ships to subscribers on demand.
+2. **Audit-trail viewer LWCs** — `deliveryActivityLog`, `deliveryWatcherDigestHistory`, `deliveryOnboardingHistory` (post-PR #820) all read `ActivityLog__c` directly.
+3. **Retention policy** — `ActivityLogRetentionDaysNumber__c` on `DeliveryHubSettings__c` drives the cleanup batch; subscribers can dial retention up for compliance or down for storage.
+
+**Service rule.** If your service flips a flag, posts to Slack, sends an email, fires a platform event, or completes an external sync — write an ActivityLog row. The audit-trail LWCs assume nothing happens silently.
+
+**Reference.** `DeliveryFeatureSyncService.writeAuditRow()` (one row per Feature toggle), `DeliveryFeatureApprovalService.applyIfFullyGranted()` (one row when approval cascade applies), `DeliveryWatcherService.persistDigest()` (one row per Watcher run regardless of whether signals fired).
+
+---
+
+## 8. Hash-chain audit on REST mutations
+
+**Pattern.** Every REST endpoint that mutates state through `DeliveryPublicApiService` writes the resulting `ActivityLog__c` row through the same `DeliveryAuditChainService` trigger path as in-org mutations. The endpoint **does not** compute hashes itself.
+
+**Why.** The audit chain is only tamper-detectable if every link is in it. Letting REST endpoints bypass the chain (or computing hashes in a different code path) creates two ledgers and breaks `DeliveryAuditChainService.validateChain()`. The trigger-driven, single-code-path approach also means a REST PR can't accidentally ship a different hash algorithm — `DeliveryCryptoService.computeChainHash` is the single source of truth.
+
+**Endpoint rule.** REST endpoints don't insert `ActivityLog__c` directly. They call the underlying service (e.g., `DeliveryFeatureApprovalService.grant()`), which inserts the activity-log row, which fires the trigger, which writes the hash. The chain is computed exactly once.
+
+**Reference.** `DeliveryAuditChainService.setHashOnInsert` (the trigger handler) + `DeliveryFeatureApprovalService.applyIfFullyGranted()` (the REST-callable service that writes the row). PR #802 referenced this pattern for the four new cockpit REST routes.
+
+---
+
+## Cross-cutting: data integrity guard rails
+
+Three rules that aren't a pattern per se but apply to every change:
+
+1. **Never fabricate realistic financial data.** Sample loaders under `scripts/feature-data/` use obvious placeholder values (`Sample Vendor A`, `1.0` hours, `TDF / placeholder sample` descriptions). Sample data that looks realistic gets shipped to subscriber orgs that then post it to their CRM — and once it's there, it's nearly impossible to scrub. Placeholder-only is non-negotiable.
+2. **Never DML against production.** All anonymous-apex iteration happens in scratch orgs first. `cci task run` against a production org requires explicit user confirmation in the PR description.
+3. **Picklist values written by Apex services are passed directly.** `SyncItem__c.StatusPk__c` is not restricted; Salesforce will accept anything. The `DeliverySyncItemTriggerHandler` no-op trigger is intentional. Services that write picklist values should pass safe known values directly. `TestDataFactory` defaults to allowlist-compliant values.
+
+---
+
+## Related reading
+
+- `docs/CONTRIBUTING.md` — how to apply these principles in a new PR (branch naming, test pattern, PMD ruleset, upload-beta gotcha checklist)
+- `docs/ARCHITECTURE.md` — the object model + service-layer map
+- `docs/FIELD_NAMING.md` — the typed-suffix field naming convention these principles assume
+- `docs/audits/architecture-governor-review-2026-05-21.md` — the most recent audit showing where the patterns actually held in production code

--- a/docs/FLOW_REFERENCE.md
+++ b/docs/FLOW_REFERENCE.md
@@ -1,0 +1,236 @@
+# Delivery Hub — Flow Reference
+
+> End-to-end user flows through the Delivery Hub cockpit + Watcher v1 + onboarding-track + REST surfaces. Living document — superseded the point-in-time `docs/audits/e2e-walkthrough-2026-05-21.md` audit by capturing the post-Wave-1 state (PRs #818 / #819 / #820 / #821 merged to `main`).
+
+Each flow declares its current status:
+- **OK** — end-to-end working for the happy-path user.
+- **PARTIAL** — works for some paths; one or more known gaps remain. Gap rows cite the audit they trace to.
+- **NOT END-TO-END** — code shipped but a load-bearing UI / wiring component is missing.
+
+---
+
+## Flow 1 — Feature Catalog browse — OK
+
+**Persona.** Any user with `DeliveryHubAdmin` or `DeliveryHubApp` PSG.
+
+**Path.**
+1. User navigates to `Feature Cockpit` App Page (FlexiPage `DeliveryFeatureCockpit`).
+2. `deliveryFeatureCockpit` LWC calls `DeliveryFeatureCatalogController.getCatalog()`.
+3. Controller joins `FeatureDefinition__mdt` (package catalog) ⨯ `Feature__c` (per-tenant runtime row) and returns a list of `FeatureCatalogRowDTO`.
+4. LWC renders one card per row with status badge + admin-only Enable / Disable / Show Dependencies buttons (gated by `DeliveryHubDashboardController.isAdminUser()`).
+
+**Status.** OK. The catalog browse path is the foundation of every other cockpit flow.
+
+---
+
+## Flow 2 — Admin toggles a feature — OK
+
+**Persona.** Admin (`DeliveryHubAdmin` PSG holder).
+
+**Path.**
+1. Admin clicks Enable / Disable on a Feature Cockpit card.
+2. LWC calls `DeliveryFeatureCatalogController.toggleFeature(featureId, action)`.
+3. Controller calls `enforceCascadeOrThrow(featureId, action)`:
+   - `DeliveryFeatureGraphService.computeCascade()` walks the dependency graph (BFS, depth cap 10).
+   - If any Hard edge is violated, `AuraHandledException` is raised and the LWC auto-opens the cascade-preview modal.
+4. If cascade is clean, controller flips `Feature__c.EnabledDateTime__c` (set or null).
+5. `FeatureTrigger` fires `DeliveryFeatureTriggerHandler.onAfterUpdate()`.
+6. Handler calls `DeliveryFeatureSyncService.syncFeaturesToSettings()` — mirrors the toggle into the legacy `DeliveryHubSettings__c.Enable*DateTime__c` field.
+7. Handler calls `DeliveryFeatureSyncService.writeAuditRow()` — inserts an `ActivityLog__c` row with action `Feature_Toggle`.
+8. `ActivityLogTrigger` fires `DeliveryAuditChainService.setHashOnInsert()` — computes the SHA-256 chain hash.
+
+**Status.** OK end-to-end. Audit-trail viewer (Flow Cross-1) closed the only standing gap from the 5/21 audit.
+
+---
+
+## Flow 3 — Non-admin onboarding gate — PARTIAL
+
+**Persona.** Non-admin user (`DeliveryHubApp` PSG).
+
+**Path.**
+1. Non-admin opens the Feature record page; `deliveryFeatureOnboarding` LWC renders.
+2. LWC calls `DeliveryOnboardingService.getProgress(featureId)` — joins `OnboardingTrack__mdt` + `OnboardingLesson__mdt` + `OnboardingQuiz__mdt` + `OnboardingChecklistItem__mdt` with the user's `OnboardingProgress__c` row.
+3. User progresses through lessons, takes the quiz (graded by `DeliveryOnboardingService.gradeQuiz()`), completes Manual checklist items via attestation.
+4. When `CompletedDateTime__c` is populated on `OnboardingProgress__c`, the Feature Cockpit's non-admin Enable refusal lifts.
+5. Non-admin can then toggle the feature (Flow 2 path).
+
+**Status.** PARTIAL. End-to-end happy path works (Lessons → Manual checklist → toggle). Known gaps:
+- **External checklist evaluators are PR 4 stubs.** `SoqlQuery` / `RestCall` / `WebhookReceived` verification methods always fall back to Manual attestation in the current build. Tracked in `docs/audits/e2e-walkthrough-2026-05-21.md` Flow 3 row 3.
+- **No completion notification.** User navigates back to the cockpit manually to discover the gate has lifted. Closed in flight by PR #822 (notification layer), not yet merged to `main`.
+- **Quiz retry gate.** Verified honored per `e2e-walkthrough-2026-05-21.md` Flow 3 row 2 correction (`deliveryFeatureOnboarding.js:169` reads `quizAllowsRetry`). Polish opportunity (button label "Retry Quiz" vs "Submit Quiz") tracked separately.
+- **Error toast doesn't link to the feature record page.** User navigates manually. Cosmetic.
+
+---
+
+## Flow 4 — Approval workflow — PARTIAL (was NOT END-TO-END)
+
+**Persona.** Requester (admin or non-admin); separate Approver.
+
+**Path.**
+1. Requester opens a Feature record page; `deliveryFeatureApprovalSubmit` LWC renders (added in PR #818).
+2. Requester selects action (Enable / Disable), adds a reason, clicks Submit.
+3. LWC calls `DeliveryFeatureApprovalService.submit(featureId, action, reason)`.
+4. Service creates `FeatureToggleRequest__c` with Status=Pending + a frozen `CascadeSnapshotJsonTxt__c` (so the approver sees what they're approving even if dependencies change later).
+5. Service walks the cascade graph (BFS) and inserts one `FeatureToggleApproval__c` row per non-Optional cascade node + a root-level row for the originally-requested feature.
+6. Approver opens the `deliveryFeatureApprovalInbox` LWC (mounted on `DeliveryHubAdminHome` FlexiPage).
+7. Inbox calls `DeliveryFeatureApprovalService.listPending()` and renders each pending row.
+8. Approver clicks Grant or Reject, optionally adds a note.
+9. Service stamps the approval row + calls `applyIfFullyGranted()` — when every required approval row resolves, flips the underlying `Feature__c`, auto-marks Soft / non-required rows Status='Auto', stamps the request Applied + AppliedDateTime, and writes an `ActivityLog__c` row.
+10. Same trigger path as Flow 2 fires (sync + audit chain).
+
+**Status.** PARTIAL. End-to-end now works (submission UI shipped in PR #818, caller-is-approver security guard shipped in PR #815). Known gaps:
+- **No approver auto-assign in current `main`.** `ApproverUserLookup__c` is null at create; admin must open each `FeatureToggleApproval__c` row to assign. Closed in flight by PR-E `feat/approval-routing-auto-assign` branch (visible in `git log --all`), not yet merged.
+- **No notification to requester on grant.** Closed in flight by PR #822, not yet merged.
+
+---
+
+## Flow 5 — Dependency cascade preview + edit — OK (was PARTIAL)
+
+**Persona.** Admin.
+
+**Path.**
+1. Admin opens the Feature record page.
+2. `deliveryFeatureDependencyEditor` LWC renders (added in PR #819 — closes the "no UI to create FeatureDependency__c records" gap from the 5/21 audit).
+3. Admin adds / removes dependencies inline; LWC calls `DeliveryFeatureDepEditorController` methods.
+4. Cascade preview pane (`deliveryFeatureCascadePreview` modal) renders the BFS expansion via `DeliveryFeatureGraphService.computeCascade()`.
+5. Admin commits dependency changes; controller writes `FeatureDependency__c` rows.
+
+**Status.** OK end-to-end as of PR #819. The audit's "no UI to create FeatureDependency__c records" gap is closed.
+
+---
+
+## Flow 6 — Dev-loop mirror — PARTIAL
+
+**Persona.** Developer (external).
+
+**Path.**
+1. CI (GitHub Actions) provisions a scratch org via CumulusCI.
+2. CI calls `POST /services/apexrest/delivery/deliveryhub/v1/api/scratch-orgs` with `{branch, orgId, loginUrl, cciFlow, workItemName, expiresAt}`.
+3. `DeliveryPublicApiService.postScratchOrg()` authenticates via `X-Api-Key`, resolves the WorkItem by `Name` if provided, inserts `ScratchOrgInstance__c` with Status=Active.
+4. During teardown, CI calls `PATCH /scratch-orgs/{id}` with `{state, lastSyncAt}`. `DeliveryPublicApiService.patchScratchOrg()` validates against the `ScratchOrgState` GVS and updates the row.
+5. `deliveryDevLoopGuide` LWC on `ScratchOrgInstance__c` record pages renders the matching `DevLoopGuide__mdt` content.
+
+**Status.** PARTIAL. REST routes + LWC ship; missing wiring:
+- **No example GitHub Action workflow** in `.github/workflows/` that actually calls the endpoint. Subscriber devs roll their own.
+- **No auto-create of `WorkItem__c`** when a branch name doesn't match an existing WI. Tracked in `docs/audits/e2e-walkthrough-2026-05-21.md` Flow 6 row 2.
+
+---
+
+## Flow 7 — Dataset loading — PARTIAL
+
+**Persona.** Developer.
+
+**Path.**
+1. Developer opens the Feature record page; `deliveryDatasetTemplates` LWC renders.
+2. LWC reads `DatasetTemplate__c` rows matching the feature, displays each with a "Copy command" button.
+3. Developer copies the CLI command and runs it locally: `cci task run execute_anon --path scripts/feature-data/<feature>.apex --org <alias>`.
+4. Apex script seeds sample data (idempotent, placeholder values only).
+
+**Status.** PARTIAL. Code + CLI path ship; missing:
+- **`DatasetTemplateAssignment__c` rows are not auto-inserted** after a successful load. The audit-trail object ships empty.
+- **`load_feature_data` CCI task is a debug-stub wrapper.** Direct anonymous-apex invocation is the canonical path (per `scripts/feature-data/README.md`).
+- **Only `invoice_generation.apex` ships.** Other features have no script.
+
+---
+
+## Flow 8 — Watcher daily digest — PARTIAL
+
+**Persona.** Admin (recipient of the digest).
+
+**Path.**
+1. Subscriber admin enables Watcher: sets `DeliveryHubSettings__c.EnableWatcherDigestDateTime__c` to a non-null DateTime and populates `WatcherDigestRecipientUserIdsTxt__c` with comma-separated User Ids.
+2. Scheduled job (`DeliveryWatcherScheduler.execute()`) runs daily at the configured cron.
+3. `DeliveryWatcherService.runDailySweep()` reads the master flag, walks the enabled per-signal flags, and invokes each `Watcher*QueryService.query()` method.
+4. Signal services (`WatcherSLABreachQueryService` / `WatcherStuckStageQueryService` / `WatcherARAgingQueryService` shipping; `WatcherFailedSyncTrendQueryService` / `WatcherPaymentOpsQueryService` / `WatcherUnhappySignalQueryService` / `WatcherUpcomingSignoffQueryService` are PR-B stubs returning empty) return their entries.
+5. Service merges into a `WatcherRunResultDTO`, persists a `WatcherDigest__c` row (always — even on quiet days, for the 14-day stabilization gate), and posts a multi-section Slack message when there's something to say.
+6. `deliveryWatcherDigestHistory` LWC (added in PR #820) renders the run history.
+
+**Status.** PARTIAL. Signal pipeline works; missing:
+- **No admin setup UI for the master flag + recipient list.** Subscribers must open Setup → Custom Settings → DeliveryHubSettings → edit to flip the flag and populate recipients. No user picker, no friendly form. `deliveryHubSetup` LWC could be extended.
+- **Slack post is fire-and-forget.** No fallback if the webhook 4xx / 5xx's; the `WatcherDigest__c` row records `StatusPk__c='Success'` regardless.
+- **4 of 7 signal services are stubs.** Functional, returning empty results, with full implementations queued for Phase 2.5+.
+
+---
+
+## Cross-flow — Audit-trail viewers — OK (NEW since PR #820)
+
+**Persona.** Admin.
+
+**Path.** Three read-only LWCs surface `ActivityLog__c`, `WatcherDigest__c`, and `OnboardingProgress__c` history:
+
+| LWC | Mounts on | Data |
+|---|---|---|
+| `deliveryActivityLog` | App Page or any record page | `ActivityLog__c` rows scoped to org or to a specific record via `recordId` |
+| `deliveryWatcherDigestHistory` | App Page | `WatcherDigest__c` rows, one per Watcher run |
+| `deliveryOnboardingHistory` | App Page (org-wide view) or User record page (user-scoped) | `OnboardingProgress__c` rows |
+
+**Status.** OK. Audit-chain hash readout supported via `deliveryAuditChainViewer` (existed pre-cycle).
+
+---
+
+## Cross-flow — In-app notifications — NOT IN `main` YET
+
+Closed in flight by PR #822 (`feat(notify): in-app notifications on toggle/approval/onboarding events`). The branch exists; the PR is open but not merged to `main` as of 2026-05-26. When merged, the notification matrix becomes:
+
+| Event | In-app bell | Slack | Email |
+|---|---|---|---|
+| Feature toggle (admin direct flip) | Y | (existing weekly digest) | N |
+| Approval grant / reject (notifies requester) | Y | N | N |
+| Onboarding completion (notifies user) | Y | N | N |
+| Watcher daily digest | N | Y | N |
+
+Until PR #822 merges, all four event rows are silent in-platform; subscribers polled the cockpit / inbox manually.
+
+---
+
+## Cross-flow — REST surface map
+
+The full REST surface as of `release/0.248.0.3`:
+
+| Method | Path | Purpose | Auth | Audit |
+|---|---|---|---|---|
+| `GET`  | `/services/apexrest/delivery/deliveryhub/v1/api/dashboard` | Portal home | `X-Api-Key` | N |
+| `GET`  | `/work-items` | List WIs scoped to entity | `X-Api-Key` | N |
+| `GET`  | `/work-items/{id}` | Single WI detail | `X-Api-Key` | N |
+| `GET`  | `/activity-feed` | Org activity stream | `X-Api-Key` | N |
+| `GET`  | `/conversations` | Comment threads | `X-Api-Key` | N |
+| `GET`  | `/pending-approvals` | Approvals awaiting | `X-Api-Key` | N |
+| `GET`  | `/work-logs` | Time-log rows | `X-Api-Key` | N |
+| `GET`  | `/files` | Linked content | `X-Api-Key` | N |
+| `GET`  | `/board-summary` | AI-summarized board state | `X-Api-Key` | N |
+| `GET`  | `/documents` | Document list | `X-Api-Key` | N |
+| `GET`  | `/documents/{token}` | Single document detail | Public token | N |
+| `GET`  | `/feature-toggle-requests` | Audit list of requests (paginated, post PR #813) | `X-Api-Key` | N |
+| `POST` | `/features/{name}/toggle` | Submit a toggle request (idempotency key, post PR #813) | `X-Api-Key` | Y |
+| `POST` | `/feature-toggle-approvals/{id}/grant` | Approver grants | `X-Api-Key` + caller-is-approver guard (PR #815) | Y |
+| `POST` | `/feature-toggle-approvals/{id}/reject` | Approver rejects | `X-Api-Key` + caller-is-approver guard (PR #815) | Y |
+| `POST` | `/scratch-orgs` | CI provisioning hook | `X-Api-Key` | Y |
+| `PATCH`| `/scratch-orgs/{id}` | CI state update (rate-limited, post PR #813) | `X-Api-Key` | Y |
+
+Public-facing per-route documentation lives in `docs/PUBLIC_API_GUIDE.md` (refresh owned by a parallel agent).
+
+---
+
+## Status summary
+
+| Flow | Status | Closed-since-5/21 deltas |
+|---|---|---|
+| 1. Feature catalog browse | OK | — |
+| 2. Admin toggle | OK | Audit-trail viewer (Flow Cross-1) closed via PR #820 |
+| 3. Non-admin onboarding | PARTIAL | Quiz retry gate confirmed honored (was wrong in 5/21 audit) |
+| 4. Approval workflow | PARTIAL (was NOT END-TO-END) | Submission UI shipped (PR #818); caller-is-approver guard shipped (PR #815) |
+| 5. Dependency cascade | OK (was PARTIAL) | Inline editor shipped (PR #819) |
+| 6. Dev-loop mirror | PARTIAL | — |
+| 7. Dataset loading | PARTIAL | — |
+| 8. Watcher digest | PARTIAL | Digest history viewer shipped (PR #820) |
+| X. Audit-trail viewers | OK (NEW) | Shipped via PR #820 |
+| X. In-app notifications | NOT IN MAIN | PR #822 in flight |
+
+---
+
+## Related reading
+
+- `docs/audits/e2e-walkthrough-2026-05-21.md` — point-in-time audit that originally surfaced the Flow 4 / Flow 5 / Cross-flow gaps that this doc now reports closed.
+- `docs/audits/documentation-gap-audit-2026-05-26.md` — companion audit that registers documentation surfaces (this doc closes the "no flow-reference document" gap).
+- `docs/DESIGN_PRINCIPLES.md` — the patterns each flow assumes (ActivityLog on every side effect, PSG admin check, GVS picklists, etc.).
+- `docs/ARCHITECTURE.md` — the object model the flows traverse.

--- a/docs/audits/documentation-gap-audit-2026-05-26.md
+++ b/docs/audits/documentation-gap-audit-2026-05-26.md
@@ -1,0 +1,154 @@
+# Documentation Gap Audit — 2026-05-26 (Differential)
+
+> Five-day follow-up to `documentation-gap-audit-2026-05-21.md`. Same scope (architecture / design docs / inline docstrings / object descriptions / REST endpoint docs / Custom Setting flag help). README + setup + REST API guide are owned by a parallel agent and explicitly out of scope here.
+
+## Headline
+
+Inline documentation coverage on **Apex services, REST endpoints, LWCs, Custom Objects, Custom Setting fields** is at or near 100%. The remaining gaps are concentrated on:
+- **7 `__mdt` types** ship without object-level `<description>` (admin-readable in Setup → Custom Metadata).
+- **23 of 80 LWCs** still lack a top-of-file `@description` ApexDoc block.
+- **No design-principles document** existed (`docs/DESIGN_PRINCIPLES.md`).
+- **No contributor guide** existed (`docs/CONTRIBUTING.md`).
+- **No flow-reference document** existed; the only end-to-end flow narrative lived in `docs/audits/e2e-walkthrough-2026-05-21.md` (an audit, not a guide).
+
+This PR closes the three missing top-priority architecture docs and registers the inline-doc gaps for future cleanup.
+
+---
+
+## Differential from 2026-05-21
+
+### Closed since 2026-05-21
+
+| Audit row | Closed by | Notes |
+|---|---|---|
+| §1 README still pinned at 0.239 | parallel README-refresh agent | Out of scope here; flagged for the parallel agent. |
+| §2 `Feature__c` / `FeatureDependency__c` / `WatcherDigest__c` / `FeatureToggleRequest__c` / `FeatureToggleApproval__c` / `OnboardingProgress__c` / `ScratchOrgInstance__c` / `DatasetTemplate__c` / `DatasetTemplateAssignment__c` object-level `<description>` | PRs #793 / #794 / #796 / #799 / #802 / #803 / #804 / #807 | All 9 new `__c` objects now ship with multi-sentence `<description>` in their `.object-meta.xml`. Verified in this scan. |
+| §3 4 new REST routes "no docs" | PRs #802 / #804 (inline ApexDoc above each route method) | `postFeatureToggle` / `postFeatureApprovalDecision` / `postScratchOrg` / `patchScratchOrg` all carry `@description` blocks with body shape + verb + status codes. Public-facing guide (`docs/PUBLIC_API_GUIDE.md`) refresh is owned by the parallel REST-API-doc agent. |
+| §4 `load_feature_data` CCI task missing description | PR #803 | `cumulusci.yml:104` ships a one-line description plus a pointer to `scripts/feature-data/`. `scripts/feature-data/README.md` exists. |
+| §6 No upgrade guide for 0.243–0.247 release notes | Out of scope | Parallel README-refresh agent owns CHANGELOG roll-up. |
+| §7 No architecture diagrams | Partially closed by this PR | `docs/FLOW_REFERENCE.md` introduces ASCII flow tables for every flow + the cross-flow notification matrix. Mermaid render is a follow-on. |
+
+### Still open
+
+| Gap | Severity | Owner |
+|---|---|---|
+| **7 `__mdt` types missing `<description>`** (see §3) | Medium | This PR flags; metadata-only fix queued. |
+| **23 of 80 LWCs missing top-of-file `@description`** (see §4) | Low | This PR flags; pattern is established (57 of 80 already comply). |
+| **No `docs/DESIGN_PRINCIPLES.md`** (codifies the 8 patterns that recur across every PR) | High | **CLOSED by this PR.** |
+| **No `docs/CONTRIBUTING.md`** (CLAUDE.md is internal-tooling-flavoured, not a contributor guide) | High | **CLOSED by this PR.** |
+| **No `docs/FLOW_REFERENCE.md`** (`e2e-walkthrough` is point-in-time audit, not living doc) | High | **CLOSED by this PR.** |
+| **No Mermaid diagrams** for Feature state machine / Watcher signal flow / Onboarding track content | Medium | Deferred — ASCII tables in `docs/FLOW_REFERENCE.md` close the readability gap. |
+| **No public `docs/REST_API_GUIDE.md` refresh** for the 4 new cockpit routes | High | Parallel REST-API-doc agent. |
+
+### Newly surfaced
+
+None. The post-5/21 ship cycle (#812 - #821) was code only, no new sObjects or REST routes that could create new doc-surface gaps. PR #822 (in-app notifications) is in flight on a feature branch but not merged to main; its docs land when the PR lands.
+
+---
+
+## 1. Apex Service Class Headers — PASS
+
+All 56 `*Service.cls` files under `force-app/main/default/classes/` start with a `/**` ApexDoc block. Sample sweep on 8 of the highest-leverage services (`DeliveryFeatureApprovalService`, `DeliveryWatcherService`, `DeliveryOnboardingService`, `DeliveryPublicApiService`, `DeliveryRateLimitService`, `DeliveryFeatureSyncService`, `DeliveryFeatureGraphService`, `DeliveryUserAutoAssignService`) confirmed:
+
+- Purpose stated (1-3 sentences)
+- Layer in the cockpit architecture noted where relevant
+- Sharing model implicit in the class declaration (`global with sharing` / `public without sharing`)
+- Side effects called out (audit-log rows, settings mirror, Slack post, etc.)
+- Re-entry / recursion guards documented inline
+
+**No service-class header gaps surfaced.**
+
+## 2. REST Endpoints — PASS
+
+Surveyed: `DeliveryPublicApiService`, `DeliveryBountyApiService`, `DeliveryDocActionRestApi`, `DeliveryFileBytesResource`, `DeliveryTaskAPI`, `DeliveryWebhookReceiverApi`, `DeliveryPublicSubmissionService`, `DeliveryHubSyncService`, `DeliveryGanttRemoteController`.
+
+All `@HttpGet / @HttpPost / @HttpPatch / @HttpPut / @HttpDelete` methods carry an ApexDoc block describing:
+
+- URL pattern
+- Method + body shape (where applicable)
+- Auth requirement
+- Return shape / status codes
+
+`DeliveryPublicApiService` uses single `@HttpGet` / `@HttpPost` / `@HttpPatch` entry points that route internally; per-resource methods (`postFeatureToggle`, `postFeatureApprovalDecision`, `postScratchOrg`, `patchScratchOrg`, `getFeatureToggleRequests`) all carry per-route ApexDoc.
+
+**No endpoint-level inline-doc gaps surfaced.** The public-facing `docs/PUBLIC_API_GUIDE.md` refresh is owned by a parallel agent.
+
+## 3. Custom Metadata Type Object Descriptions — 7 GAPS
+
+The following `__mdt` objects ship a `<label>` + `<pluralLabel>` but no `<description>`. Setup → Custom Metadata Types displays a blank description column for these, which means admins clicking through have no context for what the type is for.
+
+| `__mdt` | Status | Recommendation |
+|---|---|---|
+| `DashboardCard__mdt` | Missing | "Executive Dashboard card configuration (CMT-driven). One record per displayed card. Click-drill + info-popover supported." |
+| `DevLoopGuide__mdt` | Missing | "Per-feature dev-loop guide content. Surfaced by `deliveryDevLoopGuide` LWC on `ScratchOrgInstance__c` record pages. Markdown-friendly." |
+| `FeatureDefinition__mdt` | Missing | "Package-shipped registry of subscribable Delivery Hub features. Joined to per-tenant `Feature__c` at runtime by `DeliveryFeatureCatalogController`." |
+| `OnboardingChecklistItem__mdt` | Missing | "One row per gated checklist item inside an `OnboardingTrack__mdt`. Verification methods: Manual (PR 3) / SoqlQuery / RestCall / WebhookReceived (PR 4 stubs)." |
+| `OnboardingLesson__mdt` | Missing | "Lesson card content inside an `OnboardingTrack__mdt`. Markdown body + completion stamp on `OnboardingProgress__c`." |
+| `OnboardingQuiz__mdt` | Missing | "Multiple-choice quiz block inside an `OnboardingTrack__mdt`. `AllowRetryDateTime__c` populated = retries allowed (read by `deliveryFeatureOnboarding.js`)." |
+| `OnboardingTrack__mdt` | Missing | "Top-level onboarding track. Linked to a `FeatureDefinition__mdt` to enforce the gated-toggle pattern (non-admin must complete the track before flipping the feature)." |
+
+All seven are Public-visibility `__mdt`. The fix is pure metadata (one `<description>` insert per file). Bundle into a 30-min PR — not in scope for this audit PR.
+
+## 4. LWC Top-of-File `@description` — 23 GAPS (of 80)
+
+The 23 LWCs below are missing a top-of-file `/** @description ... */` ApexDoc block. The 57 that comply use the canonical four-line shape (`@name` / `@license` / `@description` / `@author`).
+
+Older / less-recently-touched LWCs are over-represented in the gap list. New LWCs since PR #793 all comply.
+
+```
+deliveryActivityDashboard       deliveryGuide
+deliveryAiDraftPanel            deliveryHoursPills
+deliveryAiSettingsCard          deliveryHubBoard
+deliveryAuditChainViewer        deliveryHubSetup
+deliveryBudgetSummary           deliveryHubWorkspace
+deliveryBurndownChart           deliveryKanbanOpenAiSettings
+deliveryClientDashboard         deliveryKanbanSettingsContainer
+deliveryExecutiveDashboard      deliveryManageRequest
+deliveryGeneralSettingsCard     deliveryOpenAiSettingsCard
+deliveryGhostRecorder           deliveryPermissionAnalyzer
+                                deliveryProjectBurnUpChart
+                                deliveryProjectMonthlyHours
+                                deliverySettingsContainer
+```
+
+`deliveryHubSetup` is the most user-facing miss — it's the admin entry point for `DeliveryHubSettings__c`. Worth prioritising.
+
+Recommended fix: one PR that drops the canonical 4-line block onto each of the 23 (~30 min metadata-only).
+
+## 5. Custom Object Descriptions — PASS
+
+Verified: all 25 `__c` objects under `force-app/main/default/objects/*__c/` carry `<description>` blocks. The 9 new cockpit objects (`Feature__c`, `FeatureDependency__c`, `FeatureToggleRequest__c`, `FeatureToggleApproval__c`, `OnboardingProgress__c`, `ScratchOrgInstance__c`, `DatasetTemplate__c`, `DatasetTemplateAssignment__c`, `WatcherDigest__c`) all ship multi-sentence descriptions with layer-of-architecture notes.
+
+**No gaps.**
+
+## 6. DeliveryHubSettings__c Fields — PASS
+
+All 66 fields under `force-app/main/default/objects/DeliveryHubSettings__c/fields/` carry at least one of `<description>` / `<inlineHelpText>`. 14 new Watcher fields shipped in PR #807 all comply. **No gaps.**
+
+## 7. Architecture Bundle Status — CLOSED
+
+The three "missing architecture-level docs" the 5/21 audit recommended now exist:
+
+| Doc | Path | Status |
+|---|---|---|
+| Design principles | `docs/DESIGN_PRINCIPLES.md` | **NEW in this PR** |
+| Contributor guide | `docs/CONTRIBUTING.md` | **NEW in this PR** |
+| End-to-end flow reference | `docs/FLOW_REFERENCE.md` | **NEW in this PR** |
+
+`docs/ARCHITECTURE.md` (object model + Apex layers) already existed and is current.
+
+---
+
+## Top-3 still-open gaps
+
+1. **7 `__mdt` types missing `<description>`** — high admin-confusion potential; the cockpit and onboarding admin journey both pass through Setup → Custom Metadata Types. Bundle as a single 30-min metadata PR.
+2. **23 LWCs missing top-of-file `@description`** — established convention (57 of 80 comply); cleanup is mechanical. The `deliveryHubSetup` LWC is the highest-priority miss because it's the admin entry point for `DeliveryHubSettings__c`.
+3. **No public `docs/REST_API_GUIDE.md` refresh** for the four new cockpit REST routes — inline ApexDoc is complete, but external-facing guide lags. Parallel REST-API-doc agent owns.
+
+---
+
+## Verdict
+
+What ships now is **functionally documented at the implementation layer** (ApexDoc, object descriptions, field help text) and now also **conceptually documented at the architecture layer** (`docs/DESIGN_PRINCIPLES.md` + `docs/CONTRIBUTING.md` + `docs/FLOW_REFERENCE.md`). The remaining gaps are cleanup-class items (Mermaid diagrams, `__mdt` descriptions, 23 LWC headers) that don't block subscriber adoption.
+
+**Recommendation:** ship the three architecture docs in this PR. Bundle the `__mdt` description + LWC `@description` cleanups into a single follow-on metadata-only PR (~45 min total).


### PR DESCRIPTION
## Summary

- Adds **docs/DESIGN_PRINCIPLES.md** — codifies the 8 patterns that recur across every PR (DateTime-not-Boolean toggles, GVS-from-day-one picklists, __c vs __mdt, namespace-safe Apex, receiver-side gate, PSG DeveloperName admin check, ActivityLog on every side effect, hash-chain audit on REST mutations).
- Adds **docs/CONTRIBUTING.md** — branch workflow, Apex naming (≤36-char class names so *Test fits), SOQL conventions (WITH SYSTEM_MODE, typed describe), Custom Settings + metadata rules, permset hygiene, test patterns (Test.calculatePermissionSetGroup pattern), PMD ruleset (strict AvoidDebugStatements + severity 4), and a pre-merge upload-beta gotcha checklist baked from the consolidated feedback memories.
- Adds **docs/FLOW_REFERENCE.md** — end-to-end narrative for all 8 cockpit/Watcher flows + cross-flow audit-trail viewers + REST surface map. Status updated per Wave-1 closures (#818 submission UI, #819 dep editor, #820 audit viewers); PR-E auto-assign + PR #822 notifications flagged as in-flight (not yet in main).
- Adds **docs/audits/documentation-gap-audit-2026-05-26.md** — differential audit vs the 5/21 doc-gap audit. Closed: 9 new __c objects ship descriptions; 4 new REST routes carry per-route ApexDoc; load_feature_data CCI task has a description. Still open: 7 __mdt types missing <description>; 23 of 80 LWCs missing top-of-file @description; public PUBLIC_API_GUIDE.md refresh for cockpit routes (parallel agent).

## Files added

- docs/DESIGN_PRINCIPLES.md (new)
- docs/CONTRIBUTING.md (new)
- docs/FLOW_REFERENCE.md (new)
- docs/audits/documentation-gap-audit-2026-05-26.md (new)

## Scope guardrails

Docs-only. No code, LWC, metadata, README, or REST-API-guide changes — those are owned by parallel agents per the audit-fan-out plan.

## Differential from 5/21 doc-gap audit

**Closed:**
- §2 9 new __c objects ship multi-sentence object-level <description> (verified in this scan).
- §3 4 new cockpit REST routes carry inline ApexDoc above each route method (postFeatureToggle / postFeatureApprovalDecision / postScratchOrg / patchScratchOrg).
- §4 load_feature_data CCI task has a one-line description + pointer to scripts/feature-data/.

**Still open:**
1. **7 __mdt types missing <description>** (DashboardCard / DevLoopGuide / FeatureDefinition / OnboardingChecklistItem / OnboardingLesson / OnboardingQuiz / OnboardingTrack) — 30-min metadata-only follow-on PR.
2. **23 of 80 LWCs missing top-of-file @description** — convention established (57 of 80 comply); deliveryHubSetup is the highest-priority miss.
3. **No public docs/REST_API_GUIDE.md refresh** for the 4 new cockpit REST routes — owned by parallel REST-API-doc agent.

## Test plan

- [ ] Reviewers confirm DESIGN_PRINCIPLES.md accurately captures the 8 patterns (no fabricated rules)
- [ ] Reviewers confirm CONTRIBUTING.md is consistent with current CLAUDE.md (no contradictions)
- [ ] Reviewers confirm FLOW_REFERENCE.md status markers match what's actually shipped on main as of 2026-05-26 (PR #822 / approval auto-assign correctly flagged as in-flight, not merged)
- [ ] No CI required for docs-only changes