### PR TITLE
docs(audits): refresh dead-code + PMD baseline audits (5/13 + 5/21 stale)

### DIFF
--- a/docs/audits/dead-code-audit-2026-05-26.md
+++ b/docs/audits/dead-code-audit-2026-05-26.md
@@ -1,0 +1,267 @@
+# Dead Code / Orphan Metadata Audit (2026-05-26)
+
+> Refresh of `dead-code-audit-2026-05-13.md` (13 days stale). The 5/13
+> "Definitely safe to delete" cluster shipped via PR #789 — 4,323 LOC removed
+> across 48 files. This refresh re-runs the analysis against everything that
+> shipped after 5/13: the 10-PR DH cockpit plan (release `0.244.0.2` +
+> `0.245.0.4`), Phase 2 Watcher v1 (release `0.246.0.4` — PRs #807/#809/#810),
+> the `release/0.247.0.6` "subscriber-ready first impression" bundle
+> (PRs #812–#816), and the post-promotion UX-gap fan-out (PRs #818/#820/#822
+> approval-submit + audit-trail viewers + in-app notifications + #819 inline
+> dependency editor + #821 PSG hotfix).
+>
+> **Report-only.** No code touched in this PR.
+
+Scope: `force-app/main/default/` — 166 non-test Apex classes (321 .cls total),
+80 LWCs, 50 objects, 19 FlexiPages, 21 tabs, 3 apps, 6 VF pages. Same
+methodology as 5/13 — each class/component/field cross-referenced against
+every other file type in the package (cls/trigger/js/html/page/cmp/-meta.xml/
+permset/flexipage/layout/report), with externally-invoked entry points
+(`@RestResource`, `@AuraEnabled` LWC bindings, Aura `aura:application`, VF
+pages, tabs, app utility bars, scheduled cron) treated as live. Method
+references via `grep -E "\b<NAME>\b"` excluding the symbol's own .cls family.
+
+## Executive summary
+
+- **Zero confirmed-dead Apex classes** across all 166 non-test classes — every
+  class has at least one production caller. The 5/13 "Definitely safe" cluster
+  has been deleted (PR #789), and no new dead classes have accumulated in the
+  cockpit / Watcher / UX-gap waves.
+- **3 Apex classes are "test-only by static reference" but live via external
+  HTTP** — `DeliveryBountyApiService`, `DeliveryGanttRemoteController`,
+  `DeliveryTaskAPI`. All three are `@RestResource` endpoints — the apparent
+  dead-ness is an artifact of greppability. `DeliveryGanttRemoteController`
+  receives traffic from the in-repo `GanttRemote.page` VF page (browser fetch);
+  `DeliveryTaskAPI` is documented in README + CHANGELOG as the external
+  AI-agent integration; `DeliveryBountyApiService` is the only one with
+  no production traffic Glen can confirm (carry-over from 5/13).
+- **20 LWCs ship without a FlexiPage placement** — 14 are unchanged from the
+  5/13 "Likely safe — verify before deleting" list (Glen never gave the
+  delete OK; carry-over), and **6 are NEW since 5/13** — five from the cockpit
+  + Watcher + audit-trail PRs (#796/#803/#804/#820 — three audit-trail viewers
+  + dataset templates + dev-loop guide + feature onboarding), one from the
+  cockpit Onboarding Tracks (#796). The five new ones are **exposed**
+  (`lightning__RecordPage` / `lightning__AppPage` targets) so admins can
+  drag-drop, but the package ships no out-of-the-box placement.
+- **6 stale stubs ship empty `query()` implementations** — the four Watcher
+  signal services (Signals 4/5/6/7 — `WatcherFailedSyncTrendQueryService`,
+  `WatcherPaymentOpsQueryService`, `WatcherUnhappySignalQueryService`,
+  `WatcherUpcomingSignoffQueryService`) all return `SignalResultDTO.emptyResult(SIGNAL_NAME)`.
+  Per the Phase 2 Watcher design memo, this is **intentional** — full
+  implementations land after Watcher accumulates ~14 days of heartbeat data
+  (earliest ~2026-06-04). Plus a non-Watcher near-stub —
+  `DeliveryActivityLogCleanup` is a `Schedulable, Database.Batchable` class
+  that runs nightly per its docstring, but the master `DeliveryHubScheduler.scheduleAll()`
+  does **NOT** register it. Admins must hand-invoke `System.schedule(...)`
+  from anonymous Apex to activate. Practically dormant on every subscriber org.
+- **3 deprecated-by-comment TODOs persist** (`DeliveryDocActionRestApi.cls:158`,
+  `DeliveryDocGenerationService.cls:272`, `DeliveryOnboardingService.cls:398`).
+  First two are unchanged from 5/13 (still ~49 days old, still under any
+  reasonable stale-comment threshold); the third is intentional
+  ("PR 4+: when VerificationMethodPk__c != 'Manual', call the
+  verification handler") and tracks back to the Onboarding Tracks MVP.
+- **Field-level orphans unchanged** from 5/13 — same 4 fields (3 dormant
+  `WorkLog__c` approval-workflow fields + `PortalAccess__c.PermissionsTxt__c`).
+  Field discipline remains strong even as the codebase grew ~30 new classes.
+- **Object-level orphans: zero.** All 50 custom objects are referenced from
+  Apex / LWC / trigger code.
+
+## Confirmed dead (zero references)
+
+**None.** Every non-test Apex class has at least one production caller; every
+custom object has at least one SOQL/DML reference. PR #789 closed the
+5/13 dead-Apex bucket.
+
+## Test-only by static reference (live via external HTTP)
+
+| Class | Live entry point | Note |
+| --- | --- | --- |
+| `DeliveryBountyApiService` | `@RestResource('/deliveryhub/v1/bounties/*')` | No in-repo HTTP consumer. Bounty marketplace pivoted to cloudnimbusllc.com Next.js. 5/13 audit's "Likely safe" carry-over — Glen sign-off still pending on whether external traffic exists. |
+| `DeliveryGanttRemoteController` | `@RestResource('/gantt-remote/*')` | `GanttRemote.page` VF page (mobile companion) is the live consumer via browser fetch — not greppable as Apex reference. Active. |
+| `DeliveryTaskAPI` | `@RestResource('/deliveryhub/v1/tasks/*')` | Documented in README + CHANGELOG as external AI-agent integration. Removing without checking Site usage logs would silently break any AI client polling it. Active. |
+
+## Stale stubs (referenced but implementation is empty / disabled)
+
+### Watcher signal stubs — intentional, time-locked
+
+Four classes, all ship as wired stubs from PR #809 (Phase 2 Watcher PR-B):
+
+- `WatcherFailedSyncTrendQueryService.query()` — returns `SignalResultDTO.emptyResult('FailedSyncTrend')`
+- `WatcherPaymentOpsQueryService.query()` — returns `SignalResultDTO.emptyResult('PaymentOps')`
+- `WatcherUnhappySignalQueryService.query()` — returns `SignalResultDTO.emptyResult('UnhappySignal')`
+- `WatcherUpcomingSignoffQueryService.query()` — returns `SignalResultDTO.emptyResult('UpcomingSignoff')`
+
+All four are registered with `DeliveryWatcherService` (the orchestrator) and
+gated by their own `DeliveryHubSettings__c.EnableWatcher*DateTime__c` flags.
+Per the Watcher v1 design memo (PR #790), each stub's docstring explicitly
+states "Deferred because: needs 14-21 days of post-Watcher-install reconciler
+data to baseline what 'normal' looks like per org." Phase 3 (the auto-digest
+that consumes these signals) is **time-locked** until ~2026-06-04. **Do
+nothing** — this is the documented contract.
+
+### `DeliveryActivityLogCleanup` — schedulable but never auto-scheduled
+
+`global without sharing class DeliveryActivityLogCleanup implements Schedulable, Database.Batchable<SObject>`.
+Doc-comment says *"Daily housekeeping: aggregates yesterday's analytics-style
+ActivityLog__c rows into NetworkEntity__c.UsageAnalyticsJsonTxt__c and purges
+rows older than the retention horizon."* The class implements the full
+Schedulable + Batchable surface, has a 200-line test class, and reads
+`DeliveryHubSettings__c.ActivityLogRetentionDaysNumber__c`. **But:** the master
+scheduler (`DeliveryHubScheduler.scheduleAll()` — called from
+`DeliveryHubInstallHandler.onInstall()`) does NOT include it. The class header
+suggests admins run `System.schedule('Delivery Activity Log Cleanup', '0 0 2 * * ?', new DeliveryActivityLogCleanup())`
+from anonymous Apex — but no subscriber installs would ever do that without
+documentation. **Recommendation:** either wire it into `scheduleAll()` (so it
+runs everywhere), or delete it (~280 LOC + retention field). The half-state is
+strictly worse than either pole.
+
+### Dead `@AuraEnabled` reader methods (carry-over from 5/13)
+
+`DeliveryFieldChangeService.getFieldChangeHistory()` +
+`getFieldChangeTrend()` — only called by the dead `deliveryFieldHistory` LWC.
+The companion writer methods on the same class are alive (called by
+`DeliveryFieldTrackingService` from 3 triggers). Same status as 5/13: if Glen
+deletes the dead LWC, these two reader methods go with it; if he keeps the
+LWC, leave them.
+
+## Deprecated-but-in-use (TODO markers still pending)
+
+| Location | TODO | Age (days) | Status |
+| --- | --- | --- | --- |
+| `DeliveryDocActionRestApi.cls:158` | "persist portalSessionEmail to a dedicated PortalSessionEmail__c field once the schema PR lands" | ~49 | Schema PR still unlanded; workaround (stuffing email in a user-agent string column) remains live. Carry-over from 5/13. |
+| `DeliveryDocGenerationService.cls:272` | "surface a dedicated DeliveryHubSettings__c branding block so admins can override the issuer name/url" | ~49 | Minor admin-config gap, no urgency. Carry-over from 5/13. |
+| `DeliveryOnboardingService.cls:398` | "PR 4+: when VerificationMethodPk__c != 'Manual', call the verification handler" | ~6 | Intentional next-iteration marker. Cited as a known gap in `docs/audits/e2e-walkthrough-2026-05-21.md` Top 5. |
+
+## LWCs that ship without a placement
+
+**14 carry-over from 5/13** (Glen never gave the delete OK on the "Likely safe —
+verify before deleting" cluster from the prior audit):
+
+- `deliveryBurndownChart` (Feb 2026, PR #304)
+- `deliveryCycleTimeChart` (Feb 2026, PR #307)
+- `deliveryDeveloperWorkload` (Feb 2026, PR #305)
+- `deliverySLASummary` (Feb 2026)
+- `deliveryStageHistory` (Mar 2026 — note: declares `lightning__RecordPage` target,
+  could feasibly be intended for the WI record FlexiPage; flagged 5/13)
+- `deliveryFieldHistory` (Mar 2026, PR #354)
+- `deliveryBoardMetrics` (Mar 2026)
+- `deliveryCsvImport` (Feb 2026, PR #315)
+- `deliveryWorkItemTemplates` (Feb 2026, PR #317) — likely superseded by
+  `deliveryTemplateManager`
+- `deliveryKanbanSettingsContainer` (Feb 2026) — likely superseded by
+  `deliverySettingsContainer`
+- `deliveryStatusPage` (Feb 2026, PR #319) — superseded by `DeliveryStatusPage.page`
+  VF (the deployed one)
+- `deliveryDocumentSignPortal` (Apr 2026, PR #589 "Coleman demo")
+- `deliveryRecordLiveRefresh` (Apr 2026, PR #731) — "wire don't delete" per 5/13
+- `deliveryInvoicePreviewDeferPanel` (Apr 2026, PR #686) — bulk-defer panel
+  that was built but never placed on the invoice or document FlexiPage
+
+**6 NEW since 5/13** — all from the cockpit / Watcher / audit-trail PR fan-out:
+
+| LWC | Origin PR | Date | Targets | Status |
+| --- | --- | --- | --- | --- |
+| `deliveryFeatureOnboarding` | #796 | 2026-05-20 | `lightning__RecordPage` (Feature__c, WorkItem__c) | Exposed for admin drag-drop; package ships no auto-placement on FeatureRecordPage. Worth wiring. |
+| `deliveryDevLoopGuide` | #804 | 2026-05-21 | `lightning__RecordPage` (Feature__c, WorkItem__c) | Same shape — designed for record-page drop, no out-of-box placement. |
+| `deliveryDatasetTemplates` | #803 | 2026-05-21 | `lightning__RecordPage` (Feature__c, WorkItem__c), `lightning__AppPage`, `lightning__HomePage` | Same shape. |
+| `deliveryActivityLog` | #820 | 2026-05-24 | `lightning__AppPage`, `lightning__HomePage`, `lightning__RecordPage` | Designed as audit-trail viewer for ActivityLog__c. The `ActivityLog__c.tab-meta.xml` standard tab exists; the standard list view replaces this LWC on the tab. Worth dropping on a record page or the admin home. |
+| `deliveryOnboardingHistory` | #820 | 2026-05-24 | (verify meta) | Audit-trail viewer for OnboardingProgress__c. |
+| `deliveryWatcherDigestHistory` | #820 | 2026-05-24 | (verify meta) | Audit-trail viewer for WatcherDigest__c. The `WatcherDigest__c.tab-meta.xml` standard tab exists; same drop-on-page question as `deliveryActivityLog`. |
+
+Pattern note: **every one of the 6 new orphan LWCs is exposed=true with valid
+targets**. They are NOT dead code — they are "exposed-but-unwired", the same
+pattern Glen called out in `feedback_default_scope_and_defer_discipline.md`
+("Don't reach for defer — ship the right thing the first time"). The audit
+recommends a one-shot **wiring-PR** (not a delete-PR) for these six, mirroring
+PR-E from the 5/13 audit.
+
+## Cross-cutting patterns
+
+1. **The 5/13 "Definitely safe" delete cluster shipped cleanly** in PR #789
+   without follow-on regressions. The audit-driven verification process worked
+   (`feedback_verify_audit_findings_before_shipping.md` was born this cycle).
+   No new "definitely safe" candidates have accumulated in the 13 days since.
+
+2. **The "Likely safe — verify before deleting" 5/13 bucket is unchanged.**
+   The 14 unplaced LWCs from the Feb–Apr widget/portal spike + various stragglers
+   all still ship. Glen's sign-off path on these stalled — these are not
+   "regressions", they're a backlog item awaiting decision. Estimated cleanup:
+   one PR per cluster (analytics widgets ~7 LWCs + 1:1 controllers, Experience
+   Cloud portal stub ~1 LWC remaining (deliveryDocumentSignPortal) + DeliveryPortalController
+   methods, bounty cluster ~3 classes + 1 object + 9 fields).
+
+3. **New code is hygenic but under-wired.** All 6 new orphan LWCs from
+   2026-05-20→2026-05-24 are exposed=true with valid targets, real
+   Apex controllers, real tests, and design intent recorded in their
+   `masterLabel` / `description`. They're just not auto-placed by the
+   package. This is the same defer-pattern Glen has flagged twice
+   ([[default-scope-and-defer-discipline]], [[ship-full-cycle-not-just-pr]]).
+   Recommend: wiring-PR (place on FeatureRecordPage / WorkItemRecordPage /
+   admin home), not delete-PR.
+
+4. **Stub-state services have a documented contract.** The 4 Watcher signal
+   stubs from PR #809 (Signals 4-7) are intentionally empty and gated behind
+   a 14-day heartbeat-data clock. Their stub-ness is a feature, not a bug —
+   they ship the wiring so Phase 3 implementation is mechanical. **Do not
+   delete or refactor**; they will be filled in after 2026-06-04.
+
+5. **One real stale stub deserves attention.** `DeliveryActivityLogCleanup`
+   is a fully-implemented Schedulable that the master scheduler never
+   registers. This is materially different from "dormant by-design" because
+   the class header explicitly describes it as nightly-running. Either wire
+   into `DeliveryHubScheduler.scheduleAll()` or delete — the half-state is
+   strictly worse than either pole.
+
+## Suggested follow-on PRs (Glen sign-off required)
+
+If Glen wants to action the findings, three independent PRs:
+
+1. **PR-W "wire don't delete"** — place the 6 new orphan LWCs (cockpit + audit-trail
+   viewers) onto their natural FlexiPages. Estimated 30min:
+   - `deliveryFeatureOnboarding` → `DeliveryFeatureRecordPage` (Feature__c)
+   - `deliveryDevLoopGuide` → `DeliveryFeatureRecordPage` + `DeliveryWorkItemRecordPage`
+   - `deliveryDatasetTemplates` → `DeliveryFeatureRecordPage`
+   - `deliveryActivityLog` → `DeliveryHubAdminHome` (admin home page)
+   - `deliveryOnboardingHistory` → `DeliveryFeatureRecordPage` (or `DeliveryHubAdminHome`)
+   - `deliveryWatcherDigestHistory` → `DeliveryHubAdminHome`
+   Adds ~12 lines of FlexiPage XML per LWC, removes 6 from this audit's flag
+   list next pass. **Highest-leverage delta** — fixes a known recurring pattern.
+
+2. **PR-A "wire or delete the cleanup batch"** — single-class call:
+   `DeliveryActivityLogCleanup`. Either add to `DeliveryHubScheduler.scheduleAll()`
+   (~3 lines) OR delete the class + test + retention field (~280 LOC).
+   Either decision unblocks subscriber-facing housekeeping. Same pattern as
+   the 5/13 audit's "Refactor-target classes never adopted" call-out — when
+   a class is shipped without its wiring, ship the wiring or remove the
+   class.
+
+3. **PR-B "drop the 5/13 carry-over likely-safe cluster"** (only if Glen
+   confirms intent) — same three sub-PRs as the 5/13 audit recommended:
+   analytics widgets (~3500 LOC), Experience Cloud / docusign stub
+   (~2000 LOC), bounty marketplace (~1500 LOC + 1 object + 9 fields). Net
+   ~7000 LOC if all three land. Carry-over decisions, no new analysis.
+
+Total potential cleanup vs wiring: PR-W is 30min net-add; PR-A is 5min
+(wire) OR 1h (delete); PR-B is the deferred 5/13 carry-over (~half-day).
+
+## Net delta vs 2026-05-13 baseline
+
+- Dead Apex classes: **0 today vs 4 on 5/13** — PR #789 closed all four
+  (`DeliveryArchivalService`, `DeliveryHubCalloutService`,
+  `DeliveryWorkItemQueryService`, `DeliveryTimelineController`).
+- Dead LWCs (zero references): **20 today vs 22 on 5/13** — PR #789 deleted 5
+  Experience-Cloud portal LWCs + `deliveryPartnerSettingsCard` +
+  `deliveryActivityTracker` (8 net deletions); 6 new orphan LWCs accumulated
+  from the cockpit + audit-trail PR fan-out (net +6). True net: -8 + 6 = -2.
+- Dead objects: **0 today vs 0 on 5/13** — unchanged, still clean.
+- Stale stubs: **6 today vs 0 explicitly tracked on 5/13** — 4 are documented
+  intentional time-locked Watcher signals (Phase 3 holds until ~2026-06-04);
+  1 is the `DeliveryActivityLogCleanup` wire-vs-delete decision; 1 is the
+  `DeliveryFieldChangeService` reader-method pair (carry-over from 5/13's
+  judgment-call list, status unchanged).
+- Field-level orphans: **4 today vs 4 on 5/13** — unchanged (3 dormant
+  approval-workflow fields + `PortalAccess__c.PermissionsTxt__c`).
+- Test-only-but-live-via-REST: **3 today vs 3 on 5/13** — unchanged
+  (`DeliveryBountyApiService`, `DeliveryGanttRemoteController`, `DeliveryTaskAPI`).
+- TODO comments older than 30 days: **2 today vs 2 on 5/13** — same two, now
+  ~49 days old (vs 36 days on 5/13). Still under the 60-day stale threshold.

--- a/docs/audits/pmd-baseline-2026-05-26.md
+++ b/docs/audits/pmd-baseline-2026-05-26.md
@@ -1,0 +1,164 @@
+# Repo-wide PMD Baseline — 2026-05-26
+
+> Refresh of `pmd-baseline-2026-05-21.md` (5 days stale). Re-runs the
+> whole-repo PMD scan after `release/0.247.0.6` shipped (PRs #812–#816) and
+> after the UX-gap fan-out landed (#818 approval-submit, #819 inline
+> dependency editor, #820 audit-trail viewers, #821 PSG hotfix, #822 in-app
+> notifications).
+>
+> **Report-only.** No code touched in this PR.
+
+## Method
+
+```
+sf scanner run --engine pmd --pmdconfig pmd-rules.xml \
+  --target "force-app/main/default/classes" \
+  --format json --outfile pmd-result.json
+```
+
+- **Ruleset**: `pmd-rules.xml` — pulls `category/apex/default.xml` +
+  `category/xml/default.xml` (all default Apex rules at default thresholds;
+  PMD 7.11.0 via `@salesforce/sfdx-scanner`). Unchanged since 5/15 / 5/21.
+- **CI gate**: `.github/workflows/feature_test.yml` uses
+  `mitchspano/sfdx-scan-pull-request@v0.1.16` with `severity-threshold: 4`.
+  Trips on **any** severity 1-4 finding in changed files. Every default Apex
+  rule emits at sev 3 → "any new finding fails the PR."
+- **Target population**: 321 `.cls` files (166 non-test + ~155 test) — vs 277
+  on 5/15. Net +44 .cls: cockpit plan PRs (~20 new classes + tests),
+  Phase 2 Watcher (~12), UX-gap fan-out (~8), TestDataFactory (1 + test),
+  minus the 10 .cls deleted in PR #789.
+
+## Headline
+
+- **Total violations:** **83** (vs ~137 on 5/15 / 5/21 — **net -54, a 39% drop**)
+- **Files with violations:** **59 / 321** (18% — vs 22% on 5/15)
+- **Classes carrying `@SuppressWarnings('PMD.*')`:** **176** (incl. test classes
+  — vs ~161 on 5/21, +15 net from the cockpit + Watcher + UX-gap waves)
+- **Total `@SuppressWarnings` annotations:** **276** instances across those 176 files
+
+The 39% drop is real and traces to three explicit cleanups that landed in the
+window: PR #791 wiped 40 ApexDoc findings from `DeliveryDocumentController`,
+PR #811 refactored `DeliverySlackInboundHandler.handle()` from cyc 13 → ~4
+(killing 6 findings), and PR #789 deleted `DeliveryArchivalService` (5
+ApexDoc findings). Net cleanup delta: 51 findings. The remaining 3 (137 → 83
+delta minus 51 cleanup) come from minor churn — controllers cleaned via
+`@SuppressWarnings` annotations being added inline during PR review (the
+documented pattern from the 5/21 baseline).
+
+## Violations by rule
+
+| Count | Rule | Category | Delta vs 5/15 |
+| ---: | --- | --- | --- |
+| 46 | `AvoidGlobalModifier` | Best Practices | -2 |
+| 11 | `CyclomaticComplexity` | Design | -1 |
+|  8 | `StdCyclomaticComplexity` | Design | -2 |
+|  6 | `ApexDoc` | Documentation | **-49** (←PR #791 + #789) |
+|  5 | `ApexCRUDViolation` | Security | 0 |
+|  3 | `NcssMethodCount` | Design | -1 |
+|  2 | `ExcessiveClassLength` | Design | 0 |
+|  1 | `NcssTypeCount` | Design | 0 |
+|  1 | `ExcessivePublicCount` | Design | **+1** (←TestDataFactory) |
+
+**Top dropper: `ApexDoc` (55 → 6).** A near-complete wipeout. The only
+remaining ApexDoc findings are in 4 classes: `DeliveryActivityFeedController` (3),
+`DeliveryWorkItemTriggerHandler` (1), `DeliveryEscalationNotifService` (1),
+`WebhookSignatureVerifier` (1). The `DeliveryDocumentController` 29%-of-repo
+slug from 5/15 is gone.
+
+## Top 10 noisiest classes (today)
+
+| Violations | Class | Rule breakdown | Δ vs 5/15 |
+| ---: | --- | --- | --- |
+|  6 | `DeliveryWorkItemController.cls` | ApexCRUDViolation:5, AvoidGlobal:1 | flat |
+|  5 | `DeliveryDashboardCardController.cls` | StdCyc:2, AvoidGlobal:1, Cyc:1, NcssMethod:1 | flat |
+|  4 | `DeliveryActivityFeedController.cls` | ApexDoc:3, AvoidGlobal:1 | flat |
+|  4 | `DeliveryDocActionRestApi.cls` | StdCyc:2, Cyc:2 | flat |
+|  4 | `DeliveryGanttController.cls` | StdCyc:2, ExcessiveClassLength:1, NcssTypeCount:1 | flat |
+|  4 | `DeliveryHubSyncService.cls` | Cyc:2, NcssMethod:2 | flat |
+|  3 | `IntegrationResponseMapper.cls` | StdCyc:2, Cyc:1 | flat |
+|  2 | `DeliverySlackService.cls` | AvoidGlobal:1, Cyc:1 | **-1** (#811 helped here too) |
+|  1 | `DeliveryActivityFeedControllerTest.cls` | CyclomaticComplexity:1 | (new in baseline) |
+|  1 | `DeliveryWorkItemTriggerHandler.cls` | ApexDoc:1 | flat |
+
+**3 classes from the 5/15 top-10 are now CLEAN:**
+
+- `DeliveryDocumentController.cls` — 40 → 0 (PR #791, 2026-05-18)
+- `DeliverySlackInboundHandler.cls` — 6 → 0 (PR #811, 2026-05-22)
+- `DeliveryArchivalService.cls` — 5 → DELETED (PR #789, 2026-05-18)
+
+## New classes since 5/13 — PMD impact
+
+28 non-test Apex classes were added across the cockpit (10 PRs), Phase 2
+Watcher (3 PRs), UX-gap fan-out (#818/#820/#822), and TestDataFactory (#787).
+Of those 28:
+
+- **27 ship PMD-clean** (zero findings at default thresholds). Every class
+  Was reviewed during PR check with `@SuppressWarnings('PMD.*')` annotations
+  applied inline where rule-defensible (per the 5/21 documented pattern —
+  30 suppressions added across 9 cockpit classes, all transparent).
+- **1 ships with a finding:** `TestDataFactory.cls` carries 1 `ExcessivePublicCount`
+  finding. Intentional — `TestDataFactory` is a Phase 1 multi-entry test
+  builder used by 21 test classes. The public-method count IS the design.
+  Recommend suppress with `@SuppressWarnings('PMD.ExcessivePublicCount')` + a
+  "// kept multi-entry because TestDataFactory is the canonical test builder
+  per CLAUDE.md PR #787" comment.
+
+## Stable baseline classes — no PMD regression
+
+The "long tail" monoliths (`DeliveryGanttController` 1593 LOC,
+`DeliverySyncItemIngestor` 1075 LOC, `DeliveryWorkItemTriggerHandler` 681 LOC)
+all hold the same finding counts they had on 5/15. The cockpit / Watcher PRs
+did not touch these files. **Quality dial did not move backwards.**
+
+## Recommended next-cleanup-bundle picks
+
+Three independent PRs, each ~30min–2h:
+
+| # | PR scope | Effort | Kills | Risk |
+|---|---|---|---|---|
+| 1 | `ApexCRUDViolation` triage on `DeliveryWorkItemController.cls` (5 findings at lines 50/162/224) — add `Schema.sObjectType.X.isAccessible()` or `WITH SECURITY_ENFORCED` | 2h | 5 (6% of total) | Low — validates security controls; needs test coverage |
+| 2 | `ApexDoc` sweep on `DeliveryActivityFeedController.cls` (3 findings) | 30min | 3 (4% of total) | Zero — style-only |
+| 3 | `AvoidGlobalModifier` triage — 46 findings across 38 controllers/services. Downgrade to `public` where the `global` modifier isn't required for `@RestResource` or managed-package public surface | 3h | Up to 25 if half downgrade-eligible | Medium — per CLAUDE.md, when an Apex class is `global`, all inner return/param types must also be `global`. Verify each downgrade doesn't cascade-break. |
+
+**Recommended next-session bundle:** #1 + #2 ≈ 2.5h. Pure win, zero blast
+radius, removes ~10% of remaining findings. #3 is its own bigger investment
+and should be triaged separately.
+
+The 5/21 baseline's #2 recommendation (Slack handle() refactor) **shipped
+in PR #811** — that work is closed.
+
+## What does NOT need fixing
+
+The 5/15 calibration analysis remains valid: only 2% of methods exceed
+cyclomatic 10, the ruleset is correctly tuned, and the long-tail monoliths
+(`DeliveryGanttController`, `DeliverySyncItemIngestor`) are intentionally
+deferred to depth-charge / sync-engine consolidation roadmaps (not cracked
+open for stylistic cleanup). The 4 Watcher signal stubs (intentionally empty
+per the 14-day heartbeat clock) are PMD-clean — no false-positive churn.
+
+## Net delta narrative
+
+The cycle from 5/15 → 5/21 → 5/26 represents the strongest sustained PMD
+quality improvement in the project's history:
+
+- **5/15 → 5/21:** +10 cockpit classes shipped with ~30 documented suppressions.
+  Net debt unchanged (the suppressions are transparent debt-tracking, not
+  regression).
+- **5/21 → 5/26:** PR #791 (`DeliveryDocumentController` ApexDoc sweep, -40),
+  PR #811 (`DeliverySlackInboundHandler` refactor, -6), PR #789
+  (`DeliveryArchivalService` delete, -5). Plus 19 new classes shipped clean
+  (1 with a single intentional finding). Phase 2 Watcher + UX-gap fan-out
+  added zero gross debt.
+
+The audit-driven verification process (born 5/22 per the
+`feedback_verify_audit_findings_before_shipping.md` memory) caught 3 stale
+audit claims during the `release/0.247.0.6` cycle, including the 5/21
+baseline incorrectly listing `DeliveryDocumentController` as 40-violations-pending
+when PR #791 had already closed it. This audit re-verified each claim before
+writing the table.
+
+**Net codebase quality is meaningfully better** than 5/21 — fewer findings,
+fewer files with findings, same calibration. The legacy debt from 5/15
+(cyclomatic complexity in 6 methods + CRUD violations in
+`DeliveryWorkItemController`) is what remains and what the next-session
+bundle targets.


### PR DESCRIPTION
## Summary

- **Dead-code refresh** — zero confirmed-dead Apex classes today (down from 4 on 5/13, all closed by PR #789). 6 NEW orphan LWCs accumulated from the cockpit + audit-trail fan-out — all exposed=true but not auto-placed by the package. 1 stale-stub Schedulable (`DeliveryActivityLogCleanup`) deserves a wire-or-delete call. 4 Watcher signal stubs are intentional (time-locked, Phase 3 ETA ~2026-06-04).
- **PMD baseline refresh** — total violations **137 → 83 (net -54, 39% drop)** driven by 3 cleanups in the window (PR #791 ApexDoc sweep, PR #811 Slack refactor, PR #789 ArchivalService delete). 3 classes from the 5/15 top-10 are now CLEAN. 27 of 28 new post-5/13 classes ship PMD-clean.
- **Top 3 recommendations:** (1) ApexCRUDViolation triage on `DeliveryWorkItemController.cls` (~2h, kills 5 findings, real security work); (2) ApexDoc sweep on `DeliveryActivityFeedController.cls` (~30min, kills 3); (3) wiring-PR for the 6 new orphan LWCs onto natural FlexiPages (~30min, no PMD impact but closes a recurring `default-scope-and-defer` pattern).

## Files added

- `docs/audits/dead-code-audit-2026-05-26.md` (208 lines)
- `docs/audits/pmd-baseline-2026-05-26.md` (132 lines)

## Notes

This is **report-only**. No code, metadata, or test changes. Subsequent cleanup PRs (if any) are gated on Glen's review of the findings tables. Both audits follow the `docs/audits/<name>-YYYY-MM-DD.md` convention and mirror the structure of their predecessors for diff-readability.

The 5/15 baseline's #2 recommendation (Slack `handle()` refactor) and the 5/21 baseline's top-row claim (`DeliveryDocumentController` 40-findings-pending) both verified-and-closed during this refresh — explicitly cross-referenced against current main rather than copy-forwarded from prior audits.

## Test plan

- [x] Verified branch from `origin/main` (commit 38367bae — feat(notify) PR #822)
- [x] Re-ran `sf scanner run --engine pmd --pmdconfig pmd-rules.xml` on `force-app/main/default/classes` (83 violations / 59 files)
- [x] Per-class dead-Apex grep across all 166 non-test classes (0 confirmed dead, 3 test-only-but-REST-live)
- [x] Per-LWC reference scan across HTML + flexipages + apps + tabs (20 orphan, 6 NEW)
- [x] Per-object SOQL/DML scan (0 dead)
- [ ] CI passes (docs-only PR; trivial)