### PR TITLE
chore(mdt): add <description> to 7 cockpit __mdt types (closes doc-gap-audit-2026-05-26 #1)

### DIFF
--- a/force-app/main/default/objects/DashboardCard__mdt/DashboardCard__mdt.object-meta.xml
+++ b/force-app/main/default/objects/DashboardCard__mdt/DashboardCard__mdt.object-meta.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/meta/metadata">
+    <description>Catalog row backing one tile on the Delivery Hub dashboard. Each row defines a tile's icon, title, query/summary source, and target route. Subscribers extend the dashboard by adding rows; no Apex change required.</description>
     <label>Dashboard Card</label>
     <pluralLabel>Dashboard Cards</pluralLabel>
     <visibility>Public</visibility>

--- a/force-app/main/default/objects/DevLoopGuide__mdt/DevLoopGuide__mdt.object-meta.xml
+++ b/force-app/main/default/objects/DevLoopGuide__mdt/DevLoopGuide__mdt.object-meta.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Catalog row backing the deliveryDevLoopGuide LWC (Layer 6). Each row maps a development phase to the recommended scratch-org commands, branch-naming convention, and PR template. Seed-data ships 4 examples; subscribers extend.</description>
     <label>Dev Loop Guide</label>
     <pluralLabel>Dev Loop Guides</pluralLabel>
     <visibility>Public</visibility>

--- a/force-app/main/default/objects/FeatureDefinition__mdt/FeatureDefinition__mdt.object-meta.xml
+++ b/force-app/main/default/objects/FeatureDefinition__mdt/FeatureDefinition__mdt.object-meta.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Static catalog entry for one Delivery Hub feature. Pairs with a runtime Feature__c row that carries enabled/disabled state, last-toggled metadata, and approval-routing. The mdt row defines the feature's identity (label, description, category, icon, settings-field link); the __c row is the per-tenant on/off + audit-trail. Layer 4 of the cockpit architecture.</description>
     <label>Feature Definition</label>
     <pluralLabel>Feature Definitions</pluralLabel>
     <visibility>Public</visibility>

--- a/force-app/main/default/objects/OnboardingChecklistItem__mdt/OnboardingChecklistItem__mdt.object-meta.xml
+++ b/force-app/main/default/objects/OnboardingChecklistItem__mdt/OnboardingChecklistItem__mdt.object-meta.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>One step in an onboarding track's checklist (Layer 5). Each row defines a verification method (Manual attestation, SOQL query, REST call, or webhook receipt — the latter three are stubs as of release/0.248.x) plus the prompt and the query/URL to evaluate. Bound to a parent OnboardingTrack__mdt via TrackTxt__c.</description>
     <label>Onboarding Checklist Item</label>
     <pluralLabel>Onboarding Checklist Items</pluralLabel>
     <visibility>Public</visibility>

--- a/force-app/main/default/objects/OnboardingLesson__mdt/OnboardingLesson__mdt.object-meta.xml
+++ b/force-app/main/default/objects/OnboardingLesson__mdt/OnboardingLesson__mdt.object-meta.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>One narrative lesson in an onboarding track (Layer 5). Renders Markdown body, optional reference URL, and an estimated duration in the deliveryFeatureOnboarding LWC. Bound to a parent OnboardingTrack__mdt via TrackTxt__c. Ordered by SortOrderNumber__c.</description>
     <label>Onboarding Lesson</label>
     <pluralLabel>Onboarding Lessons</pluralLabel>
     <visibility>Public</visibility>

--- a/force-app/main/default/objects/OnboardingQuiz__mdt/OnboardingQuiz__mdt.object-meta.xml
+++ b/force-app/main/default/objects/OnboardingQuiz__mdt/OnboardingQuiz__mdt.object-meta.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>One quiz attached to an onboarding track (Layer 5). Stores quiz questions as JSON, a pass threshold, and an AllowRetryDateTime__c flag (populated = retries permitted, null = single attempt). Bound to a parent OnboardingTrack__mdt via TrackTxt__c.</description>
     <label>Onboarding Quiz</label>
     <pluralLabel>Onboarding Quizzes</pluralLabel>
     <visibility>Public</visibility>

--- a/force-app/main/default/objects/OnboardingTrack__mdt/OnboardingTrack__mdt.object-meta.xml
+++ b/force-app/main/default/objects/OnboardingTrack__mdt/OnboardingTrack__mdt.object-meta.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>The root container for an onboarding curriculum (Layer 5). One row per track (e.g. Invoice_Generation_Track). Child OnboardingLesson__mdt / OnboardingQuiz__mdt / OnboardingChecklistItem__mdt rows bind via TrackTxt__c. Optionally gated by a Feature__c — non-admins cannot enable that feature until the track's CompletedDateTime__c is populated on their OnboardingProgress__c.</description>
     <label>Onboarding Track</label>
     <pluralLabel>Onboarding Tracks</pluralLabel>
     <visibility>Public</visibility>


### PR DESCRIPTION
## Summary
- Adds admin-readable `<description>` to 7 cockpit-era `__mdt` types that shipped without one: `DashboardCard`, `DevLoopGuide`, `FeatureDefinition`, `OnboardingChecklistItem`, `OnboardingLesson`, `OnboardingQuiz`, `OnboardingTrack`.
- Each description names the layer (4/5/6), explains what each row carries, and points at the pairing LWC / runtime object.
- Closes `docs/audits/documentation-gap-audit-2026-05-26.md` finding #1.

## Test plan
- [ ] feature-test green (pure metadata, no code)
- [ ] upload-beta green
- [ ] Manual on install: Setup → Custom Metadata Types → confirm Description column populated for each of the 7 types

🤖 Generated with [Claude Code](https://claude.com/claude-code)