### PR TITLE
chore(pmd): AvoidGlobalModifier suppressions + DeliveryActivityFeedController ApexDoc (closes pmd-baseline-2026-05-26 backlog)

### DIFF
--- a/force-app/main/default/classes/DeliveryActivityDashboardController.cls
+++ b/force-app/main/default/classes/DeliveryActivityDashboardController.cls
@@ -5,7 +5,7 @@
  * Returns aggregate analytics from ActivityLog__c for user tracking and adoption metrics.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity')
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryActivityDashboardController {
 
     /** @description Wrapper for a ranked item (user or component) with its activity count. */

--- a/force-app/main/default/classes/DeliveryActivityFeedController.cls
+++ b/force-app/main/default/classes/DeliveryActivityFeedController.cls
@@ -8,7 +8,7 @@
  *               WorkLog approval workflows.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation,PMD.ExcessiveParameterList,PMD.CyclomaticComplexity')
+@SuppressWarnings('PMD.ApexCRUDViolation,PMD.ExcessiveParameterList,PMD.CyclomaticComplexity,PMD.AvoidGlobalModifier')
 global with sharing class DeliveryActivityFeedController {
 
     private static final Integer PAGE_SIZE = 25;
@@ -623,9 +623,11 @@ global with sharing class DeliveryActivityFeedController {
     }
 
     /**
-     * Render a value for the activity-feed detail line. Null / blank become
-     * '(empty)' so users see signal instead of a bare arrow or the literal
+     * @description Render a value for the activity-feed detail line. Null / blank
+     * become '(empty)' so users see signal instead of a bare arrow or the literal
      * Apex String.valueOf(null) output of "null".
+     * @param v The raw string value (typically an old/new field value or stage name).
+     * @return '(empty)' when v is null or blank; otherwise v unchanged.
      */
     private static String displayValue(String v) {
         return String.isBlank(v) ? '(empty)' : v;

--- a/force-app/main/default/classes/DeliveryActivityTimelineController.cls
+++ b/force-app/main/default/classes/DeliveryActivityTimelineController.cls
@@ -6,7 +6,7 @@
  * unified, chronological event feed for a given Work Item.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.CyclomaticComplexity')
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryActivityTimelineController {
 
     private static final Integer PAGE_SIZE = 20;

--- a/force-app/main/default/classes/DeliveryAiController.cls
+++ b/force-app/main/default/classes/DeliveryAiController.cls
@@ -9,7 +9,7 @@
  * @author Cloud Nimbus LLC
  */
 // Complexity is distributed across many small, focused helper methods — aggregate is expected.
-@SuppressWarnings('PMD.CyclomaticComplexity')
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryAiController {
 
     /**

--- a/force-app/main/default/classes/DeliveryBountyApiService.cls
+++ b/force-app/main/default/classes/DeliveryBountyApiService.cls
@@ -9,6 +9,7 @@
  */
 @SuppressWarnings('PMD.ApexCRUDViolation')
 @RestResource(urlMapping='/deliveryhub/v1/bounties/*')
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global without sharing class DeliveryBountyApiService {
 
     // ── GET: Public Bounty Browsing ──────────────────────────────────────

--- a/force-app/main/default/classes/DeliveryBountyApiService.cls
+++ b/force-app/main/default/classes/DeliveryBountyApiService.cls
@@ -7,9 +7,8 @@
  *               URL Pattern: /services/apexrest/delivery/deliveryhub/v1/bounties/{resource}
  * @author       Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation')
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.AvoidGlobalModifier')
 @RestResource(urlMapping='/deliveryhub/v1/bounties/*')
-@SuppressWarnings('PMD.AvoidGlobalModifier')
 global without sharing class DeliveryBountyApiService {
 
     // ── GET: Public Bounty Browsing ──────────────────────────────────────

--- a/force-app/main/default/classes/DeliveryBurndownController.cls
+++ b/force-app/main/default/classes/DeliveryBurndownController.cls
@@ -6,6 +6,7 @@
  *              totals of created, completed, and open items over a 12-week window.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryBurndownController {
 
     /** @description Number of weeks of history to return. */

--- a/force-app/main/default/classes/DeliveryClientOnboardingController.cls
+++ b/force-app/main/default/classes/DeliveryClientOnboardingController.cls
@@ -6,7 +6,7 @@
  *               in one step.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation, PMD.ExcessiveParameterList')
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.ExcessiveParameterList, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryClientOnboardingController {
 
     private static final String DEFAULT_WORKFLOW = 'Software_Delivery';

--- a/force-app/main/default/classes/DeliveryCsvImportController.cls
+++ b/force-app/main/default/classes/DeliveryCsvImportController.cls
@@ -6,7 +6,7 @@
  *               available field schema for dynamic column mapping.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.CyclomaticComplexity')
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryCsvImportController {
 
     private static final Integer BATCH_SIZE = 200;

--- a/force-app/main/default/classes/DeliveryCycleTimeController.cls
+++ b/force-app/main/default/classes/DeliveryCycleTimeController.cls
@@ -5,6 +5,7 @@
  * time data for completed work items and current stage age breakdowns for active items.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryCycleTimeController {
 
     /** @description Number of days to look back for completed work items */

--- a/force-app/main/default/classes/DeliveryDashboardCardController.cls
+++ b/force-app/main/default/classes/DeliveryDashboardCardController.cls
@@ -5,7 +5,7 @@
  *               Reads DashboardCard__mdt records and resolves data for each card.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexDoc')
+@SuppressWarnings('PMD.ApexDoc, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryDashboardCardController {
 
     @AuraEnabled(cacheable=true)

--- a/force-app/main/default/classes/DeliveryDataLineageController.cls
+++ b/force-app/main/default/classes/DeliveryDataLineageController.cls
@@ -6,6 +6,7 @@
  *               representation of the sync chain.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryDataLineageController {
 
     /**

--- a/force-app/main/default/classes/DeliveryDependencyGraphController.cls
+++ b/force-app/main/default/classes/DeliveryDependencyGraphController.cls
@@ -6,6 +6,7 @@
  *              of work item dependencies for visualization.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryDependencyGraphController {
 
     /**

--- a/force-app/main/default/classes/DeliveryDocActionRestApi.cls
+++ b/force-app/main/default/classes/DeliveryDocActionRestApi.cls
@@ -22,9 +22,8 @@
  *               bundle without going through Aura.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation, PMD.ApexDoc')
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.ApexDoc, PMD.AvoidGlobalModifier')
 @RestResource(urlMapping='/sign/*')
-@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryDocActionRestApi {
 
     /** @description Handles GET /sign/<token>. Writes the document bundle to the response body. */

--- a/force-app/main/default/classes/DeliveryDocActionRestApi.cls
+++ b/force-app/main/default/classes/DeliveryDocActionRestApi.cls
@@ -24,6 +24,7 @@
  */
 @SuppressWarnings('PMD.ApexCRUDViolation, PMD.ApexDoc')
 @RestResource(urlMapping='/sign/*')
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryDocActionRestApi {
 
     /** @description Handles GET /sign/<token>. Writes the document bundle to the response body. */

--- a/force-app/main/default/classes/DeliveryFieldChangeService.cls
+++ b/force-app/main/default/classes/DeliveryFieldChangeService.cls
@@ -7,7 +7,7 @@
  *               retrieving change history and trend data.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity')
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryFieldChangeService {
 
     /**

--- a/force-app/main/default/classes/DeliveryGanttRemoteController.cls
+++ b/force-app/main/default/classes/DeliveryGanttRemoteController.cls
@@ -8,6 +8,7 @@
  * @author Cloud Nimbus LLC
  */
 @RestResource(urlMapping='/gantt-remote/*')
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryGanttRemoteController {
 
     /**

--- a/force-app/main/default/classes/DeliveryGhostController.cls
+++ b/force-app/main/default/classes/DeliveryGhostController.cls
@@ -5,6 +5,7 @@
  * Logs user activity to ActivityLog__c and creates quick work items.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryGhostController {
 
     /**

--- a/force-app/main/default/classes/DeliveryGuideController.cls
+++ b/force-app/main/default/classes/DeliveryGuideController.cls
@@ -2,6 +2,7 @@
  * @description Controller for the Delivery Guide component.
  * Provides org context and Ghost Recorder installation detection.
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryGuideController {
 
     private static final Set<String> GHOST_RECORDER_APP_NAMES = new Set<String>{

--- a/force-app/main/default/classes/DeliveryHubBoardController.cls
+++ b/force-app/main/default/classes/DeliveryHubBoardController.cls
@@ -4,7 +4,7 @@
  * @description Controller for the Delivery Hub Board LWC.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity')
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryHubBoardController {
 
     /**

--- a/force-app/main/default/classes/DeliveryHubCommentController.cls
+++ b/force-app/main/default/classes/DeliveryHubCommentController.cls
@@ -6,6 +6,7 @@
  * Uses standard DML so the DeliverySyncEngine Trigger picks it up automatically.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryHubCommentController {
 
     /**

--- a/force-app/main/default/classes/DeliveryHubDashboardController.cls
+++ b/force-app/main/default/classes/DeliveryHubDashboardController.cls
@@ -5,7 +5,7 @@
  * Returns System Pulse metrics and client-facing dashboard data.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity')
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryHubDashboardController {
 
     /** @description Wrapper for a work item summary row used in the client dashboard. */

--- a/force-app/main/default/classes/DeliveryHubFilesController.cls
+++ b/force-app/main/default/classes/DeliveryHubFilesController.cls
@@ -5,6 +5,7 @@
  * Returns all files linked to a Work Item and its related Comments and Requests.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryHubFilesController {
 
     /** @description Represents a single file attachment linked to a work item or its related records. */

--- a/force-app/main/default/classes/DeliveryHubPoller.cls
+++ b/force-app/main/default/classes/DeliveryHubPoller.cls
@@ -7,6 +7,7 @@
  * V3: Polls all active vendors, not just the first one.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global without sharing class DeliveryHubPoller {
 
     /**

--- a/force-app/main/default/classes/DeliveryHubPollerController.cls
+++ b/force-app/main/default/classes/DeliveryHubPollerController.cls
@@ -5,6 +5,7 @@
  * Exposes the Delivery Hub polling logic to the Lightning UI for manual and on-load refreshes.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryHubPollerController {
     
     @TestVisible 

--- a/force-app/main/default/classes/DeliveryHubSettingsController.cls
+++ b/force-app/main/default/classes/DeliveryHubSettingsController.cls
@@ -5,7 +5,7 @@
  * Handles General and AI configuration via Custom Settings.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.ExcessivePublicCount')
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.ExcessivePublicCount, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryHubSettingsController {
 
     /**

--- a/force-app/main/default/classes/DeliveryHubSetupController.cls
+++ b/force-app/main/default/classes/DeliveryHubSetupController.cls
@@ -7,7 +7,7 @@
  */
 // without sharing: Required so any user (including Standard Users without sharing rules)
 // can read/write NetworkEntity__c and DeliveryHubSettings__c during initial org setup.
-@SuppressWarnings('PMD.ApexSharingViolations, PMD.CyclomaticComplexity')
+@SuppressWarnings('PMD.ApexSharingViolations, PMD.CyclomaticComplexity, PMD.AvoidGlobalModifier')
 global without sharing class DeliveryHubSetupController {
 
     /** @description DTO holding the org's Delivery Hub connection status for the setup LWC. */

--- a/force-app/main/default/classes/DeliveryHubSyncService.cls
+++ b/force-app/main/default/classes/DeliveryHubSyncService.cls
@@ -8,6 +8,7 @@
  */
 @SuppressWarnings('PMD.StdCyclomaticComplexity')
 @RestResource(urlMapping='/deliveryhub/v1/sync/*')
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global without sharing class DeliveryHubSyncService {
 
     /**

--- a/force-app/main/default/classes/DeliveryHubSyncService.cls
+++ b/force-app/main/default/classes/DeliveryHubSyncService.cls
@@ -6,9 +6,8 @@
  * V2 Architecture: Supports DAG routing and multi-tenant data segregation.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.StdCyclomaticComplexity')
+@SuppressWarnings('PMD.StdCyclomaticComplexity, PMD.AvoidGlobalModifier')
 @RestResource(urlMapping='/deliveryhub/v1/sync/*')
-@SuppressWarnings('PMD.AvoidGlobalModifier')
 global without sharing class DeliveryHubSyncService {
 
     /**

--- a/force-app/main/default/classes/DeliveryMetricsService.cls
+++ b/force-app/main/default/classes/DeliveryMetricsService.cls
@@ -7,7 +7,7 @@
  *               completion rate data.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexDoc, PMD.ExcessivePublicCount')
+@SuppressWarnings('PMD.ApexDoc, PMD.ExcessivePublicCount, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryMetricsService {
 
     // -------------------------------------------------------------------------

--- a/force-app/main/default/classes/DeliveryPortalAccessService.cls
+++ b/force-app/main/default/classes/DeliveryPortalAccessService.cls
@@ -6,7 +6,7 @@
  * to a given NetworkEntity__c, and returns the list of entities they can access.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation')
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.AvoidGlobalModifier')
 global without sharing class DeliveryPortalAccessService {
 
     /**

--- a/force-app/main/default/classes/DeliveryPortalController.cls
+++ b/force-app/main/default/classes/DeliveryPortalController.cls
@@ -7,7 +7,7 @@
  * but validates access via NetworkEntity relationship.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity')
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.AvoidGlobalModifier')
 global without sharing class DeliveryPortalController {
 
     /**

--- a/force-app/main/default/classes/DeliveryPublicApiService.cls
+++ b/force-app/main/default/classes/DeliveryPublicApiService.cls
@@ -7,9 +7,8 @@
  * URL Pattern: /services/apexrest/delivery/deliveryhub/v1/api/{resource}
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity')
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.AvoidGlobalModifier')
 @RestResource(urlMapping='/deliveryhub/v1/api/*')
-@SuppressWarnings('PMD.AvoidGlobalModifier')
 global without sharing class DeliveryPublicApiService {
 
     /** @description Page size for paginated list endpoints (LIMIT cap). */

--- a/force-app/main/default/classes/DeliveryPublicApiService.cls
+++ b/force-app/main/default/classes/DeliveryPublicApiService.cls
@@ -9,6 +9,7 @@
  */
 @SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity')
 @RestResource(urlMapping='/deliveryhub/v1/api/*')
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global without sharing class DeliveryPublicApiService {
 
     /** @description Page size for paginated list endpoints (LIMIT cap). */

--- a/force-app/main/default/classes/DeliveryPublicSubmissionService.cls
+++ b/force-app/main/default/classes/DeliveryPublicSubmissionService.cls
@@ -9,6 +9,7 @@
  */
 @SuppressWarnings('PMD.ApexCRUDViolation')
 @RestResource(urlMapping='/deliveryhub/v1/submit')
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global without sharing class DeliveryPublicSubmissionService {
 
     /** Maximum submissions allowed per email address within the rate limit window. */

--- a/force-app/main/default/classes/DeliveryPublicSubmissionService.cls
+++ b/force-app/main/default/classes/DeliveryPublicSubmissionService.cls
@@ -7,9 +7,8 @@
  * sanitization to prevent abuse.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation')
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.AvoidGlobalModifier')
 @RestResource(urlMapping='/deliveryhub/v1/submit')
-@SuppressWarnings('PMD.AvoidGlobalModifier')
 global without sharing class DeliveryPublicSubmissionService {
 
     /** Maximum submissions allowed per email address within the rate limit window. */

--- a/force-app/main/default/classes/DeliveryQuickRequestController.cls
+++ b/force-app/main/default/classes/DeliveryQuickRequestController.cls
@@ -5,7 +5,7 @@
  *              Creates work items with optional AI enhancement via OpenAI.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity')
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryQuickRequestController {
 
     /**

--- a/force-app/main/default/classes/DeliveryRecurringItemService.cls
+++ b/force-app/main/default/classes/DeliveryRecurringItemService.cls
@@ -5,6 +5,7 @@
  * Handles scheduled creation of recurring items and on-demand cloning from templates.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryRecurringItemService {
 
     // Fields to copy when cloning a work item (descriptive / config fields only)

--- a/force-app/main/default/classes/DeliveryReleaseNotesController.cls
+++ b/force-app/main/default/classes/DeliveryReleaseNotesController.cls
@@ -6,6 +6,7 @@
  * returns structured data for formatted release notes display.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryReleaseNotesController {
 
     /** @description Default workflow type when none is specified. */

--- a/force-app/main/default/classes/DeliveryRequestManagerController.cls
+++ b/force-app/main/default/classes/DeliveryRequestManagerController.cls
@@ -8,6 +8,7 @@
  */
 // without sharing: Required so vendor request routing, status updates, and SyncItem creation
 // succeed regardless of the running user's sharing rules on WorkRequest__c / SyncItem__c.
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global without sharing class DeliveryRequestManagerController {
     
     /**

--- a/force-app/main/default/classes/DeliverySLAService.cls
+++ b/force-app/main/default/classes/DeliverySLAService.cls
@@ -6,6 +6,7 @@
  *               counts for dashboard components and warning day thresholds for At Risk detection.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliverySLAService {
 
     /** @description Hardcoded fallback: days for Critical priority (used when no CMT rules exist) */

--- a/force-app/main/default/classes/DeliverySavedFilterController.cls
+++ b/force-app/main/default/classes/DeliverySavedFilterController.cls
@@ -5,7 +5,7 @@
  *              Returns only the running user's own filters (Private sharing model).
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity')
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.AvoidGlobalModifier')
 global with sharing class DeliverySavedFilterController {
 
     /**

--- a/force-app/main/default/classes/DeliveryScoreService.cls
+++ b/force-app/main/default/classes/DeliveryScoreService.cls
@@ -6,7 +6,7 @@
  *               Backlog Health, Priority Balance, and Activity.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.ExcessivePublicCount, PMD.ApexDoc')
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.ExcessivePublicCount, PMD.ApexDoc, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryScoreService {
 
     // -------------------------------------------------------------------------

--- a/force-app/main/default/classes/DeliverySlackService.cls
+++ b/force-app/main/default/classes/DeliverySlackService.cls
@@ -6,7 +6,7 @@
  *              The test-connection method runs synchronously from an LWC user action.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexSuggestUsingNamedCred')
+@SuppressWarnings('PMD.ApexSuggestUsingNamedCred, PMD.AvoidGlobalModifier')
 global with sharing class DeliverySlackService {
 
     // ── Public API ───────────────────────────────────────────────────────────

--- a/force-app/main/default/classes/DeliveryStageHistoryController.cls
+++ b/force-app/main/default/classes/DeliveryStageHistoryController.cls
@@ -6,6 +6,7 @@
  *               chronological stage transition timeline for a Work Item.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryStageHistoryController {
 
     /**

--- a/force-app/main/default/classes/DeliveryStatusPageController.cls
+++ b/force-app/main/default/classes/DeliveryStatusPageController.cls
@@ -8,6 +8,7 @@
  *               can access the data without record-level restrictions.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global without sharing class DeliveryStatusPageController {
 
     /** @description Simple wrapper for a completed item shown on the VF page */

--- a/force-app/main/default/classes/DeliverySyncRetryController.cls
+++ b/force-app/main/default/classes/DeliverySyncRetryController.cls
@@ -7,6 +7,7 @@
  *              from the default view but visible when includeDismissed=true.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliverySyncRetryController {
 
     /** @description Summary of a failed sync item for display. */

--- a/force-app/main/default/classes/DeliveryTaskAPI.cls
+++ b/force-app/main/default/classes/DeliveryTaskAPI.cls
@@ -9,9 +9,8 @@
  *               Authenticates via X-Api-Key header matched against NetworkEntity__c.ApiKeyTxt__c.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.ApexSOQLInjection')
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.ApexSOQLInjection, PMD.AvoidGlobalModifier')
 @RestResource(urlMapping='/deliveryhub/v1/tasks/*')
-@SuppressWarnings('PMD.AvoidGlobalModifier')
 global without sharing class DeliveryTaskAPI {
 
     /**

--- a/force-app/main/default/classes/DeliveryTaskAPI.cls
+++ b/force-app/main/default/classes/DeliveryTaskAPI.cls
@@ -11,6 +11,7 @@
  */
 @SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.ApexSOQLInjection')
 @RestResource(urlMapping='/deliveryhub/v1/tasks/*')
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global without sharing class DeliveryTaskAPI {
 
     /**

--- a/force-app/main/default/classes/DeliveryTemplateManagerController.cls
+++ b/force-app/main/default/classes/DeliveryTemplateManagerController.cls
@@ -5,7 +5,7 @@
  *               create, and clone work item templates.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation')
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryTemplateManagerController {
 
     /**

--- a/force-app/main/default/classes/DeliveryTimeLoggerController.cls
+++ b/force-app/main/default/classes/DeliveryTimeLoggerController.cls
@@ -8,7 +8,7 @@
  *              isApprovalRequired check for the UI.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation')
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryTimeLoggerController {
 
     /**

--- a/force-app/main/default/classes/DeliveryVelocityService.cls
+++ b/force-app/main/default/classes/DeliveryVelocityService.cls
@@ -6,7 +6,7 @@
  *               and capacity utilization using DeveloperCapacity__mdt configuration.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexDoc, PMD.ExcessivePublicCount')
+@SuppressWarnings('PMD.ApexDoc, PMD.ExcessivePublicCount, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryVelocityService {
 
     private static final Integer DEFAULT_WEEKS = 8;

--- a/force-app/main/default/classes/DeliveryWebhookReceiverApi.cls
+++ b/force-app/main/default/classes/DeliveryWebhookReceiverApi.cls
@@ -12,6 +12,7 @@
  * @author Cloud Nimbus LLC
  */
 @RestResource(urlMapping='/deliveryhub/v1/webhook/*')
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryWebhookReceiverApi {
 
     /**

--- a/force-app/main/default/classes/DeliveryWorkItemController.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemController.cls
@@ -4,7 +4,7 @@
  * @description Controller for retrieving and seeding demo WorkItem__c records.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity')
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryWorkItemController {
 
     /**

--- a/force-app/main/default/classes/DeliveryWorkItemDependenciesController.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemDependenciesController.cls
@@ -5,6 +5,7 @@
  *              Returns blocking and blocked-by work item relationships for a given work item.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryWorkItemDependenciesController {
 
     /** @description Summary of a related work item shown in the dependency view. */

--- a/force-app/main/default/classes/DeliveryWorkItemETAService.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemETAService.cls
@@ -9,6 +9,7 @@
  * @author Mahipal Jat
  * @date July 22, 2025
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryWorkItemETAService {
 
     // #################################################################################

--- a/force-app/main/default/classes/DeliveryWorkItemQuotesController.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemQuotesController.cls
@@ -5,7 +5,7 @@
  *              Returns all WorkRequest__c quotes linked to a work item and supports bid acceptance.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation')
+@SuppressWarnings('PMD.ApexCRUDViolation,PMD.AvoidGlobalModifier')
 global with sharing class DeliveryWorkItemQuotesController {
 
     /** @description Represents a single vendor quote (WorkRequest__c) on a work item. */

--- a/force-app/main/default/classes/DeliveryWorkflowBuilderController.cls
+++ b/force-app/main/default/classes/DeliveryWorkflowBuilderController.cls
@@ -5,7 +5,7 @@
  *               for WorkflowType, WorkflowStage, and WorkflowPersonaView custom metadata.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation,PMD.CyclomaticComplexity')
+@SuppressWarnings('PMD.ApexCRUDViolation,PMD.CyclomaticComplexity,PMD.AvoidGlobalModifier')
 global with sharing class DeliveryWorkflowBuilderController {
 
     // ── Query Methods ────────────────────────────────────────────────────

--- a/force-app/main/default/classes/DeliveryWorkflowConfigService.cls
+++ b/force-app/main/default/classes/DeliveryWorkflowConfigService.cls
@@ -6,7 +6,7 @@
  * color maps, transition maps, and persona column maps in deliveryHubBoard.js.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity')
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.StdCyclomaticComplexity, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryWorkflowConfigService {
 
     // -------------------------------------------------------------------------

--- a/force-app/main/default/classes/DeliveryWorkloadController.cls
+++ b/force-app/main/default/classes/DeliveryWorkloadController.cls
@@ -6,6 +6,7 @@
  * breakdown to help managers identify overloaded developers and unassigned items.
  * @author Cloud Nimbus LLC
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryWorkloadController {
 
     /**


### PR DESCRIPTION
## Summary

- **A) Suppressed `PMD.AvoidGlobalModifier`** on 54 intentionally-global classes. Every class verified for an external entry point before suppressing (REST endpoint or `@AuraEnabled global static` method). No class downgrades in this PR — `global -> public` is a separate design-review pass per the 5/21 baseline recommendation #3.
- **B) ApexDoc sweep** on `DeliveryActivityFeedController.displayValue()` — added `@description` / `@param` / `@return` tags. Original block comment was descriptive but used informal phrasing; replaced with proper ApexDoc form.

## Net PMD impact (per `docs/audits/pmd-baseline-2026-05-26.md`)

- **Before:** 83 violations
- **After:** 34 violations
- **Delta:** -49 (-59%)

Breakdown:
- 46 `AvoidGlobalModifier` findings closed (suppressed, not downgraded)
- 3 `ApexDoc` findings closed on `DeliveryActivityFeedController`

`DeliveryActivityFeedController` was a top-10 noisiest class (4 violations); it now ships PMD-clean.

## Classes suppressed — categorized

### REST endpoint classes (8) — `@RestResource` requires global
- `DeliveryBountyApiService` — `/deliveryhub/v1/bounties/*`
- `DeliveryDocActionRestApi` — `/sign/*`
- `DeliveryGanttRemoteController` — `/gantt-remote/*`
- `DeliveryHubSyncService` — `/deliveryhub/v1/sync/*`
- `DeliveryPublicApiService` — `/deliveryhub/v1/api/*`
- `DeliveryPublicSubmissionService` — `/deliveryhub/v1/submit`
- `DeliveryTaskAPI` — `/deliveryhub/v1/tasks/*`
- `DeliveryWebhookReceiverApi` — `/deliveryhub/v1/webhook/*`

### LWC-callable controllers/services (46) — `@AuraEnabled global static` methods require global class
`DeliveryActivityDashboardController`, `DeliveryActivityFeedController`, `DeliveryActivityTimelineController`, `DeliveryAiController`, `DeliveryBurndownController`, `DeliveryClientOnboardingController`, `DeliveryCsvImportController`, `DeliveryCycleTimeController`, `DeliveryDashboardCardController`, `DeliveryDataLineageController`, `DeliveryDependencyGraphController`, `DeliveryFieldChangeService`, `DeliveryGhostController`, `DeliveryGuideController`, `DeliveryHubBoardController`, `DeliveryHubCommentController`, `DeliveryHubDashboardController`, `DeliveryHubFilesController`, `DeliveryHubPoller`, `DeliveryHubPollerController`, `DeliveryHubSettingsController`, `DeliveryHubSetupController`, `DeliveryMetricsService`, `DeliveryPortalAccessService`, `DeliveryPortalController`, `DeliveryQuickRequestController`, `DeliveryRecurringItemService`, `DeliveryReleaseNotesController`, `DeliveryRequestManagerController`, `DeliverySavedFilterController`, `DeliveryScoreService`, `DeliverySLAService`, `DeliverySlackService`, `DeliveryStageHistoryController`, `DeliveryStatusPageController`, `DeliverySyncRetryController`, `DeliveryTemplateManagerController`, `DeliveryTimeLoggerController`, `DeliveryVelocityService`, `DeliveryWorkflowBuilderController`, `DeliveryWorkflowConfigService`, `DeliveryWorkItemController`, `DeliveryWorkItemDependenciesController`, `DeliveryWorkItemETAService`, `DeliveryWorkItemQuotesController`, `DeliveryWorkloadController`

## Classes LEFT for a follow-up `global -> public` downgrade review

None. Every one of the 54 classes carries either `@RestResource` (must be global) or `@AuraEnabled global static` methods (the class container must be global for the methods to compile). There were no "questionable" globals in this batch — all 54 are demonstrably intentional.

If a future review wants to consider whether some `@AuraEnabled` methods could be `public static` instead of `global static`, that's a separate axis from the class-level suppression — a `public static` AuraEnabled method works fine inside a `public` class, so a wholesale downgrade pass could happen later without touching this PR.

## Test plan

- [x] PMD scan locally: 83 -> 34 (-49); `DeliveryActivityFeedController` now PMD-clean
- [x] No `System.debug` or hardcoded Ids introduced (apex-scan strictly-enforced rules)
- [x] No new public/global methods added (ApexDoc rule applies to new declarations only)
- [x] No file-encoding corruption (UTF-8 no-BOM preserved on all 54 files)
- [ ] CI feature-test green (apex-scan + apex-unit-tests)
- [ ] upload-beta green

## Why this is zero-behavior-risk

`@SuppressWarnings` annotations are erased at compile time and do not affect generated bytecode. The single behavioral edit (ApexDoc tags in `displayValue`) is comment-only. The accompanying `DeliveryActivityFeedControllerTest` requires no updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)