### PR TITLE
docs(devloop): example GitHub Action workflow + adoption guide for POST /scratch-orgs (closes Flow 6 #1 gap)

### DIFF
--- a/.github/workflows/example-scratch-org-create.yml
+++ b/.github/workflows/example-scratch-org-create.yml
@@ -1,0 +1,97 @@
+# Example: call POST /scratch-orgs on the Delivery Hub from a subscriber's repo.
+#
+# Copy this file into YOUR OWN repo (not into the Delivery Hub repo). Then:
+#   1. Add the two secrets listed below to that repo.
+#   2. Remove the `if: false` safety guard on each job.
+#   3. Drop the `branches: ['__never-matches__']` filter (or change it to your
+#      real branch patterns) so the trigger actually fires.
+#
+# When a subscriber dev opens / pushes a PR, this workflow:
+#   - On `opened` / `synchronize` — provisions a CumulusCI scratch org and
+#     POSTs a ScratchOrgInstance__c row into the DH org via the public REST
+#     API. The DH cockpit's `deliveryDevLoopGuide` LWC then shows the org
+#     alongside the matching WorkItem__c (matched by branch name).
+#   - On `closed` — PATCHes the row to state=Decommissioned so the cockpit
+#     can hide / clean it up. See `example-scratch-org-decommission.yml`
+#     in this same directory for the teardown half.
+#
+# Endpoint contract (source of truth: force-app/main/default/classes/DeliveryPublicApiService.cls):
+#   URL:   POST {DH_BASE_URL}/services/apexrest/delivery/deliveryhub/v1/api/scratch-orgs
+#   Auth:  X-Api-Key header — value comes from NetworkEntity__c.ApiKeyTxt__c on
+#          the DH side. (NOT a Salesforce session/Bearer token. NOT OAuth.)
+#   Body:  { "orgId":           "<required — Salesforce 15/18-char org id>",
+#            "branch":          "<optional — git branch name>",
+#            "loginUrl":        "<optional — scratch login URL from cci org info>",
+#            "cciFlow":         "<optional — cumulusci flow that built the org>",
+#            "workItemName":    "<optional — WorkItem__c.Name to link the row to>",
+#            "expiresAt":       "<optional — ISO-8601 timestamp, e.g. 2026-06-02T00:00:00Z>" }
+#   Resp:  201 { "success": true, "data": { "id": "<soi-id>", "state": "Active" } }
+#          400/500 { "success": false, "error": "<message>" }
+
+name: Example - Create Scratch Org on PR
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    # Safety filter — remove (or change to your real branch patterns) when you
+    # adopt this workflow. While present, the trigger never fires.
+    branches: ['__never-matches__']
+
+jobs:
+  create-scratch-org:
+    runs-on: ubuntu-latest
+    # Safety guard — remove when you adopt this workflow.
+    if: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Replace this stub with however you provision your scratch org.
+      # The example below assumes you use CumulusCI and have stored the
+      # resulting `cci org info` JSON for the new org. The three values
+      # you must capture for the POST body are:
+      #   - the org id           -> orgId
+      #   - the login URL        -> loginUrl
+      #   - the flow you ran     -> cciFlow
+      - name: Provision scratch org (stub — replace with your tooling)
+        id: provision
+        run: |
+          # Example placeholders — wire to your own provisioning step.
+          echo "org_id=00DXX0000000000XXX" >> "$GITHUB_OUTPUT"
+          echo "login_url=https://example-scratch.my.salesforce.com" >> "$GITHUB_OUTPUT"
+          echo "cci_flow=ci_feature" >> "$GITHUB_OUTPUT"
+
+      - name: POST /scratch-orgs on the Delivery Hub
+        env:
+          DH_BASE_URL:    ${{ secrets.DH_BASE_URL }}    # e.g. https://my-dh-instance.my.salesforce.com
+          DH_API_KEY:     ${{ secrets.DH_API_KEY }}     # NetworkEntity__c.ApiKeyTxt__c value from your DH org
+          ORG_ID:         ${{ steps.provision.outputs.org_id }}
+          LOGIN_URL:      ${{ steps.provision.outputs.login_url }}
+          CCI_FLOW:       ${{ steps.provision.outputs.cci_flow }}
+          BRANCH_NAME:    ${{ github.head_ref }}
+          # Convention: name your WorkItem__c records after the branch (or
+          # whatever scheme you use) so DH can link the scratch row to the WI.
+          # Pass null / omit the field if you don't want auto-linking.
+          WORK_ITEM_NAME: ${{ github.head_ref }}
+        run: |
+          # 7-day expiry as ISO-8601 (matches default scratch lifetime).
+          EXPIRES_AT="$(date -u -d '+7 days' +'%Y-%m-%dT%H:%M:%SZ')"
+
+          # Build JSON body with jq so branch names with quotes/specials are safe.
+          BODY="$(jq -n \
+            --arg orgId        "$ORG_ID" \
+            --arg branch       "$BRANCH_NAME" \
+            --arg loginUrl     "$LOGIN_URL" \
+            --arg cciFlow      "$CCI_FLOW" \
+            --arg workItemName "$WORK_ITEM_NAME" \
+            --arg expiresAt    "$EXPIRES_AT" \
+            '{orgId: $orgId, branch: $branch, loginUrl: $loginUrl,
+              cciFlow: $cciFlow, workItemName: $workItemName,
+              expiresAt: $expiresAt}')"
+
+          curl --fail-with-body -sS -X POST \
+            -H "X-Api-Key: $DH_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "$DH_BASE_URL/services/apexrest/delivery/deliveryhub/v1/api/scratch-orgs"

--- a/.github/workflows/example-scratch-org-decommission.yml
+++ b/.github/workflows/example-scratch-org-decommission.yml
@@ -1,0 +1,61 @@
+# Example: PATCH /scratch-orgs/{id} on PR close/merge — companion to
+# `example-scratch-org-create.yml`. Marks the ScratchOrgInstance__c row as
+# Decommissioned so the DH cockpit can hide / sweep it.
+#
+# Copy this file into YOUR OWN repo. Same adoption steps apply:
+#   1. Add the DH_BASE_URL + DH_API_KEY secrets.
+#   2. Remove the `if: false` safety guard.
+#   3. Drop the `branches: ['__never-matches__']` filter.
+#
+# Endpoint contract (source of truth: DeliveryPublicApiService.cls):
+#   URL:   PATCH {DH_BASE_URL}/services/apexrest/delivery/deliveryhub/v1/api/scratch-orgs/{id}
+#   Auth:  X-Api-Key header (same NetworkEntity__c.ApiKeyTxt__c as create).
+#   Body:  { "state":      "<required — one of the ScratchOrgState GVS values>",
+#            "lastSyncAt": "<optional — ISO-8601 timestamp>" }
+#   Resp:  200 { "success": true, "data": { "id": "<soi-id>", "state": "<new-state>" } }
+#          400/404 { "success": false, "error": "<message>" }
+#
+# Storing the SOI id between workflows: this example assumes you persisted the
+# `data.id` returned by the create workflow somewhere your decommission run can
+# read (a job artifact, a repo variable keyed by PR number, the PR body, etc.).
+# Replace the `SOI_ID` lookup with whatever scheme you use.
+
+name: Example - Decommission Scratch Org on PR Close
+
+on:
+  pull_request:
+    types: [closed]
+    # Safety filter — remove when you adopt this workflow.
+    branches: ['__never-matches__']
+
+jobs:
+  decommission-scratch-org:
+    runs-on: ubuntu-latest
+    # Safety guard — remove when you adopt this workflow.
+    if: false
+
+    steps:
+      - name: Resolve ScratchOrgInstance__c id for this PR (stub — replace)
+        id: lookup
+        run: |
+          # Replace this with however you stored the SOI id from the create run.
+          echo "soi_id=a01XX000000000XXX" >> "$GITHUB_OUTPUT"
+
+      - name: PATCH /scratch-orgs/{id} on the Delivery Hub
+        env:
+          DH_BASE_URL: ${{ secrets.DH_BASE_URL }}
+          DH_API_KEY:  ${{ secrets.DH_API_KEY }}
+          SOI_ID:      ${{ steps.lookup.outputs.soi_id }}
+        run: |
+          LAST_SYNC="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+          BODY="$(jq -n \
+            --arg state      'Decommissioned' \
+            --arg lastSyncAt "$LAST_SYNC" \
+            '{state: $state, lastSyncAt: $lastSyncAt}')"
+
+          curl --fail-with-body -sS -X PATCH \
+            -H "X-Api-Key: $DH_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "$DH_BASE_URL/services/apexrest/delivery/deliveryhub/v1/api/scratch-orgs/$SOI_ID"

--- a/docs/EXAMPLE_GITHUB_ACTIONS.md
+++ b/docs/EXAMPLE_GITHUB_ACTIONS.md
@@ -1,0 +1,114 @@
+# Example GitHub Actions — Dev-Loop Mirror (Layer 6)
+
+Copy-paste starters for wiring a subscriber's GitHub repo into the Delivery
+Hub's dev-loop cockpit. Two workflows ship under `.github/workflows/`:
+
+| File | Trigger | Endpoint |
+|---|---|---|
+| `example-scratch-org-create.yml` | `pull_request: [opened, synchronize]` | `POST /scratch-orgs` |
+| `example-scratch-org-decommission.yml` | `pull_request: [closed]` | `PATCH /scratch-orgs/{id}` |
+
+> Both files ship with `if: false` AND a `branches: ['__never-matches__']`
+> filter so they never run inside the Delivery Hub's own CI. They are meant to
+> be copied into a subscriber's repo, not executed in this one.
+
+## What it does
+
+When a subscriber dev opens a PR, the create workflow provisions a scratch org
+(via your existing CumulusCI step) and POSTs a `ScratchOrgInstance__c` row
+into the Delivery Hub org. The DH cockpit's `deliveryDevLoopGuide` LWC then
+shows the org alongside the matching `WorkItem__c` (matched by branch name,
+when you pass `workItemName` in the body). When the PR closes, the
+decommission workflow PATCHes the row to `state=Decommissioned` so the cockpit
+can hide or sweep it.
+
+## What you need
+
+1. **A Delivery Hub instance URL.** The base URL of your DH org, e.g.
+   `https://my-dh-instance.my.salesforce.com`. The workflow appends
+   `/services/apexrest/delivery/deliveryhub/v1/api/scratch-orgs` to it.
+2. **An API key.** Generate a `NetworkEntity__c` row in your DH org and
+   capture its `ApiKeyTxt__c` value (`DeliveryPublicApiService.generateApiKey()`
+   helper exists for this). The DH public REST API authenticates via an
+   `X-Api-Key` header — it does NOT use a Salesforce session, OAuth Bearer
+   token, or Named Credential.
+3. **Two GitHub secrets in the subscriber repo:**
+   - `DH_BASE_URL` — the URL from step 1
+   - `DH_API_KEY` — the key from step 2
+
+## Adoption checklist
+
+- [ ] Copy `example-scratch-org-create.yml` and
+      `example-scratch-org-decommission.yml` into your repo's `.github/workflows/`.
+- [ ] Add the `DH_BASE_URL` + `DH_API_KEY` secrets.
+- [ ] In each workflow, remove the `if: false` line on the job AND change the
+      `branches: ['__never-matches__']` filter to your real branch patterns (or
+      delete it to fire on every PR).
+- [ ] Replace the `Provision scratch org (stub — replace with your tooling)`
+      step in the create workflow with your actual CumulusCI (or other) scratch
+      provisioning step. Capture its `orgId`, `loginUrl`, and `cciFlow` as step
+      outputs the POST step can read.
+- [ ] Decide how to persist the returned `data.id` between the create and
+      decommission runs (job artifact, repo variable keyed by PR number, a
+      comment on the PR, etc.) and update the decommission workflow's `lookup`
+      step accordingly.
+- [ ] Open a throw-away PR to verify a `ScratchOrgInstance__c` row appears in
+      the DH cockpit, then close it to verify the row flips to
+      `Decommissioned`.
+
+## Endpoint contract (POST)
+
+```
+POST {DH_BASE_URL}/services/apexrest/delivery/deliveryhub/v1/api/scratch-orgs
+X-Api-Key: <ApiKeyTxt__c>
+Content-Type: application/json
+
+{
+  "orgId":        "<required — Salesforce 15/18-char scratch org id>",
+  "branch":       "<optional — git branch name>",
+  "loginUrl":     "<optional — scratch login URL from cci org info>",
+  "cciFlow":      "<optional — cumulusci flow that built the org>",
+  "workItemName": "<optional — WorkItem__c.Name to link the row to>",
+  "expiresAt":    "<optional — ISO-8601 timestamp>"
+}
+```
+
+Success (201):
+
+```json
+{ "success": true, "data": { "id": "a01XX...", "state": "Active" } }
+```
+
+Error (400/500):
+
+```json
+{ "success": false, "error": "<message>" }
+```
+
+## Pairing PATCH — decommission on PR close
+
+`example-scratch-org-decommission.yml` fires on `pull_request: [closed]` and
+PATCHes the row to mark it for cleanup. You need the `ScratchOrgInstance__c.Id`
+the create workflow received (see the persistence note in the adoption
+checklist above) — pass it on the URL path, and POST `{ "state":
+"Decommissioned" }` in the body. The DH cockpit's sweeper picks up
+non-Active rows past their `ExpiresDateTime__c`.
+
+```
+PATCH {DH_BASE_URL}/services/apexrest/delivery/deliveryhub/v1/api/scratch-orgs/{id}
+X-Api-Key: <ApiKeyTxt__c>
+Content-Type: application/json
+
+{
+  "state":      "<required — one of the ScratchOrgState GVS values>",
+  "lastSyncAt": "<optional — ISO-8601 timestamp>"
+}
+```
+
+## Reference
+
+The single source of truth for the endpoint contract is
+[`force-app/main/default/classes/DeliveryPublicApiService.cls`](../force-app/main/default/classes/DeliveryPublicApiService.cls).
+See in particular `postScratchOrg` (≈ line 662) and `patchScratchOrg`
+(≈ line 713), plus the `handlePost` / `handlePatch` routers near the top of
+the file for the auth + rate-limit gates that wrap both endpoints.


### PR DESCRIPTION
## Summary

- Adds two copy-pasteable example workflows under `.github/workflows/` so subscribers can wire their repo's PR flow into the DH dev-loop cockpit's `POST /scratch-orgs` + `PATCH /scratch-orgs/{id}` endpoints (shipped in PR #804). Each ships with an `if: false` safety guard AND a `branches: ['__never-matches__']` filter so they cannot run inside DH's own CI.
- Adds `docs/EXAMPLE_GITHUB_ACTIONS.md` — adoption checklist, endpoint contract for both routes, auth model (X-Api-Key header — NOT Bearer / OAuth / session), pointer to `DeliveryPublicApiService.cls` as the source of truth.

Closes the Flow 6 #1 gap from [`docs/audits/e2e-walkthrough-2026-05-21.md`](../blob/main/docs/audits/e2e-walkthrough-2026-05-21.md):
> No example GitHub Action workflow shipped in `.github/workflows/` that actually calls the endpoint. Subscriber devs would need to write their own.

## Safety

- Workflow ships with `if: false` AND a `branches: ['__never-matches__']` filter — it cannot fire in DH's own CI. Both guards are documented in-file with adoption instructions.
- Pure docs / `.github` change. No apex, LWC, or metadata touched.

## Notes / surprises during implementation

- Audit speculated a Bearer auth model — actual handler authenticates via `X-Api-Key` header matched against `NetworkEntity__c.ApiKeyTxt__c` (see `DeliveryPublicApiService.authenticateRequest`). Workflow + doc match the real model.
- Audit speculated a `pullRequestNumber` / `pullRequestUrl` / `createdByLogin` body — actual `postScratchOrg` accepts `{orgId (req), branch, loginUrl, cciFlow, workItemName, expiresAt}`. Workflow + doc match the real shape. Linking to a `WorkItem__c` is done via `workItemName` (DH looks up by `Name`), not PR metadata.
- URL pattern is `/services/apexrest/delivery/deliveryhub/v1/api/scratch-orgs` (the class urlMapping is `/deliveryhub/v1/api/*`, prefixed by the standard `/services/apexrest/delivery/` apexrest namespace path).

## Test plan

- [x] Confirmed no existing workflow under `.github/workflows/` references `scratch-orgs` (gap is real).
- [x] Verified workflow body keys, URL path, auth header, and response envelope against `DeliveryPublicApiService.postScratchOrg` / `patchScratchOrg` / `sendSuccess` / `sendError`.
- [ ] Docs-only — no DH-side change to test. Subscriber adoption testing happens in their own repos after they copy the files and remove the safety guards.

Generated with [Claude Code](https://claude.com/claude-code)