### PR TITLE
chore(cockpit): catalog card links + onboarding-gate toast action link (closes Flow 1 + Flow 3 #1 gaps)

### DIFF
--- a/force-app/main/default/lwc/deliveryFeatureCockpit/__tests__/deliveryFeatureCockpit.test.js
+++ b/force-app/main/default/lwc/deliveryFeatureCockpit/__tests__/deliveryFeatureCockpit.test.js
@@ -1,0 +1,258 @@
+import { createElement } from 'lwc';
+import { NavigationMixin } from 'lightning/navigation';
+import DeliveryFeatureCockpit from 'c/deliveryFeatureCockpit';
+import getCatalog from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.getCatalog';
+import isAdminApex from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.isAdmin';
+import toggleFeature from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.toggleFeature';
+
+// Apex methods auto-mocked via force-app/test/jest-mocks/apex/.
+
+// ── Test Data ──────────────────────────────────────────────────────
+
+const FEATURE_ID_A = 'a0F000000000001';
+const FEATURE_ID_B = 'a0F000000000002';
+
+const MOCK_CATALOG = [
+    {
+        featureId: FEATURE_ID_A,
+        name: 'FeatureA',
+        label: 'Alpha feature',
+        description: 'Test description',
+        category: 'Core',
+        maturity: 'GA',
+        icon: 'standard:apps',
+        isActive: false,
+        settingsFieldApiName: 'EnableAlphaDateTime__c',
+        docsUrl: 'https://example.test/docs/alpha'
+    },
+    {
+        featureId: FEATURE_ID_B,
+        name: 'FeatureB',
+        label: 'Bravo feature',
+        description: 'Bravo description',
+        category: 'Core',
+        maturity: 'Beta',
+        icon: 'standard:apps',
+        isActive: true,
+        settingsFieldApiName: 'EnableBravoDateTime__c',
+        docsUrl: ''
+    },
+    {
+        // mdt-only row — no Feature__c yet — should NOT render View record button
+        featureId: null,
+        name: 'CharlieDefinition',
+        label: 'Charlie (unbacked)',
+        description: '',
+        category: 'Core',
+        maturity: 'Alpha',
+        icon: 'standard:apps',
+        isActive: false,
+        settingsFieldApiName: '',
+        docsUrl: ''
+    }
+];
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function createComponent() {
+    const element = createElement('c-delivery-feature-cockpit', {
+        is: DeliveryFeatureCockpit
+    });
+    document.body.appendChild(element);
+    return element;
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function findButtonsByLabel(element, label) {
+    const buttons = element.shadowRoot.querySelectorAll('lightning-button');
+    return Array.from(buttons).filter((b) => b.label === label);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe('c-delivery-feature-cockpit', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    describe('basic rendering', () => {
+        it('renders the lightning-card with the Feature Cockpit title', () => {
+            const element = createComponent();
+            const card = element.shadowRoot.querySelector('lightning-card');
+            expect(card).not.toBeNull();
+            expect(card.title).toBe('Feature Cockpit');
+        });
+
+        it('renders one card per catalog row', async () => {
+            const element = createComponent();
+            isAdminApex.emit(true);
+            getCatalog.emit(MOCK_CATALOG);
+            await flushPromises();
+
+            const cards = element.shadowRoot.querySelectorAll('.feature-card');
+            expect(cards.length).toBe(MOCK_CATALOG.length);
+        });
+    });
+
+    describe('Flow 1 gap — catalog card navigation', () => {
+        it('renders a "View record" button on cards backed by a Feature__c row', async () => {
+            const element = createComponent();
+            isAdminApex.emit(true);
+            getCatalog.emit(MOCK_CATALOG);
+            await flushPromises();
+
+            const viewButtons = findButtonsByLabel(element, 'View record');
+            // Two rows have a featureId; the mdt-only Charlie row does not
+            expect(viewButtons.length).toBe(2);
+
+            const featureIds = viewButtons.map((b) => b.dataset.featureId);
+            expect(featureIds).toContain(FEATURE_ID_A);
+            expect(featureIds).toContain(FEATURE_ID_B);
+        });
+
+        it('does NOT render a "View record" button on mdt-only rows (no featureId)', async () => {
+            const element = createComponent();
+            isAdminApex.emit(true);
+            getCatalog.emit([MOCK_CATALOG[2]]);
+            await flushPromises();
+
+            const viewButtons = findButtonsByLabel(element, 'View record');
+            expect(viewButtons.length).toBe(0);
+        });
+
+        it('invokes NavigationMixin.Navigate with the Feature__c record page when View record is clicked', async () => {
+            const element = createComponent();
+            isAdminApex.emit(true);
+            getCatalog.emit(MOCK_CATALOG);
+            await flushPromises();
+
+            // Spy on the symbol-keyed mixin method that NavigationMixin
+            // installs on the element instance. sfdx-lwc-jest ships a stub
+            // that defaults to a jest.fn() returning undefined.
+            const navigateSpy = jest.fn();
+            element[NavigationMixin.Navigate] = navigateSpy;
+
+            const viewButtons = findButtonsByLabel(element, 'View record');
+            viewButtons[0].click();
+            await flushPromises();
+
+            expect(navigateSpy).toHaveBeenCalledTimes(1);
+            const ref = navigateSpy.mock.calls[0][0];
+            expect(ref.type).toBe('standard__recordPage');
+            expect(ref.attributes.recordId).toBe(FEATURE_ID_A);
+            expect(ref.attributes.actionName).toBe('view');
+            expect(ref.attributes.objectApiName).toContain('Feature__c');
+        });
+
+        it('renders the "View Docs" link only when docsUrl is populated, with rel=noopener noreferrer', async () => {
+            const element = createComponent();
+            isAdminApex.emit(true);
+            getCatalog.emit(MOCK_CATALOG);
+            await flushPromises();
+
+            const anchors = element.shadowRoot.querySelectorAll('a[target="_blank"]');
+            const docAnchors = Array.from(anchors).filter(
+                (a) => a.textContent.trim() === 'View Docs'
+            );
+            // Alpha has docsUrl; Bravo + Charlie do not → exactly 1 anchor
+            expect(docAnchors.length).toBe(1);
+            expect(docAnchors[0].getAttribute('rel')).toBe('noopener noreferrer');
+            expect(docAnchors[0].getAttribute('href')).toBe(
+                'https://example.test/docs/alpha'
+            );
+        });
+    });
+
+    describe('Flow 3 #1 gap — onboarding-gate toast action link', () => {
+        it('dispatches a ShowToastEvent with messageData URL token on onboarding-gate failure', async () => {
+            const element = createComponent();
+            isAdminApex.emit(true);
+            getCatalog.emit(MOCK_CATALOG);
+            await flushPromises();
+
+            // Resolve GenerateUrl with a fake record-page URL so the toast
+            // takes the with-link branch.
+            element[NavigationMixin.GenerateUrl] = jest
+                .fn()
+                .mockResolvedValue(
+                    '/lightning/r/Feature__c/' + FEATURE_ID_A + '/view'
+                );
+
+            // Drive the onboarding-gate failure path. The handler matches on
+            // the substring "onboarding track" in the Apex error message.
+            toggleFeature.mockRejectedValueOnce({
+                body: { message: 'Linked onboarding track is incomplete.' }
+            });
+
+            const toastHandler = jest.fn();
+            element.addEventListener('lightning__showtoast', toastHandler);
+
+            // Alpha is inactive → Enable button present
+            const enableButtons = findButtonsByLabel(element, 'Enable');
+            const alphaBtn = enableButtons.find(
+                (b) => b.dataset.featureId === FEATURE_ID_A
+            );
+            expect(alphaBtn).toBeDefined();
+            alphaBtn.click();
+
+            // Wait for toggleFeature.catch → GenerateUrl.then → toast dispatch
+            await flushPromises();
+            await flushPromises();
+            await flushPromises();
+
+            expect(toastHandler).toHaveBeenCalledTimes(1);
+            const detail = toastHandler.mock.calls[0][0].detail;
+            expect(detail.title).toBe('Onboarding required');
+            expect(detail.variant).toBe('warning');
+            // The action-link contract: message contains a {0} token AND
+            // messageData carries a {url,label} entry.
+            expect(detail.message).toContain('{0}');
+            expect(Array.isArray(detail.messageData)).toBe(true);
+            expect(detail.messageData.length).toBe(1);
+            expect(detail.messageData[0].url).toContain(FEATURE_ID_A);
+            expect(detail.messageData[0].label).toBe('Open feature record page');
+        });
+
+        it('falls back to a link-less toast when URL generation rejects', async () => {
+            const element = createComponent();
+            isAdminApex.emit(true);
+            getCatalog.emit(MOCK_CATALOG);
+            await flushPromises();
+
+            // Force GenerateUrl to reject so the catch-fallback fires
+            element[NavigationMixin.GenerateUrl] = jest
+                .fn()
+                .mockRejectedValue(new Error('nav unavailable'));
+
+            toggleFeature.mockRejectedValueOnce({
+                body: { message: 'You must complete the onboarding track first.' }
+            });
+
+            const toastHandler = jest.fn();
+            element.addEventListener('lightning__showtoast', toastHandler);
+
+            const enableButtons = findButtonsByLabel(element, 'Enable');
+            const alphaBtn = enableButtons.find(
+                (b) => b.dataset.featureId === FEATURE_ID_A
+            );
+            alphaBtn.click();
+
+            await flushPromises();
+            await flushPromises();
+            await flushPromises();
+
+            expect(toastHandler).toHaveBeenCalledTimes(1);
+            const detail = toastHandler.mock.calls[0][0].detail;
+            expect(detail.title).toBe('Onboarding required');
+            expect(detail.variant).toBe('warning');
+            // No messageData on the fallback toast — pure-text message
+            expect(detail.messageData).toBeUndefined();
+        });
+    });
+});

--- a/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.html
+++ b/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.html
@@ -90,14 +90,26 @@
                                 </template>
 
                                 <template lwc:if={feature.hasFeatureId}>
-                                    <div class="slds-m-top_x-small">
-                                        <lightning-button
-                                            label="Show dependencies"
-                                            variant="neutral"
-                                            data-feature-id={feature.featureId}
-                                            data-feature-label={feature.label}
-                                            onclick={handleShowDependencies}>
-                                        </lightning-button>
+                                    <div class="slds-m-top_x-small slds-grid slds-grid_vertical-align-center slds-gutters_xx-small">
+                                        <div class="slds-col slds-no-flex">
+                                            <lightning-button
+                                                label="View record"
+                                                variant="neutral"
+                                                icon-name="utility:open"
+                                                icon-position="left"
+                                                data-feature-id={feature.featureId}
+                                                onclick={handleViewRecord}>
+                                            </lightning-button>
+                                        </div>
+                                        <div class="slds-col slds-no-flex">
+                                            <lightning-button
+                                                label="Show dependencies"
+                                                variant="neutral"
+                                                data-feature-id={feature.featureId}
+                                                data-feature-label={feature.label}
+                                                onclick={handleShowDependencies}>
+                                            </lightning-button>
+                                        </div>
                                     </div>
                                 </template>
 

--- a/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.js
+++ b/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.js
@@ -12,6 +12,7 @@
  * @author Cloud Nimbus LLC
  */
 import { LightningElement, wire, track } from 'lwc';
+import { NavigationMixin } from 'lightning/navigation';
 import { refreshApex } from '@salesforce/apex';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import getCatalog from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.getCatalog';
@@ -22,7 +23,7 @@ const DESCRIPTION_TRUNCATE_AT = 140,
     ELLIPSIS = '…',
     EMPTY = 0;
 
-export default class DeliveryFeatureCockpit extends LightningElement {
+export default class DeliveryFeatureCockpit extends NavigationMixin(LightningElement) {
     @track features = [];
     @track errorMessage = '';
     @track isLoaded = false;
@@ -161,11 +162,11 @@ export default class DeliveryFeatureCockpit extends LightningElement {
                 const isCascadeGate = typeof msg === 'string'
                     && /^Cannot (enable|disable):/i.test(msg);
                 if (isOnboardingGate) {
-                    this.dispatchEvent(new ShowToastEvent({
-                        title: 'Onboarding required',
-                        message: 'Open the feature record page to complete the track, then try again.',
-                        variant: 'warning'
-                    }));
+                    // Closes Flow 3 #1 gap (audit 2026-05-21): the toast now
+                    // carries an action link to the Feature__c record page
+                    // (where the onboarding LWC mounts) so the user can jump
+                    // straight to the track instead of navigating manually.
+                    this.fireOnboardingGateToast(featureId, featureLabel);
                 } else if (isCascadeGate) {
                     this.dispatchEvent(new ShowToastEvent({
                         title: 'Dependency blocked toggle',
@@ -181,6 +182,69 @@ export default class DeliveryFeatureCockpit extends LightningElement {
                     }));
                 }
             });
+    }
+
+    // Builds and dispatches the onboarding-gate toast with a {url} action
+    // link to the Feature__c record page. NavigationMixin.GenerateUrl is
+    // async; we fall back to a link-less toast if URL generation fails
+    // (e.g. tests without the mixin installed) so the user still sees the
+    // refusal message.
+    fireOnboardingGateToast(featureId, featureLabel) {
+        const labelSuffix = featureLabel ? ` for "${featureLabel}"` : '';
+        const fallback = () => {
+            this.dispatchEvent(new ShowToastEvent({
+                title: 'Onboarding required',
+                message: `Open the feature record page${labelSuffix} to complete the track, then try again.`,
+                variant: 'warning'
+            }));
+        };
+        try {
+            this[NavigationMixin.GenerateUrl]({
+                type: 'standard__recordPage',
+                attributes: {
+                    recordId: featureId,
+                    objectApiName: '%%%NAMESPACE_DOT%%%Feature__c',
+                    actionName: 'view'
+                }
+            })
+                .then((url) => {
+                    if (!url) {
+                        fallback();
+                        return;
+                    }
+                    this.dispatchEvent(new ShowToastEvent({
+                        title: 'Onboarding required',
+                        message: `Complete the onboarding track${labelSuffix}, then try again. {0}`,
+                        messageData: [
+                            { url, label: 'Open feature record page' }
+                        ],
+                        variant: 'warning',
+                        mode: 'sticky'
+                    }));
+                })
+                .catch(() => fallback());
+        } catch (e) {
+            fallback();
+        }
+    }
+
+    // Closes Flow 1 gap (audit 2026-05-21): catalog cards now expose a
+    // "View record" affordance that navigates to the Feature__c record
+    // page. Skipped (button hidden via getter) when no featureId — mdt-only
+    // rows have nothing to navigate to.
+    handleViewRecord(event) {
+        const featureId = event.currentTarget.dataset.featureId;
+        if (!featureId) {
+            return;
+        }
+        this[NavigationMixin.Navigate]({
+            type: 'standard__recordPage',
+            attributes: {
+                recordId: featureId,
+                objectApiName: '%%%NAMESPACE_DOT%%%Feature__c',
+                actionName: 'view'
+            }
+        });
     }
 
     openCascadeModal(featureId, featureLabel) {

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.toggleFeature.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.toggleFeature.js
@@ -1,0 +1,6 @@
+/**
+ * Mock for DeliveryFeatureCatalogController.toggleFeature (imperative).
+ * Default resolves to null; tests override with mockResolvedValue /
+ * mockRejectedValue to drive happy- and gate-failure paths.
+ */
+module.exports = { default: jest.fn(() => Promise.resolve(null)) };


### PR DESCRIPTION
## Summary

Two small navigation-dead-end gaps from `docs/audits/e2e-walkthrough-2026-05-21.md` — combined into one PR because both are about adding navigation hops out of the cockpit.

- **Flow 1 (catalog card discovery dead-end):** `deliveryFeatureCockpit` cards now expose a "View record" button that navigates to the Feature__c record page via `NavigationMixin.Navigate`. Hidden for mdt-only catalog rows (no `Feature__c` yet) to mirror the existing approval-submit picker filter. The "View Docs" link (when `DocsUrl__c` is populated) already shipped — verified during this PR.
- **Flow 3 #1 (onboarding-gate manual nav):** when `toggleFeature` throws the onboarding-gate refusal, the toast now carries an action link to the Feature__c record page (where the onboarding LWC mounts). Uses `ShowToastEvent` `messageData` with a `{0}` URL token; sticky mode so the user has time to click. Falls back gracefully to the original link-less warning toast if `GenerateUrl` rejects.

## Audit reference

`docs/audits/e2e-walkthrough-2026-05-21.md` — Flow 1 ("card has no link to a feature record page or docs — discovery dead-ends at the catalog") and Flow 3 #1 ("Error toast doesn't link to the feature record page. User must navigate manually.").

## Audit-correction finding

The Flow 1 audit line called out "no link to a feature record page **or docs**." The Docs link is already shipped — see `deliveryFeatureCockpit.html` lines 71-75 (gated on `feature.hasDocsUrl`, renders only when `FeatureDefinition__mdt.DocsUrl__c` is populated, opens in a new tab with `rel="noopener noreferrer"`). This PR adds only the record-page link; the audit doc may want a one-line correction noting the Docs link was already present.

## Test plan

- [x] Jest suite added at `force-app/main/default/lwc/deliveryFeatureCockpit/__tests__/deliveryFeatureCockpit.test.js`:
  - Cards render one per catalog row
  - "View record" button renders only on rows backed by a `Feature__c` id (mdt-only Charlie row gets no button)
  - Clicking "View record" invokes `NavigationMixin.Navigate` with the right record-page reference (recordId, objectApiName contains `Feature__c`, actionName=view)
  - "View Docs" anchor renders only when `docsUrl` populated, with `rel=noopener noreferrer` and the right `href`
  - Onboarding-gate failure with a working `GenerateUrl` dispatches a toast with `messageData: [{url, label}]` and a `{0}` token in the message
  - Onboarding-gate failure with a rejecting `GenerateUrl` falls back to a link-less warning toast
- [ ] Manual (post-merge, on a scratch with the package installed):
  - Open the Feature Cockpit app page → confirm each catalog card with a backing `Feature__c` shows "View record" → click navigates to the Feature__c record page
  - As a non-admin user with an incomplete onboarding track, click Enable on a feature → toast appears with "Open feature record page" link → clicking the link navigates to the record page where the onboarding LWC mounts

## Bake-ins (compliance)

- No template ternaries — getter-driven conditional render (`feature.hasFeatureId`, `feature.hasDocsUrl`)
- No `@api boolean` defaulting to true (no new `@api` props)
- `lightning-button` / `lightning-button-icon` for actions
- Docs link opens in new tab with `rel="noopener noreferrer"`
- No Apex changes
- No permset / testSuite / object metadata changes
- `%%%NAMESPACE_DOT%%%` token used on the `objectApiName` for namespace safety in the packaging context

🤖 Generated with [Claude Code](https://claude.com/claude-code)