### PR TITLE
chore(cleanup): get-name vs get-local-name per-callsite review + safe migrations (closes code-quality-audit-2026-05-26 #3)

### DIFF
--- a/docs/audits/get-name-discretion-audit-2026-05-26.md
+++ b/docs/audits/get-name-discretion-audit-2026-05-26.md
@@ -1,0 +1,132 @@
+# getName() vs getLocalName() Per-Callsite Discretion Audit — 2026-05-26
+
+> Closes finding #3 from `docs/audits/code-quality-audit-2026-05-26.md`
+> ("Apex `getDescribe().getName()` where `getLocalName()` is cleaner — 9
+> across 7 files — P2 cosmetic").
+>
+> Reference memory:
+> `~/.claude/projects/C--Projects-Delivery-Hub/memory/feedback_get_local_name_vs_get_name_nuance.md`
+>
+> CLAUDE.md says "`getLocalName()` not `getName()` for field/object API
+> names in managed package context." That rule is correct as a default
+> but overstates the case. Per the memory, two patterns LEGITIMATELY
+> require `getName()`:
+>
+> 1. **Dynamic SOQL string-building** — `Database.query('SELECT Id FROM '
+>    + Foo__c.SObjectType.getDescribe().getName())` needs the
+>    namespace-prefixed form. `getLocalName()` here breaks subscriber-org
+>    SOQL.
+> 2. **Lightning record URL construction** — `/lightning/r/' +
+>    sobj.getName() + '/' + recordId + '/view` needs the prefixed form
+>    to navigate correctly in subscriber installs.
+>
+> This audit walks each of the 9 (actually 13 — the 5/26 code-quality
+> audit table consolidated multiple lines per file) callsites and applies
+> per-callsite discretion: migrate to `getLocalName()` where the call
+> context only needs the bare form; KEEP `getName()` with an inline
+> justification comment where the call is load-bearing.
+
+## Executive summary
+
+| Bucket | Count |
+|---|---|
+| Production `.getName()` callsites on `SObjectType` / `DescribeFieldResult` | **13** |
+| Migrated to `getLocalName()` | **10** |
+| Kept on `getName()` (load-bearing) | **3** |
+| Ambiguous (flagged for follow-up) | **0** |
+
+`UserInfo.getName()` callsites (7) are out of scope — they return the
+running user's display name, not an API name, so the
+`getName()`/`getLocalName()` discretion doesn't apply.
+
+One test-file callsite (`DeliveryWorkItemTriggerHandlerTest.cls:465`)
+compares against the literal `'User'` (standard object — no namespace
+either way), so the migration is moot. Left unchanged.
+
+## Per-callsite table
+
+### KEPT on `getName()` (load-bearing — do NOT migrate)
+
+| File:line | Pattern | Reason |
+|---|---|---|
+| `DeliverySyncItemIngestor.cls:694` | `'SELECT Id FROM ' + type.getDescribe().getName() + ' WHERE Id = :candidateId LIMIT 1'` | **Dynamic SOQL** — the namespaced object name is required for the query to resolve in the packaging org and in subscriber installs. `getLocalName()` here would break subscriber-side validation. |
+| `DeliverySyncItemIngestor.cls:985` | `'/lightning/r/' + entity.getSObjectType().getDescribe().getName() + '/' + entity.Id + '/view'` | **Lightning record URL** — `/lightning/r/delivery__NetworkEntity__c/<id>/view` resolves in subscriber installs; the bare form 404s. |
+| `DeliveryGanttController.cls:859` | `byAnyName.put(dfr.getName().toLowerCase(), sf)` | **INTENTIONAL 3-form index** — adjacent to `byAnyName.put(mapKey.toLowerCase(), sf)` and `byAnyName.put(dfr.getLocalName().toLowerCase(), sf)`. The whole point is to accept all 3 input forms (map-key, bare, namespaced) from LWC callers. Removing `getName()` narrows the accepted-input set. |
+
+Each KEPT callsite was annotated with an inline comment in this PR
+documenting the discretion, so future mechanical-replace passes don't
+silently regress them.
+
+### MIGRATED `getName()` → `getLocalName()` (safe — bare form works equally well)
+
+| File:line | Context | Reason migration is safe |
+|---|---|---|
+| `DeliveryContentDocLinkTriggerHandler.cls:69` | `cdl.LinkedEntityId.getSObjectType().getDescribe().getLocalName()` (was `:65`) | Result is consumed by `sObjName.endsWithIgnoreCase('WorkItem__c')`. Both forms (`WorkItem__c` and `delivery__WorkItem__c`) satisfy the predicate. |
+| `DeliveryCsvImportController.cls:179` | `entry.put('apiName', dfr.getLocalName())` (was `:175`) | LWC consumer (`deliveryCsvImport.js`) displays this in dropdown labels (`${f.label} (${f.apiName})`) and uses it as an internal lookup key in `apiToApi` (consistent round-trip). The downstream `resolveField()` is namespace-tolerant. Migration cleans up `delivery__` prefix leaking to admins. |
+| `DeliveryCsvImportController.cls:244` | `wi.put(dfr.getLocalName(), coerceValue(dfr, val))` (was `:240`) | `SObject.put()` accepts both bare and namespaced forms identically. |
+| `DeliveryCsvImportController.cls:248` | `'" for field ' + dfr.getLocalName() + ': '` (was `:244`) | Debug log; bare form is cleaner. |
+| `DeliveryHubCommentController.cls:120` | `... + type.getDescribe().getLocalName()` (was `:117`) | User-facing `AuraHandledException` message; bare name reads cleaner than `delivery__WorkItem__c` to subscriber admins. |
+| `DeliverySyncEngine.cls:359` | `String name = rec.getSObjectType().getDescribe().getLocalName()` (was `:357`) | `name` is used in `endsWithIgnoreCase('WorkItem__c')` checks below. Both forms satisfy the predicate. |
+| `DeliverySyncEngine.cls:400` | Debug log inside `WARN` (was `:396`) | Diagnostic log; bare form is cleaner. |
+| `DeliverySyncEngine.cls:413` | `String fullApiName = rec.getSObjectType().getDescribe().getLocalName()` (was `:408`) | Result is passed through `.replace('delivery__', '')` to derive `cleanName`. Migration makes the `.replace()` a no-op safety net (kept for defense in depth). `ObjectTypePk__c` stores the bare form. |
+| `DeliverySyncItemIngestor.cls:217` | `castId.getSobjectType().getDescribe().getLocalName().endsWithIgnoreCase('WorkItem__c')` (was `:215`) | `endsWithIgnoreCase` works either way. |
+| `DeliverySyncItemIngestor.cls:570` | `stripNamespace(type.getDescribe().getLocalName())` (was `:565`) | `stripNamespace` becomes a no-op safety net (kept for defense in depth). |
+| `DeliverySyncItemIngestor.cls:648` | `stripNamespace(type.getDescribe().getLocalName())` (was `:644`) | Same as :570 (sibling function). |
+| `DeliverySyncItemIngestor.cls:796` | `endsWithIgnoreCase('WorkItem__c')` paired (was `:784`) | `endsWithIgnoreCase` works either way. |
+| `DeliverySyncItemIngestor.cls:820` | `endsWithIgnoreCase('WorkItem__c')` paired (was `:807`) | `endsWithIgnoreCase` works either way. |
+| `DeliverySyncItemPendingResolver.cls:278` | `endsWithIgnoreCase('WorkItem__c')` paired (was `:276`) | `endsWithIgnoreCase` works either way. |
+
+(Line numbers post-migration. Original audit-2026-05-26 line numbers
+were pre-migration.)
+
+### AMBIGUOUS (flagged for follow-up)
+
+**None.** Every callsite was unambiguously classifiable as either
+load-bearing-keep or safe-to-migrate after manual context inspection.
+
+## Verification
+
+- All 10 migrated callsites use the result either in `endsWithIgnoreCase`,
+  `SObject.put()` (which accepts both forms), debug logs, user-facing
+  error messages, or as the input to `stripNamespace()`/`.replace()`
+  (which become defense-in-depth no-ops after migration).
+- The 3 KEPT callsites each have an inline annotation comment explaining
+  why `getName()` is required, citing the
+  `[[get-local-name-vs-get-name-nuance]]` memory by name for future
+  maintainers.
+- Existing test suite (`DeliveryCsvImportControllerTest`,
+  `DeliverySyncEngineTest`, `DeliverySyncItemIngestorTest`,
+  `DeliverySyncItemPendingResolverTest`,
+  `DeliveryContentDocLinkTriggerHandlerTest`,
+  `DeliveryHubCommentControllerTest`, `DeliveryGanttControllerTest`)
+  exercises the migrated paths. The CSV test (`DeliveryCsvImportControllerTest`)
+  uses `endsWith('BriefDescriptionTxt__c')` against `apiName` values, which
+  is satisfied by both forms.
+
+## Test-file callsite (informational)
+
+`DeliveryWorkItemTriggerHandlerTest.cls:465` calls
+`ref.getDescribe().getName()` and compares it to the literal string
+`'User'`. Standard objects have no namespace prefix in either form, so
+both methods return `'User'` and the assertion is identical. Left
+unchanged — no behavior or hygiene difference.
+
+## Lessons / CLAUDE.md amendment recommendation
+
+The 5/26 code-quality audit's recommendation #4 already proposes amending
+CLAUDE.md to:
+
+> "Prefer `getLocalName()` for comparison and DTO emission; use
+> `getName()` when building dynamic SOQL or Lightning URLs that need
+> the runtime-resolved object name."
+
+This audit confirms the recommendation is correct. Three production
+callsites genuinely need `getName()`; the other 10 were latent
+mechanical-replace risk that's now annotated and reduced.
+
+## Out of scope
+
+- `UserInfo.getName()` (7 callsites) — running-user display name, not an
+  API name. Different signature, different semantics.
+- The 53 `global` classes missing `AvoidGlobalModifier` suppressions —
+  separate backlog item (5/21 PMD baseline recommendation #3).

--- a/force-app/main/default/classes/DeliveryContentDocLinkTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryContentDocLinkTriggerHandler.cls
@@ -62,7 +62,11 @@ public without sharing class DeliveryContentDocLinkTriggerHandler {
 
         for (ContentDocumentLink cdl : newLinks) {
             if (cdl.LinkedEntityId != null) {
-                String sObjName = cdl.LinkedEntityId.getSObjectType().getDescribe().getName();
+                // getLocalName() (not getName()) — returns bare 'WorkItem__c'
+                // regardless of namespace, which the endsWithIgnoreCase guard below
+                // accepts either way. CLAUDE.md prefers getLocalName() for
+                // comparison; only dynamic SOQL / Lightning URL build need getName().
+                String sObjName = cdl.LinkedEntityId.getSObjectType().getDescribe().getLocalName();
                 if (sObjName.endsWithIgnoreCase('WorkItem__c')) {
                     docToWorkItemMap.put(cdl.ContentDocumentId, cdl.LinkedEntityId);
                 }

--- a/force-app/main/default/classes/DeliveryCsvImportController.cls
+++ b/force-app/main/default/classes/DeliveryCsvImportController.cls
@@ -172,7 +172,11 @@ global with sharing class DeliveryCsvImportController {
                 continue;
             }
             Map<String, String> entry = new Map<String, String>();
-            entry.put('apiName', dfr.getName());
+            // getLocalName() (not getName()) — strips the delivery__ namespace
+            // prefix so the dropdown label in deliveryCsvImport LWC reads as
+            // 'BriefDescriptionTxt__c' instead of 'delivery__BriefDescriptionTxt__c'.
+            // resolveField() below is namespace-tolerant (handles both forms).
+            entry.put('apiName', dfr.getLocalName());
             entry.put('label', dfr.getLabel());
             entry.put('type', dfr.getType().name());
             fieldList.add(entry);
@@ -237,11 +241,14 @@ global with sharing class DeliveryCsvImportController {
         }
 
         try {
-            wi.put(dfr.getName(), coerceValue(dfr, val));
+            // getLocalName() (not getName()) — SObject.put() accepts both the
+            // namespaced and bare forms, and the error message below is cleaner
+            // without the delivery__ prefix leaking to the debug log.
+            wi.put(dfr.getLocalName(), coerceValue(dfr, val));
         } catch (Exception ex) {
             System.debug(LoggingLevel.WARN,
                 'CSV Import: Could not coerce value "' + val +
-                '" for field ' + dfr.getName() + ': ' + ex.getMessage());
+                '" for field ' + dfr.getLocalName() + ': ' + ex.getMessage());
         }
     }
 

--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -844,6 +844,11 @@ public with sharing class DeliveryGanttController {
                 WorkItem__c.SObjectType.getDescribe().fields.getMap();
             // Comprehensive 3-form index: map key, getLocalName(), getName()
             // — all lowercased. Lookup by any of those forms finds the token.
+            // getName() (not getLocalName()) — INTENTIONALLY kept here as the
+            // third index form. Per [[get-local-name-vs-get-name-nuance]]
+            // memory, this is an INTENTIONAL 3-form index designed to accept
+            // bare, namespaced, AND map-key inputs from LWC callers. Removing
+            // getName() narrows the accepted-input set.
             Map<String, Schema.SObjectField> byAnyName =
                 new Map<String, Schema.SObjectField>();
             for (String mapKey : fieldMap.keySet()) {

--- a/force-app/main/default/classes/DeliveryHubCommentController.cls
+++ b/force-app/main/default/classes/DeliveryHubCommentController.cls
@@ -114,6 +114,9 @@ global with sharing class DeliveryHubCommentController {
             }
         }
 
-        throw new AuraHandledException('Unsupported object type or work item not found: ' + type.getDescribe().getName());
+        // getLocalName() (not getName()) — user-facing AuraHandledException
+        // message; bare name reads cleaner than 'delivery__WorkItem__c' to
+        // subscriber admins reading the toast.
+        throw new AuraHandledException('Unsupported object type or work item not found: ' + type.getDescribe().getLocalName());
     }
 }

--- a/force-app/main/default/classes/DeliverySyncEngine.cls
+++ b/force-app/main/default/classes/DeliverySyncEngine.cls
@@ -354,7 +354,9 @@ public without sharing class DeliverySyncEngine {
     }
 
     private static Id getWorkItemId(SObject rec) {
-        String name = rec.getSObjectType().getDescribe().getName();
+        // getLocalName() (not getName()) — returned name is compared via
+        // endsWithIgnoreCase below, which works regardless of namespace.
+        String name = rec.getSObjectType().getDescribe().getLocalName();
         if (name.endsWithIgnoreCase('WorkItem__c') && !name.endsWithIgnoreCase('WorkItemComment__c') && !name.endsWithIgnoreCase('WorkItemDependency__c')) {
             return rec.Id;
         }
@@ -391,9 +393,11 @@ public without sharing class DeliverySyncEngine {
         // every 15-min tick — see PR #742 reconciler namespace bug post-mortem
         // for the cascade pattern). Refuse cleanly with a WARN log.
         if (allowedFields == null || allowedFields.isEmpty()) {
+            // getLocalName() (not getName()) — debug log; bare name reads
+            // cleaner than 'delivery__Foo__c' in the diagnostic line.
             System.debug(LoggingLevel.WARN,
                 '[DeliverySyncEngine] Skipping outbound SyncItem — allowedFields empty for '
-                + rec.getSObjectType().getDescribe().getName() + ' ' + rec.Id);
+                + rec.getSObjectType().getDescribe().getLocalName() + ' ' + rec.Id);
             return null;
         }
 
@@ -405,7 +409,10 @@ public without sharing class DeliverySyncEngine {
         item.LocalRecordIdTxt__c = (String)rec.Id;
         item.WorkItemLookup__c = getWorkItemId(rec); // MANDATORY: Required for Vendor's SOQL Security Filtering
 
-        String fullApiName = rec.getSObjectType().getDescribe().getName();
+        // getLocalName() (not getName()) — returns the bare form directly,
+        // which is what ObjectTypePk__c stores. The .replace('delivery__', '')
+        // below is now a no-op safety net (kept for defense in depth).
+        String fullApiName = rec.getSObjectType().getDescribe().getLocalName();
         String cleanName = fullApiName.replace('delivery__', '');
         item.ObjectTypePk__c = cleanName;
 

--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -212,7 +212,9 @@ public without sharing class DeliverySyncItemIngestor {
             if (localParentId == null) {
                 try {
                     Id castId = (Id) parentWorkItemRef;
-                    if (castId.getSobjectType().getDescribe().getName().endsWithIgnoreCase('WorkItem__c')) {
+                    // getLocalName() (not getName()) — endsWithIgnoreCase works
+                    // either way; bare form keeps the check readable.
+                    if (castId.getSobjectType().getDescribe().getLocalName().endsWithIgnoreCase('WorkItem__c')) {
                         localParentId = castId;
                     }
                 } catch (Exception e) {
@@ -562,7 +564,10 @@ public without sharing class DeliverySyncItemIngestor {
         if (String.isBlank(remoteId)) {
             return null;
         }
-        String cleanName = stripNamespace(type.getDescribe().getName());
+        // getLocalName() (not getName()) — returns the bare form directly.
+        // The stripNamespace() wrapper becomes a no-op safety net (kept for
+        // defense in depth in case the schema describe ever returns prefixed).
+        String cleanName = stripNamespace(type.getDescribe().getLocalName());
 
         List<SyncItem__c> ledger = [
             SELECT LocalRecordIdTxt__c
@@ -641,7 +646,8 @@ public without sharing class DeliverySyncItemIngestor {
         if (String.isBlank(globalSourceId)) {
             return null;
         }
-        String cleanName = stripNamespace(type.getDescribe().getName());
+        // getLocalName() (not getName()) — same rationale as findLocalId() above.
+        String cleanName = stripNamespace(type.getDescribe().getLocalName());
 
         List<SyncItem__c> ledger = [
             SELECT LocalRecordIdTxt__c
@@ -681,6 +687,10 @@ public without sharing class DeliverySyncItemIngestor {
         if (candidateId == null || candidateId.getSobjectType() != type) {
             return false;
         }
+        // getName() (NOT getLocalName()) — LOAD-BEARING: dynamic SOQL requires
+        // the namespace-prefixed form ('delivery__Foo__c') in the packaging /
+        // subscriber context, otherwise the query fails to resolve the SObject.
+        // Per [[get-local-name-vs-get-name-nuance]] memory — do NOT migrate.
         String soql = 'SELECT Id FROM ' + type.getDescribe().getName() + ' WHERE Id = :candidateId LIMIT 1';
         List<SObject> existing = Database.queryWithBinds(
             soql,
@@ -781,7 +791,8 @@ public without sharing class DeliverySyncItemIngestor {
         }
         try {
             Id castId = (Id) targetRef;
-            if (castId.getSobjectType().getDescribe().getName().endsWithIgnoreCase('WorkItem__c')) {
+            // getLocalName() (not getName()) — endsWithIgnoreCase works either way.
+            if (castId.getSobjectType().getDescribe().getLocalName().endsWithIgnoreCase('WorkItem__c')) {
                 return castId;
             }
         } catch (Exception e) {
@@ -804,7 +815,8 @@ public without sharing class DeliverySyncItemIngestor {
         }
         try {
             Id castId = (Id) candidate;
-            return castId.getSobjectType().getDescribe().getName().endsWithIgnoreCase('WorkItem__c') ? castId : null;
+            // getLocalName() (not getName()) — endsWithIgnoreCase works either way.
+            return castId.getSobjectType().getDescribe().getLocalName().endsWithIgnoreCase('WorkItem__c') ? castId : null;
         } catch (Exception e) {
             System.debug(LoggingLevel.FINE, 'Candidate is not a local WorkItem Id: ' + e.getMessage());
             return null;
@@ -966,6 +978,10 @@ public without sharing class DeliverySyncItemIngestor {
                 entityName = 'Unknown Org';
             }
             String orgUrl = Url.getOrgDomainUrl().toExternalForm();
+            // getName() (NOT getLocalName()) — LOAD-BEARING: Lightning record URL
+            // requires the namespace-prefixed form. /lightning/r/delivery__NetworkEntity__c/...
+            // resolves in subscriber installs; the bare form 404s.
+            // Per [[get-local-name-vs-get-name-nuance]] memory — do NOT migrate.
             String recordUrl = orgUrl + '/lightning/r/' + entity.getSObjectType().getDescribe().getName() + '/' + entity.Id + '/view';
             Map<String, String> notificationContext = new Map<String, String>{
                 'entityName' => entityName,

--- a/force-app/main/default/classes/DeliverySyncItemPendingResolver.cls
+++ b/force-app/main/default/classes/DeliverySyncItemPendingResolver.cls
@@ -273,7 +273,8 @@ global inherited sharing class DeliverySyncItemPendingResolver implements Queuea
         // 3. Ref may itself be a local Id (same-org test scenarios)
         try {
             Id castId = (Id) remoteRef;
-            if (castId.getSobjectType().getDescribe().getName().endsWithIgnoreCase('WorkItem__c')) {
+            // getLocalName() (not getName()) — endsWithIgnoreCase works either way.
+            if (castId.getSobjectType().getDescribe().getLocalName().endsWithIgnoreCase('WorkItem__c')) {
                 return castId;
             }
         } catch (Exception e) {


### PR DESCRIPTION
## Summary

- **13 production `getName()` callsites analyzed** (on `SObjectType` / `DescribeFieldResult`; `UserInfo.getName()` excluded as different semantics).
- **10 callsites migrated `getName()` → `getLocalName()`** (safe — each paired with `endsWithIgnoreCase`, `SObject.put()`, `stripNamespace()`, or a user-facing/debug log).
- **3 callsites KEPT on `getName()`** with inline justification comments — load-bearing.

Closes finding #3 from `docs/audits/code-quality-audit-2026-05-26.md` ("Apex `getDescribe().getName()` where `getLocalName()` is cleaner — 9 across 7 files — P2 cosmetic").

## Discretion table

### KEPT (load-bearing — annotated in code)

| File:line | Reason |
|---|---|
| `DeliverySyncItemIngestor.cls:694` | Dynamic SOQL — needs `delivery__Foo__c` to resolve in subscriber installs |
| `DeliverySyncItemIngestor.cls:985` | Lightning record URL — bare form 404s |
| `DeliveryGanttController.cls:859` | INTENTIONAL 3-form input index (mapKey + getLocalName + getName) — removing narrows the accepted-input set |

### MIGRATED

| File:line | Pairing that makes migration safe |
|---|---|
| `DeliveryContentDocLinkTriggerHandler.cls:69` | `endsWithIgnoreCase` |
| `DeliveryCsvImportController.cls:179` | LWC dropdown label (apiName) — cleaner UX; downstream `resolveField()` namespace-tolerant |
| `DeliveryCsvImportController.cls:244` | `SObject.put()` accepts both forms |
| `DeliveryCsvImportController.cls:248` | Debug log |
| `DeliveryHubCommentController.cls:120` | User-facing `AuraHandledException` |
| `DeliverySyncEngine.cls:359` | `endsWithIgnoreCase` |
| `DeliverySyncEngine.cls:400` | Debug log |
| `DeliverySyncEngine.cls:413` | `.replace('delivery__', '')` becomes no-op safety net |
| `DeliverySyncItemIngestor.cls:217` | `endsWithIgnoreCase` |
| `DeliverySyncItemIngestor.cls:570` | `stripNamespace()` becomes no-op safety net |
| `DeliverySyncItemIngestor.cls:648` | `stripNamespace()` becomes no-op safety net |
| `DeliverySyncItemIngestor.cls:796` | `endsWithIgnoreCase` |
| `DeliverySyncItemIngestor.cls:820` | `endsWithIgnoreCase` |
| `DeliverySyncItemPendingResolver.cls:278` | `endsWithIgnoreCase` |

## References

- Audit doc: `docs/audits/get-name-discretion-audit-2026-05-26.md`
- Source audit: `docs/audits/code-quality-audit-2026-05-26.md` finding #3
- Memory establishing the nuance: `~/.claude/projects/C--Projects-Delivery-Hub/memory/feedback_get_local_name_vs_get_name_nuance.md`
- Related: `~/.claude/projects/C--Projects-Delivery-Hub/memory/feedback_namespace_safe_typed_sobject_describe.md`

## Test plan

- [ ] feature-test (CI) — existing test suite still passes; migrated callsites are exercised by `DeliveryCsvImportControllerTest`, `DeliverySyncEngineTest`, `DeliverySyncItemIngestorTest`, `DeliverySyncItemPendingResolverTest`, `DeliveryContentDocLinkTriggerHandlerTest`, `DeliveryHubCommentControllerTest`, `DeliveryGanttControllerTest`
- [ ] upload-beta (CI) — verifies the 2 KEPT load-bearing callsites still build dynamic SOQL / Lightning URLs with the namespaced form in the `delivery__` packaging org
- [ ] Manual review of the 3 KEPT inline annotation comments (this PR's main artifact for future maintenance — prevents accidental mechanical-replace regressions)

## What this PR does NOT do

- Does not touch the `DeliveryWorkItemTriggerHandlerTest.cls:465` test-file callsite — compares to literal `'User'` (standard object, no namespace either way), so migration is moot
- Does not amend CLAUDE.md (recommendation #4 from the 5/26 code-quality audit) — separate concern
- Does not touch the 53 `global`-classes `AvoidGlobalModifier` backlog (5/21 PMD baseline recommendation #3)

STOP at PR-open per brief. No merge, no promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)