### PR TITLE
fix(watcher): capture Slack delivery status — StatusPk__c reflects actual webhook response (closes Flow 8 #3 gap)

### DIFF
--- a/force-app/main/default/classes/DeliverySlackService.cls
+++ b/force-app/main/default/classes/DeliverySlackService.cls
@@ -134,25 +134,54 @@ global with sharing class DeliverySlackService {
     }
 
     /**
-     * @description Asynchronously posts the Watcher v1 daily digest to Slack.
+     * @description Synchronously posts the Watcher v1 daily digest to Slack
+     *              and returns the delivery outcome so the orchestrator can
+     *              reflect Slack delivery status on the WatcherDigest__c
+     *              audit row (StatusPk__c + SlackResponseTxt__c).
+     *
+     *              Synchronous (not @future) because the orchestrator runs
+     *              from a Queueable that implements Database.AllowsCallouts
+     *              (WatcherDigestRunQueueable) or from an AuraEnabled entry
+     *              point — both contexts permit a synchronous HTTP callout.
+     *              The trade-off (a few-hundred-ms blocking call once per
+     *              day) is worth the data integrity win — subscribers no
+     *              longer see false `Success` status when Slack 4xx/5xx'd.
+     *
      *              Reuses the SlackWebhookUrlTxt__c webhook. Payload is the
      *              JSON-serialised Block Kit map produced by
-     *              DeliveryWatcherDigestFormatter.buildBlockKit — pre-injected
-     *              with `channel` when WatcherDigestSlackChannelTxt__c is set
-     *              on org defaults. No-ops silently when Slack isn't
-     *              configured (mirrors postStageChanges).
+     *              DeliveryWatcherDigestFormatter.buildBlockKit — pre-
+     *              injected with `channel` when WatcherDigestSlackChannelTxt__c
+     *              is set on org defaults.
      * @param payloadJson Pre-serialised Block Kit JSON.
+     * @return SlackPostResultDTO describing whether a post was attempted,
+     *         whether it was delivered (2xx), the HTTP status code, and a
+     *         255-char preview of the response (or exception message).
      */
-    @future(callout=true)
-    public static void postWatcherDigest(String payloadJson) {
+    public static SlackPostResultDTO postWatcherDigest(String payloadJson) {
+        SlackPostResultDTO outcome = new SlackPostResultDTO();
         if (String.isBlank(payloadJson)) {
-            return;
+            return outcome;
         }
         DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
         if (settings == null || String.isBlank(settings.SlackWebhookUrlTxt__c)) {
-            return;
+            return outcome;
         }
-        post(settings.SlackWebhookUrlTxt__c, payloadJson);
+        outcome.attempted = true;
+        try {
+            HttpResponse res = postRaw(settings.SlackWebhookUrlTxt__c, payloadJson);
+            outcome.statusCode = res.getStatusCode();
+            outcome.delivered = (outcome.statusCode >= 200 && outcome.statusCode < 300);
+            outcome.responseText = buildResponsePreview(res);
+        } catch (CalloutException ce) {
+            outcome.statusCode = 0;
+            outcome.delivered = false;
+            outcome.responseText = clipForField('CalloutException: ' + ce.getMessage());
+        } catch (Exception e) {
+            outcome.statusCode = 0;
+            outcome.delivered = false;
+            outcome.responseText = clipForField(e.getTypeName() + ': ' + e.getMessage());
+        }
+        return outcome;
     }
 
     /**
@@ -181,23 +210,72 @@ global with sharing class DeliverySlackService {
 
     /**
      * @description Sends a JSON payload to the given Slack Incoming Webhook URL.
+     *              Swallows exceptions so the caller (legacy @future paths)
+     *              doesn't crash on a Slack outage. New callers that need
+     *              response visibility should use postRaw() instead.
      * @param url  The Slack webhook endpoint
      * @param body The serialised JSON payload
      * @return HttpResponse or null if the callout threw
      */
     private static HttpResponse post(String url, String body) {
+        try {
+            return postRaw(url, body);
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN, '[DeliverySlackService] callout failed: ' + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * @description Sends a JSON payload to the given Slack Incoming Webhook URL
+     *              and lets exceptions propagate. Used by postWatcherDigest so
+     *              the orchestrator can distinguish 4xx/5xx from CalloutException
+     *              and persist both onto WatcherDigest__c.SlackResponseTxt__c.
+     * @param url  The Slack webhook endpoint
+     * @param body The serialised JSON payload
+     * @return HttpResponse from Slack (may be non-2xx)
+     */
+    private static HttpResponse postRaw(String url, String body) {
         HttpRequest req = new HttpRequest();
         req.setEndpoint(url);
         req.setMethod('POST');
         req.setHeader('Content-Type', 'application/json');
         req.setBody(body);
         req.setTimeout(10000);
-        try {
-            return new Http().send(req);
-        } catch (Exception e) {
-            System.debug(LoggingLevel.WARN, '[DeliverySlackService] callout failed: ' + e.getMessage());
-            return null;
+        return new Http().send(req);
+    }
+
+    /** @description Field cap for SlackResponseTxt__c (Text(255)). */
+    private static final Integer SLACK_RESPONSE_FIELD_LEN = 255;
+
+    /**
+     * @description Builds the 255-char Slack response preview persisted on
+     *              WatcherDigest__c.SlackResponseTxt__c. Format:
+     *              `HTTP {code} {status} | {body}`, clipped to the field cap.
+     * @param res HttpResponse from Slack.
+     * @return Compact response preview, never null.
+     */
+    private static String buildResponsePreview(HttpResponse res) {
+        if (res == null) {
+            return clipForField('HTTP <no response>');
         }
+        String status = res.getStatus() == null ? '' : res.getStatus();
+        String body = res.getBody() == null ? '' : res.getBody();
+        String bodyClip = body.length() > 500 ? body.substring(0, 500) : body;
+        return clipForField('HTTP ' + res.getStatusCode() + ' ' + status + ' | ' + bodyClip);
+    }
+
+    /**
+     * @description Null-tolerant string clip for the SlackResponseTxt__c field
+     *              cap. Returns empty string when the input is null.
+     * @param value Value to clip.
+     * @return Trimmed value, never null.
+     */
+    private static String clipForField(String value) {
+        if (value == null) {
+            return '';
+        }
+        return value.length() <= SLACK_RESPONSE_FIELD_LEN ? value : value.substring(0, SLACK_RESPONSE_FIELD_LEN);
     }
 
     /**
@@ -388,5 +466,36 @@ global with sharing class DeliverySlackService {
             'text' => headerText,
             'blocks' => blocks
         });
+    }
+
+    // ── Inner DTOs ───────────────────────────────────────────────────────────
+
+    /**
+     * @description Outcome of a Slack webhook post. Returned by
+     *              postWatcherDigest so callers can reflect Slack delivery
+     *              status onto WatcherDigest__c (StatusPk__c +
+     *              SlackResponseTxt__c).
+     */
+    public class SlackPostResultDTO {
+
+        /** @description True when an HTTP request was actually sent (false on blank payload / no webhook). */
+        public Boolean attempted;
+
+        /** @description True when Slack responded with a 2xx status code. */
+        public Boolean delivered;
+
+        /** @description HTTP status code returned by Slack, or 0 when the callout threw. */
+        public Integer statusCode;
+
+        /** @description Preview of the Slack response (HTTP code + status + truncated body) or exception text. */
+        public String responseText;
+
+        /** @description Default constructor — outcome defaults to "not attempted, not delivered". */
+        public SlackPostResultDTO() {
+            this.attempted = false;
+            this.delivered = false;
+            this.statusCode = 0;
+            this.responseText = '';
+        }
     }
 }

--- a/force-app/main/default/classes/DeliveryWatcherDigestHistoryController.cls
+++ b/force-app/main/default/classes/DeliveryWatcherDigestHistoryController.cls
@@ -11,9 +11,10 @@
  *               and DeliveryOnboardingHistoryController.
  *
  *               The viewer presents Run Date Time, Status, Signal Counts,
- *               Recipient User Ids (used as a Slack-delivered proxy until
- *               PR 3 of the Watcher plan adds a real DeliveredDateTime__c
- *               field), Run Mode, and the body notes.
+ *               Recipient User Ids, Slack delivery (derived from
+ *               StatusPk__c — `Slack_Failed` indicates the post 4xx/5xx'd or
+ *               threw; see fix/watcher-slack-delivery-status-2026-05-26),
+ *               Run Mode, and the body notes.
  * @author       Cloud Nimbus LLC
  */
 @SuppressWarnings('PMD.ApexCRUDViolation')
@@ -25,9 +26,10 @@ public with sharing class DeliveryWatcherDigestHistoryController {
 
     /**
      * @description Flat row shape for lightning-datatable. Slack delivery is
-     *              inferred from whether RecipientUserIdsTxt__c is populated;
-     *              there is no per-run DeliveredDateTime__c yet, so this is
-     *              the best proxy we can offer the viewer.
+     *              now derived from StatusPk__c: a recipient list was
+     *              configured AND the StatusPk__c is NOT `Slack_Failed`.
+     *              `slackResponse` exposes the captured response text on
+     *              failure rows (empty otherwise) for debugging.
      */
     public class DigestRow {
         @AuraEnabled public Id id;
@@ -39,6 +41,7 @@ public with sharing class DeliveryWatcherDigestHistoryController {
         @AuraEnabled public Decimal runDurationMs;
         @AuraEnabled public String recipientUserIds;
         @AuraEnabled public Boolean slackDelivered;
+        @AuraEnabled public String slackResponse;
         @AuraEnabled public String notes;
         @AuraEnabled public String errorMessage;
     }
@@ -67,7 +70,8 @@ public with sharing class DeliveryWatcherDigestHistoryController {
         List<WatcherDigest__c> rows = [
             SELECT Id, Name, RunDateTime__c, StatusPk__c, RunModePk__c,
                    SignalCountsTxt__c, RunDurationMsNumber__c,
-                   RecipientUserIdsTxt__c, DigestBodyTxt__c, ErrorMessageTxt__c
+                   RecipientUserIdsTxt__c, DigestBodyTxt__c, ErrorMessageTxt__c,
+                   SlackResponseTxt__c
             FROM WatcherDigest__c
             WITH SYSTEM_MODE
             ORDER BY RunDateTime__c DESC NULLS LAST
@@ -85,7 +89,9 @@ public with sharing class DeliveryWatcherDigestHistoryController {
             r.signalCounts = w.SignalCountsTxt__c;
             r.runDurationMs = w.RunDurationMsNumber__c;
             r.recipientUserIds = w.RecipientUserIdsTxt__c;
-            r.slackDelivered = String.isNotBlank(w.RecipientUserIdsTxt__c);
+            r.slackDelivered = String.isNotBlank(w.RecipientUserIdsTxt__c)
+                && w.StatusPk__c != 'Slack_Failed';
+            r.slackResponse = w.SlackResponseTxt__c;
             r.notes = truncate(w.DigestBodyTxt__c, BODY_TRUNCATE);
             r.errorMessage = w.ErrorMessageTxt__c;
             out.add(r);

--- a/force-app/main/default/classes/DeliveryWatcherService.cls
+++ b/force-app/main/default/classes/DeliveryWatcherService.cls
@@ -73,8 +73,17 @@ global with sharing class DeliveryWatcherService {
         result.status = computeStatus(result);
         result.digestBodyMarkdown = buildBodyMarkdown(result);
 
-        persistDigest(result, settings);
-        postSlackIfRecipients(result, settings);
+        // Slack BEFORE persist so the digest row reflects actual delivery
+        // outcome on first insert (no second DML round trip). Synchronous
+        // callout — see DeliverySlackService.postWatcherDigest header for the
+        // architecture note. Closes Flow 8 #3 audit gap (subscribers used to
+        // see false `Success` even when the webhook 4xx/5xx'd).
+        DeliverySlackService.SlackPostResultDTO slackOutcome = postSlackIfRecipients(result, settings);
+        if (slackOutcome != null && slackOutcome.attempted && !slackOutcome.delivered) {
+            result.status = 'Slack_Failed';
+        }
+
+        persistDigest(result, settings, slackOutcome);
         stampHeartbeat(settings, result.status);
         return result;
     }
@@ -269,10 +278,13 @@ global with sharing class DeliveryWatcherService {
     }
 
     /**
-     * @description Computes the run-level status: Failed if every signal
-     *              threw, Partial if at least one threw, Success otherwise.
-     *              A signal "succeeded" when its DTO slot is non-null
-     *              (PR-C onward: SLA / Stuck / AR each contribute).
+     * @description Computes the signal-collection status: Failed if every
+     *              signal threw, Partial if at least one threw, Success
+     *              otherwise. A signal "succeeded" when its DTO slot is
+     *              non-null (PR-C onward: SLA / Stuck / AR each contribute).
+     *              Slack-delivery outcome is a separate downgrade applied by
+     *              the caller after the post (`Slack_Failed` overrides
+     *              `Success` when the webhook 4xx/5xx'd or threw).
      * @param result Aggregated result.
      * @return One of `Success`, `Partial`, `Failed` (GVS-backed).
      */
@@ -311,11 +323,19 @@ global with sharing class DeliveryWatcherService {
     /**
      * @description Inserts a WatcherDigest__c audit row capturing this run.
      *              Wrapped in try/catch — persistence must not nullify a
-     *              successful sweep.
-     * @param result   Aggregated result.
-     * @param settings Org-default settings row.
+     *              successful sweep. Receives the Slack delivery outcome so
+     *              the row's StatusPk__c and SlackResponseTxt__c reflect what
+     *              actually happened (closes Flow 8 #3 audit gap — subscribers
+     *              previously saw `Success` even when the webhook 4xx/5xx'd).
+     * @param result       Aggregated result.
+     * @param settings     Org-default settings row.
+     * @param slackOutcome Slack post outcome; may be null when no post was attempted.
      */
-    private static void persistDigest(WatcherRunResultDTO result, DeliveryHubSettings__c settings) {
+    private static void persistDigest(
+        WatcherRunResultDTO result,
+        DeliveryHubSettings__c settings,
+        DeliverySlackService.SlackPostResultDTO slackOutcome
+    ) {
         try {
             WatcherDigest__c row = new WatcherDigest__c(
                 RunDateTime__c = Datetime.now(),
@@ -327,6 +347,7 @@ global with sharing class DeliveryWatcherService {
                 FlaggedDocumentIdsTxt__c = buildFlaggedDocumentIds(result),
                 ErrorMessageTxt__c = buildErrorMessageTxt(result),
                 RecipientUserIdsTxt__c = truncate(settings.WatcherDigestRecipientUserIdsTxt__c, 255),
+                SlackResponseTxt__c = buildSlackResponseTxt(slackOutcome),
                 RunModePk__c = Test.isRunningTest() ? 'Test' : 'Scheduled'
             );
             insert row;
@@ -335,6 +356,27 @@ global with sharing class DeliveryWatcherService {
             System.debug(LoggingLevel.WARN,
                 '[DeliveryWatcherService] WatcherDigest__c insert failed: ' + e.getMessage());
         }
+    }
+
+    /**
+     * @description Returns the SlackResponseTxt__c value to persist. Empty
+     *              when no Slack post was attempted (quiet day, no recipient
+     *              list, master-flag-off path) or when delivery succeeded
+     *              (we only persist the response text on failure for the
+     *              audit trail — keeps successful-day rows compact). The
+     *              response text is already clipped to 255 chars by
+     *              DeliverySlackService.
+     * @param slackOutcome Outcome from the Slack post; may be null.
+     * @return Slack response preview when delivery failed, otherwise empty.
+     */
+    private static String buildSlackResponseTxt(DeliverySlackService.SlackPostResultDTO slackOutcome) {
+        if (slackOutcome == null || !slackOutcome.attempted) {
+            return '';
+        }
+        if (slackOutcome.delivered) {
+            return '';
+        }
+        return slackOutcome.responseText == null ? '' : slackOutcome.responseText;
     }
 
     /**
@@ -423,27 +465,45 @@ global with sharing class DeliveryWatcherService {
      * @description Posts the Block Kit payload to Slack when (a) a recipient
      *              list is configured AND (b) the formatter returned a
      *              non-null payload (quiet days return null → silent).
+     *              Returns the Slack delivery outcome so the caller can
+     *              reflect it on the WatcherDigest__c row's StatusPk__c +
+     *              SlackResponseTxt__c. Any exception thrown while building
+     *              the payload is captured into the returned DTO so the
+     *              audit still records the Slack-side failure.
      * @param result   Aggregated result.
      * @param settings Org-default settings row.
+     * @return SlackPostResultDTO with `attempted=false` when no post was
+     *         attempted (no recipients / quiet day); otherwise the actual
+     *         outcome from DeliverySlackService. Never returns null.
      */
-    private static void postSlackIfRecipients(WatcherRunResultDTO result, DeliveryHubSettings__c settings) {
+    private static DeliverySlackService.SlackPostResultDTO postSlackIfRecipients(
+        WatcherRunResultDTO result,
+        DeliveryHubSettings__c settings
+    ) {
+        DeliverySlackService.SlackPostResultDTO skipped = new DeliverySlackService.SlackPostResultDTO();
         if (String.isBlank(settings.WatcherDigestRecipientUserIdsTxt__c)) {
-            return;
+            return skipped;
         }
         try {
             String label = Datetime.now().format('yyyy-MM-dd HH:mm');
             Map<String, Object> blockKit = DeliveryWatcherDigestFormatter.buildBlockKit(result, label);
             if (blockKit == null) {
-                return; // Quiet day — Slack silent, audit row already written.
+                return skipped; // Quiet day — Slack silent, audit row still written.
             }
             String channelOverride = settings.WatcherDigestSlackChannelTxt__c;
             if (String.isNotBlank(channelOverride)) {
                 blockKit.put('channel', channelOverride);
             }
-            DeliverySlackService.postWatcherDigest(JSON.serialize(blockKit));
+            return DeliverySlackService.postWatcherDigest(JSON.serialize(blockKit));
         } catch (Exception e) {
-            System.debug(LoggingLevel.WARN,
-                '[DeliveryWatcherService] Slack post failed: ' + e.getMessage());
+            // Payload-build failure: don't poison the run, but DO surface the
+            // failure as a Slack-side problem so the audit row reflects it.
+            DeliverySlackService.SlackPostResultDTO buildFail = new DeliverySlackService.SlackPostResultDTO();
+            buildFail.attempted = true;
+            buildFail.delivered = false;
+            String msg = 'Payload build failed: ' + e.getTypeName() + ': ' + e.getMessage();
+            buildFail.responseText = msg.length() > 255 ? msg.substring(0, 255) : msg;
+            return buildFail;
         }
     }
 
@@ -451,15 +511,20 @@ global with sharing class DeliveryWatcherService {
 
     /**
      * @description Stamps LastWatcherHeartbeatDateTime__c on the org-default
-     *              settings when the run succeeded (or partially succeeded).
+     *              settings when the signal-collection sweep succeeded (or
+     *              partially succeeded, OR succeeded-but-Slack-failed).
+     *              Heartbeat tracks "the watcher woke up and queried", which
+     *              is independent of Slack delivery — a Slack outage must not
+     *              keep the 14-day stabilization gate from clearing. Only
+     *              `Failed` (orchestrator-side blow-up) skips the stamp.
      *              Used by the scheduler's idempotency gate AND the 14-day
      *              stabilization gate that precedes Phase 3 auto-digest.
      * @param settings Org-default settings row (already loaded).
-     * @param status   Run status (Success / Partial / Failed).
+     * @param status   Run status (Success / Partial / Failed / Slack_Failed).
      */
     private static void stampHeartbeat(DeliveryHubSettings__c settings, String status) {
         if (status == 'Failed') {
-            return; // Heartbeat tracks successful runs only.
+            return; // Heartbeat tracks successful sweeps only; Slack_Failed still counts.
         }
         try {
             settings.LastWatcherHeartbeatDateTime__c = Datetime.now();

--- a/force-app/main/default/classes/DeliveryWatcherServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryWatcherServiceTest.cls
@@ -11,6 +11,11 @@
  *                - signal-throw → captured into errorMessages (validated
  *                  via tampered settings shape would be too invasive;
  *                  rely on stub flag-gate to keep coverage tractable)
+ *                - Slack 2xx → StatusPk__c='Success', SlackResponseTxt__c empty
+ *                - Slack 4xx → StatusPk__c='Slack_Failed', SlackResponseTxt__c populated
+ *                - Slack 5xx → StatusPk__c='Slack_Failed', SlackResponseTxt__c populated
+ *                - CalloutException → StatusPk__c='Slack_Failed', SlackResponseTxt__c contains exception
+ *                  (closes Flow 8 #3 audit gap from e2e-walkthrough-2026-05-21.md)
  * @author Cloud Nimbus LLC
  */
 @IsTest
@@ -19,22 +24,66 @@ private class DeliveryWatcherServiceTest {
     private static User testUser = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
 
     /**
-     * @description Mock that always returns 200 OK for the Slack callout.
+     * @description Configurable Slack mock — defaults to 200 OK for the
+     *              existing happy-path tests; the Slack-delivery-status
+     *              tests construct it with explicit status + body.
      */
     private class SlackMock implements HttpCalloutMock {
         public Integer callCount = 0;
+        public Integer statusCode = 200;
+        public String body = 'ok';
+        public String statusText = 'OK';
+
+        /** @description Default constructor — 200 OK. */
+        public SlackMock() {}
+
         /**
-         * @description Records each invocation + returns a canned 200 OK so the
-         *              @future callout path executes end-to-end in test context.
+         * @description Configurable constructor for the new Slack-delivery-
+         *              status tests.
+         * @param statusCode  HTTP status to return.
+         * @param statusText  HTTP status line text (e.g. "Bad Request").
+         * @param body        Response body to return.
+         */
+        public SlackMock(Integer statusCode, String statusText, String body) {
+            this.statusCode = statusCode;
+            this.statusText = statusText;
+            this.body = body;
+        }
+
+        /**
+         * @description Records each invocation + returns a canned response so
+         *              the synchronous callout path executes end-to-end in
+         *              test context.
          * @param req Inbound HttpRequest from DeliverySlackService.postWatcherDigest.
-         * @return Canned HttpResponse (status 200, body "ok").
+         * @return Canned HttpResponse with configured status + body.
          */
         public HttpResponse respond(HttpRequest req) {
             this.callCount++;
             HttpResponse res = new HttpResponse();
-            res.setStatusCode(200);
-            res.setBody('ok');
+            res.setStatusCode(this.statusCode);
+            res.setStatus(this.statusText);
+            res.setBody(this.body);
             return res;
+        }
+    }
+
+    /**
+     * @description Mock that simulates a CalloutException (e.g. DNS failure /
+     *              SSL error / timeout). Used by the Slack-delivery-status
+     *              test that proves CalloutException → Slack_Failed.
+     */
+    private class ThrowingSlackMock implements HttpCalloutMock {
+        public Integer callCount = 0;
+
+        /**
+         * @description Throws a CalloutException so DeliverySlackService can
+         *              catch it and reflect it in the SlackPostResultDTO.
+         * @param req Inbound HttpRequest (unused — we throw before reading).
+         * @return Never returns; always throws.
+         */
+        public HttpResponse respond(HttpRequest req) {
+            this.callCount++;
+            throw new System.CalloutException('Simulated network error: connection refused');
         }
     }
 
@@ -223,6 +272,152 @@ private class DeliveryWatcherServiceTest {
                 'SignalCountsTxt__c should reflect AR:1 — got: ' + rows.get(0).SignalCountsTxt__c);
             System.assert(String.isNotBlank(rows.get(0).FlaggedDocumentIdsTxt__c),
                 'AR invoices should populate FlaggedDocumentIdsTxt__c');
+        }
+    }
+
+    // ── Slack-delivery-status tests (Flow 8 #3 audit gap) ──────────────────
+
+    /**
+     * @description 2xx Slack response → StatusPk__c stays `Success` and
+     *              SlackResponseTxt__c stays empty (we only persist the
+     *              response text on failure to keep success rows compact).
+     */
+    @IsTest
+    static void testSlack2xxKeepsSuccessStatus() {
+        System.runAs(testUser) {
+            insertWatcherEnabledSettings(String.valueOf(UserInfo.getUserId()));
+            seedAlertableWorkItem();
+            SlackMock mock = new SlackMock(200, 'OK', 'ok');
+            Test.setMock(HttpCalloutMock.class, mock);
+
+            Test.startTest();
+            DeliveryWatcherService.WatcherRunResultDTO result =
+                DeliveryWatcherService.runAndReturnSummary();
+            Test.stopTest();
+
+            System.assertEquals('Success', result.status, '2xx Slack response should leave status Success');
+            System.assertEquals(1, mock.callCount, 'Exactly one Slack callout should fire');
+            List<WatcherDigest__c> rows = [
+                SELECT StatusPk__c, SlackResponseTxt__c FROM WatcherDigest__c
+            ];
+            System.assertEquals(1, rows.size(), 'One audit row should have been written');
+            System.assertEquals('Success', rows.get(0).StatusPk__c,
+                'Persisted status should match — 2xx Slack response keeps Success');
+            System.assert(String.isBlank(rows.get(0).SlackResponseTxt__c),
+                'Successful Slack post should not persist response text (keep success rows compact) — got: '
+                + rows.get(0).SlackResponseTxt__c);
+        }
+    }
+
+    /**
+     * @description 4xx Slack response → StatusPk__c downgrades to
+     *              `Slack_Failed` and SlackResponseTxt__c captures the
+     *              response code + body. Closes the false-Success audit gap.
+     */
+    @IsTest
+    static void testSlack4xxDowngradesToSlackFailed() {
+        System.runAs(testUser) {
+            insertWatcherEnabledSettings(String.valueOf(UserInfo.getUserId()));
+            seedAlertableWorkItem();
+            SlackMock mock = new SlackMock(404, 'Not Found', 'no_service');
+            Test.setMock(HttpCalloutMock.class, mock);
+
+            Test.startTest();
+            DeliveryWatcherService.WatcherRunResultDTO result =
+                DeliveryWatcherService.runAndReturnSummary();
+            Test.stopTest();
+
+            System.assertEquals('Slack_Failed', result.status,
+                '4xx Slack response should downgrade status to Slack_Failed');
+            System.assertEquals(1, mock.callCount, 'Exactly one Slack callout should fire');
+            List<WatcherDigest__c> rows = [
+                SELECT StatusPk__c, SlackResponseTxt__c FROM WatcherDigest__c
+            ];
+            System.assertEquals(1, rows.size(), 'One audit row should have been written');
+            System.assertEquals('Slack_Failed', rows.get(0).StatusPk__c,
+                'Persisted status should match — 4xx Slack response → Slack_Failed');
+            System.assert(String.isNotBlank(rows.get(0).SlackResponseTxt__c),
+                'SlackResponseTxt__c should be populated on 4xx');
+            System.assert(rows.get(0).SlackResponseTxt__c.contains('404'),
+                'SlackResponseTxt__c should include the status code 404 — got: '
+                + rows.get(0).SlackResponseTxt__c);
+            System.assert(rows.get(0).SlackResponseTxt__c.contains('no_service'),
+                'SlackResponseTxt__c should include the response body — got: '
+                + rows.get(0).SlackResponseTxt__c);
+
+            // Heartbeat must still stamp on Slack_Failed — signals collected
+            // cleanly, only Slack delivery failed.
+            DeliveryHubSettings__c after = DeliveryHubSettings__c.getOrgDefaults();
+            System.assertNotEquals(null, after.LastWatcherHeartbeatDateTime__c,
+                'Heartbeat should still stamp on Slack_Failed (signal sweep succeeded)');
+        }
+    }
+
+    /**
+     * @description 5xx Slack response → StatusPk__c downgrades to
+     *              `Slack_Failed`. Same path as 4xx but proves the >=300
+     *              boundary catches server errors too.
+     */
+    @IsTest
+    static void testSlack5xxDowngradesToSlackFailed() {
+        System.runAs(testUser) {
+            insertWatcherEnabledSettings(String.valueOf(UserInfo.getUserId()));
+            seedAlertableWorkItem();
+            SlackMock mock = new SlackMock(503, 'Service Unavailable', 'try later');
+            Test.setMock(HttpCalloutMock.class, mock);
+
+            Test.startTest();
+            DeliveryWatcherService.WatcherRunResultDTO result =
+                DeliveryWatcherService.runAndReturnSummary();
+            Test.stopTest();
+
+            System.assertEquals('Slack_Failed', result.status,
+                '5xx Slack response should downgrade status to Slack_Failed');
+            List<WatcherDigest__c> rows = [
+                SELECT StatusPk__c, SlackResponseTxt__c FROM WatcherDigest__c
+            ];
+            System.assertEquals('Slack_Failed', rows.get(0).StatusPk__c,
+                'Persisted status should match — 5xx Slack response → Slack_Failed');
+            System.assert(rows.get(0).SlackResponseTxt__c.contains('503'),
+                'SlackResponseTxt__c should include the status code 503 — got: '
+                + rows.get(0).SlackResponseTxt__c);
+        }
+    }
+
+    /**
+     * @description CalloutException during the Slack POST → StatusPk__c
+     *              downgrades to `Slack_Failed` and SlackResponseTxt__c
+     *              captures the exception message (prefixed
+     *              `CalloutException:`).
+     */
+    @IsTest
+    static void testSlackCalloutExceptionDowngradesToSlackFailed() {
+        System.runAs(testUser) {
+            insertWatcherEnabledSettings(String.valueOf(UserInfo.getUserId()));
+            seedAlertableWorkItem();
+            ThrowingSlackMock mock = new ThrowingSlackMock();
+            Test.setMock(HttpCalloutMock.class, mock);
+
+            Test.startTest();
+            DeliveryWatcherService.WatcherRunResultDTO result =
+                DeliveryWatcherService.runAndReturnSummary();
+            Test.stopTest();
+
+            System.assertEquals('Slack_Failed', result.status,
+                'CalloutException should downgrade status to Slack_Failed');
+            System.assertEquals(1, mock.callCount,
+                'Exactly one Slack callout attempt should be made (the one that threw)');
+            List<WatcherDigest__c> rows = [
+                SELECT StatusPk__c, SlackResponseTxt__c FROM WatcherDigest__c
+            ];
+            System.assertEquals('Slack_Failed', rows.get(0).StatusPk__c,
+                'Persisted status should match — CalloutException → Slack_Failed');
+            System.assert(rows.get(0).SlackResponseTxt__c.startsWith('CalloutException:'),
+                'SlackResponseTxt__c should be prefixed with CalloutException: — got: '
+                + rows.get(0).SlackResponseTxt__c);
+            System.assert(rows.get(0).SlackResponseTxt__c.contains('Simulated network error'),
+                'SlackResponseTxt__c should include the exception message — got: '
+                + rows.get(0).SlackResponseTxt__c);
         }
     }
 

--- a/force-app/main/default/classes/DeliveryWatcherServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryWatcherServiceTest.cls
@@ -34,8 +34,12 @@ private class DeliveryWatcherServiceTest {
         public String body = 'ok';
         public String statusText = 'OK';
 
-        /** @description Default constructor — 200 OK. */
-        public SlackMock() {}
+        /** @description Default constructor — 200 OK. Body intentionally
+         *               empty; defaults live in the field initializers. */
+        @SuppressWarnings('PMD.EmptyStatementBlock')
+        public SlackMock() {
+            // Defaults from field initializers; no override needed.
+        }
 
         /**
          * @description Configurable constructor for the new Slack-delivery-

--- a/force-app/main/default/classes/WatcherDigestHistoryControllerTest.cls
+++ b/force-app/main/default/classes/WatcherDigestHistoryControllerTest.cls
@@ -3,9 +3,11 @@
  * @license      BSL 1.1 — See LICENSE.md
  * @description  Tests for DeliveryWatcherDigestHistoryController — the
  *               read-only audit-trail viewer for WatcherDigest__c. Covers
- *               ordering, the recordLimit guardrails, the slackDelivered
- *               proxy (RecipientUserIdsTxt__c populated -> true), notes
- *               truncation, and that contextId is ignored without erroring.
+ *               ordering, the recordLimit guardrails, slackDelivered
+ *               derivation (true when recipients populated AND status NOT
+ *               Slack_Failed; false otherwise), slackResponse surfacing on
+ *               failure rows, notes truncation, and that contextId is
+ *               ignored without erroring.
  * @author       Cloud Nimbus LLC
  */
 @IsTest
@@ -63,6 +65,36 @@ private class WatcherDigestHistoryControllerTest {
 
             System.assertEquals(1, out.size(), 'Should return the one row');
             System.assertEquals(false, out[0].slackDelivered, 'slackDelivered=false when recipient list is blank');
+        }
+    }
+
+    /**
+     * @description When a recipient list was configured AND the digest row's
+     *              StatusPk__c is `Slack_Failed`, slackDelivered must read
+     *              false and slackResponse must expose the captured response
+     *              for debugging (closes Flow 8 #3 audit gap derivative).
+     */
+    @IsTest
+    static void slackDeliveredFalseAndResponseSurfacedWhenSlackFailed() {
+        System.runAs(runningUser) {
+            insert new WatcherDigest__c(
+                RunDateTime__c = Datetime.now(),
+                StatusPk__c = 'Slack_Failed',
+                RunModePk__c = 'Test',
+                RecipientUserIdsTxt__c = UserInfo.getUserId(),
+                SlackResponseTxt__c = 'HTTP 503 Service Unavailable | try later'
+            );
+
+            Test.startTest();
+            List<DeliveryWatcherDigestHistoryController.DigestRow> out =
+                DeliveryWatcherDigestHistoryController.recent(50, null);
+            Test.stopTest();
+
+            System.assertEquals(1, out.size(), 'Should return the one row');
+            System.assertEquals(false, out[0].slackDelivered,
+                'slackDelivered=false when StatusPk__c is Slack_Failed, even with recipients');
+            System.assertEquals('HTTP 503 Service Unavailable | try later', out[0].slackResponse,
+                'slackResponse should round-trip the captured Slack response text');
         }
     }
 

--- a/force-app/main/default/classes/WatcherDigestRunQueueable.cls
+++ b/force-app/main/default/classes/WatcherDigestRunQueueable.cls
@@ -5,9 +5,11 @@
  *              Enqueued by DeliveryHubScheduler.enqueueWatcherDigestIfDue at
  *              the configured GMT hour once per day. Implements
  *              Database.AllowsCallouts so the orchestrator's downstream
- *              DeliverySlackService.postWatcherDigest @future callout chain
- *              is permitted in the same job. Mirrors
- *              DeliveryForecastAlertQueueable shape.
+ *              DeliverySlackService.postWatcherDigest synchronous callout is
+ *              permitted in the same job. (postWatcherDigest used to be
+ *              @future; promoted to synchronous so the WatcherDigest__c
+ *              StatusPk__c reflects actual Slack delivery outcome — closes
+ *              Flow 8 #3 audit gap.) Mirrors DeliveryForecastAlertQueueable shape.
  * @author Cloud Nimbus LLC
  */
 @SuppressWarnings('PMD.ApexDoc')

--- a/force-app/main/default/globalValueSets/WatcherDigestStatus.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/WatcherDigestStatus.globalValueSet-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
-    <description>Outcome status for a WatcherDigest__c run. Success = every enabled signal returned cleanly. Partial = at least one signal threw but the orchestrator caught and continued. Failed = the orchestrator itself errored before any signal ran.</description>
+    <description>Outcome status for a WatcherDigest__c run. Success = every enabled signal returned cleanly AND Slack delivery succeeded (or no Slack post was attempted). Partial = at least one signal threw but the orchestrator caught and continued. Failed = the orchestrator itself errored before any signal ran. Slack_Failed = signals ran cleanly but the Slack webhook returned non-2xx or threw — subscribers may not have received the digest (see SlackResponseTxt__c for the response).</description>
     <masterLabel>Watcher Digest Status</masterLabel>
     <sorted>false</sorted>
     <customValue>
@@ -17,5 +17,10 @@
         <fullName>Failed</fullName>
         <default>false</default>
         <label>Failed</label>
+    </customValue>
+    <customValue>
+        <fullName>Slack_Failed</fullName>
+        <default>false</default>
+        <label>Slack Failed</label>
     </customValue>
 </GlobalValueSet>

--- a/force-app/main/default/layouts/WatcherDigest__c-Watcher Digest Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/WatcherDigest__c-Watcher Digest Layout.layout-meta.xml
@@ -72,6 +72,10 @@
                 <behavior>Edit</behavior>
                 <field>ErrorMessageTxt__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>SlackResponseTxt__c</field>
+            </layoutItems>
         </layoutColumns>
         <style>OneColumn</style>
     </layoutSections>

--- a/force-app/main/default/lwc/deliveryWatcherDigestHistory/deliveryWatcherDigestHistory.js
+++ b/force-app/main/default/lwc/deliveryWatcherDigestHistory/deliveryWatcherDigestHistory.js
@@ -31,6 +31,7 @@ const COLUMNS = [
     { label: 'Signal Counts', fieldName: 'signalCounts', type: 'text', initialWidth: 260 },
     { label: 'Duration (ms)', fieldName: 'runDurationMs', type: 'number', sortable: true, initialWidth: 130 },
     { label: 'Slack Delivered', fieldName: 'slackDelivered', type: 'boolean', initialWidth: 140 },
+    { label: 'Slack Response', fieldName: 'slackResponse', type: 'text', wrapText: true, initialWidth: 220 },
     { label: 'Notes', fieldName: 'notes', type: 'text', wrapText: true }
 ];
 

--- a/force-app/main/default/objects/WatcherDigest__c/fields/SlackResponseTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/WatcherDigest__c/fields/SlackResponseTxt__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>SlackResponseTxt__c</fullName>
+    <description>Snapshot of the Slack webhook HTTP response captured after the digest post. Format: `HTTP {statusCode} {statusMessage} | {body}` (body truncated to 500 chars), or `CalloutException: {message}` when the request threw. Populated only when a Slack post was attempted (non-blank recipient list + non-quiet day) AND delivery failed (status not 2xx, or exception). Empty on success runs / runs where Slack wasn't invoked. Used to diagnose why a WatcherDigest__c StatusPk__c was downgraded to Slack_Failed.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Slack webhook response text (status + body) when the digest post failed. Empty on success or quiet runs.</inlineHelpText>
+    <label>Slack Response</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
@@ -1211,6 +1211,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>WatcherDigest__c.SlackResponseTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>WatcherDigest__c.StatusPk__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
@@ -1200,6 +1200,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>WatcherDigest__c.SlackResponseTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>WatcherDigest__c.StatusPk__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
## Summary

- **Capture Slack response on the audit row.** `DeliverySlackService.postWatcherDigest` is now synchronous and returns a new `SlackPostResultDTO` (attempted / delivered / statusCode / responseText). The orchestrator reorders flow so the Slack post happens BEFORE the `WatcherDigest__c` insert, and the captured outcome is reflected on the row's `StatusPk__c` + the new `SlackResponseTxt__c` field on a single DML.
- **New `Slack_Failed` GVS value.** Added to `WatcherDigestStatus` global value set. When the webhook returns 4xx/5xx or the request throws a `CalloutException`, `StatusPk__c` downgrades from `Success` to `Slack_Failed` and the response text (truncated to 255 chars) is captured for debugging.
- **New `SlackResponseTxt__c` field (Text 255).** Populated only on Slack-delivery-failure rows (success rows stay compact). Field perms added to both `DeliveryHubAdmin_App` (READ+WRITE) and `DeliveryHubApp` (READ). Added to the Watcher Digest layout next to `ErrorMessageTxt__c`. Plumbed through `DeliveryWatcherDigestHistoryController` + LWC viewer so admins see why a delivery failed.
- **Test coverage.** Four new orchestrator tests (2xx / 4xx / 5xx / CalloutException) + one controller test for the new `slackDelivered` derivation.

## The bug shape

> Per `docs/audits/e2e-walkthrough-2026-05-21.md` Flow 8 #3: \"Slack post is fire-and-forget. No fallback if the webhook 4xx/5xx's. The `WatcherDigest__c` row records `StatusPk__c='Success'` even if Slack didn't deliver.\"

Subscribers reading the WatcherDigest__c audit trail (e.g. via `deliveryWatcherDigestHistory` LWC) would believe digests delivered when they actually didn't. Worse: the controller's `slackDelivered` boolean was derived from \"was a recipient list configured?\" — a useless proxy that always returned `true` once the admin had set the recipient field, regardless of Slack's actual response.

The root cause was `@future(callout=true)` on `postWatcherDigest` — async means the orchestrator can't observe the response in the same transaction, so it pre-stamped `Success` then enqueued the callout. After PR-B (2026-05-21) this has been the live behavior on every Watcher run.

## What changed

| Layer | Change |
|---|---|
| `DeliverySlackService.postWatcherDigest` | Removed `@future`; returns `SlackPostResultDTO`; catches `CalloutException` separately + generic `Exception` fallback. Helpers: `postRaw` (lets exceptions propagate), `buildResponsePreview` (`HTTP {code} {status} \| {body}` clipped to 255), `clipForField` (null-safe). |
| `DeliveryWatcherService.runAndReturnSummary` | Reordered: dispatch -> compute status -> render body -> **Slack post** -> downgrade `result.status` to `Slack_Failed` if `attempted && !delivered` -> **persist** WatcherDigest__c (single insert with final status + captured `SlackResponseTxt__c`) -> heartbeat. |
| `DeliveryWatcherService.persistDigest` | Takes a 3rd param `SlackPostResultDTO slackOutcome`; populates `SlackResponseTxt__c` via `buildSlackResponseTxt` (empty on success / not-attempted, populated on failure). |
| `DeliveryWatcherService.postSlackIfRecipients` | Returns the DTO (never null); payload-build exceptions captured into the DTO as a Slack-side failure so the audit row reflects it. |
| `DeliveryWatcherService.stampHeartbeat` | Doc + behavior update: heartbeat stamps on `Slack_Failed` too. Signal sweep succeeded; Slack outage shouldn't block the Phase 3 14-day stabilization gate. |
| `WatcherDigest__c.SlackResponseTxt__c` | NEW field, Text(255). Capture format: `HTTP {code} {status} \| {body-clip-500}` or `CalloutException: {message}`. |
| `WatcherDigestStatus` GVS | NEW value `Slack_Failed` (label \"Slack Failed\"). |
| `DeliveryHubAdmin_App` + `DeliveryHubApp` permsets | Added field perms for `WatcherDigest__c.SlackResponseTxt__c` (READ+WRITE admin, READ app). |
| `WatcherDigest__c-Watcher Digest Layout` | Added the new field to the \"Digest Body\" section. |
| `DeliveryWatcherDigestHistoryController` | `slackDelivered` now correctly derived: `recipients populated AND StatusPk__c != 'Slack_Failed'`. New `slackResponse` field exposed on the row DTO. |
| `deliveryWatcherDigestHistory` LWC | New \"Slack Response\" column so admins can see the captured response text. |
| `WatcherDigestRunQueueable` header | Doc updated — `postWatcherDigest` is no longer `@future`. |

## Files touched

- `force-app/main/default/classes/DeliverySlackService.cls` — sync postWatcherDigest + DTO + helpers
- `force-app/main/default/classes/DeliveryWatcherService.cls` — reordered flow + downgrade logic + slackOutcome plumbing
- `force-app/main/default/classes/DeliveryWatcherServiceTest.cls` — 4 new tests + configurable + throwing mocks
- `force-app/main/default/classes/DeliveryWatcherDigestHistoryController.cls` — corrected slackDelivered derivation, added slackResponse
- `force-app/main/default/classes/WatcherDigestHistoryControllerTest.cls` — new derivation test
- `force-app/main/default/classes/WatcherDigestRunQueueable.cls` — header doc
- `force-app/main/default/objects/WatcherDigest__c/fields/SlackResponseTxt__c.field-meta.xml` — NEW
- `force-app/main/default/globalValueSets/WatcherDigestStatus.globalValueSet-meta.xml` — Slack_Failed value
- `force-app/main/default/layouts/WatcherDigest__c-Watcher Digest Layout.layout-meta.xml` — layout entry
- `force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml` — FLS
- `force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml` — FLS
- `force-app/main/default/lwc/deliveryWatcherDigestHistory/deliveryWatcherDigestHistory.js` — new column

## Test plan

- [ ] CI feature-test runs `DeliveryWatcherServiceTest` (5 existing + 4 new) and `WatcherDigestHistoryControllerTest` (5 existing + 1 new) clean
- [ ] CI feature-test runs `WatcherDigestRunQueueableTest` (unchanged, both pass — quiet path doesn't need Slack mock)
- [ ] CI feature-test runs `DeliverySlackServiceTest` clean (the legacy `postWatcherDigest` callers discard the new return value — non-breaking signature change)
- [ ] upload-beta + upload-prod green
- [ ] Post-merge in subscriber sandbox: temporarily set `WatcherDigestRecipientUserIdsTxt__c` + an invalid Slack webhook URL, manually run `DeliveryWatcherService.run()`, verify the latest `WatcherDigest__c` row has `StatusPk__c = 'Slack_Failed'` and `SlackResponseTxt__c` populated

## Reference

- Audit: `docs/audits/e2e-walkthrough-2026-05-21.md` Flow 8 #3
- Prior Watcher PRs: #807 (schema), #809 (orchestrator), #810 (signals 2+3)
- Memory tie-ins: design preserves [[fan-out-dont-queue]] discipline (one focused PR), single-DML write keeps the audit row truthful

\U0001f916 Generated with [Claude Code](https://claude.com/claude-code)