### PR TITLE
feat(dataset): record DatasetTemplateAssignment__c row after admin Mark-as-Loaded (closes Flow 7 #2 gap)

### DIFF
--- a/force-app/main/default/classes/DeliveryDatasetController.cls
+++ b/force-app/main/default/classes/DeliveryDatasetController.cls
@@ -85,6 +85,23 @@ global with sharing class DeliveryDatasetController {
     }
 
     /**
+     * @description Compact payload for the "last loaded by X on Y" subline
+     *              the LWC renders on each template card. Mirrors a single
+     *              DatasetTemplateAssignment__c without leaking the SObject.
+     *              All fields nullable — empty when no assignment row exists
+     *              for the template yet (first-load case).
+     */
+    global class LastAssignmentDTO {
+        @AuraEnabled public Id assignmentId;
+        @AuraEnabled public Id templateId;
+        @AuraEnabled public DateTime loadedAt;
+        @AuraEnabled public String loadedByName;
+        @AuraEnabled public String outcome;
+        @AuraEnabled public Integer recordsLoaded;
+        @AuraEnabled public String notes;
+    }
+
+    /**
      * @description Returns DatasetTemplate__c rows whose FeatureLookup__c
      *              points at the given feature. Cacheable so the LWC can
      *              @wire it without re-querying on every render.
@@ -320,6 +337,187 @@ global with sharing class DeliveryDatasetController {
             return null;
         }
         return null;
+    }
+
+    /**
+     * @description Records that an admin successfully loaded a dataset
+     *              template via the `cci task run load_feature_data` CLI
+     *              command (the cockpit "Mark as Loaded" button is the
+     *              explicit-attestation entry point — CCI runs out-of-band
+     *              so we cannot auto-detect completion). Inserts a
+     *              DatasetTemplateAssignment__c audit row tied to the running
+     *              user + current datetime, OutcomePk__c='Success'.
+     *
+     *              Idempotent same-day: if the running user already has an
+     *              assignment row for this template with LoadedDateTime__c
+     *              inside today's calendar day, updates that row instead of
+     *              inserting a duplicate (the admin clicked twice, or
+     *              re-confirmed a load — one click per template per day is
+     *              the documented contract).
+     *
+     *              Admin-gated. Reuses the same PSG check shape as
+     *              DeliveryFeatureCatalogController.isAdmin so non-admins
+     *              cannot pollute the audit trail.
+     * @param templateId DatasetTemplate__c Id the admin loaded. Required.
+     * @param notes Optional notes about what was loaded / why. ≤1000 chars
+     *              (matches NotesTxt__c LongTextArea length). Trimmed and
+     *              null-coalesced when blank.
+     * @return The inserted-or-updated DatasetTemplateAssignment__c row.
+     */
+    @AuraEnabled
+    global static DatasetTemplateAssignment__c recordAssignment(Id templateId, String notes) {
+        assertAdminOrThrow();
+        if (templateId == null) {
+            throw new AuraHandledException('templateId is required.');
+        }
+        List<DatasetTemplate__c> templates = [
+            SELECT Id FROM DatasetTemplate__c
+            WHERE Id = :templateId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (templates.isEmpty()) {
+            throw new AuraHandledException('Dataset template not found.');
+        }
+        String safeNotes = sanitizeNotes(notes);
+
+        // Same-day idempotency: did this user already record a load for this
+        // template today? Use today's start/end as a half-open window so the
+        // assertion is timezone-safe (the running user's TZ defines "today").
+        Datetime startOfDay = Datetime.newInstance(Date.today(), Time.newInstance(0, 0, 0, 0));
+        Datetime startOfTomorrow = startOfDay.addDays(1);
+        Id runningUserId = UserInfo.getUserId();
+        List<DatasetTemplateAssignment__c> existing = [
+            SELECT Id, NotesTxt__c, RecordsLoadedNumber__c, OutcomePk__c, LoadedDateTime__c
+            FROM DatasetTemplateAssignment__c
+            WHERE DatasetTemplateLookup__c = :templateId
+              AND LoadedByUserLookup__c = :runningUserId
+              AND LoadedDateTime__c >= :startOfDay
+              AND LoadedDateTime__c < :startOfTomorrow
+            WITH SYSTEM_MODE
+            ORDER BY LoadedDateTime__c DESC NULLS LAST
+            LIMIT 1
+        ];
+        DatasetTemplateAssignment__c row;
+        if (!existing.isEmpty()) {
+            row = existing.get(0);
+            row.NotesTxt__c = safeNotes;
+            row.LoadedDateTime__c = Datetime.now();
+            try {
+                update row;
+            } catch (Exception e) {
+                System.debug(LoggingLevel.WARN,
+                    '[DeliveryDatasetController.recordAssignment] update failed: ' + e.getMessage());
+                throw new AuraHandledException('Unable to update the existing assignment row.');
+            }
+        } else {
+            row = new DatasetTemplateAssignment__c(
+                DatasetTemplateLookup__c = templateId,
+                LoadedByUserLookup__c = runningUserId,
+                LoadedDateTime__c = Datetime.now(),
+                OutcomePk__c = 'Success',
+                NotesTxt__c = safeNotes
+            );
+            try {
+                insert row;
+            } catch (Exception e) {
+                System.debug(LoggingLevel.WARN,
+                    '[DeliveryDatasetController.recordAssignment] insert failed: ' + e.getMessage());
+                throw new AuraHandledException('Unable to record the dataset assignment.');
+            }
+        }
+        return row;
+    }
+
+    /**
+     * @description Returns the most-recent DatasetTemplateAssignment__c row
+     *              for the given template (across all users), packed into a
+     *              compact DTO suitable for the LWC "last loaded by X on Y"
+     *              subline. Returns null when no assignment row exists yet.
+     *              Cacheable so the LWC can @wire it without re-querying on
+     *              every render.
+     * @param templateId DatasetTemplate__c id whose most-recent load should
+     *                   be returned.
+     * @return LastAssignmentDTO or null when no row exists.
+     */
+    @AuraEnabled(cacheable=true)
+    global static LastAssignmentDTO getLastAssignment(Id templateId) {
+        if (templateId == null) {
+            return null;
+        }
+        try {
+            List<DatasetTemplateAssignment__c> rows = [
+                SELECT Id, DatasetTemplateLookup__c, LoadedDateTime__c,
+                       LoadedByUserLookup__c, LoadedByUserLookup__r.Name,
+                       OutcomePk__c, RecordsLoadedNumber__c, NotesTxt__c
+                FROM DatasetTemplateAssignment__c
+                WHERE DatasetTemplateLookup__c = :templateId
+                WITH SYSTEM_MODE
+                ORDER BY LoadedDateTime__c DESC NULLS LAST
+                LIMIT 1
+            ];
+            if (rows.isEmpty()) {
+                return null;
+            }
+            DatasetTemplateAssignment__c a = rows.get(0);
+            LastAssignmentDTO dto = new LastAssignmentDTO();
+            dto.assignmentId = a.Id;
+            dto.templateId = a.DatasetTemplateLookup__c;
+            dto.loadedAt = a.LoadedDateTime__c;
+            if (a.LoadedByUserLookup__c != null && a.LoadedByUserLookup__r != null) {
+                dto.loadedByName = a.LoadedByUserLookup__r.Name;
+            }
+            dto.outcome = a.OutcomePk__c;
+            if (a.RecordsLoadedNumber__c != null) {
+                dto.recordsLoaded = a.RecordsLoadedNumber__c.intValue();
+            }
+            dto.notes = a.NotesTxt__c;
+            return dto;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryDatasetController.getLastAssignment] failed: ' + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * @description Throws an AuraHandledException when the running user is
+     *              not a DH admin. Reuses the same PermissionSetGroup gate
+     *              as DeliveryFeatureCatalogController.isAdmin (both
+     *              namespaced + bare DeveloperName forms accepted per
+     *              [[namespace-safe-typed-sobject-describe]]).
+     */
+    private static void assertAdminOrThrow() {
+        Boolean isAdmin = ![
+            SELECT Id FROM PermissionSetAssignment
+            WHERE AssigneeId = :UserInfo.getUserId()
+              AND PermissionSetGroup.DeveloperName IN
+                  ('DeliveryHubAdmin', 'delivery__DeliveryHubAdmin')
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ].isEmpty();
+        if (!isAdmin) {
+            throw new AuraHandledException('Only Delivery Hub admins can record dataset assignments.');
+        }
+    }
+
+    /**
+     * @description Trims optional admin notes and clamps to the NotesTxt__c
+     *              column length (1000 chars). Returns null when blank so we
+     *              don't insert empty strings into the audit row.
+     * @param notes Raw notes from the LWC.
+     * @return Sanitized notes string or null when blank.
+     */
+    private static String sanitizeNotes(String notes) {
+        if (String.isBlank(notes)) {
+            return null;
+        }
+        String trimmed = notes.trim();
+        Integer maxLen = 1000;
+        if (trimmed.length() > maxLen) {
+            trimmed = trimmed.substring(0, maxLen);
+        }
+        return trimmed;
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryDatasetControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryDatasetControllerTest.cls
@@ -181,7 +181,11 @@ private class DeliveryDatasetControllerTest {
             TimeZoneSidKey = 'America/New_York',
             UserName = 'ddctt+' + Crypto.getRandomLong() + '@dh-test.example.test'
         );
-        insert u;
+        // Setup-object insert isolated in runAs(current) to avoid MIXED_DML
+        // against the caller's subsequent DatasetTemplate__c inserts.
+        System.runAs(new User(Id = UserInfo.getUserId())) {
+            insert u;
+        }
         return u;
     }
 

--- a/force-app/main/default/classes/DeliveryDatasetControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryDatasetControllerTest.cls
@@ -157,4 +157,249 @@ private class DeliveryDatasetControllerTest {
         Test.stopTest();
         System.assertEquals(true, thrown, 'Null templateId must produce an exception.');
     }
+
+    // ────────────────────────────────────────────────────────────────────
+    // recordAssignment + getLastAssignment — writer + reader of the
+    // DatasetTemplateAssignment__c audit row (Flow 7 #2 gap closure).
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Builds a standard (non-admin) User. Used to assert the
+     *              admin gate fires on recordAssignment.
+     * @return Inserted standard User.
+     */
+    private static User buildStandardUser() {
+        Profile p = [SELECT Id FROM Profile WHERE Name = 'Standard User' LIMIT 1];
+        User u = new User(
+            Alias = 'ddctt',
+            Email = 'ddctt+' + Crypto.getRandomLong() + '@example.test',
+            EmailEncodingKey = 'UTF-8',
+            LastName = 'DatasetTester',
+            LanguageLocaleKey = 'en_US',
+            LocaleSidKey = 'en_US',
+            ProfileId = p.Id,
+            TimeZoneSidKey = 'America/New_York',
+            UserName = 'ddctt+' + Crypto.getRandomLong() + '@dh-test.example.test'
+        );
+        insert u;
+        return u;
+    }
+
+    /**
+     * @description Builds an admin User with the DeliveryHubAdmin PSG
+     *              assigned so the assertAdminOrThrow gate lets calls
+     *              through. Calculates the PSG before assignment per
+     *              [[psg-must-be-calculated-before-assignment-in-test]] —
+     *              the namespaced packaging-org test context leaves PSGs
+     *              "Outdated" after install and PermissionSetAssignment
+     *              insert will fail without the recalc.
+     * @return Inserted admin User.
+     */
+    private static User buildAdminUser() {
+        Profile p = [SELECT Id FROM Profile WHERE Name = 'Standard User' LIMIT 1];
+        User u = new User(
+            Alias = 'ddcta',
+            Email = 'ddcta+' + Crypto.getRandomLong() + '@example.test',
+            EmailEncodingKey = 'UTF-8',
+            LastName = 'DatasetAdmin',
+            LanguageLocaleKey = 'en_US',
+            LocaleSidKey = 'en_US',
+            ProfileId = p.Id,
+            TimeZoneSidKey = 'America/New_York',
+            UserName = 'ddcta+' + Crypto.getRandomLong() + '@dh-test.example.test'
+        );
+        List<PermissionSetGroup> psgs = [
+            SELECT Id FROM PermissionSetGroup
+            WHERE DeveloperName IN ('DeliveryHubAdmin', 'delivery__DeliveryHubAdmin')
+            LIMIT 1
+        ];
+        System.runAs(new User(Id = UserInfo.getUserId())) {
+            insert u;
+            if (!psgs.isEmpty()) {
+                Test.calculatePermissionSetGroup(psgs[0].Id);
+                insert new PermissionSetAssignment(
+                    AssigneeId = u.Id,
+                    PermissionSetGroupId = psgs[0].Id
+                );
+            }
+        }
+        return u;
+    }
+
+    @IsTest
+    static void testRecordAssignmentInsertsRow() {
+        User admin = buildAdminUser();
+        DatasetTemplate__c t = TestDataFactory.newDatasetTemplate();
+
+        Test.startTest();
+        DatasetTemplateAssignment__c inserted;
+        System.runAs(admin) {
+            inserted = DeliveryDatasetController.recordAssignment(t.Id, 'Loaded the invoice demo seed.');
+        }
+        Test.stopTest();
+
+        System.assertNotEquals(null, inserted, 'recordAssignment must return the inserted row.');
+        System.assertNotEquals(null, inserted.Id, 'Returned row must be persisted (have an Id).');
+        DatasetTemplateAssignment__c reloaded = [
+            SELECT Id, DatasetTemplateLookup__c, LoadedByUserLookup__c, OutcomePk__c,
+                   NotesTxt__c, LoadedDateTime__c
+            FROM DatasetTemplateAssignment__c
+            WHERE Id = :inserted.Id
+            LIMIT 1
+        ];
+        System.assertEquals(t.Id, reloaded.DatasetTemplateLookup__c, 'Template lookup must match.');
+        System.assertEquals(admin.Id, reloaded.LoadedByUserLookup__c, 'LoadedBy must be the running admin.');
+        System.assertEquals('Success', reloaded.OutcomePk__c, 'Outcome must default to Success.');
+        System.assertEquals('Loaded the invoice demo seed.', reloaded.NotesTxt__c, 'Notes must round-trip.');
+        System.assertNotEquals(null, reloaded.LoadedDateTime__c, 'LoadedDateTime__c must be populated.');
+    }
+
+    @IsTest
+    static void testRecordAssignmentRequiresAdmin() {
+        User standard = buildStandardUser();
+        DatasetTemplate__c t = TestDataFactory.newDatasetTemplate();
+
+        Boolean thrown = false;
+        Test.startTest();
+        System.runAs(standard) {
+            try {
+                DeliveryDatasetController.recordAssignment(t.Id, 'no perms');
+            } catch (AuraHandledException e) {
+                thrown = true;
+            } catch (Exception e) {
+                thrown = true;
+            }
+        }
+        Test.stopTest();
+
+        System.assertEquals(true, thrown, 'Non-admin caller must hit the admin gate.');
+        Integer rows = [
+            SELECT COUNT() FROM DatasetTemplateAssignment__c
+            WHERE DatasetTemplateLookup__c = :t.Id
+        ];
+        System.assertEquals(0, rows, 'No audit row should land when the gate fires.');
+    }
+
+    @IsTest
+    static void testRecordAssignmentUpdatesExistingSameDayRow() {
+        User admin = buildAdminUser();
+        DatasetTemplate__c t = TestDataFactory.newDatasetTemplate();
+
+        Test.startTest();
+        DatasetTemplateAssignment__c first;
+        DatasetTemplateAssignment__c second;
+        System.runAs(admin) {
+            first = DeliveryDatasetController.recordAssignment(t.Id, 'first click');
+            second = DeliveryDatasetController.recordAssignment(t.Id, 'second click — same day');
+        }
+        Test.stopTest();
+
+        System.assertEquals(first.Id, second.Id,
+            'Same-day idempotency: second call must update the same row, not insert a duplicate.');
+        Integer rows = [
+            SELECT COUNT() FROM DatasetTemplateAssignment__c
+            WHERE DatasetTemplateLookup__c = :t.Id
+              AND LoadedByUserLookup__c = :admin.Id
+        ];
+        System.assertEquals(1, rows, 'Only one audit row should exist for this user+template today.');
+        DatasetTemplateAssignment__c reloaded = [
+            SELECT Id, NotesTxt__c FROM DatasetTemplateAssignment__c
+            WHERE Id = :second.Id
+            LIMIT 1
+        ];
+        System.assertEquals('second click — same day', reloaded.NotesTxt__c,
+            'Notes should reflect the most-recent click.');
+    }
+
+    @IsTest
+    static void testRecordAssignmentRejectsInvalidTemplateId() {
+        User admin = buildAdminUser();
+        // Borrow the running-user Id as a non-null Id of the WRONG sObject
+        // type — recordAssignment looks the template up by Id and must throw
+        // when no DatasetTemplate__c row matches.
+        Id bogus = UserInfo.getUserId();
+
+        Boolean thrown = false;
+        Test.startTest();
+        System.runAs(admin) {
+            try {
+                DeliveryDatasetController.recordAssignment(bogus, null);
+            } catch (AuraHandledException e) {
+                thrown = true;
+            } catch (Exception e) {
+                thrown = true;
+            }
+        }
+        Test.stopTest();
+
+        System.assertEquals(true, thrown, 'Bogus / wrong-type templateId must throw.');
+    }
+
+    @IsTest
+    static void testRecordAssignmentRejectsNullTemplateId() {
+        User admin = buildAdminUser();
+
+        Boolean thrown = false;
+        Test.startTest();
+        System.runAs(admin) {
+            try {
+                DeliveryDatasetController.recordAssignment(null, 'no id');
+            } catch (AuraHandledException e) {
+                thrown = true;
+            } catch (Exception e) {
+                thrown = true;
+            }
+        }
+        Test.stopTest();
+
+        System.assertEquals(true, thrown, 'Null templateId must throw.');
+    }
+
+    @IsTest
+    static void testGetLastAssignmentReturnsMostRecentRow() {
+        DatasetTemplate__c t = TestDataFactory.newDatasetTemplate();
+        DatasetTemplateAssignment__c older = TestDataFactory.buildDatasetTemplateAssignment(
+            t.Id, new Map<String, Object>{
+                'LoadedDateTime__c' => Datetime.now().addHours(-3),
+                'RecordsLoadedNumber__c' => 4
+            }
+        );
+        DatasetTemplateAssignment__c newer = TestDataFactory.buildDatasetTemplateAssignment(
+            t.Id, new Map<String, Object>{
+                'LoadedDateTime__c' => Datetime.now().addMinutes(-2),
+                'RecordsLoadedNumber__c' => 11
+            }
+        );
+        insert new List<DatasetTemplateAssignment__c>{ older, newer };
+
+        Test.startTest();
+        DeliveryDatasetController.LastAssignmentDTO dto =
+            DeliveryDatasetController.getLastAssignment(t.Id);
+        Test.stopTest();
+
+        System.assertNotEquals(null, dto, 'Must return a DTO when assignments exist.');
+        System.assertEquals(newer.Id, dto.assignmentId,
+            'Must return the most-recent row by LoadedDateTime__c DESC.');
+        System.assertEquals(t.Id, dto.templateId, 'Template id should round-trip.');
+        System.assertEquals(11, dto.recordsLoaded, 'recordsLoaded must reflect the newest row.');
+    }
+
+    @IsTest
+    static void testGetLastAssignmentNullReturnsNull() {
+        Test.startTest();
+        DeliveryDatasetController.LastAssignmentDTO dto =
+            DeliveryDatasetController.getLastAssignment(null);
+        Test.stopTest();
+        System.assertEquals(null, dto, 'Null templateId must return null (not throw).');
+    }
+
+    @IsTest
+    static void testGetLastAssignmentReturnsNullWhenNoRowsExist() {
+        DatasetTemplate__c t = TestDataFactory.newDatasetTemplate();
+        Test.startTest();
+        DeliveryDatasetController.LastAssignmentDTO dto =
+            DeliveryDatasetController.getLastAssignment(t.Id);
+        Test.stopTest();
+        System.assertEquals(null, dto, 'No assignment rows means null DTO (first-load case).');
+    }
 }

--- a/force-app/main/default/lwc/deliveryDatasetTemplates/deliveryDatasetTemplates.html
+++ b/force-app/main/default/lwc/deliveryDatasetTemplates/deliveryDatasetTemplates.html
@@ -59,6 +59,15 @@
                                         onclick={handleCopyCommand}>
                                     </lightning-button>
                                     <lightning-button
+                                        label="Mark as Loaded"
+                                        variant="success"
+                                        icon-name="utility:check"
+                                        class="slds-m-left_x-small"
+                                        data-template-id={t.templateId}
+                                        data-template-name={t.name}
+                                        onclick={handleOpenMarkAsLoaded}>
+                                    </lightning-button>
+                                    <lightning-button
                                         label="Recent Loads"
                                         variant="neutral"
                                         class="slds-m-left_x-small"
@@ -77,6 +86,12 @@
                             <template lwc:if={t.hasApexScriptPath}>
                                 <div class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
                                     Loader: <code>{t.apexScriptPath}</code>
+                                </div>
+                            </template>
+
+                            <template lwc:if={t.hasLastLoadedSubline}>
+                                <div class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
+                                    {t.lastLoadedSubline}
                                 </div>
                             </template>
                         </li>
@@ -112,4 +127,62 @@
 
         </div>
     </lightning-card>
+
+    <template lwc:if={isMarkAsLoadedModalOpen}>
+        <section role="dialog" tabindex="-1" aria-modal="true"
+            aria-labelledby="markAsLoadedHeading"
+            class="slds-modal slds-fade-in-open slds-modal_small">
+            <div class="slds-modal__container">
+                <header class="slds-modal__header">
+                    <lightning-button-icon
+                        icon-name="utility:close"
+                        variant="bare-inverse"
+                        size="large"
+                        alternative-text="Cancel"
+                        title="Cancel"
+                        class="slds-modal__close"
+                        onclick={handleCloseMarkAsLoaded}>
+                    </lightning-button-icon>
+                    <h2 id="markAsLoadedHeading" class="slds-modal__title slds-hyphenate">
+                        Mark Dataset as Loaded
+                    </h2>
+                    <p class="slds-m-top_x-small slds-text-body_small slds-text-color_weak">
+                        Template: <strong>{markAsLoadedTemplateName}</strong>
+                    </p>
+                </header>
+                <div class="slds-modal__content slds-p-around_medium">
+                    <p class="slds-text-body_small slds-m-bottom_small">
+                        Click <em>Confirm</em> after you have finished running
+                        <code>cci task run load_feature_data</code> locally.
+                        A DatasetTemplateAssignment audit row will be created
+                        with you as the loader, timestamped now.
+                    </p>
+                    <lightning-textarea
+                        name="notes"
+                        label="Notes (optional)"
+                        max-length="1000"
+                        placeholder="What dataset did you load? Any caveats?"
+                        value={markAsLoadedNotes}
+                        onchange={handleMarkAsLoadedNotesChange}>
+                    </lightning-textarea>
+                </div>
+                <footer class="slds-modal__footer">
+                    <lightning-button
+                        label="Cancel"
+                        variant="neutral"
+                        onclick={handleCloseMarkAsLoaded}
+                        disabled={isSubmittingMarkAsLoaded}>
+                    </lightning-button>
+                    <lightning-button
+                        label="Confirm"
+                        variant="brand"
+                        class="slds-m-left_x-small"
+                        onclick={handleSubmitMarkAsLoaded}
+                        disabled={isSubmittingMarkAsLoaded}>
+                    </lightning-button>
+                </footer>
+            </div>
+        </section>
+        <div class="slds-backdrop slds-backdrop_open"></div>
+    </template>
 </template>

--- a/force-app/main/default/lwc/deliveryDatasetTemplates/deliveryDatasetTemplates.js
+++ b/force-app/main/default/lwc/deliveryDatasetTemplates/deliveryDatasetTemplates.js
@@ -23,6 +23,8 @@ import getTemplatesForWorkItem from '@salesforce/apex/%%%NAMESPACE_DOT%%%Deliver
 import getRecentAssignmentsForTemplate from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDatasetController.getRecentAssignmentsForTemplate';
 import formatCciCommand from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDatasetController.formatCciCommand';
 import isSubscriberOrgApex from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDatasetController.isSubscriberOrg';
+import getLastAssignment from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDatasetController.getLastAssignment';
+import recordAssignment from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDatasetController.recordAssignment';
 
 const FEATURE_OBJECT = 'Feature__c',
     WORK_ITEM_OBJECT = 'WorkItem__c',
@@ -40,6 +42,13 @@ export default class DeliveryDatasetTemplates extends LightningElement {
     @track isLoaded = false;
     @track selectedTemplateId = null;
     @track isSubscriberOrg = false;
+
+    // ── Mark-as-Loaded modal state ──────────────────────────────────────
+    @track isMarkAsLoadedModalOpen = false;
+    @track markAsLoadedTemplateId = null;
+    @track markAsLoadedTemplateName = '';
+    @track markAsLoadedNotes = '';
+    @track isSubmittingMarkAsLoaded = false;
 
     wiredTemplatesResult;
     wiredRecentResult;
@@ -106,10 +115,13 @@ export default class DeliveryDatasetTemplates extends LightningElement {
                 hasApexScriptPath: !!t.apexScriptPath,
                 recordCountEstimate: typeof t.recordCountEstimate === 'number' ? t.recordCountEstimate : null,
                 hasRecordCountEstimate: typeof t.recordCountEstimate === 'number',
-                featureName: t.featureName || ''
+                featureName: t.featureName || '',
+                lastLoadedSubline: '',
+                hasLastLoadedSubline: false
             }));
             this.errorMessage = '';
             this.isLoaded = true;
+            this.loadLastAssignmentSublines();
         } else if (result.error) {
             this.errorMessage = (result.error && result.error.body && result.error.body.message)
                 ? result.error.body.message
@@ -117,6 +129,50 @@ export default class DeliveryDatasetTemplates extends LightningElement {
             this.templates = [];
             this.isLoaded = true;
         }
+    }
+
+    // Imperative fan-out: for each template card, fetch the most-recent
+    // assignment so we can render a "Last loaded by X on Y" subline. Best-
+    // effort — failures degrade silently to "no subline".
+    loadLastAssignmentSublines() {
+        const templateIds = (this.templates || [])
+            .map(t => t.templateId)
+            .filter(id => !!id);
+        templateIds.forEach(templateId => {
+            getLastAssignment({ templateId })
+                .then(dto => this.mergeLastAssignment(templateId, dto))
+                .catch(() => {
+                    // best-effort — don't surface a toast for the subline path
+                });
+        });
+    }
+
+    mergeLastAssignment(templateId, dto) {
+        if (!dto) {
+            return;
+        }
+        const formatted = this.formatLastLoadedSubline(dto);
+        this.templates = (this.templates || []).map(t => {
+            if (t.templateId !== templateId) {
+                return t;
+            }
+            return Object.assign({}, t, {
+                lastLoadedSubline: formatted,
+                hasLastLoadedSubline: !!formatted
+            });
+        });
+    }
+
+    formatLastLoadedSubline(dto) {
+        if (!dto || !dto.loadedAt) {
+            return '';
+        }
+        const when = new Date(dto.loadedAt);
+        const datePart = Number.isNaN(when.getTime())
+            ? String(dto.loadedAt)
+            : when.toLocaleDateString();
+        const who = dto.loadedByName || 'Unknown user';
+        return `Last loaded by ${who} on ${datePart}`;
     }
 
     outcomeBadgeFor(outcome) {
@@ -226,6 +282,76 @@ export default class DeliveryDatasetTemplates extends LightningElement {
         this.selectedTemplateId = templateId || null;
     }
 
+    // ── Mark-as-Loaded modal ────────────────────────────────────────────
+
+    handleOpenMarkAsLoaded(event) {
+        const templateId = event.currentTarget.dataset.templateId;
+        const templateName = event.currentTarget.dataset.templateName || '';
+        if (!templateId) {
+            return;
+        }
+        this.markAsLoadedTemplateId = templateId;
+        this.markAsLoadedTemplateName = templateName;
+        this.markAsLoadedNotes = '';
+        this.isMarkAsLoadedModalOpen = true;
+    }
+
+    handleCloseMarkAsLoaded() {
+        if (this.isSubmittingMarkAsLoaded) {
+            // In-flight submission — let it finish before closing.
+            return;
+        }
+        this.isMarkAsLoadedModalOpen = false;
+        this.markAsLoadedTemplateId = null;
+        this.markAsLoadedTemplateName = '';
+        this.markAsLoadedNotes = '';
+    }
+
+    handleMarkAsLoadedNotesChange(event) {
+        this.markAsLoadedNotes = event.target.value || '';
+    }
+
+    handleSubmitMarkAsLoaded() {
+        if (!this.markAsLoadedTemplateId || this.isSubmittingMarkAsLoaded) {
+            return;
+        }
+        this.isSubmittingMarkAsLoaded = true;
+        recordAssignment({
+            templateId: this.markAsLoadedTemplateId,
+            notes: this.markAsLoadedNotes
+        })
+            .then(() => {
+                this.dispatchEvent(new ShowToastEvent({
+                    title: 'Load recorded',
+                    message: `Audit row created for "${this.markAsLoadedTemplateName}".`,
+                    variant: 'success'
+                }));
+                // Refresh the recent-loads panel (if it's currently showing
+                // this template) AND the per-card last-loaded subline so the
+                // admin sees their entry immediately.
+                if (this.wiredRecentResult) {
+                    refreshApex(this.wiredRecentResult);
+                }
+                this.loadLastAssignmentSublines();
+                this.isSubmittingMarkAsLoaded = false;
+                this.isMarkAsLoadedModalOpen = false;
+                this.markAsLoadedTemplateId = null;
+                this.markAsLoadedTemplateName = '';
+                this.markAsLoadedNotes = '';
+            })
+            .catch(err => {
+                const msg = (err && err.body && err.body.message)
+                    ? err.body.message
+                    : 'Unable to record this load.';
+                this.dispatchEvent(new ShowToastEvent({
+                    title: 'Could not record load',
+                    message: msg,
+                    variant: 'error'
+                }));
+                this.isSubmittingMarkAsLoaded = false;
+            });
+    }
+
     handleRefresh() {
         if (this.wiredTemplatesResult) {
             refreshApex(this.wiredTemplatesResult);
@@ -233,5 +359,6 @@ export default class DeliveryDatasetTemplates extends LightningElement {
         if (this.wiredRecentResult) {
             refreshApex(this.wiredRecentResult);
         }
+        this.loadLastAssignmentSublines();
     }
 }

--- a/force-app/main/default/objects/DatasetTemplateAssignment__c/fields/NotesTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/DatasetTemplateAssignment__c/fields/NotesTxt__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>NotesTxt__c</fullName>
+    <description>Free-form admin notes captured when the cockpit "Mark as Loaded" button is clicked — what dataset was loaded, caveats, anything the admin wants to leave on the audit row. Distinct from ErrorSummaryTxt__c (which is loader-error output only).</description>
+    <inlineHelpText>Optional notes from the admin marking this load — what was loaded, caveats, etc.</inlineHelpText>
+    <label>Notes</label>
+    <length>1000</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>4</visibleLines>
+</CustomField>

--- a/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
@@ -410,6 +410,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>DatasetTemplateAssignment__c.NotesTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Feature__c.FeatureDefinitionTxt__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
@@ -404,6 +404,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>DatasetTemplateAssignment__c.NotesTxt__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>Feature__c.FeatureDefinitionTxt__c</field>
         <readable>true</readable>


### PR DESCRIPTION
## Summary

- **Apex (`DeliveryDatasetController.cls`)** — new `recordAssignment(templateId, notes)` writer (admin-gated, same-day idempotent) + `getLastAssignment(templateId)` reader for the per-card "Last loaded by X on Y" subline. Reuses the namespace-safe PSG check shape from `DeliveryFeatureCatalogController.isAdmin`.
- **LWC (`deliveryDatasetTemplates`)** — new "Mark as Loaded" button next to "Copy Load Command", modal with an optional notes textarea (max 1000 chars), and a "Last loaded by X on Y" subline that refreshes after each successful confirmation.
- **Tests** — 7 new methods covering insert + admin-gating + same-day idempotency + null/invalid id guards + DESC ordering + first-load null DTO.

## Why

Closes the **Flow 7 #2** gap from `docs/audits/e2e-walkthrough-2026-05-21.md`:
> Nothing writes `DatasetTemplateAssignment__c` rows after a successful load. The audit-trail object is shipped empty.

Subscribers loading dataset templates now have an audit trail visible on each template card and in the "Recent Loads" panel.

## Design notes

- The CCI `load_feature_data` task runs out-of-band (local CLI), so we cannot auto-detect completion. The "Mark as Loaded" button is the explicit-admin-attestation entry point — reasonable trade-off for v1 vs. an external webhook/CCI post-task hook.
- **Same-day idempotency**: if the running admin clicks Mark as Loaded twice for the same template inside one calendar day, the second click updates the existing row (notes + timestamp). Prevents accidental audit-trail spam from double-clicks or re-confirmations.
- **Field-naming verification per `[[grep-field-naming-before-brief]]`**: confirmed there was no existing `NotesTxt__c` on `DatasetTemplateAssignment__c`. Added the field as `LongTextArea(1000)` rather than overloading `ErrorSummaryTxt__c` (which is loader-errors-only by description).
- **Permset entries**: added `NotesTxt__c` field perms (read+edit) to BOTH `DeliveryHubApp` and `DeliveryHubAdmin_App` per the per-PR checklist.
- **PSG calculation in admin-user test helper**: calls `Test.calculatePermissionSetGroup` before `PermissionSetAssignment` insert per `[[psg-must-be-calculated-before-assignment-in-test]]` — the namespaced packaging scratch leaves PSGs "Outdated" after install.

## Audit-correction findings

None — the gap is real and unaddressed in `release/0.247.0.6`. Verified directly:

- `DeliveryDatasetController.cls` has zero writer methods on `main` as of this PR; only `getRecentAssignmentsForTemplate` / `getAssignmentsForScratchOrg` readers exist.
- No `NotesTxt__c` field existed on `DatasetTemplateAssignment__c` prior to this PR.

## Verification scope

- Apex method admin-gating + happy path + idempotency + invalid input
- LWC button placement + modal + last-loaded subline rendering
- Schema delta (new field + permset entries in both permsets)

## Test plan

- [ ] CI: `DeliveryDatasetControllerTest` runs clean in feature-test + upload-beta (7 new methods)
- [ ] Manual (subscriber install context):
  - [ ] Open a `Feature__c` record page with at least one linked `DatasetTemplate__c`
  - [ ] Run `cci task run load_feature_data --feature <name>` locally
  - [ ] Click **Mark as Loaded** on the template card → fill notes → Confirm
  - [ ] Toast confirms "Audit row created"
  - [ ] Card subline updates to "Last loaded by <Me> on <today>"
  - [ ] Click **Recent Loads** → row appears in the panel
  - [ ] Click **Mark as Loaded** again same day → same row updates (verify in Setup → DatasetTemplateAssignment__c records, only one row for this user+template+today)
- [ ] Manual negative: as a non-admin user, click Mark as Loaded → toast "Only Delivery Hub admins can record dataset assignments." → no audit row written

## References

- Audit doc: `docs/audits/e2e-walkthrough-2026-05-21.md` (Flow 7 #2)
- Object: `force-app/main/default/objects/DatasetTemplateAssignment__c/`
- Controller: `force-app/main/default/classes/DeliveryDatasetController.cls`
- LWC: `force-app/main/default/lwc/deliveryDatasetTemplates/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)