### PR TITLE
feat(rest): add GET /watcher-health + GET /onboarding-progress read endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Three REST surfaces ship with the package, all under `/services/apexrest/deliver
 | **Sync API** | `/deliveryhub/v1/sync/*` | Org-to-org bidirectional sync | `X-Api-Key` + HMAC (opt-in) |
 | **Task API** | `/deliveryhub/v1/tasks/*` | CI/CD agents, AI agents | `X-Api-Key` |
 
-The Public API covers dashboard reads, work items, comments, work logs, activity feed, documents, document signing, feature toggle requests, and scratch-org mirror writes.
+The Public API covers dashboard reads, work items, comments, work logs, activity feed, documents, document signing, feature toggle requests, scratch-org mirror writes, entity-scoped Watcher health (`GET /watcher-health`), and onboarding-track progress (`GET /onboarding-progress`).
 
 Highlights from the recent hardening pass (`release/0.247.x` PR #813):
 

--- a/docs/PUBLIC_API_GUIDE.md
+++ b/docs/PUBLIC_API_GUIDE.md
@@ -129,6 +129,13 @@ These routes are intentionally **tenant-less** (no portal-entity scoping). They'
 | POST | `/api/scratch-orgs` | Insert a `ScratchOrgInstance__c` row. Body: `{branch, orgId, loginUrl, cciFlow, workItemName (opt), expiresAt (opt ISO-8601), autoCreateWorkItem (opt bool)}`. Returns `{id, state: "Active", workItemId, workItemAutoCreated}`. |
 | PATCH | `/api/scratch-orgs/{id}` | Update state on teardown. Body: `{state, lastSyncAt (opt)}`. State must match a `ScratchOrgState` GVS value. **Rate-limited** since PR #813 (previously bypassed the gate). |
 
+### Monitoring & onboarding (read-only)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/watcher-health` | **Entity-scoped.** Returns the caller's slice of the most recent Watcher digest run: `{lastRunAt, overallStatus, flaggedWorkItemCount, flaggedDocumentCount, flaggedWorkItems[], flaggedDocuments[]}`. The Watcher digest itself is org-wide; this endpoint filters the flagged-Id payloads down to records the calling entity owns — it never exposes another tenant's flagged items, the org-wide signal totals, the internal digest body, recipient list, or Slack payload. |
+| GET | `/api/onboarding-progress` | **Subject-scoped via the `X-Portal-User` header.** Returns onboarding-track progress for the user that email resolves to: `[{track, startedAt, completedAt, isComplete, walkthroughScheduledAt, walkthroughCompletedAt, lessonsCompletedCount}]`. Optional `?track=<DeveloperName>` filters to one track. Quiz score/attempts are intentionally **omitted** (PII minimisation). An email that matches no active Salesforce User returns an empty list. |
+
 ---
 
 ### GET /api/dashboard
@@ -1499,6 +1506,76 @@ curl -s -X PATCH \
 | 400 | Missing/blank `state` or unparseable `lastSyncAt` |
 | 404 | No scratch-org row with the given id |
 | 500 | DML failure |
+
+---
+
+### GET /api/watcher-health
+
+Returns the calling entity's slice of the most recent Watcher digest run. The digest is produced org-wide by `DeliveryWatcherService`; this endpoint filters the run's flagged work-item and document Ids down to records owned by the authenticated entity, so a tenant sees only its own at-risk items.
+
+```bash
+curl -H "X-Api-Key: YOUR_API_KEY" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  "YOUR_INSTANCE_URL/services/apexrest/delivery/deliveryhub/v1/api/watcher-health"
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "lastRunAt": "2026-05-27T14:00:00.000Z",
+    "overallStatus": "Attention",
+    "flaggedWorkItemCount": 1,
+    "flaggedDocumentCount": 0,
+    "flaggedWorkItems": [
+      {
+        "id": "a01...",
+        "name": "WI-0042",
+        "title": "Build the export job",
+        "status": "In Progress",
+        "stage": "In Development",
+        "slaTargetDate": "2026-05-25"
+      }
+    ],
+    "flaggedDocuments": []
+  }
+}
+```
+
+- `overallStatus` is derived **only** from the caller's own flagged records: `Healthy` (none flagged), `Attention` (one or more flagged), or `Unknown` (no Watcher run has been recorded yet).
+- The org-wide signal counts, the rendered digest body, the recipient list, and the Slack delivery payload are **never** returned.
+
+### GET /api/onboarding-progress
+
+Returns onboarding-track progress for the user identified by the `X-Portal-User` header. This realises the REST surface `DeliveryOnboardingService` was built for (an external onboarding portal driving the same flow).
+
+```bash
+curl -H "X-Api-Key: YOUR_API_KEY" \
+  -H "X-Portal-User: jordan@example.com" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  "YOUR_INSTANCE_URL/services/apexrest/delivery/deliveryhub/v1/api/onboarding-progress?track=Software_Delivery"
+```
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "track": "Software_Delivery",
+      "startedAt": "2026-05-20T09:00:00.000Z",
+      "completedAt": "2026-05-24T17:30:00.000Z",
+      "isComplete": true,
+      "walkthroughScheduledAt": null,
+      "walkthroughCompletedAt": "2026-05-23T15:00:00.000Z",
+      "lessonsCompletedCount": 4
+    }
+  ]
+}
+```
+
+- `X-Portal-User` is **required**; without it the endpoint returns 400.
+- The email is resolved to an active Salesforce User (by `Username` or `Email`). An unmatched email returns `"data": []` with a 200 — a portal whose users aren't yet provisioned as Users degrades cleanly rather than erroring.
+- Quiz score and attempt counts are intentionally omitted; only completion state, timestamps, and a completed-lesson count are exposed.
 
 ---
 

--- a/force-app/main/default/classes/DeliveryPublicApiService.cls
+++ b/force-app/main/default/classes/DeliveryPublicApiService.cls
@@ -120,6 +120,7 @@ global without sharing class DeliveryPublicApiService {
     private static void routeGet(String resource, Id entityId) {
         if (routeGetCore(resource, entityId)) { return; }
         if (routeGetExtended(resource, entityId)) { return; }
+        if (routeGetMonitoring(resource, entityId)) { return; }
         sendError(404, 'Unknown resource: ' + resource);
     }
 
@@ -143,6 +144,22 @@ global without sharing class DeliveryPublicApiService {
         // API key still authenticates the caller via authenticateRequest(); the
         // feature toggle registry isn't per-tenant.
         if (resource == 'feature-toggle-requests') { getFeatureToggleRequests(); return true; }
+        return false;
+    }
+
+    /**
+     * @description Third routing tier — monitoring + onboarding read endpoints.
+     *              Kept separate from routeGetExtended so neither router method
+     *              accrues excessive cyclomatic complexity.
+     * @param resource Path segment after /api/.
+     * @param entityId The authenticated (or delegated) NetworkEntity__c.Id.
+     * @return true if a monitoring route was matched and handled.
+     */
+    private static Boolean routeGetMonitoring(String resource, Id entityId) {
+        // Watcher health — entity-scoped slice of the org-wide digest.
+        if (resource == 'watcher-health') { getWatcherHealth(entityId); return true; }
+        // Onboarding progress — subject-scoped via the X-Portal-User header.
+        if (resource == 'onboarding-progress') { getOnboardingProgress(); return true; }
         return false;
     }
 
@@ -521,6 +538,227 @@ global without sharing class DeliveryPublicApiService {
             'reason' => req.ReasonTxt__c,
             'requestedAt' => req.RequestedDateTime__c
         };
+    }
+
+    // ── Watcher Health (entity-scoped) ──────────────────────────────────
+
+    /**
+     * @description GET /api/watcher-health — returns the caller entity's slice
+     *              of the most recent Watcher digest run: a freshness timestamp,
+     *              an overallStatus derived solely from the caller's own flagged
+     *              records, and the caller's own flagged work items + documents.
+     *              The WatcherDigest__c run is org-wide; this endpoint
+     *              deliberately filters the flagged-Id payloads down to records
+     *              owned by the authenticated entity, so one tenant never sees
+     *              another tenant's flagged items, the org-wide signal totals,
+     *              the internal digest body, or the Slack payload.
+     * @param entityId The authenticated (or delegated) NetworkEntity__c.Id.
+     */
+    private static void getWatcherHealth(Id entityId) {
+        List<WatcherDigest__c> digests = [
+            SELECT RunDateTime__c, FlaggedWorkItemIdsTxt__c, FlaggedDocumentIdsTxt__c
+            FROM WatcherDigest__c
+            WITH SYSTEM_MODE
+            ORDER BY RunDateTime__c DESC NULLS LAST
+            LIMIT 1
+        ];
+        if (digests.isEmpty()) {
+            sendSuccess(new Map<String, Object>{
+                'lastRunAt' => null,
+                'overallStatus' => 'Unknown',
+                'flaggedWorkItemCount' => 0,
+                'flaggedDocumentCount' => 0,
+                'flaggedWorkItems' => new List<Object>(),
+                'flaggedDocuments' => new List<Object>()
+            });
+            return;
+        }
+        WatcherDigest__c digest = digests.get(0);
+        List<Map<String, Object>> flaggedWorkItems = buildEntityFlaggedWorkItems(
+            parseCsvIds(digest.FlaggedWorkItemIdsTxt__c), entityId
+        );
+        List<Map<String, Object>> flaggedDocuments = buildEntityFlaggedDocuments(
+            parseCsvIds(digest.FlaggedDocumentIdsTxt__c), entityId
+        );
+        Boolean clean = flaggedWorkItems.isEmpty() && flaggedDocuments.isEmpty();
+        sendSuccess(new Map<String, Object>{
+            'lastRunAt' => digest.RunDateTime__c,
+            'overallStatus' => clean ? 'Healthy' : 'Attention',
+            'flaggedWorkItemCount' => flaggedWorkItems.size(),
+            'flaggedDocumentCount' => flaggedDocuments.size(),
+            'flaggedWorkItems' => flaggedWorkItems,
+            'flaggedDocuments' => flaggedDocuments
+        });
+    }
+
+    private static List<Map<String, Object>> buildEntityFlaggedWorkItems(Set<Id> ids, Id entityId) {
+        List<Map<String, Object>> out = new List<Map<String, Object>>();
+        if (ids.isEmpty()) { return out; }
+        for (WorkItem__c wi : [
+            SELECT Id, Name, BriefDescriptionTxt__c, StatusPk__c, StageNamePk__c, SLATargetDate__c
+            FROM WorkItem__c
+            WHERE Id IN :ids AND ClientNetworkEntityLookup__c = :entityId
+            WITH SYSTEM_MODE
+            ORDER BY SLATargetDate__c ASC NULLS LAST
+            LIMIT 200
+        ]) {
+            out.add(new Map<String, Object>{
+                'id' => wi.Id,
+                'name' => wi.Name,
+                'title' => wi.BriefDescriptionTxt__c,
+                'status' => wi.StatusPk__c,
+                'stage' => wi.StageNamePk__c,
+                'slaTargetDate' => wi.SLATargetDate__c
+            });
+        }
+        return out;
+    }
+
+    private static List<Map<String, Object>> buildEntityFlaggedDocuments(Set<Id> ids, Id entityId) {
+        List<Map<String, Object>> out = new List<Map<String, Object>>();
+        if (ids.isEmpty()) { return out; }
+        for (DeliveryDocument__c doc : [
+            SELECT Id, Name, StatusPk__c, TemplatePk__c, DueDateDate__c
+            FROM DeliveryDocument__c
+            WHERE Id IN :ids AND NetworkEntityId__c = :entityId
+            WITH SYSTEM_MODE
+            ORDER BY DueDateDate__c ASC NULLS LAST
+            LIMIT 200
+        ]) {
+            out.add(new Map<String, Object>{
+                'id' => doc.Id,
+                'name' => doc.Name,
+                'status' => doc.StatusPk__c,
+                'template' => doc.TemplatePk__c,
+                'dueDate' => doc.DueDateDate__c
+            });
+        }
+        return out;
+    }
+
+    /**
+     * @description Parses a comma-separated Id payload (WatcherDigest__c stores
+     *              its flagged record Ids this way) into a Set&lt;Id&gt;,
+     *              silently skipping blanks and malformed tokens.
+     * @param csv Comma-separated Id string, possibly null / blank.
+     * @return Set of valid Ids (never null).
+     */
+    private static Set<Id> parseCsvIds(String csv) {
+        Set<Id> ids = new Set<Id>();
+        if (String.isBlank(csv)) { return ids; }
+        for (String token : csv.split(',')) {
+            String trimmed = (token == null) ? '' : token.trim();
+            if (String.isBlank(trimmed)) { continue; }
+            try {
+                ids.add(Id.valueOf(trimmed));
+            } catch (Exception e) {
+                System.debug(LoggingLevel.WARN,
+                    '[DeliveryPublicApiService.parseCsvIds] skipping malformed Id token "' + trimmed + '": ' + e.getMessage());
+            }
+        }
+        return ids;
+    }
+
+    // ── Onboarding Progress (subject-scoped via X-Portal-User) ──────────
+
+    /**
+     * @description GET /api/onboarding-progress — returns onboarding-track
+     *              progress for the user identified by the X-Portal-User header.
+     *              Realises the REST exposure DeliveryOnboardingService was
+     *              built for ("external onboarding portal drives the same flow").
+     *              Optional ?track=&lt;DeveloperName&gt; filters to one track.
+     *              Quiz score / attempts are intentionally omitted (PII
+     *              minimisation) — only completion state + timestamps + a
+     *              completed-lesson count are returned. The header email is
+     *              resolved to an active User; an unmatched email yields an
+     *              empty list (200), so a portal whose users aren't yet
+     *              provisioned as Salesforce Users degrades cleanly.
+     */
+    private static void getOnboardingProgress() {
+        String email = getPortalEmail();
+        if (String.isBlank(email)) {
+            sendError(400, 'X-Portal-User header is required.');
+            return;
+        }
+        Id subjectUserId = resolveUserIdByEmail(email);
+        if (subjectUserId == null) {
+            sendSuccess(new List<Object>());
+            return;
+        }
+        String trackFilter = RestContext.request.params.get('track');
+        List<Map<String, Object>> data = new List<Map<String, Object>>();
+        for (OnboardingProgress__c row : queryOnboardingProgress(subjectUserId, trackFilter)) {
+            data.add(buildOnboardingProgressMap(row));
+        }
+        sendSuccess(data);
+    }
+
+    private static Id resolveUserIdByEmail(String email) {
+        List<User> users = [
+            SELECT Id FROM User
+            WHERE IsActive = true AND (Username = :email OR Email = :email)
+            WITH SYSTEM_MODE
+            ORDER BY Username ASC
+            LIMIT 1
+        ];
+        return users.isEmpty() ? null : users.get(0).Id;
+    }
+
+    private static List<OnboardingProgress__c> queryOnboardingProgress(Id subjectUserId, String trackFilter) {
+        if (String.isNotBlank(trackFilter)) {
+            return [
+                SELECT TrackTxt__c, StartedDateTime__c, CompletedDateTime__c,
+                       WalkthroughScheduledDateTime__c, WalkthroughCompletedDateTime__c,
+                       LessonsCompletedJsonTxt__c
+                FROM OnboardingProgress__c
+                WHERE UserLookup__c = :subjectUserId AND TrackTxt__c = :trackFilter
+                WITH SYSTEM_MODE
+                ORDER BY CreatedDate DESC
+                LIMIT 100
+            ];
+        }
+        return [
+            SELECT TrackTxt__c, StartedDateTime__c, CompletedDateTime__c,
+                   WalkthroughScheduledDateTime__c, WalkthroughCompletedDateTime__c,
+                   LessonsCompletedJsonTxt__c
+            FROM OnboardingProgress__c
+            WHERE UserLookup__c = :subjectUserId
+            WITH SYSTEM_MODE
+            ORDER BY CreatedDate DESC
+            LIMIT 100
+        ];
+    }
+
+    private static Map<String, Object> buildOnboardingProgressMap(OnboardingProgress__c row) {
+        return new Map<String, Object>{
+            'track' => row.TrackTxt__c,
+            'startedAt' => row.StartedDateTime__c,
+            'completedAt' => row.CompletedDateTime__c,
+            'isComplete' => row.CompletedDateTime__c != null,
+            'walkthroughScheduledAt' => row.WalkthroughScheduledDateTime__c,
+            'walkthroughCompletedAt' => row.WalkthroughCompletedDateTime__c,
+            'lessonsCompletedCount' => countLessonsCompleted(row.LessonsCompletedJsonTxt__c)
+        };
+    }
+
+    /**
+     * @description Counts entries in LessonsCompletedJsonTxt__c (a JSON array of
+     *              {lesson, completedAt} objects). Tolerates null / malformed
+     *              JSON by returning 0.
+     * @param raw Raw JSON string from the progress row.
+     * @return Count of completed lessons.
+     */
+    private static Integer countLessonsCompleted(String raw) {
+        if (String.isBlank(raw)) { return 0; }
+        try {
+            Object parsed = JSON.deserializeUntyped(raw);
+            if (parsed instanceof List<Object>) {
+                return ((List<Object>) parsed).size();
+            }
+        } catch (Exception ignore) {
+            return 0;
+        }
+        return 0;
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryPublicApiServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryPublicApiServiceTest.cls
@@ -1694,6 +1694,225 @@ private class DeliveryPublicApiServiceTest {
     }
 
     // ==========================================
+    // GET WATCHER-HEALTH (entity-scoped slice of the org-wide digest)
+    // ==========================================
+
+    /**
+     * @description With no WatcherDigest__c row yet, the endpoint degrades to a
+     *              200 "Unknown" snapshot rather than erroring.
+     */
+    @IsTest
+    static void testGetWatcherHealthNoDigest() {
+        System.runAs(testUser) {
+            RestRequest req = buildGetRequest('/services/apexrest/delivery/deliveryhub/v1/api/watcher-health');
+            req.addHeader('X-Api-Key', TEST_API_KEY);
+            RestResponse res = new RestResponse();
+            RestContext.request = req;
+            RestContext.response = res;
+
+            Test.startTest();
+            DeliveryPublicApiService.handleGet();
+            Test.stopTest();
+
+            System.assertEquals(200, res.statusCode, 'Should return 200 even with no digest');
+            Map<String, Object> data = (Map<String, Object>) parseResponse(res).get('data');
+            System.assertEquals('Unknown', data.get('overallStatus'), 'No digest -> Unknown');
+            System.assertEquals(0, (Integer) data.get('flaggedWorkItemCount'), 'No flagged WIs');
+            System.assertEquals(null, data.get('lastRunAt'), 'No run timestamp');
+        }
+    }
+
+    /**
+     * @description The org-wide digest flags one of THIS entity's work items and
+     *              one belonging to another tenant. Only the caller's own item
+     *              must surface, and overallStatus must be Attention.
+     */
+    @IsTest
+    static void testGetWatcherHealthScopedToEntity() {
+        System.runAs(testUser) {
+            WorkItem__c mine = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'API Active Item' LIMIT 1];
+            WorkItem__c theirs = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Other Corp Item' LIMIT 1];
+            insert new WatcherDigest__c(
+                RunDateTime__c = Datetime.now(),
+                StatusPk__c = 'Success',
+                FlaggedWorkItemIdsTxt__c = mine.Id + ',' + theirs.Id
+            );
+
+            RestRequest req = buildGetRequest('/services/apexrest/delivery/deliveryhub/v1/api/watcher-health');
+            req.addHeader('X-Api-Key', TEST_API_KEY);
+            RestResponse res = new RestResponse();
+            RestContext.request = req;
+            RestContext.response = res;
+
+            Test.startTest();
+            DeliveryPublicApiService.handleGet();
+            Test.stopTest();
+
+            System.assertEquals(200, res.statusCode);
+            Map<String, Object> data = (Map<String, Object>) parseResponse(res).get('data');
+            System.assertEquals('Attention', data.get('overallStatus'), 'My flagged item -> Attention');
+            System.assertEquals(1, (Integer) data.get('flaggedWorkItemCount'),
+                'Only MY flagged item is counted, not the other tenant\'s');
+            List<Object> items = (List<Object>) data.get('flaggedWorkItems');
+            System.assertEquals(1, items.size(), 'Exactly one item returned');
+            Map<String, Object> item = (Map<String, Object>) items.get(0);
+            System.assertEquals(String.valueOf(mine.Id), (String) item.get('id'), 'Returned item is mine');
+        }
+    }
+
+    /**
+     * @description When the digest flags only another tenant's records, this
+     *              entity sees a clean Healthy snapshot with zero counts.
+     */
+    @IsTest
+    static void testGetWatcherHealthHealthyWhenNoneOfMine() {
+        System.runAs(testUser) {
+            WorkItem__c theirs = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Other Corp Item' LIMIT 1];
+            insert new WatcherDigest__c(
+                RunDateTime__c = Datetime.now(),
+                StatusPk__c = 'Success',
+                FlaggedWorkItemIdsTxt__c = String.valueOf(theirs.Id)
+            );
+
+            RestRequest req = buildGetRequest('/services/apexrest/delivery/deliveryhub/v1/api/watcher-health');
+            req.addHeader('X-Api-Key', TEST_API_KEY);
+            RestResponse res = new RestResponse();
+            RestContext.request = req;
+            RestContext.response = res;
+
+            Test.startTest();
+            DeliveryPublicApiService.handleGet();
+            Test.stopTest();
+
+            Map<String, Object> data = (Map<String, Object>) parseResponse(res).get('data');
+            System.assertEquals('Healthy', data.get('overallStatus'),
+                'Another tenant flagged, none of mine -> Healthy');
+            System.assertEquals(0, (Integer) data.get('flaggedWorkItemCount'));
+        }
+    }
+
+    // ==========================================
+    // GET ONBOARDING-PROGRESS (subject-scoped via X-Portal-User)
+    // ==========================================
+
+    /**
+     * @description Without an X-Portal-User header the endpoint can't identify a
+     *              subject, so it returns 400 rather than guessing.
+     */
+    @IsTest
+    static void testGetOnboardingProgressMissingHeader() {
+        System.runAs(testUser) {
+            RestRequest req = buildGetRequest('/services/apexrest/delivery/deliveryhub/v1/api/onboarding-progress');
+            req.addHeader('X-Api-Key', TEST_API_KEY);
+            RestResponse res = new RestResponse();
+            RestContext.request = req;
+            RestContext.response = res;
+
+            Test.startTest();
+            DeliveryPublicApiService.handleGet();
+            Test.stopTest();
+
+            System.assertEquals(400, res.statusCode, 'Missing X-Portal-User -> 400');
+            assertErrorResponse(res, 'X-Portal-User header is required');
+        }
+    }
+
+    /**
+     * @description An email that resolves to no active User degrades to an empty
+     *              200 list — a portal whose users aren't provisioned yet.
+     */
+    @IsTest
+    static void testGetOnboardingProgressUnknownEmail() {
+        System.runAs(testUser) {
+            RestRequest req = buildGetRequest('/services/apexrest/delivery/deliveryhub/v1/api/onboarding-progress');
+            req.addHeader('X-Api-Key', TEST_API_KEY);
+            req.addHeader('X-Portal-User', 'nobody-matches-this@example.invalid');
+            RestResponse res = new RestResponse();
+            RestContext.request = req;
+            RestContext.response = res;
+
+            Test.startTest();
+            DeliveryPublicApiService.handleGet();
+            Test.stopTest();
+
+            System.assertEquals(200, res.statusCode, 'Unknown email degrades to empty 200');
+            List<Object> data = (List<Object>) parseResponse(res).get('data');
+            System.assertEquals(0, data.size(), 'No progress for an unmatched email');
+        }
+    }
+
+    /**
+     * @description Returns the subject user's progress row; isComplete reflects
+     *              CompletedDateTime__c, lessonsCompletedCount reflects the JSON
+     *              payload, and quizScore is deliberately absent (PII).
+     */
+    @IsTest
+    static void testGetOnboardingProgressReturnsRows() {
+        System.runAs(testUser) {
+            User me = [SELECT Username FROM User WHERE Id = :UserInfo.getUserId() LIMIT 1];
+            TestDataFactory.newOnboardingProgress(new Map<String, Object>{
+                'TrackTxt__c' => 'API_Test_Track',
+                'CompletedDateTime__c' => Datetime.now(),
+                'QuizScoreNumber__c' => 9,
+                'LessonsCompletedJsonTxt__c' => JSON.serialize(new List<Object>{
+                    new Map<String, Object>{ 'lesson' => 'L1', 'completedAt' => '2026-05-27T00:00:00.000Z' },
+                    new Map<String, Object>{ 'lesson' => 'L2', 'completedAt' => '2026-05-27T00:00:00.000Z' }
+                })
+            });
+
+            RestRequest req = buildGetRequest('/services/apexrest/delivery/deliveryhub/v1/api/onboarding-progress');
+            req.addHeader('X-Api-Key', TEST_API_KEY);
+            req.addHeader('X-Portal-User', me.Username);
+            RestResponse res = new RestResponse();
+            RestContext.request = req;
+            RestContext.response = res;
+
+            Test.startTest();
+            DeliveryPublicApiService.handleGet();
+            Test.stopTest();
+
+            System.assertEquals(200, res.statusCode);
+            List<Object> data = (List<Object>) parseResponse(res).get('data');
+            System.assertEquals(1, data.size(), 'One progress row for this user');
+            Map<String, Object> row = (Map<String, Object>) data.get(0);
+            System.assertEquals('API_Test_Track', row.get('track'), 'Track echoed');
+            System.assertEquals(true, row.get('isComplete'), 'CompletedDateTime -> isComplete');
+            System.assertEquals(2, (Integer) row.get('lessonsCompletedCount'), 'Two lessons counted');
+            System.assertEquals(false, row.containsKey('quizScore'),
+                'Quiz score must NOT be exposed (PII minimisation)');
+        }
+    }
+
+    /**
+     * @description ?track=<name> narrows the result to the one matching track.
+     */
+    @IsTest
+    static void testGetOnboardingProgressTrackFilter() {
+        System.runAs(testUser) {
+            User me = [SELECT Username FROM User WHERE Id = :UserInfo.getUserId() LIMIT 1];
+            TestDataFactory.newOnboardingProgress(new Map<String, Object>{ 'TrackTxt__c' => 'Track_A' });
+            TestDataFactory.newOnboardingProgress(new Map<String, Object>{ 'TrackTxt__c' => 'Track_B' });
+
+            RestRequest req = buildGetRequest('/services/apexrest/delivery/deliveryhub/v1/api/onboarding-progress');
+            req.addHeader('X-Api-Key', TEST_API_KEY);
+            req.addHeader('X-Portal-User', me.Username);
+            req.addParameter('track', 'Track_B');
+            RestResponse res = new RestResponse();
+            RestContext.request = req;
+            RestContext.response = res;
+
+            Test.startTest();
+            DeliveryPublicApiService.handleGet();
+            Test.stopTest();
+
+            List<Object> data = (List<Object>) parseResponse(res).get('data');
+            System.assertEquals(1, data.size(), 'Track filter returns only the matching track');
+            Map<String, Object> row = (Map<String, Object>) data.get(0);
+            System.assertEquals('Track_B', row.get('track'), 'Filtered to Track_B');
+        }
+    }
+
+    // ==========================================
     // REST API HARDENING — 2026-05-21 AUDIT FIXES
     // ==========================================
 


### PR DESCRIPTION
## What

Two **additive, read-only** endpoints on `DeliveryPublicApiService` — no schema changes, no breaking changes to existing routes. These surface 0.250 features (Phase 2 Watcher, onboarding tracks) over the public REST API for the first time.

| Endpoint | Scope | Returns |
|---|---|---|
| `GET /api/watcher-health` | **Entity-scoped** | `{lastRunAt, overallStatus, flaggedWorkItemCount, flaggedDocumentCount, flaggedWorkItems[], flaggedDocuments[]}` |
| `GET /api/onboarding-progress` | **Subject-scoped via `X-Portal-User`** | `[{track, startedAt, completedAt, isComplete, walkthroughScheduledAt, walkthroughCompletedAt, lessonsCompletedCount}]` |

## Why

`/watcher-health` and `/onboarding-progress` were the two 0.250 features with no REST surface but genuine customer-facing value. Glen greenlit both. `DeliveryOnboardingService` was explicitly built to be REST-exposed ("external onboarding portal drives the same flow"), so this realises intended design rather than bolting on.

## Tenant-safety decisions (deliberate)

- **Watcher digest is org-wide.** This endpoint filters the run's flagged work-item / document Ids down to records the calling entity owns (`ClientNetworkEntityLookup__c` / `NetworkEntityId__c`). `overallStatus` (`Healthy` / `Attention` / `Unknown`) is derived from the caller's own slice only. It **never** exposes another tenant's flagged items, the org-wide signal totals, the rendered digest body, the recipient list, or the Slack payload.
- **Onboarding progress omits quiz score/attempts** (PII minimisation) — only completion state, timestamps, and a completed-lesson count. Email resolving to no active User returns an empty `200` (a portal whose users aren't provisioned yet degrades cleanly rather than erroring).

## How

- Routes added as a **third routing tier** (`routeGetMonitoring`) so neither `routeGetCore` nor `routeGetExtended` gains cyclomatic complexity.
- All reads use `WITH SYSTEM_MODE` (consistent with the rest of this `without sharing` REST class). No permission-set changes required.
- 6 new tests: entity isolation (mine vs. another tenant's flagged item), empty/degraded paths, `?track=` filter, missing-header 400, PII-omission assertion.

## Validation

- ✅ PMD (`pmd-rules.xml`, the CI ruleset) — clean of all blocking rules. The only two remaining are pre-existing **baseline** class-size Design warnings (`ExcessiveClassLength`, `NcssTypeCount`) that already exist on green `main`.
- ⏳ Apex tests run in CI (no local scratch org this session).

## Docs

- `docs/PUBLIC_API_GUIDE.md` — new "Monitoring & onboarding" summary table + full detail sections with curl + JSON examples.
- `README.md` — Public API coverage line updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)