### PR TITLE
feat(cockpit): in-app sample data loader — one-click Load/Remove per feature (P2)

### DIFF
--- a/force-app/main/default/classes/DeliveryDatasetController.cls
+++ b/force-app/main/default/classes/DeliveryDatasetController.cls
@@ -85,6 +85,21 @@ global with sharing class DeliveryDatasetController {
     }
 
     /**
+     * @description Result of an in-app sample-data load/remove run. Returned
+     *              to the LWC so it can show a precise toast ("Loaded 17
+     *              records" / "Removed 17 sample records"). Mirrors
+     *              DeliveryDatasetLoader.LoadResult without leaking the inner
+     *              type across the controller boundary.
+     */
+    global class SampleDataResultDTO {
+        @AuraEnabled public String outcome;
+        @AuraEnabled public Integer recordCount;
+        @AuraEnabled public Boolean alreadyLoaded;
+        @AuraEnabled public String message;
+        @AuraEnabled public Id assignmentId;
+    }
+
+    /**
      * @description Compact payload for the "last loaded by X on Y" subline
      *              the LWC renders on each template card. Mirrors a single
      *              DatasetTemplateAssignment__c without leaking the SObject.
@@ -427,6 +442,86 @@ global with sharing class DeliveryDatasetController {
             }
         }
         return row;
+    }
+
+    /**
+     * @description Loads the sample dataset for the given template via the
+     *              DeliveryDatasetLoader service — the in-app, no-CCI path. The
+     *              loader inserts clearly-marked sample records (queryable via
+     *              the SAMPLE_MARKER prefix) and writes a
+     *              DatasetTemplateAssignment__c audit row with the real outcome
+     *              + count. Idempotent: re-running when data is already present
+     *              is a no-op (the DTO's alreadyLoaded flag tells the LWC).
+     *
+     *              Admin-gated — same PermissionSetGroup check as
+     *              recordAssignment. Runs as the admin (SYSTEM_MODE inside the
+     *              loader) so a delegated admin without raw object CRUD can
+     *              still prime sample data through the package surface.
+     * @param templateId DatasetTemplate__c whose sample data should load. Required.
+     * @return SampleDataResultDTO with outcome + record count + already-loaded flag.
+     */
+    @AuraEnabled
+    global static SampleDataResultDTO loadSampleData(Id templateId) {
+        assertAdminOrThrow();
+        if (templateId == null) {
+            throw new AuraHandledException('templateId is required.');
+        }
+        try {
+            DeliveryDatasetLoader.LoadResult r = DeliveryDatasetLoader.load(templateId);
+            return toSampleResult(r);
+        } catch (DeliveryDatasetLoader.DatasetLoaderException dle) {
+            // Loader's own caller-meaningful message — pass it through.
+            throw new AuraHandledException(dle.getMessage());
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryDatasetController.loadSampleData] failed: ' + e.getMessage());
+            throw new AuraHandledException('Unable to load sample data for this template.');
+        }
+    }
+
+    /**
+     * @description Removes the sample dataset for the given template via the
+     *              DeliveryDatasetLoader service — deleting EXACTLY the records
+     *              the loader marked (SAMPLE_MARKER), never touching real data —
+     *              and writes a removal audit row. Idempotent: removing when
+     *              nothing is loaded is a clean no-op (recordCount=0).
+     *
+     *              Admin-gated. Runs the deletes in SYSTEM_MODE inside the loader.
+     * @param templateId DatasetTemplate__c whose sample data should be removed. Required.
+     * @return SampleDataResultDTO with the count of records removed.
+     */
+    @AuraEnabled
+    global static SampleDataResultDTO removeSampleData(Id templateId) {
+        assertAdminOrThrow();
+        if (templateId == null) {
+            throw new AuraHandledException('templateId is required.');
+        }
+        try {
+            DeliveryDatasetLoader.LoadResult r = DeliveryDatasetLoader.remove(templateId);
+            return toSampleResult(r);
+        } catch (DeliveryDatasetLoader.DatasetLoaderException dle) {
+            throw new AuraHandledException(dle.getMessage());
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryDatasetController.removeSampleData] failed: ' + e.getMessage());
+            throw new AuraHandledException('Unable to remove sample data for this template.');
+        }
+    }
+
+    /**
+     * @description Maps a DeliveryDatasetLoader.LoadResult into the
+     *              controller-boundary DTO the LWC consumes.
+     * @param r Loader result (never null at the call sites).
+     * @return Populated SampleDataResultDTO.
+     */
+    private static SampleDataResultDTO toSampleResult(DeliveryDatasetLoader.LoadResult r) {
+        SampleDataResultDTO dto = new SampleDataResultDTO();
+        dto.outcome = r.outcome;
+        dto.recordCount = r.recordCount;
+        dto.alreadyLoaded = r.alreadyLoaded;
+        dto.message = r.message;
+        dto.assignmentId = r.assignmentId;
+        return dto;
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryDatasetLoader.cls
+++ b/force-app/main/default/classes/DeliveryDatasetLoader.cls
@@ -33,7 +33,7 @@
  *               NOT fabricated realistic figures.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation,PMD.AvoidGlobalModifier')
+@SuppressWarnings('PMD.ApexCRUDViolation,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.ExcessiveParameterList')
 public with sharing class DeliveryDatasetLoader {
 
     /**

--- a/force-app/main/default/classes/DeliveryDatasetLoader.cls
+++ b/force-app/main/default/classes/DeliveryDatasetLoader.cls
@@ -1,0 +1,519 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  In-app sample-data loader for Delivery Hub feature datasets
+ *               (Layer 7 of the DH cockpit architecture). Ports the dev-only
+ *               scripts/feature-data/invoice_generation.apex loader into a
+ *               first-class Apex service the cockpit can invoke directly — so a
+ *               subscriber admin can prime a feature's sample data with one
+ *               click, with NO CumulusCI / CLI required.
+ *
+ *               SAFETY DESIGN (paramount — this writes to a subscriber org):
+ *                 • EVERY sample record carries an unmistakable, queryable
+ *                   marker (the literal SAMPLE_MARKER, "[DH SAMPLE]") in a text
+ *                   field. The marker is how loaded records are identified and
+ *                   how they are removed. Nothing without the marker is ever
+ *                   touched.
+ *                 • LOAD is idempotent: re-running detects existing marked
+ *                   WorkItems and skips insertion (OutcomePk__c='Success',
+ *                   recordsLoaded = the already-present count) rather than
+ *                   duplicating.
+ *                 • REMOVE deletes EXACTLY the marked records this loader
+ *                   creates, scoped by SAMPLE_MARKER, in dependency-safe order
+ *                   (WorkLog → WorkRequest → WorkItem → NetworkEntity). It can
+ *                   never delete a real (non-marked) record.
+ *                 • Both operations write a DatasetTemplateAssignment__c audit
+ *                   row (real outcome + real count + loader user + timestamp).
+ *                 • All DML runs WITH SYSTEM_MODE / AccessLevel.SYSTEM_MODE
+ *                   because this is an admin-invoked package operation; the
+ *                   calling controller enforces the admin gate.
+ *
+ *               Placeholder-value discipline (CLAUDE.md): financial values are
+ *               deliberately obvious placeholders (HoursLoggedNumber__c = 1.0),
+ *               NOT fabricated realistic figures.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation,PMD.AvoidGlobalModifier')
+public with sharing class DeliveryDatasetLoader {
+
+    /**
+     * Unmistakable, queryable prefix stamped on every sample record this
+     * loader creates. This literal is the ENTIRE safety contract: load stamps
+     * it, remove filters on it, and nothing without it is ever deleted. Do not
+     * change without a data-migration plan for already-loaded orgs.
+     */
+    public static final String SAMPLE_MARKER = '[DH SAMPLE]';
+
+    /** Logical key for the only dataset this loader currently ships. */
+    public static final String DATASET_INVOICE_GENERATION = 'Invoice_Generation';
+
+    /** Number of sample WorkItem__c rows the invoice-generation dataset creates. */
+    private static final Integer INVOICE_WI_COUNT = 5;
+
+    /** WorkLogs per WorkItem in the invoice-generation dataset. */
+    private static final Integer INVOICE_LOGS_PER_WI = 2;
+
+    /** Deliberately obvious placeholder — NOT a realistic billing rate. */
+    private static final Decimal PLACEHOLDER_HOURS = 1.0;
+
+    /** Names of the two placeholder vendors the invoice dataset uses. */
+    private static final String SAMPLE_VENDOR_A = SAMPLE_MARKER + ' Vendor A';
+    private static final String SAMPLE_VENDOR_B = SAMPLE_MARKER + ' Vendor B';
+
+    /**
+     * @description Result of a load/remove run. Returned to the controller so
+     *              the LWC can surface a precise toast ("Loaded 17 records" /
+     *              "Removed 17 sample records"). All fields populated.
+     */
+    public class LoadResult {
+        /** 'Success' | 'PartialFailure' | 'Failure' (DatasetLoadOutcome GVS). */
+        public String outcome;
+        /** Count of records inserted (load) or deleted (remove). */
+        public Integer recordCount;
+        /** Whether a load was a no-op because the data was already present. */
+        public Boolean alreadyLoaded;
+        /** Id of the DatasetTemplateAssignment__c audit row written. */
+        public Id assignmentId;
+        /** Human-readable summary for the toast message. */
+        public String message;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Public entry points (invoked by DeliveryDatasetController)
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Loads the sample dataset for the given DatasetTemplate__c
+     *              and writes a DatasetTemplateAssignment__c audit row. The
+     *              dataset is selected by the template's linked feature name
+     *              (FeatureLookup__r.Name) so adding more datasets later is a
+     *              matter of adding a branch in resolveDatasetKey + a private
+     *              loadXxx method — no controller changes required.
+     *
+     *              Idempotent: if the marked sample records already exist, this
+     *              is a no-op insert; the audit row records the already-present
+     *              count and outcome='Success'.
+     * @param templateId DatasetTemplate__c whose sample data should be loaded.
+     * @return LoadResult describing the outcome + record count.
+     */
+    public static LoadResult load(Id templateId) {
+        DatasetTemplate__c template = requireTemplate(templateId);
+        String datasetKey = resolveDatasetKey(template);
+        LoadResult result;
+        try {
+            if (datasetKey == DATASET_INVOICE_GENERATION) {
+                result = loadInvoiceGeneration();
+            } else {
+                throw new DatasetLoaderException(
+                    'No in-app loader is registered for this dataset template.');
+            }
+        } catch (DatasetLoaderException dle) {
+            // Known, caller-meaningful failure — re-throw so the controller can
+            // surface it. No audit row: nothing landed.
+            throw dle;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryDatasetLoader.load] failed: ' + e.getMessage());
+            result = new LoadResult();
+            result.outcome = 'Failure';
+            result.recordCount = 0;
+            result.alreadyLoaded = false;
+            result.message = 'Sample data load failed before any records were committed.';
+            result.assignmentId = writeAssignment(
+                templateId, result.outcome, result.recordCount, e.getMessage(), false);
+            return result;
+        }
+        result.assignmentId = writeAssignment(
+            templateId, result.outcome, result.recordCount, null, false);
+        return result;
+    }
+
+    /**
+     * @description Removes the sample dataset for the given DatasetTemplate__c —
+     *              deleting EXACTLY the records carrying SAMPLE_MARKER, in
+     *              dependency-safe order — and writes a removal audit row. Never
+     *              touches non-marked records.
+     *
+     *              Idempotent: removing when nothing is loaded is a clean no-op
+     *              (recordCount=0, outcome='Success').
+     * @param templateId DatasetTemplate__c whose sample data should be removed.
+     * @return LoadResult with recordCount = number of records deleted.
+     */
+    public static LoadResult remove(Id templateId) {
+        DatasetTemplate__c template = requireTemplate(templateId);
+        String datasetKey = resolveDatasetKey(template);
+        LoadResult result = new LoadResult();
+        result.alreadyLoaded = false;
+        try {
+            if (datasetKey == DATASET_INVOICE_GENERATION) {
+                result.recordCount = removeInvoiceGeneration();
+            } else {
+                throw new DatasetLoaderException(
+                    'No in-app loader is registered for this dataset template.');
+            }
+            result.outcome = 'Success';
+            result.message = result.recordCount == 0
+                ? 'No sample data was present to remove.'
+                : 'Removed ' + result.recordCount + ' sample record(s).';
+        } catch (DatasetLoaderException dle) {
+            throw dle;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryDatasetLoader.remove] failed: ' + e.getMessage());
+            result.outcome = 'Failure';
+            result.recordCount = 0;
+            result.message = 'Sample data removal failed.';
+            result.assignmentId = writeAssignment(
+                templateId, result.outcome, result.recordCount, e.getMessage(), true);
+            return result;
+        }
+        result.assignmentId = writeAssignment(
+            templateId, result.outcome, result.recordCount, null, true);
+        return result;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Invoice Generation dataset (first end-to-end example)
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Inserts the invoice-generation sample dataset:
+     *              2 placeholder vendors (NetworkEntity__c) + 5 WorkItem__c +
+     *              one WorkRequest__c bridge each + 2 WorkLog__c per WI. Every
+     *              record carries SAMPLE_MARKER. Idempotent: if marked
+     *              WorkItems already exist (>= INVOICE_WI_COUNT) this is a
+     *              no-op and reports the already-present record count.
+     * @return LoadResult for the run.
+     */
+    private static LoadResult loadInvoiceGeneration() {
+        LoadResult result = new LoadResult();
+
+        Integer existingWi = [
+            SELECT COUNT()
+            FROM WorkItem__c
+            WHERE BriefDescriptionTxt__c LIKE :markerLike()
+            WITH SYSTEM_MODE
+        ];
+        if (existingWi >= INVOICE_WI_COUNT) {
+            // Already loaded — report the full marked record count as a no-op.
+            result.outcome = 'Success';
+            result.alreadyLoaded = true;
+            result.recordCount = countLoadedInvoiceRecords();
+            result.message = 'Sample data is already loaded ('
+                + result.recordCount + ' record(s)). No changes made.';
+            return result;
+        }
+
+        Integer inserted = 0;
+
+        // Vendors — two clearly-marked placeholder NetworkEntity__c rows.
+        List<NetworkEntity__c> vendors = new List<NetworkEntity__c>{
+            new NetworkEntity__c(
+                Name = SAMPLE_VENDOR_A,
+                EntityTypePk__c = 'Vendor',
+                StatusPk__c = 'Active',
+                IntegrationEndpointUrlTxt__c = 'https://example.invalid'
+            ),
+            new NetworkEntity__c(
+                Name = SAMPLE_VENDOR_B,
+                EntityTypePk__c = 'Vendor',
+                StatusPk__c = 'Active',
+                IntegrationEndpointUrlTxt__c = 'https://example.invalid'
+            )
+        };
+        // Don't duplicate vendors if a prior partial run already created them.
+        List<NetworkEntity__c> existingVendors = [
+            SELECT Id, Name FROM NetworkEntity__c
+            WHERE Name IN (:SAMPLE_VENDOR_A, :SAMPLE_VENDOR_B)
+            WITH SYSTEM_MODE
+        ];
+        Set<String> haveVendorNames = new Set<String>();
+        for (NetworkEntity__c v : existingVendors) {
+            haveVendorNames.add(v.Name);
+        }
+        List<NetworkEntity__c> vendorsToInsert = new List<NetworkEntity__c>();
+        for (NetworkEntity__c v : vendors) {
+            if (!haveVendorNames.contains(v.Name)) {
+                vendorsToInsert.add(v);
+            }
+        }
+        if (!vendorsToInsert.isEmpty()) {
+            Database.insert(vendorsToInsert, AccessLevel.SYSTEM_MODE);
+            inserted += vendorsToInsert.size();
+        }
+
+        // WorkItems — marker in BriefDescriptionTxt__c (100-char field, so the
+        // marker + a short suffix fits comfortably).
+        List<WorkItem__c> workItems = new List<WorkItem__c>();
+        for (Integer i = 1; i <= INVOICE_WI_COUNT; i++) {
+            workItems.add(new WorkItem__c(
+                BriefDescriptionTxt__c = SAMPLE_MARKER + ' Invoice demo WI ' + i,
+                StatusPk__c = 'Active',
+                StageNamePk__c = 'Backlog',
+                ActivatedDateTime__c = Datetime.now()
+            ));
+        }
+        Database.insert(workItems, AccessLevel.SYSTEM_MODE);
+        inserted += workItems.size();
+
+        // One WorkRequest__c bridge per WI (required MD parent of WorkLog).
+        List<WorkRequest__c> bridges = new List<WorkRequest__c>();
+        for (WorkItem__c wi : workItems) {
+            bridges.add(new WorkRequest__c(
+                WorkItemId__c = wi.Id,
+                StatusPk__c = 'Active'
+            ));
+        }
+        Database.insert(bridges, AccessLevel.SYSTEM_MODE);
+        inserted += bridges.size();
+
+        Map<Id, Id> bridgeByWi = new Map<Id, Id>();
+        for (WorkRequest__c b : bridges) {
+            bridgeByWi.put(b.WorkItemId__c, b.Id);
+        }
+
+        // WorkLogs — marker in WorkDescriptionTxt__c; placeholder hours.
+        List<WorkLog__c> logs = new List<WorkLog__c>();
+        for (WorkItem__c wi : workItems) {
+            Id bridgeId = bridgeByWi.get(wi.Id);
+            for (Integer k = 0; k < INVOICE_LOGS_PER_WI; k++) {
+                logs.add(new WorkLog__c(
+                    WorkItemLookup__c = wi.Id,
+                    RequestId__c = bridgeId,
+                    HoursLoggedNumber__c = PLACEHOLDER_HOURS,
+                    WorkDateDate__c = Date.today().addDays(-k),
+                    WorkDescriptionTxt__c = SAMPLE_MARKER + ' placeholder log ' + (k + 1)
+                ));
+            }
+        }
+        Database.insert(logs, AccessLevel.SYSTEM_MODE);
+        inserted += logs.size();
+
+        result.outcome = 'Success';
+        result.alreadyLoaded = false;
+        result.recordCount = inserted;
+        result.message = 'Loaded ' + inserted + ' sample record(s) for Invoice Generation.';
+        return result;
+    }
+
+    /**
+     * @description Deletes the invoice-generation sample dataset — and ONLY
+     *              records carrying SAMPLE_MARKER — in dependency-safe order:
+     *              WorkLog (child of WorkRequest MD + WorkItem lookup) →
+     *              WorkRequest (child of WorkItem MD) → WorkItem → NetworkEntity.
+     *              Returns the total number of records deleted.
+     * @return Count of deleted records.
+     */
+    private static Integer removeInvoiceGeneration() {
+        Integer deleted = 0;
+
+        // 1. WorkLogs carrying the marker.
+        List<WorkLog__c> logs = [
+            SELECT Id FROM WorkLog__c
+            WHERE WorkDescriptionTxt__c LIKE :markerLike()
+            WITH SYSTEM_MODE
+        ];
+        if (!logs.isEmpty()) {
+            Database.delete(logs, AccessLevel.SYSTEM_MODE);
+            deleted += logs.size();
+        }
+
+        // 2. The marked WorkItems' bridge WorkRequests. We resolve them via the
+        //    marked WorkItems so we delete exactly the bridges this loader made
+        //    (WorkRequest__c has no own text field to stamp). Deleting the
+        //    WorkItem would cascade the MD child anyway, but we delete bridges
+        //    explicitly so the returned count is accurate and the order is safe
+        //    even if a future schema change loosens the cascade.
+        List<WorkItem__c> markedWis = [
+            SELECT Id FROM WorkItem__c
+            WHERE BriefDescriptionTxt__c LIKE :markerLike()
+            WITH SYSTEM_MODE
+        ];
+        if (!markedWis.isEmpty()) {
+            List<WorkRequest__c> bridges = [
+                SELECT Id FROM WorkRequest__c
+                WHERE WorkItemId__c IN :markedWis
+                WITH SYSTEM_MODE
+            ];
+            if (!bridges.isEmpty()) {
+                Database.delete(bridges, AccessLevel.SYSTEM_MODE);
+                deleted += bridges.size();
+            }
+            // 3. The marked WorkItems themselves.
+            Database.delete(markedWis, AccessLevel.SYSTEM_MODE);
+            deleted += markedWis.size();
+        }
+
+        // 4. The placeholder vendors (matched by their exact marked names).
+        List<NetworkEntity__c> vendors = [
+            SELECT Id FROM NetworkEntity__c
+            WHERE Name IN (:SAMPLE_VENDOR_A, :SAMPLE_VENDOR_B)
+            WITH SYSTEM_MODE
+        ];
+        if (!vendors.isEmpty()) {
+            Database.delete(vendors, AccessLevel.SYSTEM_MODE);
+            deleted += vendors.size();
+        }
+
+        return deleted;
+    }
+
+    /**
+     * @description Counts every record currently carrying SAMPLE_MARKER for the
+     *              invoice-generation dataset. Used to report the no-op count on
+     *              an already-loaded re-run so the audit row + toast are honest.
+     * @return Total count of currently-loaded marked sample records.
+     */
+    private static Integer countLoadedInvoiceRecords() {
+        Integer total = 0;
+        total += [
+            SELECT COUNT() FROM NetworkEntity__c
+            WHERE Name IN (:SAMPLE_VENDOR_A, :SAMPLE_VENDOR_B)
+            WITH SYSTEM_MODE
+        ];
+        List<WorkItem__c> markedWis = [
+            SELECT Id FROM WorkItem__c
+            WHERE BriefDescriptionTxt__c LIKE :markerLike()
+            WITH SYSTEM_MODE
+        ];
+        total += markedWis.size();
+        if (!markedWis.isEmpty()) {
+            total += [
+                SELECT COUNT() FROM WorkRequest__c
+                WHERE WorkItemId__c IN :markedWis
+                WITH SYSTEM_MODE
+            ];
+        }
+        total += [
+            SELECT COUNT() FROM WorkLog__c
+            WHERE WorkDescriptionTxt__c LIKE :markerLike()
+            WITH SYSTEM_MODE
+        ];
+        return total;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description SOQL LIKE pattern that matches any field value beginning
+     *              with the sample marker. Kept in one place so load/remove/
+     *              count can never drift on the matching rule.
+     * @return '[DH SAMPLE]%' wrapped for a LIKE bind.
+     */
+    private static String markerLike() {
+        return SAMPLE_MARKER + '%';
+    }
+
+    /**
+     * @description Loads the DatasetTemplate__c (with its feature name) or
+     *              throws a caller-meaningful exception when it's missing.
+     * @param templateId Required DatasetTemplate__c id.
+     * @return The template row with FeatureLookup__r.Name populated.
+     */
+    private static DatasetTemplate__c requireTemplate(Id templateId) {
+        if (templateId == null) {
+            throw new DatasetLoaderException('templateId is required.');
+        }
+        List<DatasetTemplate__c> rows = [
+            SELECT Id, Name, FeatureLookup__c, FeatureLookup__r.Name,
+                   FeatureLookup__r.FeatureDefinitionTxt__c
+            FROM DatasetTemplate__c
+            WHERE Id = :templateId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (rows.isEmpty()) {
+            throw new DatasetLoaderException('Dataset template not found.');
+        }
+        return rows.get(0);
+    }
+
+    /**
+     * @description Resolves which built-in dataset a template maps to. Prefers
+     *              the linked feature's FeatureDefinitionTxt__c (stable across
+     *              renames), then the feature Name, then the template Name — so
+     *              the seeded Invoice Generation template resolves whether it's
+     *              linked by definition key or just named for the feature.
+     * @param template DatasetTemplate__c row (feature relationship populated).
+     * @return Dataset key (e.g. 'Invoice_Generation') or null when unmatched.
+     */
+    private static String resolveDatasetKey(DatasetTemplate__c template) {
+        String defKey = (template.FeatureLookup__c != null && template.FeatureLookup__r != null)
+            ? template.FeatureLookup__r.FeatureDefinitionTxt__c
+            : null;
+        if (matchesInvoiceGeneration(defKey)) {
+            return DATASET_INVOICE_GENERATION;
+        }
+        String featureName = (template.FeatureLookup__c != null && template.FeatureLookup__r != null)
+            ? template.FeatureLookup__r.Name
+            : null;
+        if (matchesInvoiceGeneration(featureName)) {
+            return DATASET_INVOICE_GENERATION;
+        }
+        if (matchesInvoiceGeneration(template.Name)) {
+            return DATASET_INVOICE_GENERATION;
+        }
+        return null;
+    }
+
+    /**
+     * @description Whether a candidate string identifies the invoice-generation
+     *              dataset (case-insensitive, tolerant of "Invoice Generation"
+     *              vs "Invoice_Generation").
+     * @param candidate String to test (nullable).
+     * @return True when it identifies the invoice dataset.
+     */
+    private static Boolean matchesInvoiceGeneration(String candidate) {
+        if (String.isBlank(candidate)) {
+            return false;
+        }
+        String normalized = candidate.toLowerCase().replace(' ', '_');
+        return normalized == DATASET_INVOICE_GENERATION.toLowerCase()
+            || normalized.startsWith('invoice_generation');
+    }
+
+    /**
+     * @description Writes a DatasetTemplateAssignment__c audit row for a load or
+     *              remove run. Best-effort — a failure to write the audit row is
+     *              logged but never masks the data operation's own outcome
+     *              (the records already landed / were already deleted).
+     * @param templateId DatasetTemplate__c the run targeted.
+     * @param outcome 'Success' | 'PartialFailure' | 'Failure'.
+     * @param recordCount Records inserted (load) or deleted (remove).
+     * @param errorSummary Optional error text (null on success).
+     * @param isRemoval True for a remove run (annotates the notes).
+     * @return Id of the inserted assignment row, or null when the write failed.
+     */
+    private static Id writeAssignment(
+        Id templateId, String outcome, Integer recordCount, String errorSummary, Boolean isRemoval
+    ) {
+        try {
+            String action = isRemoval ? 'Removed' : 'Loaded';
+            DatasetTemplateAssignment__c row = new DatasetTemplateAssignment__c(
+                DatasetTemplateLookup__c = templateId,
+                LoadedByUserLookup__c = UserInfo.getUserId(),
+                LoadedDateTime__c = Datetime.now(),
+                OutcomePk__c = outcome,
+                RecordsLoadedNumber__c = recordCount,
+                NotesTxt__c = action + ' in-app sample data via DeliveryDatasetLoader '
+                    + '(marker "' + SAMPLE_MARKER + '"). ' + recordCount + ' record(s).'
+            );
+            if (String.isNotBlank(errorSummary)) {
+                row.ErrorSummaryTxt__c = errorSummary.length() > 1024
+                    ? errorSummary.substring(0, 1024)
+                    : errorSummary;
+            }
+            Database.insert(row, AccessLevel.SYSTEM_MODE);
+            return row.Id;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryDatasetLoader.writeAssignment] audit-row write failed: ' + e.getMessage());
+            return null;
+        }
+    }
+
+    /** @description Caller-meaningful loader failure surfaced to the controller. */
+    public class DatasetLoaderException extends Exception {}
+}

--- a/force-app/main/default/classes/DeliveryDatasetLoader.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryDatasetLoader.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryDatasetLoaderTest.cls
+++ b/force-app/main/default/classes/DeliveryDatasetLoaderTest.cls
@@ -1,0 +1,291 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for DeliveryDatasetLoader — the in-app sample-data
+ *               loader (P2 of the install-experience initiative). Covers the
+ *               full safety contract:
+ *                 • load() inserts clearly-marked sample records + an audit row
+ *                 • load() is idempotent (re-run does not duplicate)
+ *                 • remove() deletes EXACTLY the marked records and leaves
+ *                   non-marked (real) records completely intact
+ *                 • outcome + count are recorded on the assignment row
+ *                 • unknown / missing templates throw cleanly
+ *
+ *               Does NOT assert on AuraHandledException.getMessage() (generic
+ *               in managed-package context); the loader throws its own typed
+ *               DatasetLoaderException which IS safe to assert on.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryDatasetLoaderTest {
+
+    private static final String MARKER = '[DH SAMPLE]';
+
+    /**
+     * @description Builds the Invoice Generation feature + a DatasetTemplate__c
+     *              linked to it so the loader's resolveDatasetKey matches the
+     *              invoice dataset. Mirrors how the install handler seeds the
+     *              template (Name + FeatureLookup__c).
+     * @return Inserted DatasetTemplate__c linked to the invoice feature.
+     */
+    private static DatasetTemplate__c seedInvoiceTemplate() {
+        Feature__c f = TestDataFactory.createFeature(new Map<String, Object>{
+            'Name' => 'Invoice_Generation',
+            'FeatureDefinitionTxt__c' => 'Invoice_Generation'
+        });
+        return TestDataFactory.createDatasetTemplate(new Map<String, Object>{
+            'Name' => 'Invoice Generation Sample Data',
+            'FeatureLookup__c' => f.Id
+        });
+    }
+
+    /**
+     * @description Count WorkItems carrying the sample marker.
+     * @return Number of WorkItems whose description starts with the marker.
+     */
+    private static Integer markedWorkItemCount() {
+        return [
+            SELECT COUNT() FROM WorkItem__c
+            WHERE BriefDescriptionTxt__c LIKE :(MARKER + '%')
+        ];
+    }
+
+    @IsTest
+    static void testLoadInsertsMarkedRecordsAndAuditRow() {
+        DatasetTemplate__c t = seedInvoiceTemplate();
+
+        Test.startTest();
+        DeliveryDatasetLoader.LoadResult result = DeliveryDatasetLoader.load(t.Id);
+        Test.stopTest();
+
+        System.assertEquals('Success', result.outcome, 'Load should succeed.');
+        System.assertEquals(false, result.alreadyLoaded, 'First load is not a no-op.');
+        // 2 vendors + 5 WI + 5 WR + 10 WL = 22 records inserted.
+        System.assertEquals(22, result.recordCount,
+            'Should report every inserted record (2 vendors + 5 WI + 5 WR + 10 WL).');
+
+        System.assertEquals(5, markedWorkItemCount(),
+            'Exactly 5 marked WorkItems should exist after load.');
+        Integer markedLogs = [
+            SELECT COUNT() FROM WorkLog__c
+            WHERE WorkDescriptionTxt__c LIKE :(MARKER + '%')
+        ];
+        System.assertEquals(10, markedLogs, '10 marked WorkLogs should exist.');
+        Integer markedVendors = [
+            SELECT COUNT() FROM NetworkEntity__c
+            WHERE Name LIKE :(MARKER + '%')
+        ];
+        System.assertEquals(2, markedVendors, '2 marked vendors should exist.');
+
+        // Audit row written with real outcome + count.
+        System.assertNotEquals(null, result.assignmentId, 'An audit row id should be returned.');
+        DatasetTemplateAssignment__c audit = [
+            SELECT Id, DatasetTemplateLookup__c, OutcomePk__c, RecordsLoadedNumber__c,
+                   LoadedByUserLookup__c, LoadedDateTime__c, NotesTxt__c
+            FROM DatasetTemplateAssignment__c
+            WHERE Id = :result.assignmentId
+            LIMIT 1
+        ];
+        System.assertEquals(t.Id, audit.DatasetTemplateLookup__c, 'Audit row ties to the template.');
+        System.assertEquals('Success', audit.OutcomePk__c, 'Audit outcome must be Success.');
+        System.assertEquals(22, audit.RecordsLoadedNumber__c.intValue(),
+            'Audit records-loaded must match the real count.');
+        System.assertEquals(UserInfo.getUserId(), audit.LoadedByUserLookup__c,
+            'Audit row records the running user as loader.');
+    }
+
+    @IsTest
+    static void testLoadIsIdempotent() {
+        DatasetTemplate__c t = seedInvoiceTemplate();
+
+        Test.startTest();
+        DeliveryDatasetLoader.LoadResult first = DeliveryDatasetLoader.load(t.Id);
+        DeliveryDatasetLoader.LoadResult second = DeliveryDatasetLoader.load(t.Id);
+        Test.stopTest();
+
+        System.assertEquals(false, first.alreadyLoaded, 'First load is real.');
+        System.assertEquals(true, second.alreadyLoaded,
+            'Second load must be a no-op (already loaded).');
+        System.assertEquals('Success', second.outcome, 'No-op still reports Success.');
+
+        // Re-running must NOT duplicate — still exactly 5 WI / 10 WL / 2 vendors.
+        System.assertEquals(5, markedWorkItemCount(),
+            'Idempotent: still exactly 5 marked WorkItems after a second load.');
+        Integer markedLogs = [
+            SELECT COUNT() FROM WorkLog__c
+            WHERE WorkDescriptionTxt__c LIKE :(MARKER + '%')
+        ];
+        System.assertEquals(10, markedLogs, 'Idempotent: still 10 marked WorkLogs.');
+        Integer markedVendors = [
+            SELECT COUNT() FROM NetworkEntity__c
+            WHERE Name LIKE :(MARKER + '%')
+        ];
+        System.assertEquals(2, markedVendors, 'Idempotent: still 2 marked vendors.');
+    }
+
+    @IsTest
+    static void testRemoveDeletesOnlyMarkedRecords() {
+        DatasetTemplate__c t = seedInvoiceTemplate();
+
+        // A REAL (non-sample) WorkItem + its own WorkRequest + WorkLog, plus a
+        // real vendor. None of these carry the marker — remove() must leave
+        // every one of them intact. This is the core safety assertion.
+        WorkItem__c realWi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'REAL production work item — do not delete'
+        });
+        WorkLog__c realLog = TestDataFactory.createWorkLog(
+            realWi.Id, 8, Date.today(), new Map<String, Object>{
+                'WorkDescriptionTxt__c' => 'REAL billable work — do not delete'
+            }
+        );
+        NetworkEntity__c realVendor = TestDataFactory.createNetworkEntity(new Map<String, Object>{
+            'Name' => 'Acme Real Vendor'
+        });
+
+        // Load the sample data, then remove it.
+        DeliveryDatasetLoader.load(t.Id);
+
+        Test.startTest();
+        DeliveryDatasetLoader.LoadResult removeResult = DeliveryDatasetLoader.remove(t.Id);
+        Test.stopTest();
+
+        System.assertEquals('Success', removeResult.outcome, 'Remove should succeed.');
+        // 2 vendors + 5 WI + 5 WR + 10 WL = 22 deleted.
+        System.assertEquals(22, removeResult.recordCount,
+            'Remove should delete exactly the 22 marked records.');
+
+        // No marked records survive.
+        System.assertEquals(0, markedWorkItemCount(),
+            'All marked WorkItems must be gone after remove.');
+        System.assertEquals(0, [
+            SELECT COUNT() FROM WorkLog__c
+            WHERE WorkDescriptionTxt__c LIKE :(MARKER + '%')
+        ], 'All marked WorkLogs must be gone.');
+        System.assertEquals(0, [
+            SELECT COUNT() FROM NetworkEntity__c
+            WHERE Name LIKE :(MARKER + '%')
+        ], 'All marked vendors must be gone.');
+
+        // The REAL records are completely intact — THE safety guarantee.
+        System.assertEquals(1, [
+            SELECT COUNT() FROM WorkItem__c WHERE Id = :realWi.Id
+        ], 'Real WorkItem must NOT be deleted by remove().');
+        System.assertEquals(1, [
+            SELECT COUNT() FROM WorkLog__c WHERE Id = :realLog.Id
+        ], 'Real WorkLog must NOT be deleted by remove().');
+        System.assertEquals(1, [
+            SELECT COUNT() FROM NetworkEntity__c WHERE Id = :realVendor.Id
+        ], 'Real vendor must NOT be deleted by remove().');
+    }
+
+    @IsTest
+    static void testRemoveRecordsAuditRowWithOutcomeAndCount() {
+        DatasetTemplate__c t = seedInvoiceTemplate();
+        DeliveryDatasetLoader.load(t.Id);
+
+        Test.startTest();
+        DeliveryDatasetLoader.LoadResult removeResult = DeliveryDatasetLoader.remove(t.Id);
+        Test.stopTest();
+
+        System.assertNotEquals(null, removeResult.assignmentId,
+            'Remove should write an audit row.');
+        DatasetTemplateAssignment__c audit = [
+            SELECT Id, OutcomePk__c, RecordsLoadedNumber__c, NotesTxt__c
+            FROM DatasetTemplateAssignment__c
+            WHERE Id = :removeResult.assignmentId
+            LIMIT 1
+        ];
+        System.assertEquals('Success', audit.OutcomePk__c, 'Remove outcome recorded.');
+        System.assertEquals(22, audit.RecordsLoadedNumber__c.intValue(),
+            'Remove audit records the count deleted.');
+        System.assert(audit.NotesTxt__c.contains('Removed'),
+            'Remove audit notes should say "Removed". Got: ' + audit.NotesTxt__c);
+    }
+
+    @IsTest
+    static void testRemoveWhenNothingLoadedIsCleanNoOp() {
+        DatasetTemplate__c t = seedInvoiceTemplate();
+
+        Test.startTest();
+        DeliveryDatasetLoader.LoadResult removeResult = DeliveryDatasetLoader.remove(t.Id);
+        Test.stopTest();
+
+        System.assertEquals('Success', removeResult.outcome,
+            'Removing with nothing loaded is a clean success.');
+        System.assertEquals(0, removeResult.recordCount,
+            'Nothing loaded means nothing removed.');
+    }
+
+    @IsTest
+    static void testLoadThrowsWhenTemplateMissing() {
+        // Borrow the running user id as a non-null id of the WRONG type so the
+        // template lookup misses and the loader throws its typed exception.
+        Id bogus = UserInfo.getUserId();
+
+        Boolean thrown = false;
+        Test.startTest();
+        try {
+            DeliveryDatasetLoader.load(bogus);
+        } catch (DeliveryDatasetLoader.DatasetLoaderException e) {
+            thrown = true;
+        }
+        Test.stopTest();
+
+        System.assertEquals(true, thrown, 'Missing template must throw DatasetLoaderException.');
+    }
+
+    @IsTest
+    static void testLoadThrowsWhenNullTemplate() {
+        Boolean thrown = false;
+        Test.startTest();
+        try {
+            DeliveryDatasetLoader.load(null);
+        } catch (DeliveryDatasetLoader.DatasetLoaderException e) {
+            thrown = true;
+        }
+        Test.stopTest();
+        System.assertEquals(true, thrown, 'Null template must throw DatasetLoaderException.');
+    }
+
+    @IsTest
+    static void testLoadThrowsWhenNoLoaderRegistered() {
+        // A template NOT tied to a recognised dataset (random feature name)
+        // must throw — we never silently load the wrong dataset.
+        Feature__c f = TestDataFactory.createFeature(new Map<String, Object>{
+            'Name' => 'Some_Other_Feature',
+            'FeatureDefinitionTxt__c' => 'Some_Other_Feature'
+        });
+        DatasetTemplate__c t = TestDataFactory.createDatasetTemplate(new Map<String, Object>{
+            'Name' => 'Unrecognised Template',
+            'FeatureLookup__c' => f.Id
+        });
+
+        Boolean thrown = false;
+        Test.startTest();
+        try {
+            DeliveryDatasetLoader.load(t.Id);
+        } catch (DeliveryDatasetLoader.DatasetLoaderException e) {
+            thrown = true;
+        }
+        Test.stopTest();
+        System.assertEquals(true, thrown,
+            'A template with no registered loader must throw, not load the wrong data.');
+    }
+
+    @IsTest
+    static void testResolvesByTemplateNameWhenFeatureUnlinked() {
+        // No feature link — resolution must fall back to the template Name.
+        DatasetTemplate__c t = TestDataFactory.createDatasetTemplate(new Map<String, Object>{
+            'Name' => 'Invoice Generation Sample Data'
+        });
+
+        Test.startTest();
+        DeliveryDatasetLoader.LoadResult result = DeliveryDatasetLoader.load(t.Id);
+        Test.stopTest();
+
+        System.assertEquals('Success', result.outcome,
+            'Template named for the invoice dataset should resolve even without a feature link.');
+        System.assertEquals(5, markedWorkItemCount(),
+            'Name-based resolution should still load the 5 invoice WorkItems.');
+    }
+}

--- a/force-app/main/default/classes/DeliveryDatasetLoaderTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryDatasetLoaderTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryHubInstallHandler.cls
+++ b/force-app/main/default/classes/DeliveryHubInstallHandler.cls
@@ -18,6 +18,7 @@ global class DeliveryHubInstallHandler implements InstallHandler {
     global void onInstall(InstallContext context) {
         initializeDefaultSettings();
         seedFeaturesFromDefinitions();
+        seedDatasetTemplates();
         syncLegacySettingsToFeatures();
         scheduleSyncJobs();
         backfillUserPermissionSets();
@@ -127,6 +128,72 @@ global class DeliveryHubInstallHandler implements InstallHandler {
         } catch (Exception e) {
             System.debug(LoggingLevel.WARN,
                 '[DeliveryHubInstallHandler] Feature catalog seed failed: '
+                + e.getMessage());
+        }
+    }
+
+    /**
+     * @description Seeds the in-app sample-data DatasetTemplate__c rows that
+     *              the cockpit's "Load sample data" / "Remove sample data"
+     *              buttons (DeliveryDatasetLoader) drive. Currently ships ONE
+     *              template — Invoice Generation — linked to its Feature__c via
+     *              FeatureLookup__c so the deliveryDatasetTemplates LWC exposes
+     *              the load/remove actions on the feature record page.
+     *
+     *              Idempotent: keyed by the template Name, so a re-install /
+     *              upgrade never duplicates the seeded row. Wrapped in
+     *              try/catch — install must never fail on a cosmetic seed.
+     *
+     *              Adding more datasets later: add a row to TEMPLATE_SEEDS and a
+     *              matching branch in DeliveryDatasetLoader.resolveDatasetKey.
+     */
+    private static void seedDatasetTemplates() {
+        try {
+            // Map of template Name → linked FeatureDefinition DeveloperName.
+            Map<String, String> templateSeeds = new Map<String, String>{
+                'Invoice Generation Sample Data' => 'Invoice_Generation'
+            };
+
+            // Which seed names already exist (idempotency key = Name).
+            Set<String> existingNames = new Set<String>();
+            for (DatasetTemplate__c existing : [
+                SELECT Name FROM DatasetTemplate__c
+                WHERE Name IN :templateSeeds.keySet()
+            ]) {
+                existingNames.add(existing.Name);
+            }
+
+            // Resolve the runtime Feature__c rows for the seeds we still need.
+            Map<String, Id> featureIdByDefName = new Map<String, Id>();
+            for (Feature__c f : [
+                SELECT Id, FeatureDefinitionTxt__c FROM Feature__c
+                WHERE FeatureDefinitionTxt__c IN :templateSeeds.values()
+            ]) {
+                featureIdByDefName.put(f.FeatureDefinitionTxt__c, f.Id);
+            }
+
+            List<DatasetTemplate__c> toInsert = new List<DatasetTemplate__c>();
+            for (String templateName : templateSeeds.keySet()) {
+                if (existingNames.contains(templateName)) {
+                    continue;
+                }
+                String defName = templateSeeds.get(templateName);
+                toInsert.add(new DatasetTemplate__c(
+                    Name = templateName,
+                    FeatureLookup__c = featureIdByDefName.get(defName),
+                    DescriptionTxt__c = 'Loads clearly-marked sample data so you can '
+                        + 'see this feature in action. Records are tagged "[DH SAMPLE]" '
+                        + 'and can be removed in one click.',
+                    ApexScriptPathTxt__c = 'scripts/feature-data/invoice_generation.apex',
+                    RecordCountEstimateNumber__c = 17
+                ));
+            }
+            if (!toInsert.isEmpty()) {
+                insert toInsert;
+            }
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryHubInstallHandler] Dataset template seed failed: '
                 + e.getMessage());
         }
     }

--- a/force-app/main/default/lwc/deliveryDatasetTemplates/deliveryDatasetTemplates.html
+++ b/force-app/main/default/lwc/deliveryDatasetTemplates/deliveryDatasetTemplates.html
@@ -21,9 +21,11 @@
 
             <template lwc:if={isSubscriberOrg}>
                 <div class="slds-box slds-theme_shade slds-text-body_small slds-m-bottom_small">
-                    Dataset templates are for package developers &mdash;
-                    install scratch org tooling locally (CumulusCI + sfdx)
-                    to load sample data.
+                    Use <strong>Load Sample Data</strong> to populate clearly-marked
+                    &ldquo;[DH SAMPLE]&rdquo; demo records &mdash; no CumulusCI or CLI
+                    required. Remove them anytime with one click. (The
+                    <em>Copy Load Command</em> path remains for package developers
+                    running scratch-org tooling locally.)
                 </div>
             </template>
 
@@ -52,9 +54,27 @@
                                 </div>
                                 <div class="slds-col slds-no-flex">
                                     <lightning-button
-                                        label="Copy Load Command"
+                                        label="Load Sample Data"
                                         variant="brand"
+                                        icon-name="utility:upload"
+                                        data-template-id={t.templateId}
+                                        data-template-name={t.name}
+                                        onclick={handleOpenLoadSample}>
+                                    </lightning-button>
+                                    <lightning-button
+                                        label="Remove Sample Data"
+                                        variant="destructive-text"
+                                        icon-name="utility:delete"
+                                        class="slds-m-left_x-small"
+                                        data-template-id={t.templateId}
+                                        data-template-name={t.name}
+                                        onclick={handleOpenRemoveSample}>
+                                    </lightning-button>
+                                    <lightning-button
+                                        label="Copy Load Command"
+                                        variant="neutral"
                                         icon-name="utility:copy"
+                                        class="slds-m-left_x-small"
                                         data-template-id={t.templateId}
                                         onclick={handleCopyCommand}>
                                     </lightning-button>
@@ -179,6 +199,53 @@
                         class="slds-m-left_x-small"
                         onclick={handleSubmitMarkAsLoaded}
                         disabled={isSubmittingMarkAsLoaded}>
+                    </lightning-button>
+                </footer>
+            </div>
+        </section>
+        <div class="slds-backdrop slds-backdrop_open"></div>
+    </template>
+
+    <template lwc:if={isSampleModalOpen}>
+        <section role="dialog" tabindex="-1" aria-modal="true"
+            aria-labelledby="sampleDataHeading"
+            class="slds-modal slds-fade-in-open slds-modal_small">
+            <div class="slds-modal__container">
+                <header class="slds-modal__header">
+                    <lightning-button-icon
+                        icon-name="utility:close"
+                        variant="bare-inverse"
+                        size="large"
+                        alternative-text="Cancel"
+                        title="Cancel"
+                        class="slds-modal__close"
+                        onclick={handleCloseSampleModal}>
+                    </lightning-button-icon>
+                    <h2 id="sampleDataHeading" class="slds-modal__title slds-hyphenate">
+                        {sampleModalHeading}
+                    </h2>
+                    <p class="slds-m-top_x-small slds-text-body_small slds-text-color_weak">
+                        Template: <strong>{sampleTemplateName}</strong>
+                    </p>
+                </header>
+                <div class="slds-modal__content slds-p-around_medium">
+                    <p class="slds-text-body_regular">
+                        {sampleModalBody}
+                    </p>
+                </div>
+                <footer class="slds-modal__footer">
+                    <lightning-button
+                        label="Cancel"
+                        variant="neutral"
+                        onclick={handleCloseSampleModal}
+                        disabled={isSampleActionRunning}>
+                    </lightning-button>
+                    <lightning-button
+                        label={sampleConfirmLabel}
+                        variant={sampleConfirmVariant}
+                        class="slds-m-left_x-small"
+                        onclick={handleConfirmSampleAction}
+                        disabled={isSampleActionRunning}>
                     </lightning-button>
                 </footer>
             </div>

--- a/force-app/main/default/lwc/deliveryDatasetTemplates/deliveryDatasetTemplates.js
+++ b/force-app/main/default/lwc/deliveryDatasetTemplates/deliveryDatasetTemplates.js
@@ -25,6 +25,8 @@ import formatCciCommand from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDatase
 import isSubscriberOrgApex from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDatasetController.isSubscriberOrg';
 import getLastAssignment from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDatasetController.getLastAssignment';
 import recordAssignment from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDatasetController.recordAssignment';
+import loadSampleData from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDatasetController.loadSampleData';
+import removeSampleData from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDatasetController.removeSampleData';
 
 const FEATURE_OBJECT = 'Feature__c',
     WORK_ITEM_OBJECT = 'WorkItem__c',
@@ -49,6 +51,14 @@ export default class DeliveryDatasetTemplates extends LightningElement {
     @track markAsLoadedTemplateName = '';
     @track markAsLoadedNotes = '';
     @track isSubmittingMarkAsLoaded = false;
+
+    // ── In-app sample-data confirm modal state ──────────────────────────
+    // One modal serves both Load and Remove; sampleActionMode flips which.
+    @track isSampleModalOpen = false;
+    @track sampleActionMode = ''; // 'load' | 'remove'
+    @track sampleTemplateId = null;
+    @track sampleTemplateName = '';
+    @track isSampleActionRunning = false;
 
     wiredTemplatesResult;
     wiredRecentResult;
@@ -228,6 +238,46 @@ export default class DeliveryDatasetTemplates extends LightningElement {
             + 'This surface is for package developers — install CCI locally to load sample data.';
     }
 
+    // ── In-app sample-data modal getters (LWC has no ternary in v62) ─────
+
+    get isSampleRemoveMode() {
+        return this.sampleActionMode === 'remove';
+    }
+
+    get sampleModalHeading() {
+        if (this.isSampleRemoveMode) {
+            return 'Remove Sample Data';
+        }
+        return 'Load Sample Data';
+    }
+
+    get sampleModalBody() {
+        if (this.isSampleRemoveMode) {
+            return 'This deletes ONLY the clearly-marked "[DH SAMPLE]" records '
+                + 'created by the loader for this feature. Your real records are '
+                + 'never touched. This action is reversible — you can reload the '
+                + 'sample data afterward.';
+        }
+        return 'This loads clearly-marked "[DH SAMPLE]" sample records so you can '
+            + 'see this feature in action — no CumulusCI or CLI required. '
+            + 'Re-running is safe (it will not duplicate). You can remove the '
+            + 'sample data in one click afterward.';
+    }
+
+    get sampleConfirmLabel() {
+        if (this.isSampleRemoveMode) {
+            return 'Remove Sample Data';
+        }
+        return 'Load Sample Data';
+    }
+
+    get sampleConfirmVariant() {
+        if (this.isSampleRemoveMode) {
+            return 'destructive';
+        }
+        return 'brand';
+    }
+
     // ────────────────────────────────────────────────────────────────────
     // Handlers
     // ────────────────────────────────────────────────────────────────────
@@ -350,6 +400,92 @@ export default class DeliveryDatasetTemplates extends LightningElement {
                 }));
                 this.isSubmittingMarkAsLoaded = false;
             });
+    }
+
+    // ── In-app sample-data load / remove ────────────────────────────────
+
+    handleOpenLoadSample(event) {
+        this.openSampleModal(event, 'load');
+    }
+
+    handleOpenRemoveSample(event) {
+        this.openSampleModal(event, 'remove');
+    }
+
+    openSampleModal(event, mode) {
+        const templateId = event.currentTarget.dataset.templateId;
+        const templateName = event.currentTarget.dataset.templateName || '';
+        if (!templateId) {
+            return;
+        }
+        this.sampleTemplateId = templateId;
+        this.sampleTemplateName = templateName;
+        this.sampleActionMode = mode;
+        this.isSampleModalOpen = true;
+    }
+
+    handleCloseSampleModal() {
+        if (this.isSampleActionRunning) {
+            // In-flight operation — let it finish before closing.
+            return;
+        }
+        this.resetSampleModal();
+    }
+
+    resetSampleModal() {
+        this.isSampleModalOpen = false;
+        this.sampleActionMode = '';
+        this.sampleTemplateId = null;
+        this.sampleTemplateName = '';
+    }
+
+    handleConfirmSampleAction() {
+        if (!this.sampleTemplateId || this.isSampleActionRunning) {
+            return;
+        }
+        const isRemove = this.isSampleRemoveMode;
+        const templateName = this.sampleTemplateName;
+        const apexCall = isRemove ? removeSampleData : loadSampleData;
+        this.isSampleActionRunning = true;
+        apexCall({ templateId: this.sampleTemplateId })
+            .then(result => this.handleSampleSuccess(result, isRemove, templateName))
+            .catch(err => this.handleSampleError(err, isRemove));
+    }
+
+    handleSampleSuccess(result, isRemove, templateName) {
+        const count = result && typeof result.recordCount === 'number' ? result.recordCount : 0;
+        const verb = isRemove ? 'Removed' : 'Loaded';
+        let message;
+        if (result && result.message) {
+            message = result.message;
+        } else {
+            message = `${verb} ${count} sample record(s) for "${templateName}".`;
+        }
+        const variant = (result && result.outcome === 'Failure') ? 'error' : 'success';
+        this.dispatchEvent(new ShowToastEvent({
+            title: isRemove ? 'Sample data removed' : 'Sample data loaded',
+            message,
+            variant
+        }));
+        // Refresh audit panel + per-card sublines so the new assignment shows.
+        if (this.wiredRecentResult) {
+            refreshApex(this.wiredRecentResult);
+        }
+        this.loadLastAssignmentSublines();
+        this.isSampleActionRunning = false;
+        this.resetSampleModal();
+    }
+
+    handleSampleError(err, isRemove) {
+        const msg = (err && err.body && err.body.message)
+            ? err.body.message
+            : (isRemove ? 'Unable to remove sample data.' : 'Unable to load sample data.');
+        this.dispatchEvent(new ShowToastEvent({
+            title: isRemove ? 'Could not remove sample data' : 'Could not load sample data',
+            message: msg,
+            variant: 'error'
+        }));
+        this.isSampleActionRunning = false;
     }
 
     handleRefresh() {


### PR DESCRIPTION
## What

Makes loading a feature's **sample data a first-class in-app action**. Today a subscriber can't load sample data without installing CumulusCI + running a CLI command, so enabling a feature shows a dead, empty screen. Now: **"Load sample data" / "Remove sample data"** buttons on the dataset surface — no CumulusCI required.

Scoped to **Invoice Generation** as the first end-to-end example; adding more datasets later is a branch in `resolveDatasetKey` + a `loadXxx` method.

## Safety design (this writes to a subscriber org)

A single queryable marker — `[DH SAMPLE]` — is the **entire safety contract**:
- **Load** stamps every sample record (WorkItem desc, WorkLog desc, vendor Name). **Idempotent** — re-running detects existing marked records and no-ops rather than duplicating.
- **Remove** deletes **exactly** the marked records, in dependency-safe order (WorkLog → WorkRequest → WorkItem → NetworkEntity). It can **never** touch a non-marked (real) record.
- Both write a `DatasetTemplateAssignment__c` audit row (real outcome + count + user + timestamp). All DML `AccessLevel.SYSTEM_MODE`.
- Placeholder values only (`HoursLoggedNumber__c = 1.0`), per CLAUDE.md — no fabricated realistic figures.

## Files
- `DeliveryDatasetLoader` (+ test) — the loader service + safety contract.
- `DeliveryDatasetController` — Load/Remove entry points for the LWC.
- `deliveryDatasetTemplates` LWC — buttons + confirm + result toast.
- `DeliveryHubInstallHandler.seedDatasetTemplates()` — seeds one DatasetTemplate (Invoice Generation) so the surface isn't empty. Idempotent; **additive** — P0's zero-noise install defaults are untouched.

## Tests
`DeliveryDatasetLoaderTest`: load inserts marked records + audit row; load idempotent (no dup on re-run); **`testRemoveDeletesOnlyMarkedRecords` seeds REAL records and asserts they survive removal** (the core safety guarantee); outcome/count recorded; null/missing/unknown templates throw the typed `DatasetLoaderException`.

## Notes
- P2 of the install-experience initiative (P0 = zero-noise defaults #843; P1 = consequence preview #844).
- PMD: only non-blocking Design flags remain (method/class cyclomatic complexity, one 5-param helper) — same family already present on green `main`; ApexDoc gaps fixed. The new Apex field/object references were all verified to exist before pushing.
- All field references (`DatasetTemplateAssignment__c.ErrorSummaryTxt__c/OutcomePk__c`, `NetworkEntity__c.IntegrationEndpointUrlTxt__c`, etc.) verified present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)