### PR TITLE
fix(install): defer Feature + DatasetTemplate seeds to a Queueable so postInstall doesn't silently swallow them

### DIFF
--- a/force-app/main/default/classes/DeliveryHubInstallHandler.cls
+++ b/force-app/main/default/classes/DeliveryHubInstallHandler.cls
@@ -17,13 +17,34 @@ global class DeliveryHubInstallHandler implements InstallHandler {
      */
     global void onInstall(InstallContext context) {
         initializeDefaultSettings();
-        seedFeaturesFromDefinitions();
-        seedDatasetTemplates();
+        enqueueInstallSeed();
         syncLegacySettingsToFeatures();
         scheduleSyncJobs();
         backfillUserPermissionSets();
         backfillWorkItemStatusDefaults();
         enqueueInitialReconciliation();
+    }
+
+    /**
+     * @description Enqueues DeliveryHubInstallSeedQueueable so the Feature
+     *              catalog + DatasetTemplate samples are seeded in a fresh
+     *              transaction AFTER postInstall commits — sidesteps a
+     *              FeatureTrigger same-transaction interaction that silently
+     *              throws when the seeds run inside postInstall. Verified
+     *              empirically: 0.252.0.3 install on dh-prod + nimba left
+     *              both orgs with 0 Feature__c / 0 DatasetTemplate__c rows
+     *              even though scheduleSyncJobs (which runs AFTER the seeds
+     *              in onInstall) registered all four cron jobs cleanly. The
+     *              same seed bodies run as anonymous Apex outside the install
+     *              transaction insert 6 Features + 1 DatasetTemplate cleanly.
+     */
+    private static void enqueueInstallSeed() {
+        try {
+            System.enqueueJob(new DeliveryHubInstallSeedQueueable());
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryHubInstallHandler] enqueueInstallSeed failed: ' + e.getMessage());
+        }
     }
 
     /**
@@ -83,119 +104,6 @@ global class DeliveryHubInstallHandler implements InstallHandler {
             // left null = OFF. Admins opt in via the guided setup flow.
         );
         insert settings;
-    }
-
-    /**
-     * @description Seeds one Feature__c per FeatureDefinition__mdt that does not
-     *              already have a matching runtime row. Idempotent: re-running
-     *              the install never duplicates existing seeded rows. Defaults
-     *              the per-tenant EnabledDateTime__c to the catalog's
-     *              DefaultEnabledDateTime__c (which is currently null for every
-     *              shipped record — admins activate features explicitly via the
-     *              cockpit). Wrapped in try/catch — install must never fail on
-     *              seed (existing handler pattern).
-     */
-    private static void seedFeaturesFromDefinitions() {
-        try {
-            List<FeatureDefinition__mdt> defs = [
-                SELECT DeveloperName, DefaultEnabledDateTime__c
-                FROM FeatureDefinition__mdt
-            ];
-            if (defs.isEmpty()) {
-                return;
-            }
-            Set<String> existingDefNames = new Set<String>();
-            for (Feature__c existing : [
-                SELECT FeatureDefinitionTxt__c FROM Feature__c
-                WHERE FeatureDefinitionTxt__c != null
-            ]) {
-                existingDefNames.add(existing.FeatureDefinitionTxt__c);
-            }
-            List<Feature__c> toInsert = new List<Feature__c>();
-            for (FeatureDefinition__mdt fd : defs) {
-                if (existingDefNames.contains(fd.DeveloperName)) {
-                    continue;
-                }
-                toInsert.add(new Feature__c(
-                    Name = fd.DeveloperName,
-                    FeatureDefinitionTxt__c = fd.DeveloperName,
-                    EnabledDateTime__c = fd.DefaultEnabledDateTime__c
-                ));
-            }
-            if (!toInsert.isEmpty()) {
-                insert toInsert;
-            }
-        } catch (Exception e) {
-            System.debug(LoggingLevel.WARN,
-                '[DeliveryHubInstallHandler] Feature catalog seed failed: '
-                + e.getMessage());
-        }
-    }
-
-    /**
-     * @description Seeds the in-app sample-data DatasetTemplate__c rows that
-     *              the cockpit's "Load sample data" / "Remove sample data"
-     *              buttons (DeliveryDatasetLoader) drive. Currently ships ONE
-     *              template — Invoice Generation — linked to its Feature__c via
-     *              FeatureLookup__c so the deliveryDatasetTemplates LWC exposes
-     *              the load/remove actions on the feature record page.
-     *
-     *              Idempotent: keyed by the template Name, so a re-install /
-     *              upgrade never duplicates the seeded row. Wrapped in
-     *              try/catch — install must never fail on a cosmetic seed.
-     *
-     *              Adding more datasets later: add a row to TEMPLATE_SEEDS and a
-     *              matching branch in DeliveryDatasetLoader.resolveDatasetKey.
-     */
-    private static void seedDatasetTemplates() {
-        try {
-            // Map of template Name → linked FeatureDefinition DeveloperName.
-            Map<String, String> templateSeeds = new Map<String, String>{
-                'Invoice Generation Sample Data' => 'Invoice_Generation'
-            };
-
-            // Which seed names already exist (idempotency key = Name).
-            Set<String> existingNames = new Set<String>();
-            for (DatasetTemplate__c existing : [
-                SELECT Name FROM DatasetTemplate__c
-                WHERE Name IN :templateSeeds.keySet()
-            ]) {
-                existingNames.add(existing.Name);
-            }
-
-            // Resolve the runtime Feature__c rows for the seeds we still need.
-            Map<String, Id> featureIdByDefName = new Map<String, Id>();
-            for (Feature__c f : [
-                SELECT Id, FeatureDefinitionTxt__c FROM Feature__c
-                WHERE FeatureDefinitionTxt__c IN :templateSeeds.values()
-            ]) {
-                featureIdByDefName.put(f.FeatureDefinitionTxt__c, f.Id);
-            }
-
-            List<DatasetTemplate__c> toInsert = new List<DatasetTemplate__c>();
-            for (String templateName : templateSeeds.keySet()) {
-                if (existingNames.contains(templateName)) {
-                    continue;
-                }
-                String defName = templateSeeds.get(templateName);
-                toInsert.add(new DatasetTemplate__c(
-                    Name = templateName,
-                    FeatureLookup__c = featureIdByDefName.get(defName),
-                    DescriptionTxt__c = 'Loads clearly-marked sample data so you can '
-                        + 'see this feature in action. Records are tagged "[DH SAMPLE]" '
-                        + 'and can be removed in one click.',
-                    ApexScriptPathTxt__c = 'scripts/feature-data/invoice_generation.apex',
-                    RecordCountEstimateNumber__c = 17
-                ));
-            }
-            if (!toInsert.isEmpty()) {
-                insert toInsert;
-            }
-        } catch (Exception e) {
-            System.debug(LoggingLevel.WARN,
-                '[DeliveryHubInstallHandler] Dataset template seed failed: '
-                + e.getMessage());
-        }
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryHubInstallHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryHubInstallHandlerTest.cls
@@ -122,7 +122,9 @@ private class DeliveryHubInstallHandlerTest {
         System.runAs(testUser) {
             Integer defCount = [SELECT COUNT() FROM FeatureDefinition__mdt];
 
+            Test.startTest();
             Test.testInstall(new DeliveryHubInstallHandler(), null, false);
+            Test.stopTest();
 
             Integer seeded = [
                 SELECT COUNT() FROM Feature__c WHERE FeatureDefinitionTxt__c != null
@@ -135,6 +137,7 @@ private class DeliveryHubInstallHandlerTest {
     @IsTest
     static void testInstallFeatureSeedIsIdempotent() {
         System.runAs(testUser) {
+            Test.startTest();
             Test.testInstall(new DeliveryHubInstallHandler(), null, false);
             Integer afterFirst = [
                 SELECT COUNT() FROM Feature__c WHERE FeatureDefinitionTxt__c != null
@@ -143,8 +146,50 @@ private class DeliveryHubInstallHandlerTest {
             Integer afterSecond = [
                 SELECT COUNT() FROM Feature__c WHERE FeatureDefinitionTxt__c != null
             ];
+            Test.stopTest();
             System.assertEquals(afterFirst, afterSecond,
                 'Re-running install should not duplicate seeded Feature__c rows');
+        }
+    }
+
+    @IsTest
+    static void testInstallSeedsDatasetTemplate() {
+        System.runAs(testUser) {
+            Test.startTest();
+            Test.testInstall(new DeliveryHubInstallHandler(), null, false);
+            Test.stopTest();
+
+            List<DatasetTemplate__c> templates = [
+                SELECT Id, Name, FeatureLookup__c
+                FROM DatasetTemplate__c
+                WHERE Name = 'Invoice Generation Sample Data'
+            ];
+            System.assertEquals(1, templates.size(),
+                'Install should seed exactly one DatasetTemplate__c "Invoice Generation Sample Data"');
+
+            Feature__c invoiceFeature = [
+                SELECT Id FROM Feature__c
+                WHERE FeatureDefinitionTxt__c = 'Invoice_Generation'
+                LIMIT 1
+            ];
+            System.assertEquals(invoiceFeature.Id, templates[0].FeatureLookup__c,
+                'Seeded DatasetTemplate__c.FeatureLookup__c should resolve to the Invoice_Generation Feature__c row');
+        }
+    }
+
+    @IsTest
+    static void testInstallEnqueuesSeedQueueable() {
+        System.runAs(testUser) {
+            Test.testInstall(new DeliveryHubInstallHandler(), null, false);
+
+            // Query BEFORE Test.stopTest() so the enqueued job is still queued
+            // and observable as an AsyncApexJob row.
+            Integer queued = [
+                SELECT COUNT() FROM AsyncApexJob
+                WHERE ApexClass.Name = 'DeliveryHubInstallSeedQueueable'
+            ];
+            System.assert(queued > 0,
+                'onInstall should enqueue DeliveryHubInstallSeedQueueable');
         }
     }
 

--- a/force-app/main/default/classes/DeliveryHubInstallSeedQueueable.cls
+++ b/force-app/main/default/classes/DeliveryHubInstallSeedQueueable.cls
@@ -1,0 +1,163 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Deferred-seed Queueable for DeliveryHubInstallHandler.
+ *
+ *              WHY THIS EXISTS: the Feature__c + DatasetTemplate__c seed logic
+ *              used to run inline inside InstallHandler.onInstall. It silently
+ *              failed on real subscriber installs (verified empirically on
+ *              dh-prod + nimba after release/0.252.0.3 — both orgs ended with
+ *              0 Feature__c and 0 DatasetTemplate__c rows, yet the same
+ *              onInstall successfully scheduled all four sync cron jobs that
+ *              run AFTER the seeds). Root cause is almost certainly a
+ *              same-transaction interaction with FeatureTrigger /
+ *              DeliveryFeatureTriggerHandler, which mirrors Feature__c rows
+ *              onto DeliveryHubSettings__c on after-insert — the install
+ *              transaction's state at that moment apparently doesn't tolerate
+ *              that re-entry, and the inline try/catch swallowed the throw.
+ *
+ *              The fix: relocate the two seed bodies verbatim into this
+ *              Queueable. The InstallHandler enqueues it via
+ *              System.enqueueJob, which causes the work to run in a fresh
+ *              transaction AFTER postInstall commits — sidestepping the
+ *              interaction. Verified locally: running the same seed logic as
+ *              anonymous Apex outside the install transaction inserts 6
+ *              Feature__c + 1 DatasetTemplate__c cleanly. Idempotent.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation')
+public with sharing class DeliveryHubInstallSeedQueueable implements System.Queueable {
+
+    /**
+     * @description Queueable entry point. Runs the two seed bodies in
+     *              independent try/catch blocks so a failure in one does not
+     *              block the other.
+     * @param context Queueable context (unused).
+     */
+    public void execute(QueueableContext context) {
+        try {
+            seedFeatures();
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryHubInstallSeedQueueable] Feature catalog seed failed: '
+                + e.getMessage());
+        }
+        try {
+            seedDatasetTemplates();
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryHubInstallSeedQueueable] Dataset template seed failed: '
+                + e.getMessage());
+        }
+    }
+
+    /**
+     * @description Seeds one Feature__c per FeatureDefinition__mdt that does not
+     *              already have a matching runtime row. Idempotent: re-running
+     *              never duplicates existing seeded rows. Defaults the per-tenant
+     *              EnabledDateTime__c to the catalog's DefaultEnabledDateTime__c
+     *              (currently null for every shipped record — admins activate
+     *              features explicitly via the cockpit).
+     *
+     *              Logic relocated verbatim from
+     *              DeliveryHubInstallHandler.seedFeaturesFromDefinitions (pre-fix).
+     */
+    @TestVisible
+    private static void seedFeatures() {
+        List<FeatureDefinition__mdt> defs = [
+            SELECT DeveloperName, DefaultEnabledDateTime__c
+            FROM FeatureDefinition__mdt
+            WITH SYSTEM_MODE
+        ];
+        if (defs.isEmpty()) {
+            return;
+        }
+        Set<String> existingDefNames = new Set<String>();
+        for (Feature__c existing : [
+            SELECT FeatureDefinitionTxt__c FROM Feature__c
+            WHERE FeatureDefinitionTxt__c != null
+            WITH SYSTEM_MODE
+        ]) {
+            existingDefNames.add(existing.FeatureDefinitionTxt__c);
+        }
+        List<Feature__c> toInsert = new List<Feature__c>();
+        for (FeatureDefinition__mdt fd : defs) {
+            if (existingDefNames.contains(fd.DeveloperName)) {
+                continue;
+            }
+            toInsert.add(new Feature__c(
+                Name = fd.DeveloperName,
+                FeatureDefinitionTxt__c = fd.DeveloperName,
+                EnabledDateTime__c = fd.DefaultEnabledDateTime__c
+            ));
+        }
+        if (!toInsert.isEmpty()) {
+            insert toInsert;
+        }
+    }
+
+    /**
+     * @description Seeds the in-app sample-data DatasetTemplate__c rows that
+     *              the cockpit's "Load sample data" / "Remove sample data"
+     *              buttons (DeliveryDatasetLoader) drive. Currently ships ONE
+     *              template — Invoice Generation — linked to its Feature__c via
+     *              FeatureLookup__c so the deliveryDatasetTemplates LWC exposes
+     *              the load/remove actions on the feature record page.
+     *
+     *              Idempotent: keyed by the template Name, so a re-install /
+     *              upgrade never duplicates the seeded row.
+     *
+     *              Adding more datasets later: add a row to templateSeeds and a
+     *              matching branch in DeliveryDatasetLoader.resolveDatasetKey.
+     *
+     *              Logic relocated verbatim from
+     *              DeliveryHubInstallHandler.seedDatasetTemplates (pre-fix).
+     */
+    @TestVisible
+    private static void seedDatasetTemplates() {
+        // Map of template Name → linked FeatureDefinition DeveloperName.
+        Map<String, String> templateSeeds = new Map<String, String>{
+            'Invoice Generation Sample Data' => 'Invoice_Generation'
+        };
+
+        // Which seed names already exist (idempotency key = Name).
+        Set<String> existingNames = new Set<String>();
+        for (DatasetTemplate__c existing : [
+            SELECT Name FROM DatasetTemplate__c
+            WHERE Name IN :templateSeeds.keySet()
+            WITH SYSTEM_MODE
+        ]) {
+            existingNames.add(existing.Name);
+        }
+
+        // Resolve the runtime Feature__c rows for the seeds we still need.
+        Map<String, Id> featureIdByDefName = new Map<String, Id>();
+        for (Feature__c f : [
+            SELECT Id, FeatureDefinitionTxt__c FROM Feature__c
+            WHERE FeatureDefinitionTxt__c IN :templateSeeds.values()
+            WITH SYSTEM_MODE
+        ]) {
+            featureIdByDefName.put(f.FeatureDefinitionTxt__c, f.Id);
+        }
+
+        List<DatasetTemplate__c> toInsert = new List<DatasetTemplate__c>();
+        for (String templateName : templateSeeds.keySet()) {
+            if (existingNames.contains(templateName)) {
+                continue;
+            }
+            String defName = templateSeeds.get(templateName);
+            toInsert.add(new DatasetTemplate__c(
+                Name = templateName,
+                FeatureLookup__c = featureIdByDefName.get(defName),
+                DescriptionTxt__c = 'Loads clearly-marked sample data so you can '
+                    + 'see this feature in action. Records are tagged "[DH SAMPLE]" '
+                    + 'and can be removed in one click.',
+                ApexScriptPathTxt__c = 'scripts/feature-data/invoice_generation.apex',
+                RecordCountEstimateNumber__c = 17
+            ));
+        }
+        if (!toInsert.isEmpty()) {
+            insert toInsert;
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryHubInstallSeedQueueable.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryHubInstallSeedQueueable.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
## What

`DeliveryHubInstallHandler.seedFeaturesFromDefinitions()` and `seedDatasetTemplates()` are silently failing at install time on real subscriber orgs. This PR relocates both seed bodies into a new `DeliveryHubInstallSeedQueueable` and enqueues it from `onInstall` so the work runs in a fresh transaction AFTER `postInstall` commits.

## Why

**Verified empirically on release/0.252.0.3:** after install on both `dh-prod` and `nimba`, `Feature__c` and `DatasetTemplate__c` were each at 0 rows — yet `scheduleSyncJobs()`, which runs AFTER the seeds in `onInstall`, registered all four cron jobs cleanly. So the handler executed end-to-end; the seeds threw silently into their own try/catch.

The SAME seed logic, run as anonymous Apex outside the install transaction, inserts 6 Features + 1 DatasetTemplate cleanly. So the bodies themselves are fine — the bug is the transactional context.

Root cause is almost certainly a same-transaction interaction with `FeatureTrigger` / `DeliveryFeatureTriggerHandler`, which mirrors `Feature__c` onto `DeliveryHubSettings__c` on after-insert. The postInstall transaction's state at that moment doesn't tolerate the re-entry, and the install handler's defensive try/catch hid the error from CI for months.

## How

- **New** `DeliveryHubInstallSeedQueueable` — relocates `seedFeatures()` + `seedDatasetTemplates()` verbatim from the install handler (idempotency preserved, defaults preserved, sample-data row unchanged). Each seed body wrapped in its own try/catch so one failing doesn't block the other. `WITH SYSTEM_MODE` added on every SOQL per CLAUDE.md.
- **Edit** `DeliveryHubInstallHandler` — `onInstall` now calls `enqueueInstallSeed()` instead of running the two seeds inline. The two now-unused private methods are deleted. PMD-suppress annotations and other handler steps are unchanged.
- **Edit** `DeliveryHubInstallHandlerTest` — wraps the relevant `Test.testInstall` calls in `startTest`/`stopTest` so the enqueued Queueable executes before assertions. New `testInstallSeedsDatasetTemplate` covers the dataset-template seed (previously uncovered). New `testInstallEnqueuesSeedQueueable` asserts the AsyncApexJob is enqueued from `onInstall` — queried before `stopTest` so the job is still pending.

## Verification

- PMD: `sf scanner run --engine pmd --pmdconfig pmd-rules.xml --target <changed .cls>` → **No rule violations found.**
- Class name length: `DeliveryHubInstallSeedQueueable` = 31 chars; `+Test` suffix = 35. Under the 40-char packaging cap.
- The same logic running as anonymous Apex on dh-prod inserted 6 Features + 1 DatasetTemplate, confirming the bodies are correct outside the install transaction.

## Risk

Low. The seed logic is unchanged byte-for-byte (modulo `WITH SYSTEM_MODE`). The Queueable is enqueued, not invoked inline, so onInstall's existing happy-path is unaffected if the Queueable itself fails to enqueue (defensive try/catch around `System.enqueueJob`). Tests cover both the seed outcome and the enqueue itself.

## Why no `Test.isRunningTest()` guard

Queueables enqueued during `Test.testInstall(...)` execute when `Test.stopTest()` fires — that is precisely how the tests verify the seed outcome. A guard would break the tests and is unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)