### PR TITLE
fix(score): resolve entity context on record pages + graceful empty state

### DIFF
--- a/force-app/main/default/lwc/deliveryScore/deliveryScore.html
+++ b/force-app/main/default/lwc/deliveryScore/deliveryScore.html
@@ -2,7 +2,20 @@
     <lightning-card title="Delivery Score" icon-name="standard:calibration">
         <c-delivery-info-popover slot="actions" component-name="deliveryScore"></c-delivery-info-popover>
 
-        <!-- Loading spinner -->
+        <!-- Empty state — no client/entity context (e.g. on a record page
+             whose record is not linked to a NetworkEntity). Prevents the
+             "Loading score" infinite-spinner regression that hit MF prod on
+             WorkItem record pages without an explicit entityId. -->
+        <template lwc:if={showNoContext}>
+            <div class="slds-p-around_medium slds-text-align_center">
+                <p class="slds-text-body_regular slds-text-color_weak">No delivery score</p>
+                <p class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
+                    This record is not linked to a client.
+                </p>
+            </div>
+        </template>
+
+        <!-- Loading spinner — only while waiting for an in-flight wire. -->
         <template lwc:if={isLoading}>
             <div class="slds-p-around_large slds-align_absolute-center">
                 <lightning-spinner alternative-text="Loading score" size="medium"></lightning-spinner>

--- a/force-app/main/default/lwc/deliveryScore/deliveryScore.js
+++ b/force-app/main/default/lwc/deliveryScore/deliveryScore.js
@@ -1,12 +1,27 @@
 /**
  * @name         Delivery Hub
  * @license      BSL 1.1 — See LICENSE.md
- * @description  Delivery Score gauge — displays a 0-100 health rating for the delivery pipeline.
- *               Shows a circular SVG gauge with score/grade and an expandable factor breakdown.
+ * @description  Delivery Score gauge — displays a 0-100 health rating for the
+ *               delivery pipeline. Resolves the entity context in priority
+ *               order:
+ *                 1. an explicit `entityId` @api property (dashboard / app-page
+ *                    config),
+ *                 2. on a WorkItem__c record page — the work item's
+ *                    `ClientNetworkEntityLookup__c` (parent client),
+ *                 3. on a NetworkEntity__c record page — the recordId itself.
+ *               When none of those resolve (e.g. the component is placed on a
+ *               record page with no client linkage), the gauge renders a
+ *               friendly empty state rather than spinning forever — this is the
+ *               2026-05-29 fix for the "Loading score" stall on WorkItem record
+ *               pages that lacked an explicit entityId binding.
  * @author Cloud Nimbus LLC
  */
 import { LightningElement, api, wire, track } from "lwc";
+import { getRecord, getFieldValue } from "lightning/uiRecordApi";
 import getDeliveryScore from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryScoreService.getDeliveryScore";
+import WORK_ITEM_OBJECT from "@salesforce/schema/WorkItem__c";
+import WI_CLIENT_FIELD from "@salesforce/schema/WorkItem__c.ClientNetworkEntityLookup__c";
+import NETWORK_ENTITY_OBJECT from "@salesforce/schema/NetworkEntity__c";
 
 // SVG gauge constants
 const GAUGE_SIZE = 160;
@@ -15,11 +30,20 @@ const RADIUS = (GAUGE_SIZE - STROKE_WIDTH) / 2;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
 export default class DeliveryScore extends LightningElement {
+    /** Explicit NetworkEntity__c id — dashboard / app-page configuration. */
     @api entityId;
+
+    /** Lightning__RecordPage injects the current record id. */
+    @api recordId;
+
+    /** Lightning__RecordPage injects the namespaced object api name. */
+    @api objectApiName;
 
     @track result;
     @track expandedFactor = null;
     @track _animatedScore = 0;
+    @track _wiredClientId;
+    @track _wiredWorkItemReturned = false;
     error;
     isLoading = true;
 
@@ -27,10 +51,74 @@ export default class DeliveryScore extends LightningElement {
     _animationFrame = null;
     _mounted = false;
 
-    // ─── Wire ────────────────────────────────────────────────────────────
+    // ─── Entity context resolution ───────────────────────────────────────
 
-    @wire(getDeliveryScore, { entityId: "$entityId" })
+    /**
+     * The recordId to feed the WorkItem `getRecord` wire — null unless the
+     * component is on a WorkItem record page AND no explicit `entityId` was
+     * passed. Schema-import comparison keeps the check namespace-safe.
+     */
+    get workItemRecordIdToWire() {
+        if (this.entityId) return null;
+        if (!this.recordId || !this.objectApiName) return null;
+        return this.objectApiName === WORK_ITEM_OBJECT.objectApiName ? this.recordId : null;
+    }
+
+    @wire(getRecord, { recordId: "$workItemRecordIdToWire", fields: [WI_CLIENT_FIELD] })
+    wiredWorkItem({ data }) {
+        if (data) {
+            this._wiredClientId = getFieldValue(data, WI_CLIENT_FIELD) || null;
+            this._wiredWorkItemReturned = true;
+        }
+    }
+
+    /**
+     * The resolved entity to score against (or null if no context is
+     * available). Order: explicit @api → WI-derived client → direct
+     * NetworkEntity record page → null.
+     */
+    get effectiveEntityId() {
+        if (this.entityId) return this.entityId;
+        if (this._wiredClientId) return this._wiredClientId;
+        if (this.recordId && this.objectApiName === NETWORK_ENTITY_OBJECT.objectApiName) {
+            return this.recordId;
+        }
+        return null;
+    }
+
+    get hasEntityContext() {
+        return Boolean(this.effectiveEntityId);
+    }
+
+    /**
+     * True only when there is no entity context AND no pending lookup that
+     * could still produce one. Drives the friendly empty state in the template
+     * (prevents the "Loading score" infinite-spinner on a WorkItem page that
+     * has no client linkage).
+     */
+    get showNoContext() {
+        if (this.hasEntityContext) return false;
+        if (this.workItemRecordIdToWire && !this._wiredWorkItemReturned) {
+            return false; // still waiting on the WI record to come back
+        }
+        return true;
+    }
+
+    // ─── Wire — Apex score ───────────────────────────────────────────────
+
+    @wire(getDeliveryScore, { entityId: "$effectiveEntityId" })
     wiredScore({ data, error }) {
+        if (!this.effectiveEntityId) {
+            if (this.workItemRecordIdToWire && !this._wiredWorkItemReturned) {
+                // Still resolving the parent client — keep the spinner.
+                return;
+            }
+            // No way to resolve an entity here — show the empty state quietly.
+            this.result = undefined;
+            this.error = undefined;
+            this.isLoading = false;
+            return;
+        }
         if (data) {
             this.result = data;
             this.error = undefined;
@@ -174,7 +262,7 @@ export default class DeliveryScore extends LightningElement {
                 status: f.status,
                 isExpanded: isExpanded,
                 key: f.name,
-                statusIcon: f.status === "good" ? "\u2713" : f.status === "warning" ? "\u26A0" : "\u2717",
+                statusIcon: f.status === "good" ? "✓" : f.status === "warning" ? "⚠" : "✗",
                 statusColorClass: "status-icon status-" + f.status,
                 barColorClass: "factor-bar-fill bar-" + f.status,
                 barStyle: "width: " + f.score + "%",


### PR DESCRIPTION
Closes the "Loading score" infinite-spinner regression on the WorkItem record page in MF prod, and makes deliveryScore *useful* when placed on a WorkItem record page (shows the parent client's score by resolving `ClientNetworkEntityLookup__c`).

## What changed
- `deliveryScore.js` — adds `@api recordId`/`objectApiName`, derives the parent client via a namespace-safe `getRecord` wire against the WorkItem record, and falls back to a friendly empty state when there's no entity context.
- `deliveryScore.html` — adds an empty-state branch ("No delivery score / This record is not linked to a client") so the spinner only shows while a wire is genuinely in flight.

## Safety
- Every object/field reference goes through `@salesforce/schema/*` imports — no raw-string `getRecord` field strings introduced, namespace-safe in managed/unmanaged contexts.
- Behavior matrix:
  - On a WorkItem record page with a linked client → fetches the client id and scores against it.
  - On a WorkItem record page with no linked client → empty state, no spinner.
  - On a NetworkEntity record page → uses recordId directly as entityId (no extra fetch).
  - With an explicit `@api entityId` (app/home page config) → unchanged behavior.

Verified on MF prod WorkItem T-0194 in the user's session — the "Loading score" stall is the exact symptom this addresses.

Note: this PR does **not** address the separate pre-existing "fields query string contained object api names: [WorkItem__c]" LDS error on the same page — that's a client-side `uiRecordApi` error from a different component (Apex execution logs are namespace-clean throughout) and most likely an unmanaged shadow LWC in the org, not a code issue in the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)