### PR TITLE
fix(hours-pills): namespace-safe field imports — kills WorkItem__c LDS error on MF prod

### DIFF
--- a/force-app/main/default/lwc/deliveryHoursPills/deliveryHoursPills.js
+++ b/force-app/main/default/lwc/deliveryHoursPills/deliveryHoursPills.js
@@ -6,20 +6,31 @@
  *               logged hours). Mirrors the Project_Health_Pills dashboard card. Mounts on the
  *               WorkItem__c record page; reads via lightning/uiRecordApi (no Apex round-trip).
  *               Suppresses itself for terminal stages (Done / Cancelled / Closed / Rejected).
+ *
+ *               Fields are imported via @salesforce/schema so the platform resolves the
+ *               namespace at compile time — `delivery__WorkItem__c.delivery__Field__c` in
+ *               the managed package, plain `WorkItem__c.Field__c` in unmanaged. The earlier
+ *               version used `%%%NAMESPACE_DOT%%%` tokens in raw string literals; that
+ *               pattern does NOT round-trip through CCI's namespace injector for JS array
+ *               contents, which produced the "fields query string parameter contained
+ *               object api names: [WorkItem__c]" LDS error on MF prod's WorkItem record
+ *               page (mismatching the record's `delivery__WorkItem__c` type). Fixed 2026-05-29.
  * @author       Cloud Nimbus LLC
  */
 import { LightningElement, api, wire } from "lwc";
-import { getRecord } from "lightning/uiRecordApi";
+import { getRecord, getFieldValue } from "lightning/uiRecordApi";
+import ESTIMATED_HOURS_FIELD from "@salesforce/schema/WorkItem__c.EstimatedHoursNumber__c";
+import TOTAL_LOGGED_HOURS_FIELD from "@salesforce/schema/WorkItem__c.TotalLoggedHoursSum__c";
+import CALCULATED_ETA_FIELD from "@salesforce/schema/WorkItem__c.CalculatedETADate__c";
+import ESTIMATED_END_DEV_FIELD from "@salesforce/schema/WorkItem__c.EstimatedEndDevDate__c";
+import STAGE_FIELD from "@salesforce/schema/WorkItem__c.StageNamePk__c";
 
-// Field references — namespaced at runtime via the @salesforce/schema scheme is unavailable
-// for managed-package fields used outside the package, so we use string field names that
-// the bundler resolves through %%%NAMESPACE_DOT%%% replacement.
 const FIELDS = [
-    "%%%NAMESPACE_DOT%%%WorkItem__c.%%%NAMESPACE_DOT%%%EstimatedHoursNumber__c",
-    "%%%NAMESPACE_DOT%%%WorkItem__c.%%%NAMESPACE_DOT%%%TotalLoggedHoursSum__c",
-    "%%%NAMESPACE_DOT%%%WorkItem__c.%%%NAMESPACE_DOT%%%CalculatedETADate__c",
-    "%%%NAMESPACE_DOT%%%WorkItem__c.%%%NAMESPACE_DOT%%%EstimatedEndDevDate__c",
-    "%%%NAMESPACE_DOT%%%WorkItem__c.%%%NAMESPACE_DOT%%%StageNamePk__c"
+    ESTIMATED_HOURS_FIELD,
+    TOTAL_LOGGED_HOURS_FIELD,
+    CALCULATED_ETA_FIELD,
+    ESTIMATED_END_DEV_FIELD,
+    STAGE_FIELD
 ];
 
 const TERMINAL_STAGES = new Set(["Done", "Cancelled", "Closed", "Rejected"]);
@@ -43,37 +54,23 @@ export default class DeliveryHoursPills extends LightningElement {
         return !!this.record && !this.errorMessage;
     }
 
-    // ── Field readers (LDS getRecord shape) ───────────────────────
-
-    _field(apiName) {
-        if (!this.record || !this.record.fields) {
-            return null;
-        }
-        const namespacedKey = Object.keys(this.record.fields).find(
-            (k) => k.toLowerCase() === apiName.toLowerCase()
-                || k.toLowerCase().endsWith("__" + apiName.toLowerCase())
-        );
-        if (!namespacedKey) {
-            return null;
-        }
-        const f = this.record.fields[namespacedKey];
-        return f ? f.value : null;
-    }
+    // ── Field readers (namespace-safe via schema imports) ─────────
 
     get _estimated() {
-        return Number(this._field("EstimatedHoursNumber__c") || 0);
+        return Number(getFieldValue(this.record, ESTIMATED_HOURS_FIELD) || 0);
     }
 
     get _logged() {
-        return Number(this._field("TotalLoggedHoursSum__c") || 0);
+        return Number(getFieldValue(this.record, TOTAL_LOGGED_HOURS_FIELD) || 0);
     }
 
     get _eta() {
-        return this._field("CalculatedETADate__c") || this._field("EstimatedEndDevDate__c");
+        return getFieldValue(this.record, CALCULATED_ETA_FIELD)
+            || getFieldValue(this.record, ESTIMATED_END_DEV_FIELD);
     }
 
     get _stage() {
-        return this._field("StageNamePk__c");
+        return getFieldValue(this.record, STAGE_FIELD);
     }
 
     // ── Pill computation ──────────────────────────────────────────


### PR DESCRIPTION
## What

Kills the **"fields query string parameter contained object api names: [WorkItem__c], while the requested records had object types: [delivery__WorkItem__c]"** LDS error on the WorkItem record page in MF prod (the same error that crashes App Builder's property editor for this component — confirmed by the user's browser-console stack from `builder_framework/visualEditorPropertyEditorWrapper.js`).

## Root cause

`deliveryHoursPills.js` declared its FIELDS array as raw string literals using `"%%%NAMESPACE_DOT%%%WorkItem__c.%%%NAMESPACE_DOT%%%EstimatedHoursNumber__c"` etc. — relying on CCI's namespace-token injector to substitute `%%%NAMESPACE_DOT%%%` → `delivery__` at build time. That substitution is reliable for **Apex import paths** (`@salesforce/apex/%%%NAMESPACE_DOT%%%Class.method`) and **HTML attributes** (`object-api-name="%%%NAMESPACE_DOT%%%WorkItem__c"`), but **NOT** for arbitrary string contents inside JS array constants. The tokens got stripped to empty in the deployed managed-package file, leaving raw `WorkItem__c.Field__c` strings — which LDS correctly rejected against `delivery__WorkItem__c` records.

The comment on the old line 14 ("@salesforce/schema scheme is unavailable for managed-package fields") is simply incorrect — every other WI-record-page LWC in this package uses `@salesforce/schema/WorkItem__c.X` imports successfully (deliveryWorkItemActionCenter, deliveryTimeLogger, deliveryWorkItemStageGateWarning, deliveryRecurringConfig, deliveryWorkItemRefiner, deliveryWorkItemProgress).

## Fix

- FIELDS now uses `@salesforce/schema/WorkItem__c.<Field>` imports — namespace-correct in both managed and unmanaged contexts.
- Field readers (`_estimated`, `_logged`, `_eta`, `_stage`) switched from a bespoke `_field(apiName)` key-search helper to idiomatic `getFieldValue(record, FIELD_CONSTANT)`.
- Behavior is otherwise unchanged (pill labels, bands, thresholds, terminal-stage handling, formatters — all preserved).

## Scope-of-fix verification

A repo-wide search for the broken pattern (`"%%%NAMESPACE_DOT%%%X.%%%NAMESPACE_DOT%%%Y"` in JS) returned exactly **one** match: this file. No other LWC has the same bug.

## Verified against the captured user error

User shared the browser-console stack:
```
The "fields" query string parameter contained object api names that do not correspond to the api names of any of the requested record ids. The requested object api names were: [WorkItem__c], while the requested records had object types: [delivery__WorkItem__c]
Error creating property editor: []
```
…with the identification "this is the delivery hours pills lwc". This PR addresses exactly that component and exactly that error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)