### PR TITLE
fix(nav): namespace-safe objectApiName in NavigationMixin pageReferences

### DIFF
--- a/force-app/main/default/lwc/deliveryActivityDashboard/deliveryActivityDashboard.js
+++ b/force-app/main/default/lwc/deliveryActivityDashboard/deliveryActivityDashboard.js
@@ -11,6 +11,7 @@
 import { LightningElement, track, wire } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
 import { refreshApex } from '@salesforce/apex';
+import ACTIVITY_LOG_OBJECT from '@salesforce/schema/ActivityLog__c';
 import getActivitySummary from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryActivityDashboardController.getActivitySummary';
 import getReportIds from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.getReportIds';
 
@@ -194,7 +195,13 @@ export default class DeliveryActivityDashboard extends NavigationMixin(Lightning
         this[NavigationMixin.Navigate]({ // eslint-disable-line new-cap
             attributes: {
                 actionName: 'list',
-                objectApiName: '%%%NAMESPACE_DOT%%%ActivityLog__c'
+                // Schema-import keeps the object api name namespace-correct in
+                // both managed (`delivery__ActivityLog__c`) and unmanaged
+                // contexts. The earlier `%%%NAMESPACE_DOT%%%` string literal
+                // did NOT round-trip through CCI's namespace injector inside
+                // JS objects and silently produced a broken nav target on
+                // managed installs.
+                objectApiName: ACTIVITY_LOG_OBJECT.objectApiName
             },
             state: {
                 filterName: 'Recent'

--- a/force-app/main/default/lwc/deliveryDependencyGraph/deliveryDependencyGraph.js
+++ b/force-app/main/default/lwc/deliveryDependencyGraph/deliveryDependencyGraph.js
@@ -8,6 +8,7 @@
  */
 import { LightningElement, api, wire, track } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
+import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
 import getDependencyGraph from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDependencyGraphController.getDependencyGraph';
 import getProjectDependencyGraph from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDependencyGraphController.getProjectDependencyGraph';
 import getWorkflowConfig from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkflowConfigService.getWorkflowConfig';
@@ -452,7 +453,11 @@ export default class DeliveryDependencyGraph extends NavigationMixin(LightningEl
                 type: 'standard__recordPage',
                 attributes: {
                     recordId: nodeId,
-                    objectApiName: '%%%NAMESPACE_DOT%%%WorkItem__c',
+                    // Schema-import keeps the object api name namespace-correct
+                    // in both managed and unmanaged contexts; the earlier
+                    // `%%%NAMESPACE_DOT%%%` string literal did NOT round-trip
+                    // through CCI's namespace injector inside JS objects.
+                    objectApiName: WORK_ITEM_OBJECT.objectApiName,
                     actionName: 'view'
                 }
             });


### PR DESCRIPTION
Companion to PR #850 — same root cause (`%%%NAMESPACE_DOT%%%` tokens don't round-trip through CCI's namespace injector inside JS object/array literals), applied to two `NavigationMixin` pageReferences:

- `deliveryActivityDashboard.js:197` — Activity Logs list-view nav.
- `deliveryDependencyGraph.js:455` — record-page nav from a graph node.

Switches both to `@salesforce/schema/<Object>` imports + `OBJECT.objectApiName` — the platform resolves the namespace at compile time. Pattern matches the working record-page LWCs (`deliveryWorkItemActionCenter`, `deliveryTimeLogger`, etc.).

Found via the namespace-gap repo sweep after the `deliveryHoursPills` fix landed in #850. These were the only other two sites with the same broken pattern; the rest of `%%%NAMESPACE_DOT%%%` usage in the repo is in safe positions (Apex import paths, platform-event channel names, HTML attributes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)