### PR TITLE
fix(lwc): namespace-safe objectApiName/field refs across 12 components (#851 sweep tail)

### DIFF
--- a/force-app/main/default/lwc/deliveryBoardMetrics/deliveryBoardMetrics.js
+++ b/force-app/main/default/lwc/deliveryBoardMetrics/deliveryBoardMetrics.js
@@ -10,6 +10,7 @@ import { LightningElement, api, wire, track } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
 import { refreshApex } from '@salesforce/apex';
 import { subscribe, unsubscribe, onError } from 'lightning/empApi';
+import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
 import getBoardMetrics from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryMetricsService.getBoardMetrics';
 
 // Live updates — same channel + filter pattern as deliveryHubBoard.
@@ -365,7 +366,7 @@ export default class DeliveryBoardMetrics extends NavigationMixin(LightningEleme
         this[NavigationMixin.Navigate]({
             type: 'standard__objectPage',
             attributes: {
-                objectApiName: '%%%NAMESPACE_DOT%%%WorkItem__c',
+                objectApiName: WORK_ITEM_OBJECT.objectApiName,
                 actionName: 'list'
             }
         });

--- a/force-app/main/default/lwc/deliveryBudgetSummary/deliveryBudgetSummary.js
+++ b/force-app/main/default/lwc/deliveryBudgetSummary/deliveryBudgetSummary.js
@@ -12,6 +12,9 @@
  */
 import { LightningElement, api, track, wire } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
+import SYNC_ITEM_OBJECT from '@salesforce/schema/SyncItem__c';
+import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
+import WORK_LOG_OBJECT from '@salesforce/schema/WorkLog__c';
 import getBudgetMetrics from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.getBudgetMetrics';
 import getReportIds from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.getReportIds';
 import { refreshApex } from '@salesforce/apex';
@@ -106,7 +109,7 @@ export default class DeliveryBudgetSummary extends NavigationMixin(LightningElem
             this[NavigationMixin.Navigate]({ type: 'standard__webPage', attributes: { url: `/lightning/r/Report/${reportId}/view` } });
             return;
         }
-        this[NavigationMixin.Navigate]({ type: 'standard__objectPage', attributes: { objectApiName: '%%%NAMESPACE_DOT%%%SyncItem__c', actionName: 'list' }, state: { filterName: 'Recent' } });
+        this[NavigationMixin.Navigate]({ type: 'standard__objectPage', attributes: { objectApiName: SYNC_ITEM_OBJECT.objectApiName, actionName: 'list' }, state: { filterName: 'Recent' } });
     }
 
     handleFailedClick() {
@@ -115,7 +118,7 @@ export default class DeliveryBudgetSummary extends NavigationMixin(LightningElem
             this[NavigationMixin.Navigate]({ type: 'standard__webPage', attributes: { url: `/lightning/r/Report/${reportId}/view` } });
             return;
         }
-        this[NavigationMixin.Navigate]({ type: 'standard__objectPage', attributes: { objectApiName: '%%%NAMESPACE_DOT%%%SyncItem__c', actionName: 'list' }, state: { filterName: 'Recent' } });
+        this[NavigationMixin.Navigate]({ type: 'standard__objectPage', attributes: { objectApiName: SYNC_ITEM_OBJECT.objectApiName, actionName: 'list' }, state: { filterName: 'Recent' } });
     }
 
     handleRefresh() {
@@ -140,7 +143,7 @@ export default class DeliveryBudgetSummary extends NavigationMixin(LightningElem
         this[NavigationMixin.Navigate]({
             type: 'standard__objectPage',
             attributes: {
-                objectApiName: '%%%NAMESPACE_DOT%%%WorkItem__c',
+                objectApiName: WORK_ITEM_OBJECT.objectApiName,
                 actionName: 'list'
             },
             state: { filterName: 'In_Flight' }
@@ -183,7 +186,7 @@ export default class DeliveryBudgetSummary extends NavigationMixin(LightningElem
         }
         this[NavigationMixin.Navigate]({
             type: 'standard__objectPage',
-            attributes: { objectApiName: '%%%NAMESPACE_DOT%%%WorkLog__c', actionName: 'list' },
+            attributes: { objectApiName: WORK_LOG_OBJECT.objectApiName, actionName: 'list' },
             state: { filterName: offsetMonths === 0 ? 'This_Month' : 'Last_Month' }
         });
     }

--- a/force-app/main/default/lwc/deliveryClientDashboard/deliveryClientDashboard.js
+++ b/force-app/main/default/lwc/deliveryClientDashboard/deliveryClientDashboard.js
@@ -12,6 +12,8 @@ import { LightningElement, api, wire, track } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
 import { refreshApex } from '@salesforce/apex';
 import { getRecord, getFieldValue } from 'lightning/uiRecordApi';
+import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
+import WORK_LOG_OBJECT from '@salesforce/schema/WorkLog__c';
 import getClientDashboard from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.getClientDashboard';
 import getReportIds from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.getReportIds';
 import getWorkflowConfig from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkflowConfigService.getWorkflowConfig';
@@ -407,7 +409,7 @@ export default class DeliveryClientDashboard extends NavigationMixin(LightningEl
         this[NavigationMixin.Navigate]({ // eslint-disable-line new-cap
             attributes: {
                 actionName: 'view',
-                objectApiName: '%%%NAMESPACE_DOT%%%WorkItem__c',
+                objectApiName: WORK_ITEM_OBJECT.objectApiName,
                 recordId
             },
             type: 'standard__recordPage'
@@ -463,7 +465,7 @@ export default class DeliveryClientDashboard extends NavigationMixin(LightningEl
             this[NavigationMixin.Navigate]({ // eslint-disable-line new-cap
                 attributes: {
                     actionName: 'list',
-                    objectApiName: fallbackObject || '%%%NAMESPACE_DOT%%%WorkItem__c'
+                    objectApiName: fallbackObject || WORK_ITEM_OBJECT.objectApiName
                 },
                 state: { filterName: fallbackListView },
                 type: 'standard__objectPage'
@@ -493,7 +495,7 @@ export default class DeliveryClientDashboard extends NavigationMixin(LightningEl
             this[NavigationMixin.Navigate]({ // eslint-disable-line new-cap
                 attributes: {
                     actionName: 'list',
-                    objectApiName: '%%%NAMESPACE_DOT%%%WorkLog__c'
+                    objectApiName: WORK_LOG_OBJECT.objectApiName
                 },
                 state: { filterName: 'This_Month' },
                 type: 'standard__objectPage'

--- a/force-app/main/default/lwc/deliveryDocumentViewer/deliveryDocumentViewer.js
+++ b/force-app/main/default/lwc/deliveryDocumentViewer/deliveryDocumentViewer.js
@@ -196,7 +196,7 @@ export default class DeliveryDocumentViewer extends LightningElement {
             const objName = pageRef.attributes?.objectApiName || '';
             if (recId && !this.networkEntityId) {
                 // If we're on a Document record page, load that document directly
-                if (objName === '%%%NAMESPACE_DOT%%%DeliveryDocument__c' || objName === 'DeliveryDocument__c') {
+                if (objName === DOC_OBJECT.objectApiName) {
                     this.loadDocumentById(recId);
                 } else {
                     this.effectiveEntityId = recId;

--- a/force-app/main/default/lwc/deliveryExecutiveDashboard/deliveryExecutiveDashboard.js
+++ b/force-app/main/default/lwc/deliveryExecutiveDashboard/deliveryExecutiveDashboard.js
@@ -10,6 +10,7 @@
  * @author       Cloud Nimbus LLC
  */
 import { LightningElement, api, track } from 'lwc';
+import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
 import getCardsForPage from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDashboardCardController.getCardsForPage';
 import getCardData from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDashboardCardController.getCardData';
 
@@ -149,10 +150,9 @@ export default class DeliveryExecutiveDashboard extends LightningElement {
     }
 
     workItemApiName() {
-        // Hardcoded namespace prefix is replaced at package-build time on
-        // subscriber orgs. In source it stays as the placeholder so the
-        // packaging tool can rewrite it.
-        return '%%%NAMESPACE%%%WorkItem__c';
+        // Namespace-safe object API name resolved via @salesforce/schema import;
+        // resolves correctly on managed (delivery__) and unmanaged installs alike.
+        return WORK_ITEM_OBJECT.objectApiName;
     }
 
     get hasCards() {

--- a/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.js
+++ b/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.js
@@ -15,6 +15,7 @@ import { LightningElement, wire, track } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
 import { refreshApex } from '@salesforce/apex';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import FEATURE_OBJECT from '@salesforce/schema/Feature__c';
 import getCatalog from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.getCatalog';
 import isAdminApex from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.isAdmin';
 import toggleFeature from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.toggleFeature';
@@ -203,7 +204,7 @@ export default class DeliveryFeatureCockpit extends NavigationMixin(LightningEle
                 type: 'standard__recordPage',
                 attributes: {
                     recordId: featureId,
-                    objectApiName: '%%%NAMESPACE_DOT%%%Feature__c',
+                    objectApiName: FEATURE_OBJECT.objectApiName,
                     actionName: 'view'
                 }
             })
@@ -241,7 +242,7 @@ export default class DeliveryFeatureCockpit extends NavigationMixin(LightningEle
             type: 'standard__recordPage',
             attributes: {
                 recordId: featureId,
-                objectApiName: '%%%NAMESPACE_DOT%%%Feature__c',
+                objectApiName: FEATURE_OBJECT.objectApiName,
                 actionName: 'view'
             }
         });

--- a/force-app/main/default/lwc/deliveryGhostRecorder/deliveryGhostRecorder.js
+++ b/force-app/main/default/lwc/deliveryGhostRecorder/deliveryGhostRecorder.js
@@ -12,6 +12,7 @@
 import { LightningElement, api, track, wire } from 'lwc';
 import { CurrentPageReference, NavigationMixin } from 'lightning/navigation';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
 import createWorkItem from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGhostController.createQuickRequest';
 import logActivity from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryGhostController.logUserActivity';
 import getAttentionCount from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.getAttentionCount';
@@ -88,7 +89,7 @@ export default class DeliveryGhostRecorder extends NavigationMixin(LightningElem
 
     navigateToAttentionListView() {
         this[NavigationMixin.Navigate]({ // eslint-disable-line new-cap
-            attributes: { actionName: 'list', objectApiName: '%%%NAMESPACE_DOT%%%WorkItem__c' },
+            attributes: { actionName: 'list', objectApiName: WORK_ITEM_OBJECT.objectApiName },
             state: { filterName: 'In_Flight' },
             type: 'standard__objectPage'
         });

--- a/force-app/main/default/lwc/deliveryRecurringConfig/deliveryRecurringConfig.js
+++ b/force-app/main/default/lwc/deliveryRecurringConfig/deliveryRecurringConfig.js
@@ -11,6 +11,7 @@ import { getRecord, getFieldValue, updateRecord } from "lightning/uiRecordApi";
 import { NavigationMixin } from "lightning/navigation";
 import { ShowToastEvent } from "lightning/platformShowToastEvent";
 
+import WORK_ITEM_OBJECT from "@salesforce/schema/WorkItem__c";
 import IS_RECURRING_FIELD from "@salesforce/schema/WorkItem__c.RecurringEnabledDateTime__c";
 import IS_TEMPLATE_FIELD from "@salesforce/schema/WorkItem__c.TemplateMarkedDateTime__c";
 import RECURRENCE_SCHEDULE_FIELD from "@salesforce/schema/WorkItem__c.RecurrenceScheduleTxt__c";
@@ -132,7 +133,7 @@ export default class DeliveryRecurringConfig extends NavigationMixin(LightningEl
                 type: "standard__recordPage",
                 attributes: {
                     recordId: this.templateSourceId,
-                    objectApiName: "%%%NAMESPACE_DOT%%%WorkItem__c",
+                    objectApiName: WORK_ITEM_OBJECT.objectApiName,
                     actionName: "view"
                 }
             });

--- a/force-app/main/default/lwc/deliveryVoiceNotes/deliveryVoiceNotes.js
+++ b/force-app/main/default/lwc/deliveryVoiceNotes/deliveryVoiceNotes.js
@@ -12,6 +12,7 @@
 import { LightningElement, track, wire } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
 import createWorkItemFromVoice from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryVoiceNotesController.createWorkItemFromVoice';
 import createBatchWorkItems from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryVoiceNotesController.createBatchWorkItems';
 import getEntityNames from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryVoiceNotesController.getEntityNames';
@@ -500,7 +501,7 @@ export default class DeliveryVoiceNotes extends NavigationMixin(LightningElement
             this[NavigationMixin.Navigate]({ // eslint-disable-line new-cap
                 attributes: {
                     actionName: 'view',
-                    objectApiName: '%%%NAMESPACE_DOT%%%WorkItem__c',
+                    objectApiName: WORK_ITEM_OBJECT.objectApiName,
                     recordId: recordId
                 },
                 type: 'standard__recordPage'

--- a/force-app/main/default/lwc/deliveryWorkItemRefiner/deliveryWorkItemRefiner.js
+++ b/force-app/main/default/lwc/deliveryWorkItemRefiner/deliveryWorkItemRefiner.js
@@ -16,6 +16,7 @@ import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 // Work Item Object & Fields to Read
 import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
 import WORK_ITEM_HOURS from '@salesforce/schema/WorkItem__c.ClientPreApprovedHoursNumber__c';
+import ACCEPTANCE_CRITERIA_FIELD from '@salesforce/schema/WorkItem__c.AcceptanceCriteriaTxt__c';
 
 // Request Object & Fields to Write
 import REQUEST_OBJ from '@salesforce/schema/WorkRequest__c';
@@ -69,7 +70,7 @@ export default class DeliveryWorkItemRefiner extends NavigationMixin(LightningEl
 
     handleApplyCriteria() {
         const field = this.template.querySelector(
-            'lightning-input-field[field-name="%%%NAMESPACE_DOT%%%AcceptanceCriteriaTxt__c"]'
+            `lightning-input-field[field-name="${ACCEPTANCE_CRITERIA_FIELD.fieldApiName}"]`
         );
         if (field) {
             field.value = this.suggestedCriteria;
@@ -131,7 +132,7 @@ export default class DeliveryWorkItemRefiner extends NavigationMixin(LightningEl
             type: 'standard__recordPage',
             attributes: {
                 recordId: this.newRequestId,
-                objectApiName: '%%%NAMESPACE_DOT%%%WorkRequest__c',
+                objectApiName: REQUEST_OBJ.objectApiName,
                 actionName: 'view'
             }
         });

--- a/force-app/main/default/lwc/deliveryWorkItemTemplates/deliveryWorkItemTemplates.js
+++ b/force-app/main/default/lwc/deliveryWorkItemTemplates/deliveryWorkItemTemplates.js
@@ -10,6 +10,7 @@ import { LightningElement, wire, track } from "lwc";
 import { NavigationMixin } from "lightning/navigation";
 import { ShowToastEvent } from "lightning/platformShowToastEvent";
 
+import WORK_ITEM_OBJECT from "@salesforce/schema/WorkItem__c";
 import getTemplates from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryRecurringItemService.getTemplates";
 import cloneFromTemplate from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryRecurringItemService.cloneFromTemplate";
 
@@ -137,7 +138,7 @@ export default class DeliveryWorkItemTemplates extends NavigationMixin(Lightning
                 type: "standard__recordPage",
                 attributes: {
                     recordId: newId,
-                    objectApiName: "%%%NAMESPACE_DOT%%%WorkItem__c",
+                    objectApiName: WORK_ITEM_OBJECT.objectApiName,
                     actionName: "view"
                 }
             });


### PR DESCRIPTION
## Origin

Unremediated **tail** of the #850 / #851 / #853 namespace-safety fixes. An audit found 12 remaining High-severity bugs: `%%%NAMESPACE_DOT%%%` / `%%%NAMESPACE%%%` tokens sitting **inside JS string literals** used as object/field references.

Token replacement only runs in Apex import paths and HTML attributes — **not** inside arbitrary JS strings. So these literals shipped verbatim to managed orgs where records are `delivery__Obj__c`, breaking NavigationMixin nav, record-page compares, and `querySelector` field-name selectors. Canonical fingerprint is the same LDS / nav object-api-name mismatch chased on MF prod.

## Fix pattern (proven in #850/#851/#853)

Import the object/field via `@salesforce/schema` and use the namespace-agnostic `OBJECT.objectApiName` (nav/compare) or `FIELD.fieldApiName` (selectors). No `_vfPrefix` helper, no token in JS.

## 12 bug sites fixed (11 files)

| Component | Fix |
|---|---|
| deliveryExecutiveDashboard | `workItemApiName()` return → `WORK_ITEM_OBJECT.objectApiName` |
| deliveryDocumentViewer | `DeliveryDocument__c` record-page compare → `DOC_OBJECT.objectApiName` |
| deliveryWorkItemRefiner | `AcceptanceCriteriaTxt__c` selector → `${ACCEPTANCE_CRITERIA_FIELD.fieldApiName}` template literal; `WorkRequest__c` nav → reuse existing `REQUEST_OBJ.objectApiName` |
| deliveryVoiceNotes | `WorkItem__c` nav |
| deliveryRecurringConfig | `WorkItem__c` nav |
| deliveryWorkItemTemplates | `WorkItem__c` nav |
| deliveryGhostRecorder | `WorkItem__c` nav |
| deliveryBudgetSummary | `SyncItem__c` (×2), `WorkItem__c`, `WorkLog__c` nav |
| deliveryClientDashboard | `WorkItem__c` (×2), `WorkLog__c` nav (fallback semantics preserved) |
| deliveryBoardMetrics | `WorkItem__c` nav |
| deliveryFeatureCockpit | `Feature__c` GenerateUrl + Navigate |

## Deliberately NOT touched

- **A13 / `deliveryGuide`** — deferred to a separate PR.
- **Apex import paths** (`@salesforce/apex/%%%NAMESPACE_DOT%%%…`) and the **PE_CHANNEL** (`/event/%%%NAMESPACE_DOT%%%…__e`) string — token replacement works correctly in those positions.
- **PE-channel subscription + createRecord field-key injection** — these appear to work on prod today; left as-is pending separate verification rather than changed speculatively.
- README — untouched.

## Verification

- `npm run test:lwc`: **before 24 failed / 605 passed**, **after 24 failed / 605 passed** — the 24 are known pre-existing failures in unrelated suites (deliveryDependencyGraph, deliveryActivityLog, deliveryInvoicePreviewDeferPanel, deliveryFeatureDependencyEditor, deliveryFeatureApprovalSubmit, deliveryFeatureCascadePreview). **Zero new failures.** The two edited components with tests (deliveryClientDashboard, deliveryFeatureCockpit) pass.
- Grep confirms no JS-literal object/field token remains in any of the 11 files (only legitimate Apex-import-path + PE_CHANNEL tokens left).
- All referenced schema objects/field exist in metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)