### PR TITLE
docs(readme): bump install pin to release/0.256.0.2 (04tQr000000VhdNIAS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ It is open source under the [BSL 1.1 license](LICENSE.md) and ships as an unlock
 
 ## Install
 
-**Current release**: [`release/0.248.0.3`](https://github.com/Nimba-Solutions/Delivery-Hub/releases) (production-promoted 2026-05-25). See [GitHub Releases](https://github.com/Nimba-Solutions/Delivery-Hub/releases) for the full version history.
+**Current release**: [`release/0.256.0.2`](https://github.com/Nimba-Solutions/Delivery-Hub/releases) (production-promoted 2026-05-31). See [GitHub Releases](https://github.com/Nimba-Solutions/Delivery-Hub/releases) for the full version history.
 
 | Environment | Link |
 |---|---|
-| **Production** | [![Install in Production](https://img.shields.io/badge/Install-Production-0070d2?logo=salesforce&style=for-the-badge)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000Vgz3IAC) |
-| **Sandbox** | [![Install in Sandbox](https://img.shields.io/badge/Install-Sandbox-3e8b3e?logo=salesforce&style=for-the-badge)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000Vgz3IAC) |
+| **Production** | [![Install in Production](https://img.shields.io/badge/Install-Production-0070d2?logo=salesforce&style=for-the-badge)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000VhdNIAS) |
+| **Sandbox** | [![Install in Sandbox](https://img.shields.io/badge/Install-Sandbox-3e8b3e?logo=salesforce&style=for-the-badge)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000VhdNIAS) |
 
 **Quickstart (≈5 minutes):**
 
@@ -75,7 +75,7 @@ Delivery Hub ships **two Lightning apps**:
 - **Delivery Hub** — end-user app: Home, Workspace, Board, Timeline, Activity Feed, Voice Notes, Guide
 - **Delivery Hub Admin** — admin/superuser app: everything above plus all object tabs, cockpit objects, Permission Analyzer, Settings
 
-### Admin app tabs (current as of `release/0.252.0.3`)
+### Admin app tabs (current as of `release/0.256.0.2`)
 
 `Home` · `Workspace` · `WorkItem` · `Board` · `Timeline` · `Activity` · `Activity Dashboard` · `NetworkEntity` · `WorkRequest` · `WorkItemComment` · `SyncItem` · `ActivityLog` · **`Feature`** · **`FeatureToggleRequest`** · **`WatcherDigest`** · **`ScratchOrgInstance`** · `Permission Analyzer` · `Settings` · `Guide` · `Reports`
 


### PR DESCRIPTION
Catches the README up from a stale `release/0.248.0.3` pin (it had missed 0.252→0.255 entirely) to the current **`release/0.256.0.2`** / pkg `04tQr000000VhdNIAS`, production-promoted 2026-05-31.

0.256.0.2 carries:
- **#854** — `deliveryHoursPills` Infinity / divide-by-zero fix
- **#855** — 12-component namespace-safe `objectApiName`/field-ref sweep (the unremediated tail of #850/#851/#853)
- **#856** — `DeliveryActivityLogCleanup` wired behind the `EnableActivityLogCleanupDateTime__c` opt-in gate (off by default)

Updates: Install "Current release" line, both Production + Sandbox install badge package IDs, and the admin-app-tabs version reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)