### PR TITLE
fix(docgen): period-scope invoice snapshot WorkRequests + field-cap guard

### DIFF
--- a/force-app/main/default/classes/DeliveryDocGenerationService.cls
+++ b/force-app/main/default/classes/DeliveryDocGenerationService.cls
@@ -86,6 +86,14 @@ public with sharing class DeliveryDocGenerationService {
             Database.update(prev, AccessLevel.SYSTEM_MODE);
         }
 
+        // Bound the snapshot to the SnapshotTxt__c field cap (131,072) BEFORE we
+        // hash + persist. On long-lived entities the serialized snapshot can
+        // exceed the field length and hard-fail the insert with STRING_TOO_LONG;
+        // this trims display-only text (never hours/rates) to fit, or fails loud
+        // with diagnostics if it still cannot. Must run before the hash so the
+        // stored JSON and the tamper-evidence hash describe the same bytes.
+        boundSnapshotToFieldCap(snapshot, templateType);
+
         // Phase 4: anchor the tamper-evidence chain. The document hash is a
         // SHA-256 over the frozen snapshot JSON; any later mutation of the
         // snapshot would change the hash and break the chain that signers
@@ -219,7 +227,26 @@ public with sharing class DeliveryDocGenerationService {
         }
         snapshot.put('workLogs', serializeWorkLogs(logs));
 
-        // Work requests (for rates and status)
+        // Work requests (for rates and status). Scope to the work items that
+        // actually carry logged time in the period for money/hours templates.
+        // Previously this pulled EVERY WorkRequest ever linked to the entity (no
+        // period, no hours filter); on long-lived entities with hundreds of
+        // historical WorkRequests the serialized snapshot overflowed the
+        // SnapshotTxt__c field cap (131,072) and hard-failed the insert with
+        // STRING_TOO_LONG. Rate resolution in calculateTotalCost only consults
+        // WorkRequests for items with billed logs, so for an Invoice this
+        // narrowing is loss-free for the total. Non-money templates keep the
+        // full set (the snapshot size guard below is the universal backstop).
+        Set<Id> requestScopeIds = itemIds;
+        if (templateType == 'Invoice' || templateType == 'Daily_Hours_Summary') {
+            Set<Id> billedItemIds = new Set<Id>();
+            for (WorkLog__c wl : logs) {
+                if (wl.WorkItemLookup__c != null) {
+                    billedItemIds.add(wl.WorkItemLookup__c);
+                }
+            }
+            requestScopeIds = billedItemIds;
+        }
         List<WorkRequest__c> requests = [
             SELECT Id, WorkItemId__c, WorkItemId__r.Name, StatusPk__c,
                    HourlyRateCurrency__c, QuotedHoursNumber__c,
@@ -227,7 +254,7 @@ public with sharing class DeliveryDocGenerationService {
                    BudgetUtilizationPct__c, DeliveryEntityLookup__c,
                    DeliveryEntityLookup__r.Name
             FROM WorkRequest__c
-            WHERE WorkItemId__c IN :itemIds
+            WHERE WorkItemId__c IN :requestScopeIds
             AND StatusPk__c != 'Inactive'
             WITH SYSTEM_MODE
             ORDER BY WorkItemId__r.Name
@@ -364,6 +391,80 @@ public with sharing class DeliveryDocGenerationService {
             result.add(m);
         }
         return result;
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    //  SNAPSHOT SIZE GUARD
+    // ═══════════════════════════════════════════════════════════
+
+    // SnapshotTxt__c is a LongTextArea capped at 131,072 chars. The serialized
+    // snapshot is written there verbatim AND hashed for tamper-evidence, so it
+    // must fit. SOFT_LIMIT leaves headroom so we trim proactively rather than
+    // waiting until we're flush against the hard cap.
+    @TestVisible
+    private static final Integer SNAPSHOT_FIELD_CAP = 131072;
+    @TestVisible
+    private static final Integer SNAPSHOT_SOFT_LIMIT = 120000;
+
+    /**
+     * @description Ensures the serialized snapshot fits inside SnapshotTxt__c.
+     *              Billing-safe: only display-only free text (work log / work
+     *              item descriptions) is trimmed — the hours and rates that
+     *              drive the invoice total are never altered. If the snapshot
+     *              still exceeds the hard field cap after trimming, throws a
+     *              diagnostic AuraHandledException instead of letting the
+     *              platform raise an opaque STRING_TOO_LONG mid-insert (which
+     *              rolls the whole generation back with no actionable cause).
+     * @param snapshot The snapshot map, mutated in place to fit.
+     * @param templateType Template DeveloperName (recorded in the diagnostic).
+     */
+    @TestVisible
+    private static void boundSnapshotToFieldCap(Map<String, Object> snapshot, String templateType) {
+        if (snapshot == null || JSON.serialize(snapshot).length() <= SNAPSHOT_SOFT_LIMIT) {
+            return;
+        }
+
+        // Step 1 — drop display-only descriptions. These do not feed
+        // calculateTotalHours / calculateTotalCost, so the dollar total is
+        // unaffected; only the human-readable line text is lost, and we flag it.
+        nullOutField(snapshot, 'workLogs', 'description');
+        nullOutField(snapshot, 'workItems', 'description');
+        snapshot.put('snapshotTrimmed', true);
+
+        if (JSON.serialize(snapshot).length() <= SNAPSHOT_FIELD_CAP) {
+            return;
+        }
+
+        // Step 2 — still over the hard cap. Fail loud + diagnostic rather than
+        // ship a silently corrupt document or throw an opaque STRING_TOO_LONG.
+        throw new AuraHandledException(
+            'Document data snapshot exceeds the ' + SNAPSHOT_FIELD_CAP + '-char storage limit even after '
+            + 'trimming display text (workItems=' + sectionSize(snapshot, 'workItems')
+            + ', workLogs=' + sectionSize(snapshot, 'workLogs')
+            + ', workRequests=' + sectionSize(snapshot, 'workRequests')
+            + ', template=' + templateType + '). Narrow the billing period or split the document into '
+            + 'multiple periods. No document was created.'
+        );
+    }
+
+    /** @description Nulls a field on every map in a snapshot list section (no-op if absent). */
+    private static void nullOutField(Map<String, Object> snapshot, String sectionKey, String fieldKey) {
+        List<Object> section = (List<Object>) snapshot.get(sectionKey);
+        if (section == null) {
+            return;
+        }
+        for (Object o : section) {
+            Map<String, Object> row = (Map<String, Object>) o;
+            if (row.containsKey(fieldKey)) {
+                row.put(fieldKey, null);
+            }
+        }
+    }
+
+    /** @description Row count of a snapshot list section (0 when absent). */
+    private static Integer sectionSize(Map<String, Object> snapshot, String sectionKey) {
+        List<Object> section = (List<Object>) snapshot.get(sectionKey);
+        return section == null ? 0 : section.size();
     }
 
     // ═══════════════════════════════════════════════════════════

--- a/force-app/main/default/classes/DeliveryDocGenerationServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryDocGenerationServiceTest.cls
@@ -526,6 +526,140 @@ private class DeliveryDocGenerationServiceTest {
         }
     }
 
+    // ── Snapshot Overflow Regression ─────────────────────────────────────────
+
+    /**
+     * @description Regression (snapshot overflow): an entity carrying many
+     *              historical WorkRequests on a work item with NO logs in the
+     *              billing period must still generate a clean Invoice. Previously
+     *              every WorkRequest on the entity was serialized regardless of
+     *              period, overflowing SnapshotTxt__c (131,072) on long-lived
+     *              entities and hard-failing the insert with STRING_TOO_LONG.
+     *              The snapshot must now carry only the WorkRequests for items
+     *              with billed time in the period.
+     */
+    @IsTest
+    static void testInvoiceScopesWorkRequestsToPeriodBilledItems() {
+        System.runAs(runningUser) {
+            DeliveryTriggerControl.disableAfterLogic();
+            NetworkEntity__c client = getClient();
+
+            // A second item with NO logs in the period, loaded with WorkRequests.
+            WorkItem__c stale = new WorkItem__c(
+                BriefDescriptionTxt__c = 'Stale No-Period-Logs Item',
+                StageNamePk__c = 'In Development',
+                StatusPk__c = 'Active',
+                PriorityPk__c = 'Low',
+                ActivatedDateTime__c = Datetime.now(),
+                ClientNetworkEntityLookup__c = client.Id,
+                BillableRateCurrency__c = PLACEHOLDER_ITEM_RATE
+            );
+            insert stale;
+
+            List<WorkRequest__c> noise = new List<WorkRequest__c>();
+            for (Integer i = 0; i < 50; i++) {
+                noise.add(new WorkRequest__c(
+                    WorkItemId__c = stale.Id,
+                    StatusPk__c = 'Active',
+                    HourlyRateCurrency__c = PLACEHOLDER_REQUEST_RATE
+                ));
+            }
+            insert noise;
+            DeliveryTriggerControl.enableAfterLogic();
+
+            Test.startTest();
+            Id docId = DeliveryDocGenerationService.generateDocument(
+                client.Id, 'Invoice', periodStart(), periodEnd(), null
+            );
+            Test.stopTest();
+
+            DeliveryDocument__c persisted = [
+                SELECT SnapshotTxt__c FROM DeliveryDocument__c WHERE Id = :docId WITH SYSTEM_MODE
+            ];
+            Map<String, Object> snap = (Map<String, Object>) JSON.deserializeUntyped(persisted.SnapshotTxt__c);
+            List<Object> wrs = (List<Object>) snap.get('workRequests');
+
+            System.assert(!wrs.isEmpty(),
+                'WorkRequest for the period-billed item should still be present');
+            for (Object o : wrs) {
+                Map<String, Object> wr = (Map<String, Object>) o;
+                System.assertNotEquals(stale.Id, (String) wr.get('workItemId'),
+                    'WorkRequests on items with no period logs must be excluded from an Invoice snapshot');
+            }
+            System.assert(persisted.SnapshotTxt__c.length() < 131072,
+                'Snapshot must fit within the SnapshotTxt__c field cap');
+        }
+    }
+
+    /**
+     * @description Snapshot size guard: when the serialized snapshot exceeds the
+     *              soft limit, display-only descriptions are trimmed (and a
+     *              snapshotTrimmed marker set) so it fits the field cap, while
+     *              billing-relevant hours are preserved untouched.
+     */
+    @IsTest
+    static void testBoundSnapshotTrimsDescriptionsWhenOversized() {
+        System.runAs(runningUser) {
+            String big = 'x';
+            while (big.length() < 130000) {
+                big += big;
+            }
+            Map<String, Object> snap = new Map<String, Object>{
+                'entity'    => new Map<String, Object>{ 'name' => 'X' },
+                'workLogs'  => new List<Object>{
+                    new Map<String, Object>{ 'hours' => 5, 'description' => big }
+                },
+                'workItems' => new List<Object>()
+            };
+
+            Test.startTest();
+            DeliveryDocGenerationService.boundSnapshotToFieldCap(snap, 'Invoice');
+            Test.stopTest();
+
+            System.assertEquals(true, snap.get('snapshotTrimmed'),
+                'Oversized snapshot should be flagged as trimmed');
+            List<Object> logs = (List<Object>) snap.get('workLogs');
+            Map<String, Object> log0 = (Map<String, Object>) logs[0];
+            System.assertEquals(null, log0.get('description'),
+                'Display-only description should be trimmed to fit');
+            System.assertEquals(5, log0.get('hours'),
+                'Billing-relevant hours must be preserved through the trim');
+            System.assert(JSON.serialize(snap).length() < 131072,
+                'Trimmed snapshot must fit the field cap');
+        }
+    }
+
+    /**
+     * @description Snapshot size guard: when the snapshot is still over the hard
+     *              field cap after trimming display text (the oversize lives in a
+     *              non-trimmable field), generation fails loud with an
+     *              AuraHandledException rather than an opaque STRING_TOO_LONG.
+     *              Per CLAUDE.md we don't assert on the message in managed context.
+     */
+    @IsTest
+    static void testBoundSnapshotThrowsWhenIrreducible() {
+        System.runAs(runningUser) {
+            String big = 'x';
+            while (big.length() < 140000) {
+                big += big;
+            }
+            Map<String, Object> snap = new Map<String, Object>{
+                'entity' => new Map<String, Object>{ 'address' => big }
+            };
+
+            Boolean threw = false;
+            try {
+                Test.startTest();
+                DeliveryDocGenerationService.boundSnapshotToFieldCap(snap, 'Invoice');
+                Test.stopTest();
+            } catch (AuraHandledException e) {
+                threw = true;
+            }
+            System.assertEquals(true, threw,
+                'Irreducible oversized snapshot must throw rather than overflow the field');
+        }
+    }
+
     // ── Agreement Clauses ────────────────────────────────────────────────────
 
     /**


### PR DESCRIPTION
## Problem

`DeliveryDocGenerationService.buildSnapshot()` serialized **every** `WorkRequest__c` ever linked to the billing entity into `SnapshotTxt__c` (LongTextArea, 131,072 cap) — no period filter, no hours filter, unlike the `workItems` and `workLogs` sections which are both bounded.

On long-lived entities this overflows. dh-prod **At Large** carries 293 WorkRequests (only 56 May-relevant, 201 never logged an hour); the serialized snapshot crossed the field cap and the `DeliveryDocument__c` insert hard-failed with `STRING_TOO_LONG`, rolling back the entire May invoice generation. April generated fine — the WR count grew past the ceiling over time. It is **not** a 0.256 regression and is unrelated to the install.

## Fix

**Layer 1 — correctness (`buildSnapshot`, ~L240):** scope WorkRequests to the work items that actually carry logged time in the period, for `Invoice` / `Daily_Hours_Summary`. `calculateTotalCost` only consults WRs for billed items, so this is **loss-free for the invoice total** (293 → ~17 for May). Non-money templates keep the full set.

**Layer 2 — backstop (`boundSnapshotToFieldCap`):** runs before the snapshot is hashed + persisted. Over a soft limit → trims display-only descriptions (which never feed `hours × rate`, so the dollar total is untouched) and flags `snapshotTrimmed=true`. Still over the hard cap → throws a **diagnostic** `AuraHandledException` instead of an opaque `STRING_TOO_LONG` mid-insert. Bounds **all** templates. Runs before the hash so stored JSON and the tamper-evidence hash describe the same bytes.

## Tests

- `testInvoiceScopesWorkRequestsToPeriodBilledItems` — 50 noise WRs on a no-period-logs item are excluded; snapshot stays under cap; the billed item's WR survives.
- `testBoundSnapshotTrimsDescriptionsWhenOversized` — oversized snapshot trims descriptions, preserves hours, fits the cap.
- `testBoundSnapshotThrowsWhenIrreducible` — irreducible oversize throws rather than overflows.

## Notes

- Billing-safe by construction: only display-only free text is ever dropped; hours and rates that drive the total are never altered.
- Unblocks the May At Large invoice (250.6h × \$90 = placeholder \$22,554 once generated).
- Follow-up (separate PR, no deadline): move snapshot storage off the fixed 131,072 field to a ContentVersion to remove the ceiling entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)