### PR TITLE
fix(sync): resolve inbound child parents via findLocalId (skip stale/deleted ledger rows)

### DIFF
--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -200,11 +200,20 @@ public without sharing class DeliverySyncItemIngestor {
                 localRequestId = parentBridge.Id;
             }
 
-            // 2. Try to find parent via the Ledger (Upstream Origin)
+            // 2. Try to find parent via the Ledger (Upstream Origin).
+            // Route through findLocalId(), the canonical resolver: it filters to
+            // Inbound rows, orders by CreatedDate DESC, and validates the
+            // candidate still EXISTS (not deleted) before returning it. The
+            // previous inline lookup took an unordered LIMIT 1 with no existence
+            // check, so when a WorkItem was re-created in this org the ledger
+            // held multiple rows for the same remote id and this could grab one
+            // pointing at a now-deleted local WorkItem — stranding the child
+            // WorkLog/Comment against a dead parent (root cause of the dh-prod
+            // inbound stall, 2026-06-02).
             if (localParentId == null) {
-                List<SyncItem__c> ledger = [SELECT LocalRecordIdTxt__c FROM SyncItem__c WHERE RemoteExternalIdTxt__c = :parentWorkItemRef AND ObjectTypePk__c = 'WorkItem__c' WITH SYSTEM_MODE LIMIT 1];
-                if (!ledger.isEmpty()) {
-                    localParentId = (Id)ledger[0].LocalRecordIdTxt__c;
+                Schema.SObjectType wiType = findSObjectType('WorkItem__c');
+                if (wiType != null) {
+                    localParentId = findLocalId(wiType, parentWorkItemRef);
                 }
             }
 
@@ -604,22 +613,15 @@ public without sharing class DeliverySyncItemIngestor {
         if (String.isBlank(ref)) {
             return null;
         }
-        List<SyncItem__c> ledger = [
-            SELECT LocalRecordIdTxt__c FROM SyncItem__c
-            WHERE RemoteExternalIdTxt__c = :ref
-              AND ObjectTypePk__c = 'WorkItem__c'
-            WITH SYSTEM_MODE
-            LIMIT 1
-        ];
-        if (!ledger.isEmpty() && String.isNotBlank((String) ledger[0].LocalRecordIdTxt__c)) {
-            try {
-                Id ledgerId = (Id) ledger[0].LocalRecordIdTxt__c;
-                Schema.SObjectType wiType = findSObjectType('WorkItem__c');
-                if (wiType != null && validateLocalIdExists(wiType, ledgerId)) {
-                    return ledgerId;
-                }
-            } catch (Exception e) {
-                System.debug(LoggingLevel.FINE, 'Dep endpoint ledger cast failed: ' + e.getMessage());
+        // Route through findLocalId(): Inbound-filtered, CreatedDate DESC,
+        // existence-validated — same hardening as the WorkLog/Comment parent
+        // path. The previous inline LIMIT 1 (unordered) could pick a stale row
+        // pointing at a re-created WorkItem's deleted predecessor.
+        Schema.SObjectType wiType = findSObjectType('WorkItem__c');
+        if (wiType != null) {
+            Id resolved = findLocalId(wiType, ref);
+            if (resolved != null) {
+                return resolved;
             }
         }
         // Echo-path fallback: maybe ref is already a local Id.

--- a/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
@@ -201,6 +201,66 @@ private class DeliverySyncItemIngestorTest {
     }
 
     @IsTest
+    static void testWorkLogResolvesToLiveParentWhenLedgerHasStaleDeletedRow() {
+        // Regression (dh-prod inbound stall, 2026-06-02): when a WorkItem is
+        // re-created in this org, the inbound ledger holds MULTIPLE rows for the
+        // same remote id — some pointing at the now-deleted predecessor. The
+        // parent lookup must skip the dead row(s) and resolve the child WorkLog
+        // to the LIVE WorkItem, not strand it against a deleted parent. The old
+        // inline lookup took an unordered LIMIT 1 with no existence check and
+        // could grab the dead id; the fix routes through findLocalId(), which
+        // validates each candidate exists before returning it.
+        System.runAs(testUser) {
+            WorkItem__c liveWI = new WorkItem__c(BriefDescriptionTxt__c = 'Live re-created parent');
+            insert liveWI;
+            insert new WorkRequest__c(
+                WorkItemId__c = liveWI.Id,
+                RemoteWorkItemIdTxt__c = 'REMOTE-RECREATED-REQ',
+                StatusPk__c = 'Active'
+            );
+
+            // A predecessor WorkItem that was later deleted — its ledger row is now stale.
+            WorkItem__c deadWI = new WorkItem__c(BriefDescriptionTxt__c = 'Deleted predecessor');
+            insert deadWI;
+            Id deadWIId = deadWI.Id;
+
+            // Two Inbound ledger rows for the SAME remote WorkItem id: one stale
+            // (the soon-to-be-deleted predecessor) and one live.
+            insert new SyncItem__c(
+                DirectionPk__c = 'Inbound', StatusPk__c = 'Synced', ObjectTypePk__c = 'WorkItem__c',
+                RemoteExternalIdTxt__c = 'REMOTE-RECREATED-WI', LocalRecordIdTxt__c = deadWIId
+            );
+            insert new SyncItem__c(
+                DirectionPk__c = 'Inbound', StatusPk__c = 'Synced', ObjectTypePk__c = 'WorkItem__c',
+                RemoteExternalIdTxt__c = 'REMOTE-RECREATED-WI', LocalRecordIdTxt__c = liveWI.Id
+            );
+
+            delete deadWI; // the stale ledger row now dangles at a deleted id
+
+            Map<String, Object> payload = new Map<String, Object>{
+                'SourceId' => 'REMOTE-WORKLOG-RECREATED-1',
+                'GlobalSourceId' => 'REMOTE-WORKLOG-RECREATED-1',
+                'WorkItemLookup__c' => 'REMOTE-RECREATED-WI',
+                'HoursLoggedNumber__c' => 1.25,
+                'WorkDateDate__c' => String.valueOf(Date.today()),
+                'WorkDescriptionTxt__c' => 'Child of a re-created parent'
+            };
+
+            Test.startTest();
+            Id resultId = DeliverySyncItemIngestor.processInboundItem('WorkLog__c', payload);
+            Test.stopTest();
+
+            System.assertNotEquals(null, resultId,
+                'WorkLog must resolve and insert — not strand against the deleted predecessor');
+            WorkLog__c wl = [SELECT WorkItemLookup__c FROM WorkLog__c WHERE Id = :resultId];
+            System.assertEquals(liveWI.Id, wl.WorkItemLookup__c,
+                'Parent must resolve to the LIVE WorkItem, skipping the stale ledger row at the deleted id');
+            System.assertNotEquals(deadWIId, wl.WorkItemLookup__c,
+                'Parent must NOT resolve to the deleted predecessor id');
+        }
+    }
+
+    @IsTest
     static void testFindLocalIdIgnoresNullSourceId() {
         System.runAs(testUser) {
             // When SourceId is null (e.g., from older payloads missing routing metadata),


### PR DESCRIPTION
## Root cause — dh-prod inbound sync stall (worklogs/comments frozen since 5/19)

When a `WorkItem__c` is re-created in the receiving org, the inbound `SyncItem__c` ledger accumulates **multiple rows for the same `RemoteExternalIdTxt__c`** — some with `LocalRecordIdTxt__c` pointing at the now-**deleted** predecessor WorkItem.

The WorkLog / WorkItemComment parent lookup in `DeliverySyncItemIngestor` took an **unordered `LIMIT 1` with no existence check**:

```apex
List<SyncItem__c> ledger = [SELECT LocalRecordIdTxt__c FROM SyncItem__c
    WHERE RemoteExternalIdTxt__c = :parentWorkItemRef AND ObjectTypePk__c = 'WorkItem__c'
    WITH SYSTEM_MODE LIMIT 1];
```

So it could grab a row pointing at a **dead id** → the child stranded against a deleted parent and never landed. (Diagnosed cross-session against dh-prod ledger state.)

## Fix

Route the parent lookup through the existing canonical resolver **`findLocalId()`** (already in this class), which:
- filters to `DirectionPk__c = 'Inbound'`
- `ORDER BY CreatedDate DESC`
- iterates candidates and returns the first that **still exists** (`validateLocalIdExists`)

`resolveDependencyEndpoint()` had the identical unordered-`LIMIT 1` weakness and is rerouted the same way, preserving its echo-path fallback.

This is **code hardening** — the stale ledger rows already on dh-prod still need an operational reconcile (handled separately, MF-side), but with this in place a re-created parent no longer strands its children going forward.

## Test

`testWorkLogResolvesToLiveParentWhenLedgerHasStaleDeletedRow` — ledger holds a stale row (deleted predecessor) **and** a live row for the same remote id; the inbound WorkLog must resolve to the **LIVE** WorkItem (not the dead id) and must not strand as Pending.

## Note on CI

Confident in the approach (reroute to an already-exercised resolver). Merging promptly to get `beta_create` running; any PMD nits handled as a fast-follow cleanup per direction. `upload-beta` runs the full Apex suite as the real safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)