### PR TITLE
feat(doc-email): send invoices from configurable verified Org-Wide Email Address

### DIFF
--- a/force-app/main/default/classes/DeliveryDocEmailService.cls
+++ b/force-app/main/default/classes/DeliveryDocEmailService.cls
@@ -82,8 +82,25 @@ public with sharing class DeliveryDocEmailService {
         email.setFileAttachments(new List<Messaging.EmailFileAttachment>{ att });
         email.setSaveAsActivity(false);
 
-        // Send
-        Messaging.sendEmail(new List<Messaging.SingleEmailMessage>{ email });
+        // Send FROM a configured, verified Org-Wide Email Address when set;
+        // falls back to the running user when blank/unmatched.
+        Id oweaId = resolveFromOrgWideEmailId(settings);
+        if (oweaId != null) {
+            email.setOrgWideEmailAddressId(oweaId);
+        }
+
+        // Send \u2014 surface an actionable error if SF rejects the send (most
+        // commonly: no verified sender). We must NOT mark the document Sent
+        // when the send throws, so this guards the status update below.
+        try {
+            Messaging.sendEmail(new List<Messaging.SingleEmailMessage>{ email });
+        } catch (Exception sendEx) {
+            throw new AuraHandledException(
+                'Email could not be sent \u2014 no verified sender is configured. '
+                + 'In Delivery Hub Settings, set \'Document From (Org-Wide Email)\' to a '
+                + 'verified Org-Wide Email Address (Setup \u2192 Org-Wide Addresses), then retry.'
+            );
+        }
 
         // Update document status to Sent
         doc.StatusPk__c = 'Sent';
@@ -238,6 +255,34 @@ public with sharing class DeliveryDocEmailService {
     // ═══════════════════════════════════════════════════════════
     //  HELPERS
     // ═══════════════════════════════════════════════════════════
+
+    /**
+     * @description Resolves the Org-Wide Email Address Id to send documents FROM,
+     *              based on the configured DocumentFromOrgWideEmailTxt__c address on
+     *              org-default settings. Returns null when the setting is blank or no
+     *              verified OrgWideEmailAddress matches — the caller then falls back to
+     *              sending as the running user. Guarded so an empty query (e.g. in test
+     *              context where OrgWideEmailAddress is not insertable) returns null.
+     * @param settings The org-default DeliveryHubSettings__c (may be null).
+     * @return The matching OrgWideEmailAddress Id, or null.
+     */
+    @TestVisible
+    private static Id resolveFromOrgWideEmailId(DeliveryHubSettings__c settings) {
+        if (settings == null || String.isBlank(settings.DocumentFromOrgWideEmailTxt__c)) {
+            return null;
+        }
+        String fromAddress = settings.DocumentFromOrgWideEmailTxt__c.trim();
+        List<OrgWideEmailAddress> oweas = [
+            SELECT Id FROM OrgWideEmailAddress
+            WHERE Address = :fromAddress
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (oweas.isEmpty()) {
+            return null;
+        }
+        return oweas[0].Id;
+    }
 
     /** @description Resolves the vendor display name from the first Vendor/Both NetworkEntity. */
     public static String resolveVendorName() {

--- a/force-app/main/default/classes/DeliveryDocEmailServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryDocEmailServiceTest.cls
@@ -113,6 +113,82 @@ private class DeliveryDocEmailServiceTest {
     }
 
     @IsTest
+    static void testSendDocumentEmailOweaSettingBlankFallsBack() {
+        System.runAs(testUser) {
+            // No DocumentFromOrgWideEmailTxt__c configured → must send as before
+            // (running user) with no exception.
+            DeliveryDocument__c doc = getDoc();
+
+            Test.startTest();
+            Map<String, Object> result = DeliveryDocEmailService.sendDocumentEmail(
+                doc.Id, 'recipient@example.com'
+            );
+            Test.stopTest();
+
+            System.assertEquals(true, result.get('success'),
+                'Send should succeed and fall back to running user when OWEA setting is blank');
+
+            DeliveryDocument__c updated = getDoc();
+            System.assertEquals('Sent', updated.StatusPk__c,
+                'Document should be marked Sent on the blank-OWEA fallback path');
+        }
+    }
+
+    @IsTest
+    static void testSendDocumentEmailOweaSettingUnmatchedFallsBack() {
+        System.runAs(testUser) {
+            // OrgWideEmailAddress is NOT insertable in Apex tests, so we can only
+            // exercise the query-empty / unmatched branch: set the From address to
+            // something with no matching OWEA. resolveFromOrgWideEmailId must return
+            // null and the send must complete cleanly (running-user fallback).
+            DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+            settings.DocumentFromOrgWideEmailTxt__c = 'no-such-owea@example.com';
+            upsert settings;
+
+            DeliveryDocument__c doc = getDoc();
+
+            Test.startTest();
+            Map<String, Object> result = DeliveryDocEmailService.sendDocumentEmail(
+                doc.Id, 'recipient@example.com'
+            );
+            Test.stopTest();
+
+            System.assertEquals(true, result.get('success'),
+                'Send should succeed and fall back cleanly when no OWEA matches the configured address');
+
+            DeliveryDocument__c updated = getDoc();
+            System.assertEquals('Sent', updated.StatusPk__c,
+                'Document should be marked Sent on the unmatched-OWEA fallback path');
+        }
+    }
+
+    @IsTest
+    static void testResolveFromOrgWideEmailIdNullWhenBlankOrUnmatched() {
+        System.runAs(testUser) {
+            Test.startTest();
+            // Null settings → null.
+            System.assertEquals(null,
+                DeliveryDocEmailService.resolveFromOrgWideEmailId(null),
+                'Null settings should resolve to a null OWEA Id');
+
+            // Blank address → null.
+            DeliveryHubSettings__c blank = new DeliveryHubSettings__c();
+            System.assertEquals(null,
+                DeliveryDocEmailService.resolveFromOrgWideEmailId(blank),
+                'Blank From address should resolve to a null OWEA Id');
+
+            // Set but unmatched → null (OrgWideEmailAddress not insertable in tests).
+            DeliveryHubSettings__c unmatched = new DeliveryHubSettings__c(
+                DocumentFromOrgWideEmailTxt__c = 'no-such-owea@example.com'
+            );
+            System.assertEquals(null,
+                DeliveryDocEmailService.resolveFromOrgWideEmailId(unmatched),
+                'Unmatched From address should resolve to a null OWEA Id');
+            Test.stopTest();
+        }
+    }
+
+    @IsTest
     static void testPreviewDocumentEmail() {
         System.runAs(testUser) {
             DeliveryDocument__c doc = getDoc();

--- a/force-app/main/default/classes/DeliveryHubInstallHandlerTest.cls
+++ b/force-app/main/default/classes/DeliveryHubInstallHandlerTest.cls
@@ -194,6 +194,48 @@ private class DeliveryHubInstallHandlerTest {
     }
 
     @IsTest
+    static void testSeedQueueableDocumentFromOweaNoopWhenNoOwea() {
+        System.runAs(testUser) {
+            // Drive the seed Queueable directly. Scratch/test orgs have no verified
+            // OrgWideEmailAddress (it is not insertable in Apex), so the OWEA seed
+            // must be a clean no-op: it leaves DocumentFromOrgWideEmailTxt__c blank
+            // and never throws (the execute() try/catch swallows any issue anyway).
+            Test.startTest();
+            System.enqueueJob(new DeliveryHubInstallSeedQueueable());
+            Test.stopTest();
+
+            DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+            // getOrgDefaults() can return a transient (no-Id) instance when nothing
+            // has been persisted; either way the From address must remain blank.
+            Boolean blankFrom = settings == null
+                || String.isBlank(settings.DocumentFromOrgWideEmailTxt__c);
+            System.assert(blankFrom,
+                'OWEA seed must be a no-op (blank From) when no OrgWideEmailAddress exists');
+        }
+    }
+
+    @IsTest
+    static void testSeedQueueableDocumentFromOweaDoesNotOverwriteExisting() {
+        System.runAs(testUser) {
+            // An admin's explicit choice must never be overwritten by the seed.
+            DeliveryHubSettings__c settings = new DeliveryHubSettings__c(
+                SetupOwnerId = UserInfo.getOrganizationId(),
+                DocumentFromOrgWideEmailTxt__c = 'admin-chosen@example.com'
+            );
+            insert settings;
+
+            Test.startTest();
+            System.enqueueJob(new DeliveryHubInstallSeedQueueable());
+            Test.stopTest();
+
+            DeliveryHubSettings__c reloaded = DeliveryHubSettings__c.getOrgDefaults();
+            System.assertEquals('admin-chosen@example.com',
+                reloaded.DocumentFromOrgWideEmailTxt__c,
+                'Seed must not overwrite an admin-chosen Document From address');
+        }
+    }
+
+    @IsTest
     static void testInstallIsIdempotentOnRepeatedScheduling() {
         System.runAs(testUser) {
             Test.testInstall(new DeliveryHubInstallHandler(), null, false);

--- a/force-app/main/default/classes/DeliveryHubInstallSeedQueueable.cls
+++ b/force-app/main/default/classes/DeliveryHubInstallSeedQueueable.cls
@@ -49,6 +49,15 @@ public with sharing class DeliveryHubInstallSeedQueueable implements System.Queu
                 '[DeliveryHubInstallSeedQueueable] Dataset template seed failed: '
                 + e.getMessage());
         }
+        // Intentionally swallowed: a missing-OWEA or settings issue must never break
+        // install/upgrade. No System.debug here (AvoidDebugStatements is strictly
+        // enforced); the only consequence of failure is the admin sets the From
+        // address manually, which is the documented fallback. // NOPMD suppresses
+        // EmptyCatchBlock on the catch below.
+        try {
+            seedDocumentFromOwea();
+        } catch (Exception e) { // NOPMD — see note above; deliberately empty
+        }
     }
 
     /**
@@ -159,5 +168,59 @@ public with sharing class DeliveryHubInstallSeedQueueable implements System.Queu
         if (!toInsert.isEmpty()) {
             insert toInsert;
         }
+    }
+
+    /**
+     * @description Pre-populates DeliveryHubSettings__c.DocumentFromOrgWideEmailTxt__c
+     *              with a sensible default verified Org-Wide Email Address when the
+     *              admin has not yet chosen one. This lets outbound document emails
+     *              (invoices) send from a stable, verified sender out of the box rather
+     *              than the running user.
+     *
+     *              Selection: prefer an OWEA usable by all profiles
+     *              (IsAllowAllProfiles = true); otherwise the most recently created one.
+     *
+     *              ONLY populates when the setting is blank — never overwrites an
+     *              admin's explicit choice. Runs on install AND upgrade (idempotent:
+     *              the blank guard makes re-runs a no-op once set). The caller wraps
+     *              this in try/catch so a missing-OWEA never breaks install.
+     */
+    @TestVisible
+    private static void seedDocumentFromOwea() {
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        // Never overwrite an admin's explicit choice.
+        if (settings != null && String.isNotBlank(settings.DocumentFromOrgWideEmailTxt__c)) {
+            return;
+        }
+
+        List<OrgWideEmailAddress> oweas = [
+            SELECT Address, IsAllowAllProfiles
+            FROM OrgWideEmailAddress
+            WITH SYSTEM_MODE
+            ORDER BY CreatedDate DESC
+        ];
+        if (oweas.isEmpty()) {
+            // No verified Org-Wide Email Address exists yet — nothing to seed.
+            return;
+        }
+
+        // Prefer one usable by all profiles; else fall back to the most recently
+        // created (the list is already ordered newest-first).
+        OrgWideEmailAddress chosen = oweas[0];
+        for (OrgWideEmailAddress owea : oweas) {
+            if (owea.IsAllowAllProfiles == true) {
+                chosen = owea;
+                break;
+            }
+        }
+        if (String.isBlank(chosen.Address)) {
+            return;
+        }
+
+        if (settings == null) {
+            settings = new DeliveryHubSettings__c(SetupOwnerId = UserInfo.getOrganizationId());
+        }
+        settings.DocumentFromOrgWideEmailTxt__c = chosen.Address;
+        upsert settings;
     }
 }

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/DocumentFromOrgWideEmailTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/DocumentFromOrgWideEmailTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DocumentFromOrgWideEmailTxt__c</fullName>
+    <description>Verified Org-Wide Email Address to send outbound document emails (invoices, contracts, etc.) FROM, instead of the running user. Must exactly match the address of a verified Org-Wide Email Address (Setup &#8594; Org-Wide Addresses). When blank or unmatched, documents send from the running user.</description>
+    <inlineHelpText>Enter a verified Org-Wide Email Address (Setup &#8594; Org-Wide Addresses) to send documents from. Leave blank to send as the running user.</inlineHelpText>
+    <label>Document From (Org-Wide Email)</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## What & why

DeliveryDocument emails (invoices, contracts, etc.) currently send **FROM the running user**. This switches them to a configurable, **verified Org-Wide Email Address (OWEA)** so invoices land from a stable, branded sender — with a clean fallback to the running user when nothing is configured.

## Changes

### Core
- **New field** `DeliveryHubSettings__c.DocumentFromOrgWideEmailTxt__c` (Text, 255, not required) — holds the verified OWEA address to send FROM. Label: *Document From (Org-Wide Email)*.
- **`DeliveryDocEmailService`**
  - New private `@TestVisible Id resolveFromOrgWideEmailId(DeliveryHubSettings__c settings)` — queries `OrgWideEmailAddress WHERE Address = :configured` (`WITH SYSTEM_MODE`), returns `null` when blank/unmatched (guarded so a test-context empty query is null).
  - `sendDocumentEmail` reuses the `settings` var already fetched for the CC block, calls `email.setOrgWideEmailAddressId(...)` only when a match exists, else falls back to the running user.
  - `processScheduledDocumentSends` delegates entirely to `sendDocumentEmail`, so it inherits the OWEA resolution — it does not build its own `SingleEmailMessage` (verified: only one `SingleEmailMessage`/`sendEmail` in the class).

### Extension A — install auto-pick
- **`DeliveryHubInstallSeedQueueable.seedDocumentFromOwea`** pre-populates the setting on **install AND upgrade**, but **only when blank** (never overwrites an admin's choice). Prefers an OWEA with `IsAllowAllProfiles = true`, else the most-recently-created. Wrapped in `try/catch` in `execute()` so a missing OWEA never breaks install. No `System.debug` (uses a comment + `// NOPMD` on the deliberately-empty catch, per `AvoidDebugStatements`).

### Extension B — actionable send-failure error
- `Messaging.sendEmail(...)` in `sendDocumentEmail` is wrapped in `try/catch`; on failure it throws an `AuraHandledException` with actionable guidance ("…set 'Document From (Org-Wide Email)' to a verified Org-Wide Email Address (Setup → Org-Wide Addresses), then retry."). The document is **NOT** marked Sent when the send throws (the status update sits after the guarded send).

### Tests
- `DeliveryDocEmailServiceTest`: OWEA blank → running-user fallback; OWEA set-but-unmatched → clean fallback; `resolveFromOrgWideEmailId` null branches (null/blank/unmatched). Per CLAUDE.md, no assertion on `AuraHandledException` message text.
- `DeliveryHubInstallHandlerTest`: seed-queueable blank→no-op when no OWEA, and does-not-overwrite-admin-choice — both drive the Queueable via `Test.startTest/stopTest`.

## Notes / deviations
- The referenced handoff doc `docs/handoffs/2026-06-02-doc-email-owea.md` does **not exist** anywhere in the repo or on `origin/main`; implemented from the task spec directly. No drop-in code block was available to copy verbatim — implementation follows the spec's described shape.
- `OrgWideEmailAddress` is not insertable in Apex tests, so tests exercise only the query-empty / fallback / no-op branches; the actual `setOrgWideEmailAddressId` success path can only be validated against a live org with a verified OWEA.
- Tests were **not run locally** — no default `target-org` is set and per CLAUDE.md I avoided running against the connected prod/sandbox orgs. CI will validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
