### PR TITLE
fix(sync): don't re-stamp master-detail RequestId__c on content-matched WorkLog update

### DIFF
--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -280,14 +280,15 @@ public without sharing class DeliverySyncItemIngestor {
                 // description and convert to an UPDATE of the existing row.
                 Id contentMatch = findWorkLogByContent(localParentId, payload);
                 if (contentMatch != null) {
+                    // Convert to an UPDATE of the existing row. Do NOT re-stamp the
+                    // parent FKs: the matched record already carries the correct
+                    // WorkItemLookup__c / RequestId__c, and RequestId__c is a
+                    // master-detail field that is not editable on update — stamping
+                    // it threw "Field RequestId__c is not editable". Leaving the FKs
+                    // off the update SObject preserves the record's existing values.
                     localRecordId = contentMatch;
                     recordToUpsert = targetType.newSObject(localRecordId);
                     contentMatched = true;
-                    // Re-stamp the resolved parent FKs on the rebuilt record.
-                    putSafe(recordToUpsert, 'WorkItemLookup__c', localParentId);
-                    if (!localRequests.isEmpty()) {
-                        putSafe(recordToUpsert, 'RequestId__c', localRequests[0].Id);
-                    }
                 }
             }
         }


### PR DESCRIPTION
## Problem
The #861 content-dedup fallback (now on main) converts an apparent insert into an UPDATE of an existing WorkLog, then re-stamped `WorkItemLookup__c` + `RequestId__c`. `RequestId__c` is **master-detail** — not editable on update — so the update threw `Field delivery__RequestId__c is not editable`, failing 3 dedup tests and the `upload-beta` package gate.

## Fix
Remove the FK re-stamp from the content-match branch. The matched record already carries the correct parent + request; leaving them off the update SObject preserves the existing values. This also resolves the `AvoidDeeplyNestedIfStmts` PMD finding flagged on #861 (that nested `if` *was* the RequestId__c stamp).

One-line-ish change, fixes both the test failure and the PMD smell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)