### PR TITLE
feat(doc-email): surface From field in settings, CC semicolons, clearer send errors

### DIFF
--- a/force-app/main/default/classes/DeliveryDocEmailService.cls
+++ b/force-app/main/default/classes/DeliveryDocEmailService.cls
@@ -60,16 +60,11 @@ public with sharing class DeliveryDocEmailService {
         Messaging.SingleEmailMessage email = new Messaging.SingleEmailMessage();
         email.setToAddresses(new List<String>{ toEmail });
 
-        // CC from org settings (supports comma-separated list)
+        // CC from org settings (supports comma- AND semicolon-separated lists —
+        // Outlook pastes addresses with ';'). parseCcAddresses trims + skips blanks.
         DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
         if (settings != null && String.isNotBlank(settings.DocumentCcEmailTxt__c)) {
-            List<String> ccAddresses = new List<String>();
-            for (String addr : settings.DocumentCcEmailTxt__c.split(',')) {
-                String trimmed = addr.trim();
-                if (String.isNotBlank(trimmed)) {
-                    ccAddresses.add(trimmed);
-                }
-            }
+            List<String> ccAddresses = parseCcAddresses(settings.DocumentCcEmailTxt__c);
             if (!ccAddresses.isEmpty()) {
                 email.setCcAddresses(ccAddresses);
             }
@@ -89,16 +84,18 @@ public with sharing class DeliveryDocEmailService {
             email.setOrgWideEmailAddressId(oweaId);
         }
 
-        // Send \u2014 surface an actionable error if SF rejects the send (most
-        // commonly: no verified sender). We must NOT mark the document Sent
+        // Send \u2014 surface the REAL underlying error so the failure is
+        // diagnosable (a blanket "no verified sender" message previously masked
+        // CC-format and other send errors). We must NOT mark the document Sent
         // when the send throws, so this guards the status update below.
         try {
             Messaging.sendEmail(new List<Messaging.SingleEmailMessage>{ email });
         } catch (Exception sendEx) {
             throw new AuraHandledException(
-                'Email could not be sent \u2014 no verified sender is configured. '
-                + 'In Delivery Hub Settings, set \'Document From (Org-Wide Email)\' to a '
-                + 'verified Org-Wide Email Address (Setup \u2192 Org-Wide Addresses), then retry.'
+                'Email could not be sent: ' + sendEx.getMessage()
+                + ' \u2014 If this is a domain-verification error, verify your sending '
+                + 'domain (Setup \u2192 Email \u2192 DKIM Keys) or set a verified '
+                + 'Org-Wide Email Address in Delivery Hub Settings.'
             );
         }
 
@@ -255,6 +252,27 @@ public with sharing class DeliveryDocEmailService {
     // ═══════════════════════════════════════════════════════════
     //  HELPERS
     // ═══════════════════════════════════════════════════════════
+
+    /**
+     * @description Parses a CC email list that may use commas OR semicolons as
+     *              separators (Outlook pastes addresses with ';'). Trims each
+     *              entry and skips blanks. Returns an empty list for blank input.
+     * @param rawCc The raw CC string from settings (may be null/blank).
+     * @return A list of trimmed, non-blank email addresses.
+     */
+    public static List<String> parseCcAddresses(String rawCc) {
+        List<String> addresses = new List<String>();
+        if (String.isBlank(rawCc)) {
+            return addresses;
+        }
+        for (String addr : rawCc.split('[,;]')) {
+            String trimmed = addr.trim();
+            if (String.isNotBlank(trimmed)) {
+                addresses.add(trimmed);
+            }
+        }
+        return addresses;
+    }
 
     /**
      * @description Resolves the Org-Wide Email Address Id to send documents FROM,

--- a/force-app/main/default/classes/DeliveryDocEmailServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryDocEmailServiceTest.cls
@@ -113,6 +113,72 @@ private class DeliveryDocEmailServiceTest {
     }
 
     @IsTest
+    static void testParseCcAddressesSemicolonSeparated() {
+        System.runAs(testUser) {
+            Test.startTest();
+            // Outlook-style semicolon-separated list must parse into multiple recipients.
+            List<String> parsed = DeliveryDocEmailService.parseCcAddresses('a@x.com;b@y.com');
+            Test.stopTest();
+
+            System.assertEquals(2, parsed.size(), 'Semicolon-separated CC should parse into two addresses');
+            System.assertEquals('a@x.com', parsed[0], 'First parsed address should be trimmed and correct');
+            System.assertEquals('b@y.com', parsed[1], 'Second parsed address should be trimmed and correct');
+        }
+    }
+
+    @IsTest
+    static void testParseCcAddressesCommaSeparated() {
+        System.runAs(testUser) {
+            Test.startTest();
+            // Existing comma behavior must still work.
+            List<String> parsed = DeliveryDocEmailService.parseCcAddresses('a@x.com, b@y.com');
+            Test.stopTest();
+
+            System.assertEquals(2, parsed.size(), 'Comma-separated CC should still parse into two addresses');
+            System.assertEquals('a@x.com', parsed[0], 'First comma-parsed address should be trimmed');
+            System.assertEquals('b@y.com', parsed[1], 'Second comma-parsed address should be trimmed');
+        }
+    }
+
+    @IsTest
+    static void testParseCcAddressesMixedAndBlanks() {
+        System.runAs(testUser) {
+            Test.startTest();
+            // Mixed separators plus stray blanks/whitespace must skip blanks.
+            List<String> parsed = DeliveryDocEmailService.parseCcAddresses('a@x.com; ,b@y.com ;; c@z.com');
+            List<String> none = DeliveryDocEmailService.parseCcAddresses('   ');
+            List<String> nullIn = DeliveryDocEmailService.parseCcAddresses(null);
+            Test.stopTest();
+
+            System.assertEquals(3, parsed.size(), 'Mixed separators should yield three non-blank addresses');
+            System.assertEquals(0, none.size(), 'Whitespace-only input should yield an empty list');
+            System.assertEquals(0, nullIn.size(), 'Null input should yield an empty list');
+        }
+    }
+
+    @IsTest
+    static void testSendDocumentEmailSemicolonCc() {
+        System.runAs(testUser) {
+            // End-to-end: a semicolon-separated CC must NOT throw on send (previously
+            // the whole string became one invalid address → INVALID_EMAIL_ADDRESS).
+            DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+            settings.DocumentCcEmailTxt__c = 'cc1@example.com;cc2@example.com';
+            upsert settings;
+
+            DeliveryDocument__c doc = getDoc();
+
+            Test.startTest();
+            Map<String, Object> result = DeliveryDocEmailService.sendDocumentEmail(
+                doc.Id, 'recipient@example.com'
+            );
+            Test.stopTest();
+
+            System.assertEquals(true, result.get('success'),
+                'Send should succeed with semicolon-separated CC addresses');
+        }
+    }
+
+    @IsTest
     static void testSendDocumentEmailOweaSettingBlankFallsBack() {
         System.runAs(testUser) {
             // No DocumentFromOrgWideEmailTxt__c configured → must send as before

--- a/force-app/main/default/classes/DeliveryHubSettingsController.cls
+++ b/force-app/main/default/classes/DeliveryHubSettingsController.cls
@@ -109,6 +109,8 @@ global with sharing class DeliveryHubSettingsController {
         @AuraEnabled public String weeklyDigestRecipients { get; set; }
         /** @description Email address to CC on every document email */
         @AuraEnabled public String documentCcEmail { get; set; }
+        /** @description Verified Org-Wide Email Address to send documents (invoices) FROM */
+        @AuraEnabled public String documentFromOrgWideEmail { get; set; }
         /** @description Token for the public status page URL */
         @AuraEnabled public String statusPageToken { get; set; }
         /** @description Default billing entity ID override */
@@ -331,6 +333,7 @@ global with sharing class DeliveryHubSettingsController {
             dto.weeklyDigestDay = settings.WeeklyDigestDayTxt__c != null ? settings.WeeklyDigestDayTxt__c : 'Monday';
             dto.weeklyDigestRecipients = settings.WeeklyDigestRecipientsTxt__c;
             dto.documentCcEmail = settings.DocumentCcEmailTxt__c;
+            dto.documentFromOrgWideEmail = settings.DocumentFromOrgWideEmailTxt__c;
             dto.statusPageToken = settings.StatusPageTokenTxt__c;
             dto.defaultBillingEntityId = settings.DefaultBillingEntityIdTxt__c;
             dto.stagesToAutoShare = settings.StagesToAutoShareWithDevTeamTxt__c;
@@ -497,6 +500,7 @@ global with sharing class DeliveryHubSettingsController {
             settings.WeeklyDigestDayTxt__c = dto.weeklyDigestDay;
             settings.WeeklyDigestRecipientsTxt__c = dto.weeklyDigestRecipients;
             settings.DocumentCcEmailTxt__c = dto.documentCcEmail;
+            settings.DocumentFromOrgWideEmailTxt__c = dto.documentFromOrgWideEmail;
             settings.StatusPageTokenTxt__c = dto.statusPageToken;
             settings.DefaultBillingEntityIdTxt__c = dto.defaultBillingEntityId;
             settings.StagesToAutoShareWithDevTeamTxt__c = dto.stagesToAutoShare;

--- a/force-app/main/default/classes/DeliveryHubSettingsControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHubSettingsControllerTest.cls
@@ -95,6 +95,7 @@ private class DeliveryHubSettingsControllerTest {
             settings.WeeklyDigestDayTxt__c = 'Wednesday';
             settings.WeeklyDigestRecipientsTxt__c = 'test@example.com';
             settings.DocumentCcEmailTxt__c = 'cc@example.com';
+            settings.DocumentFromOrgWideEmailTxt__c = 'invoices@example.com';
             settings.StatusPageTokenTxt__c = 'abc-123';
             settings.DefaultBillingEntityIdTxt__c = 'a3VRu000002ZPtdMA';
             settings.StagesToAutoShareWithDevTeamTxt__c = 'In Development,Code Review';
@@ -115,6 +116,7 @@ private class DeliveryHubSettingsControllerTest {
             System.assertEquals('Wednesday', dto.weeklyDigestDay, 'Digest day should be Wednesday');
             System.assertEquals('test@example.com', dto.weeklyDigestRecipients, 'Digest recipients should be set');
             System.assertEquals('cc@example.com', dto.documentCcEmail, 'Document CC email should be set');
+            System.assertEquals('invoices@example.com', dto.documentFromOrgWideEmail, 'Document From org-wide email should be set');
             System.assertEquals('abc-123', dto.statusPageToken, 'Status page token should be set');
             System.assertEquals('a3VRu000002ZPtdMA', dto.defaultBillingEntityId, 'Default billing entity should be set');
             System.assertEquals('In Development,Code Review', dto.stagesToAutoShare, 'Stages to auto share should be set');
@@ -142,6 +144,7 @@ private class DeliveryHubSettingsControllerTest {
                 'weeklyDigestDay' => 'Friday',
                 'weeklyDigestRecipients' => 'a@b.com,c@d.com',
                 'documentCcEmail' => 'doc@test.com',
+                'documentFromOrgWideEmail' => 'from@test.com',
                 'statusPageToken' => 'xyz-789',
                 'defaultBillingEntityId' => 'a3VRu000002ZPtdMA',
                 'stagesToAutoShare' => 'Testing,Deployed',
@@ -168,6 +171,7 @@ private class DeliveryHubSettingsControllerTest {
             System.assertEquals('Friday', s.WeeklyDigestDayTxt__c, 'Digest day should be Friday');
             System.assertEquals('a@b.com,c@d.com', s.WeeklyDigestRecipientsTxt__c, 'Digest recipients should be set');
             System.assertEquals('doc@test.com', s.DocumentCcEmailTxt__c, 'Document CC email should be set');
+            System.assertEquals('from@test.com', s.DocumentFromOrgWideEmailTxt__c, 'Document From org-wide email should be saved');
             System.assertEquals('xyz-789', s.StatusPageTokenTxt__c, 'Status page token should be set');
             System.assertEquals('a3VRu000002ZPtdMA', s.DefaultBillingEntityIdTxt__c, 'Default billing entity should be set');
             System.assertEquals('Testing,Deployed', s.StagesToAutoShareWithDevTeamTxt__c, 'Stages to auto share should be set');

--- a/force-app/main/default/classes/DeliveryOverdueReminderService.cls
+++ b/force-app/main/default/classes/DeliveryOverdueReminderService.cls
@@ -215,10 +215,15 @@ public with sharing class DeliveryOverdueReminderService {
         email.setHtmlBody(body);
         email.setSaveAsActivity(false);
 
-        // CC from org settings
+        // CC from org settings — supports comma- AND semicolon-separated lists
+        // (Outlook pastes addresses with ';'). Reuses the shared CC parser so a
+        // multi-address CC isn't sent as one invalid address.
         DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
         if (settings != null && String.isNotBlank(settings.DocumentCcEmailTxt__c)) {
-            email.setCcAddresses(new List<String>{ settings.DocumentCcEmailTxt__c });
+            List<String> ccAddresses = DeliveryDocEmailService.parseCcAddresses(settings.DocumentCcEmailTxt__c);
+            if (!ccAddresses.isEmpty()) {
+                email.setCcAddresses(ccAddresses);
+            }
         }
 
         return email;

--- a/force-app/main/default/lwc/deliveryGeneralSettingsCard/deliveryGeneralSettingsCard.html
+++ b/force-app/main/default/lwc/deliveryGeneralSettingsCard/deliveryGeneralSettingsCard.html
@@ -620,6 +620,19 @@
                     </div>
                     <div class="slds-col slds-size_1-of-2 slds-p-bottom_small">
                         <lightning-input
+                            type="email"
+                            label="Document From (Org-Wide Email)"
+                            placeholder="invoices@yourdomain.com"
+                            value={documentFromOrgWideEmail}
+                            onchange={handleDocumentFromOrgWideEmailChange}
+                            onblur={handleDocumentFromOrgWideEmailSave}>
+                        </lightning-input>
+                        <p class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
+                            Verified Org-Wide Email Address to send documents (invoices) FROM. Must be a verified sender in this org; if the domain isn't verified, Salesforce blocks the send.
+                        </p>
+                    </div>
+                    <div class="slds-col slds-size_1-of-2 slds-p-bottom_small">
+                        <lightning-input
                             type="text"
                             label="Default Billing Entity ID"
                             placeholder="18-character NetworkEntity ID"

--- a/force-app/main/default/lwc/deliveryGeneralSettingsCard/deliveryGeneralSettingsCard.js
+++ b/force-app/main/default/lwc/deliveryGeneralSettingsCard/deliveryGeneralSettingsCard.js
@@ -75,6 +75,7 @@ export default class DeliveryGeneralSettingsCard extends LightningElement {
     @track weeklyDigestDay = 'Monday';
     @track weeklyDigestRecipients = '';
     @track documentCcEmail = '';
+    @track documentFromOrgWideEmail = '';
     @track statusPageToken = '';
     @track defaultBillingEntityId = '';
     @track stagesToAutoShare = '';
@@ -168,6 +169,7 @@ export default class DeliveryGeneralSettingsCard extends LightningElement {
                 this.weeklyDigestDay = data.weeklyDigestDay || 'Monday';
                 this.weeklyDigestRecipients = data.weeklyDigestRecipients || '';
                 this.documentCcEmail = data.documentCcEmail || '';
+                this.documentFromOrgWideEmail = data.documentFromOrgWideEmail || '';
                 this.statusPageToken = data.statusPageToken || '';
                 this.defaultBillingEntityId = data.defaultBillingEntityId || '';
                 this.stagesToAutoShare = data.stagesToAutoShare || '';
@@ -390,6 +392,14 @@ export default class DeliveryGeneralSettingsCard extends LightningElement {
         this.saveExtended();
     }
 
+    handleDocumentFromOrgWideEmailChange(event) {
+        this.documentFromOrgWideEmail = event.target.value;
+    }
+
+    handleDocumentFromOrgWideEmailSave() {
+        this.saveExtended();
+    }
+
     handleStatusPageTokenChange(event) {
         this.statusPageToken = event.target.value;
     }
@@ -455,6 +465,7 @@ export default class DeliveryGeneralSettingsCard extends LightningElement {
                     weeklyDigestDay: this.weeklyDigestDay,
                     weeklyDigestRecipients: this.weeklyDigestRecipients,
                     documentCcEmail: this.documentCcEmail,
+                    documentFromOrgWideEmail: this.documentFromOrgWideEmail,
                     statusPageToken: this.statusPageToken,
                     defaultBillingEntityId: this.defaultBillingEntityId,
                     stagesToAutoShare: this.stagesToAutoShare,


### PR DESCRIPTION
Completes the invoice-email feature shipped in #862 with three focused hardening changes.

## 1. Surface "Document From (Org-Wide Email)" in Settings UI
`DeliveryHubSettings__c.DocumentFromOrgWideEmailTxt__c` exists and is honored by `DeliveryDocEmailService`, but was not rendered anywhere editable. Added a **"Document From (Org-Wide Email)"** row in the **Documents & Billing** section of `deliveryGeneralSettingsCard`, immediately adjacent to the Document CC Email row (same `type="email"` input + onchange/onblur save wiring).

The controller uses an **explicit field allowlist** (DTO + getSettings + saveExtendedSettings), not describe-based, so the field was wired round-trip:
- `SettingsDTO.documentFromOrgWideEmail`
- `getSettings()` read mapping from `DocumentFromOrgWideEmailTxt__c`
- `saveExtendedSettings()` write mapping
- LWC `@track documentFromOrgWideEmail`, load mapping, change/save handlers, and `saveExtended` payload key

Help text: "Verified Org-Wide Email Address to send documents (invoices) FROM. Must be a verified sender in this org; if the domain isn't verified, Salesforce blocks the send."

## 2. CC field accepts semicolons as well as commas
Outlook pastes `a@x.com;b@y.com`, which became one invalid address → `INVALID_EMAIL_ADDRESS`. Extracted a shared `DeliveryDocEmailService.parseCcAddresses(rawCc)` helper that splits on `[,;]`, trims, and skips blanks. Replaced the inline comma-only split in `sendDocumentEmail`.

**Duplicate path fixed:** `DeliveryOverdueReminderService` previously passed the raw `DocumentCcEmailTxt__c` string directly to `setCcAddresses(new List<String>{...})` — i.e. the whole comma/semicolon string as ONE address. Now reuses `parseCcAddresses` so multi-address CC works there too.

## 3. Clearer send-failure error
The `Messaging.sendEmail` catch threw a blanket "no verified sender" `AuraHandledException` for ALL failures, which masked a CC-format error. Now includes the real underlying message:
`'Email could not be sent: ' + sendEx.getMessage() + ' — If this is a domain-verification error, verify your sending domain (Setup → Email → DKIM Keys) or set a verified Org-Wide Email Address in Delivery Hub Settings.'`
Document is still NOT marked Sent on failure (status update stays after the guarded send).

## Tests
- `parseCcAddresses`: semicolon, comma, mixed-with-blanks, whitespace-only, and null inputs.
- End-to-end semicolon-CC `sendDocumentEmail` completes without throwing.
- `DeliveryHubSettingsControllerTest`: round-trip read + save assertions for the new field.
- Per CLAUDE.md, no assertions on `AuraHandledException` message text.
- **Send-failure-throws path:** not unit-tested — `Messaging.sendEmail` cannot be made to throw in a test context. Existing success-path tests already assert status only becomes `Sent` after a successful send (the guard is structural: status update is after the try/catch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)