### PR TITLE
fix(pacing): namespace-safe blended-rate resolution (unblocks upload-beta)

### DIFF
--- a/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
@@ -768,10 +768,12 @@ global with sharing class DeliveryHoursAnalyticsController {
      *              many distinct rates exist (ambiguous — hours-only display).
      */
     private static Decimal resolveBlendedRate() {
-        Schema.DescribeSObjectResult dsr = NetworkEntity__c.SObjectType.getDescribe();
-        if (!dsr.fields.getMap().containsKey('DefaultHourlyRateCurrency__c')) {
-            return null;
-        }
+        // No describe guard: DefaultHourlyRateCurrency__c is referenced statically
+        // in the SOQL below, so it is compile-time guaranteed to exist. A
+        // fields.getMap().containsKey('DefaultHourlyRateCurrency__c') guard is also
+        // namespace-UNSAFE — in the packaging org the map key is prefixed
+        // ('delivery__defaulthourly...'), so the unprefixed containsKey returns
+        // false and the method returned null in managed contexts (upload-beta only).
         List<NetworkEntity__c> rated = [
             SELECT DefaultHourlyRateCurrency__c
             FROM NetworkEntity__c


### PR DESCRIPTION
## Why
`upload-beta` (the beta package build) has been **failing** since #866 merged — so nothing from today's work was installable. Root cause:

`resolveBlendedRate()` guarded with `dsr.fields.getMap().containsKey('DefaultHourlyRateCurrency__c')`. In the **namespaced packaging org** the map key is prefixed (`delivery__defaulthourly…`), so the unprefixed `containsKey` returns **false** → the method returns `null` early. `testPortfolioBlendedRateWhenSingleActiveRate` then failed in upload-beta (`Expected: 125, Actual: null`) while passing the non-namespaced PR-level feature-test.

## Fix
Remove the guard. `DefaultHourlyRateCurrency__c` is referenced **statically** in the very next SOQL, so it is compile-time guaranteed to exist — the describe check was dead code and namespace-unsafe.

No behavior change in non-namespaced contexts; restores correct blended-rate resolution (and the secondary $ axis) in managed orgs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)