### PR TITLE
feat(home): place Portfolio Pacing & Forecast on Home pages + info popover

### DIFF
--- a/force-app/main/default/flexipages/DeliveryHubAdminHome.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryHubAdminHome.flexipage-meta.xml
@@ -17,6 +17,12 @@
                 <identifier>c_deliveryClientDashboard</identifier>
             </componentInstance>
         </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentName>deliveryPacingForecast</componentName>
+                <identifier>c_deliveryPacingForecast</identifier>
+            </componentInstance>
+        </itemInstances>
         <name>top</name>
         <type>Region</type>
     </flexiPageRegions>

--- a/force-app/main/default/flexipages/DeliveryHubHome.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryHubHome.flexipage-meta.xml
@@ -35,6 +35,12 @@
         </itemInstances>
         <itemInstances>
             <componentInstance>
+                <componentName>deliveryPacingForecast</componentName>
+                <identifier>c_deliveryPacingForecast</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
                 <componentName>deliveryFeatureCockpit</componentName>
                 <identifier>c_deliveryFeatureCockpit_home</identifier>
             </componentInstance>

--- a/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
+++ b/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
@@ -190,6 +190,15 @@ const INFO_REGISTRY = {
         friendlyName: 'Pro Forma Timeline',
         keyFields:
             'WorkItem__c.PriorityGroupPk__c, WorkItem__c.EstimatedStartDevDate__c, WorkItem__c.EstimatedEndDevDate__c, WorkItem__c.StageNamePk__c, WorkItem__c.EstimatedHoursNumber__c, WorkItem__c.ParentWorkItemLookup__c, WorkItem__c.SortOrderNumber__c'
+    },
+    deliveryPacingForecast: {
+        dataSource:
+            'Calls DeliveryHoursAnalyticsController.getPortfolioPacing(granularity, periodsBack, periodsForward). Scans all active root WorkItem__c trees, sums WorkLog__c hours into Week/Month/Quarter buckets for the actual line, amortizes the total estimate across the planned span (earliest start → latest end) for the target line, and projects forward at a run-rate (trailing 4-period average) capped at remaining estimate. The blended $ rate is surfaced only when exactly one active NetworkEntity__c carries a DefaultHourlyRateCurrency__c (else hours-only).',
+        description:
+            'Account/org-level pacing & forecast across all active projects. Shows logged hours (bars), an amortized target line, and a run-rate forecast for the periods ahead — with a Week/Month/Quarter bucket selector and a forward horizon (Next 3 / 6 / 12 or rest of year). Hours are primary; dollars appear when a single blended rate is configured.',
+        friendlyName: 'Portfolio Pacing & Forecast',
+        keyFields:
+            'WorkItem__c.EstimatedHoursNumber__c, WorkItem__c.EstimatedStartDevDate__c, WorkItem__c.EstimatedEndDevDate__c, WorkItem__c.TotalLoggedHoursSum__c, WorkLog__c.HoursLoggedNumber__c, WorkLog__c.WorkDateDate__c, NetworkEntity__c.DefaultHourlyRateCurrency__c'
     }
 };
 

--- a/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.html
+++ b/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.html
@@ -10,6 +10,7 @@
                 </div>
             </div>
             <div class="pacing-controls">
+                <c-delivery-info-popover component-name="deliveryPacingForecast"></c-delivery-info-popover>
                 <lightning-combobox
                     name="granularity"
                     label="Bucket"


### PR DESCRIPTION
## Why
`deliveryPacingForecast` shipped in 0.261.0.2 but was **never placed on a Lightning Home page**, so it didn't appear on install. This fixes that.

## What
- **Placed on `DeliveryHubHome`** — `top` region, right after `deliveryExecutiveDashboard` (next to hours-by-month / project-health-top-10), exactly where the forecast belongs.
- **Placed on `DeliveryHubAdminHome`** — `top` region.
- **Info popover** — registered a `deliveryPacingForecast` entry in `deliveryInfoPopover`'s registry (friendly name, description, data source, key fields) and added the info icon to the card header, matching every other home card.

No new metadata objects/fields — just FlexiPage placement + the info-popover entry + the card header icon.

## Follow-up (noted, not in this PR)
Per Glen: audit all home-page LWCs for info-popover coverage + report/dashboard deep-link wiring, and consider report deep-links from the pacing card (Monthly_Hours / Budget_Health).

🤖 Generated with [Claude Code](https://claude.com/claude-code)