### PR TITLE
feat(home): info-popover coverage for all home-page cards + report deep-link audit

### DIFF
--- a/docs/audits/home-lwc-info-reports-2026-06-04.md
+++ b/docs/audits/home-lwc-info-reports-2026-06-04.md
@@ -1,0 +1,151 @@
+# Home-Page LWC Sweep — Info Popover Coverage + Report/Dashboard Deep-Links
+
+**Date:** 2026-06-04
+**Branch:** `feat/home-lwc-info-coverage`
+**Scope:** Every LWC mounted on the two Home FlexiPages —
+`DeliveryHubHome.flexipage-meta.xml` and `DeliveryHubAdminHome.flexipage-meta.xml`.
+
+This audit (1) confirms the `deliveryInfoPopover` self-documenting icon is present on
+every home-page card, and (2) maps which home cards deep-link to the pre-built reports
+under `force-app/main/default/reports/DeliveryHubVendor/`, flagging gaps + recommendations.
+
+---
+
+## Working set — home-page LWCs
+
+Derived directly from the two Home FlexiPages (`<componentName>` entries, deduplicated):
+
+| LWC | DeliveryHubHome | DeliveryHubAdminHome |
+|---|:---:|:---:|
+| deliveryGettingStarted | ✅ | |
+| deliveryHubSetup | ✅ | ✅ |
+| deliveryClientDashboard | ✅ | ✅ |
+| deliveryExecutiveDashboard | ✅ | |
+| deliveryFeatureCockpit | ✅ | |
+| deliveryFeatureApprovalInbox | ✅ | |
+| deliveryBudgetSummary | ✅ | ✅ |
+| deliveryGhostRecorder | ✅ | ✅ |
+| deliveryClientOnboarding | | ✅ |
+| deliveryDocumentViewer | | ✅ |
+| deliveryProFormaTimeline | | ✅ |
+| deliveryReleaseNotes | | ✅ |
+| deliveryActivityDashboard | | ✅ |
+| deliveryDataLineage | | ✅ |
+| deliverySyncRetryPanel | | ✅ |
+| deliveryHubHealthDashboard | | ✅ |
+| deliveryWatcherSetup | | ✅ |
+
+---
+
+## Coverage table
+
+Legend:
+- **Info popover** — `<c-delivery-info-popover>` present in `.html` **and** an `INFO_REGISTRY` entry in `deliveryInfoPopover.js`.
+- **Report deep-links** — does the card navigate to a `DeliveryHubVendor` report (via `getReportIds` + `NavigationMixin`)?
+
+| LWC | Info popover | Report / dashboard deep-links | Gaps / notes |
+|---|:---:|---|---|
+| deliveryGettingStarted | ✅ (pre-existing) | — | Setup wizard; no reportable data. No gap. |
+| deliveryHubSetup | ✅ (pre-existing) | — | Connection status card. No report surface. No gap. |
+| deliveryClientDashboard | ✅ (pre-existing) | ✅ `Recently_Completed`, `In_Flight_Work_Items`, `Blocked_Work_Items`, `Monthly_Hours`, plus per-stage `WorkItems_*` + `Attention_Items` (list-view fallback if absent) | Reference implementation. No gap. |
+| deliveryExecutiveDashboard | ✅ **(added)** | Per-card click-through via `DashboardCard__mdt.ClickThroughUrlTxt__c` | Click-through is CMT-authored, not report-bound. Optionally seed cards with report URLs (see recs). |
+| deliveryFeatureCockpit | ✅ **(added)** | — | Feature catalog; no report surface. No gap. |
+| deliveryFeatureApprovalInbox | ✅ **(added)** | — | Approval inbox; no report surface. No gap. |
+| deliveryBudgetSummary | ✅ (pre-existing) | ✅ `Monthly_Hours`, `Monthly_Hours_By_Entry_Date`, `In_Flight_Work_Items`, `Synced_Items`, `Failed_Items` | Reference implementation. No gap. |
+| deliveryGhostRecorder | ✅ (pre-existing) | ✅ `Attention_Items` (list-view fallback) | Quick-submit + attention banner. No gap. |
+| deliveryClientOnboarding | ✅ (pre-existing) | — | Intake form; creates records, no report surface. No gap. |
+| deliveryDocumentViewer | ✅ (pre-existing) | — | Per-entity document list; record-scoped, not report-scoped. No gap. |
+| deliveryProFormaTimeline | ⚠️ registry-only (no icon) | — | Gantt canvas has **no SLDS card/header slot** — see note below. |
+| deliveryReleaseNotes | ✅ (pre-existing) | ❌ none | **Recommend** a `Recently_Completed` deep-link (see recs); needs NavigationMixin wiring — deferred as non-trivial. |
+| deliveryActivityDashboard | ✅ (pre-existing) | ✅ `Activity_By_Day`, `User_Activity_Summary` | No gap. Could optionally add `Component_Usage` / `Page_Navigation`. |
+| deliveryDataLineage | ✅ (pre-existing) | — | Sync-chain map; status is live, not report-backed. No gap. |
+| deliverySyncRetryPanel | ✅ (pre-existing) | — | Failed-sync count + retry. Could optionally deep-link `Failed_Items` (recs). |
+| deliveryHubHealthDashboard | ✅ **(added)** | — | Self-assessment checks; no report surface. No gap. |
+| deliveryWatcherSetup | ✅ **(added)** | — | Admin form; no report surface. No gap. |
+
+### deliveryProFormaTimeline — why no popover icon was injected
+
+`deliveryProFormaTimeline.html` is **not** a `lightning-card`. Its entire body is a
+`<div class="timeline-root">` whose toolbar/header is rendered by the
+`@nimbus-gantt/app` framework into a `lwc:dom="manual"` container (with its own
+context menu + a fullscreen toggle that escapes the Salesforce chrome). There is no
+SLDS `slot="actions"` or header region to host `<c-delivery-info-popover>` in the
+neighboring-card style, and a floating absolutely-positioned icon would risk
+overlapping the framework's own controls. The `INFO_REGISTRY` entry already exists
+(added in a prior change), so the description is queryable; wiring a visible icon is
+left as a recommendation pending a deliberate placement decision (see recs).
+
+---
+
+## What this PR changed
+
+**Info popover — registry entries added (5):**
+`deliveryExecutiveDashboard`, `deliveryFeatureCockpit`, `deliveryFeatureApprovalInbox`,
+`deliveryHubHealthDashboard`, `deliveryWatcherSetup`. Each entry's `dataSource` /
+`keyFields` were derived from the component's actual Apex imports and field references
+(not invented).
+
+**Info popover — icon added to card actions area (5):**
+the same 5 components' `.html` files now render
+`<c-delivery-info-popover component-name="...">` in the card's `slot="actions"`,
+matching the flex-row placement used by `deliveryBudgetSummary` /
+`deliveryActivityDashboard`.
+
+**Report deep-links wired:** none added in this PR. The four components that warrant
+report deep-links already have them (`deliveryClientDashboard`, `deliveryBudgetSummary`,
+`deliveryActivityDashboard`, `deliveryGhostRecorder`). The remaining candidates require
+non-trivial NavigationMixin wiring and are listed as recommendations below rather than
+forced in, per the "low-risk and obvious only" rule.
+
+---
+
+## Recommendations
+
+### R1 — deliveryReleaseNotes → `Recently_Completed` report (low/medium effort)
+The card lists completed Work Items for a date range; a "View as report" affordance to
+the existing `Recently_Completed` report (passing the start/end dates as `fv0`/`fv1`) is
+a natural fit. Requires adding `NavigationMixin`, the `getReportIds` import, a wired
+fetch, and a handler/button — same shape as `deliveryBudgetSummary.openHoursReport`.
+Deferred here to keep the PR focused and because the component currently has no
+`NavigationMixin` and no jest test guarding it.
+
+### R2 — deliverySyncRetryPanel → `Failed_Items` report (low effort)
+The panel already centers on failed `SyncItem__c` records. A secondary "View failed
+items report" link to `Failed_Items` would let admins drill into error detail beyond the
+inline preview. `deliveryBudgetSummary.handleFailedClick` already demonstrates the exact
+pattern (report-if-present, `SyncItem__c` list-view fallback).
+
+### R3 — deliveryProFormaTimeline info icon placement (design decision)
+Registry entry exists; decide whether to (a) add a small SLDS info button into the
+gantt's own framework toolbar, or (b) wrap the timeline in a thin `lightning-card`
+header strictly to host the popover + a title. Option (b) is the lower-risk, in-pattern
+choice but changes the component's chrome — worth a quick confirm before implementing.
+
+### R4 — deliveryExecutiveDashboard card seeds
+This is CMT-driven; its click-throughs come from `DashboardCard__mdt.ClickThroughUrlTxt__c`.
+Recommend shipping a few seed `DashboardCard__mdt` rows whose click-through points at
+existing reports (e.g. `Budget_Health`, `Velocity_by_Week`, `Work_Item_Pipeline`) so the
+home dashboard is non-empty out of the box. Data/seed work, not a code change to the LWC.
+
+---
+
+## Recommendation for the new pacing card (`deliveryPacingForecast`) — NOT implemented here
+
+`deliveryPacingForecast` is owned by a concurrent PR (#869); its file is intentionally
+untouched in this PR. The `INFO_REGISTRY` entry for it already exists on `main`. For its
+report/dashboard deep-links, recommend:
+
+- **`Monthly_Hours`** — its actual-hours bars are WorkLog hours bucketed by `WorkDateDate__c`; `Monthly_Hours` is the matching report (already date-parameterized in `deliveryBudgetSummary`). **Strong fit.**
+- **`Hours_By_Project_By_Month`** — the portfolio pacing view rolls up hours across all active project trees; this report gives the per-project breakdown behind the aggregate line. **Strong fit.** (Note exact DeveloperName casing: `Hours_By_Project_By_Month`.)
+- **`Budget_Health`** — when a single blended rate is configured the card surfaces dollars; `Budget_Health` is the natural drill-down for the $ view. **Good fit, conditional on rate config.**
+- **`ETA_vs_Projected`** / **`Budget_Overrun_Heat_Map`** — relevant to the forecast/run-rate line; optional secondary links if the card grows a "forecast detail" affordance.
+
+**New "forecast" report/dashboard — is one warranted?**
+Not strictly. The pacing card already computes its target + run-rate lines in Apex
+(`DeliveryHoursAnalyticsController.getPortfolioPacing`); the existing
+`Monthly_Hours` + `Hours_By_Project_By_Month` + `Budget_Health` reports cover the
+drill-down surfaces a user would want from it. A dedicated *forecast* report would
+duplicate the amortization/run-rate math in report formulas (fragile) without adding a
+view the trio above doesn't already give. **Recommendation: wire the three existing
+reports as deep-links from the pacing card (in PR #869); defer any net-new forecast
+report until there's a concrete drill-down the existing reports can't satisfy.**

--- a/force-app/main/default/lwc/deliveryExecutiveDashboard/deliveryExecutiveDashboard.html
+++ b/force-app/main/default/lwc/deliveryExecutiveDashboard/deliveryExecutiveDashboard.html
@@ -1,6 +1,7 @@
 <template>
     <lightning-card title="Executive Dashboard" icon-name="utility:metrics">
-        <div slot="actions">
+        <div slot="actions" class="slds-grid slds-grid_vertical-align-center" style="gap: 0.25rem;">
+            <c-delivery-info-popover component-name="deliveryExecutiveDashboard"></c-delivery-info-popover>
             <lightning-button label="Refresh" icon-name="utility:refresh" onclick={handleRefresh} variant="neutral"></lightning-button>
         </div>
 

--- a/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.html
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.html
@@ -1,12 +1,15 @@
 <template>
     <lightning-card title="Pending Approvals" icon-name="standard:approval">
-        <lightning-button-icon
-            slot="actions"
-            icon-name="utility:refresh"
-            alternative-text="Refresh"
-            title="Refresh"
-            onclick={handleRefresh}>
-        </lightning-button-icon>
+        <div slot="actions" class="slds-grid slds-grid_vertical-align-center" style="gap: 0.25rem;">
+            <c-delivery-info-popover component-name="deliveryFeatureApprovalInbox"></c-delivery-info-popover>
+            <lightning-button-icon
+                icon-name="utility:refresh"
+                variant="border-filled"
+                alternative-text="Refresh"
+                title="Refresh"
+                onclick={handleRefresh}>
+            </lightning-button-icon>
+        </div>
 
         <div class="slds-p-around_medium">
             <template lwc:if={hasError}>

--- a/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.html
+++ b/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.html
@@ -1,7 +1,8 @@
 <template>
     <lightning-card title="Feature Cockpit" icon-name="standard:apps">
 
-        <div slot="actions">
+        <div slot="actions" class="slds-grid slds-grid_vertical-align-center" style="gap: 0.25rem;">
+            <c-delivery-info-popover component-name="deliveryFeatureCockpit"></c-delivery-info-popover>
             <lightning-button
                 label="Request approval to toggle"
                 icon-name="utility:approval"

--- a/force-app/main/default/lwc/deliveryHubHealthDashboard/deliveryHubHealthDashboard.html
+++ b/force-app/main/default/lwc/deliveryHubHealthDashboard/deliveryHubHealthDashboard.html
@@ -1,12 +1,14 @@
 <template>
     <lightning-card title="Delivery Hub Health" icon-name="utility:health">
-        <lightning-button
-            slot="actions"
-            label="Refresh"
-            icon-name="utility:refresh"
-            onclick={handleRefresh}
-            disabled={loading}>
-        </lightning-button>
+        <div slot="actions" class="slds-grid slds-grid_vertical-align-center" style="gap: 0.25rem;">
+            <c-delivery-info-popover component-name="deliveryHubHealthDashboard"></c-delivery-info-popover>
+            <lightning-button
+                label="Refresh"
+                icon-name="utility:refresh"
+                onclick={handleRefresh}
+                disabled={loading}>
+            </lightning-button>
+        </div>
 
         <div class="slds-p-horizontal_medium">
             <template lwc:if={loading}>

--- a/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
+++ b/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
@@ -92,6 +92,33 @@ const INFO_REGISTRY = {
         keyFields:
             'Document__c.StatusPk__c, Document__c.SnapshotJson__c, Document__c.TemplatePk__c, Document__c.TotalHoursNumber__c, Document__c.TotalCostNumber__c, NetworkEntity__c.Id, DocumentTemplate__mdt'
     },
+    deliveryExecutiveDashboard: {
+        dataSource:
+            'Calls DeliveryDashboardCardController.getCardsForPage to load the DashboardCard__mdt records configured for the given pageKey (default "home"), then DeliveryDashboardCardController.getCardData per card to resolve each card\'s value from its dataSource + filterJson. Card type (Metric / List / PieChart / BarChart / Pills) and threshold colors (critical / warning) are all authored as Custom Metadata — nothing is hardcoded.',
+        description:
+            'A CMT-driven executive dashboard. Renders a grid of admin-authored cards (metrics, lists, bar charts, and per-Work-Item traffic-light pills) for the current page. Cards support threshold-based color states and optional click-through URLs that open in a new tab.',
+        friendlyName: 'Executive Dashboard',
+        keyFields:
+            'DashboardCard__mdt.PageKeyTxt__c, DashboardCard__mdt.CardType, DashboardCard__mdt.DataSource, DashboardCard__mdt.FilterJson, DashboardCard__mdt.ThresholdCritical, DashboardCard__mdt.ThresholdWarning, DashboardCard__mdt.ClickThroughUrlTxt__c'
+    },
+    deliveryFeatureApprovalInbox: {
+        dataSource:
+            'Calls DeliveryFeatureApprovalService.getInbox to list Pending FeatureToggleApproval__c rows assigned to the running user. Approve / Reject call grant / reject with an optional decision note for the audit trail. "Show chain" calls getApprovalChain to render every step of a multi-step cascade approval request.',
+        description:
+            'Your personal approval inbox for feature-toggle requests. Lists pending requests assigned to you with the feature, the requested action (Enable / Disable), the reason, and who asked — plus inline Approve / Reject buttons, a decision-note field, and a "Show chain" view of multi-step approval chains.',
+        friendlyName: 'Feature Approval Inbox',
+        keyFields:
+            'FeatureToggleApproval__c.StatusPk__c, FeatureToggleApproval__c.ActionPk__c, FeatureToggleApproval__c.StepNumberNumber__c, FeatureToggleApproval__c.ReasonTxt__c, FeatureToggleRequest__c (feature, requestedBy), Feature__c.Label'
+    },
+    deliveryFeatureCockpit: {
+        dataSource:
+            'Calls DeliveryFeatureCatalogController.getCatalog to render the feature catalog (Feature__c rows joined with FeatureDefinition__mdt metadata) and isAdmin to gate the toggle buttons. Enable / Disable round-trips through toggleFeature, which enforces onboarding-track gating and dependency-cascade rules. "Show dependencies" opens a cascade-preview modal; "Request approval to toggle" opens the approval-submit flow.',
+        description:
+            'The Feature Catalog cockpit. Shows every Delivery Hub feature as a card with its category, maturity, mapped settings field, and Active / Inactive status. Admins get inline Enable / Disable toggles (gated by onboarding tracks and dependency cascades), a dependency-graph preview, and a "Request approval to toggle" submission flow.',
+        friendlyName: 'Feature Cockpit',
+        keyFields:
+            'Feature__c.IsActiveBoolean__c, Feature__c.Label, FeatureDefinition__mdt (Category, Maturity, Icon, SettingsFieldApiName, DocsUrl), FeatureDependency__mdt, FeatureToggleApproval__c'
+    },
     deliveryGeneralSettingsCard: {
         dataSource:
             'Loads all Delivery Hub settings via getSettings which reads the DeliveryHubSettings__c custom setting. Each toggle calls saveGeneralSettings or saveExtendedSettings to persist changes immediately. Slack webhook is saved separately via saveSlackWebhookUrl and tested via testWebhook.',
@@ -118,6 +145,15 @@ const INFO_REGISTRY = {
         friendlyName: 'Ghost Recorder',
         keyFields:
             'Activity_Log__c.ActionTypePk__c, WorkItem__c.BriefDescriptionTxt__c, WorkItem__c.PriorityPk__c, WorkItem__c.DetailsTxt__c'
+    },
+    deliveryHubHealthDashboard: {
+        dataSource:
+            'Calls DeliveryHubHealthService.runAllChecks, which runs every registered self-assessment check (connection status, sync schedule, settings integrity, seed data, guest-user access, etc.) and returns a pass / warn / fail status plus a human-readable detail per check. Checks that expose a repairKey get a one-click Repair button that calls DeliveryHubRepairService.runRepair and then re-runs the checks.',
+        description:
+            'An admin self-assessment dashboard for Delivery Hub. Runs every configured health check and renders a color-coded card per result (pass / warn / fail) with the diagnostic detail, plus one-click "Repair" buttons for checks that support automated remediation.',
+        friendlyName: 'Hub Health',
+        keyFields:
+            'DeliveryHubHealthService check results (checkKey, label, statusPk, detail, repairKey), NetworkEntity__c.StatusPk__c, DeliveryHubSettings__c, CronTrigger (sync schedule)'
     },
     deliveryHubBoard: {
         dataSource:
@@ -199,6 +235,15 @@ const INFO_REGISTRY = {
         friendlyName: 'Portfolio Pacing & Forecast',
         keyFields:
             'WorkItem__c.EstimatedHoursNumber__c, WorkItem__c.EstimatedStartDevDate__c, WorkItem__c.EstimatedEndDevDate__c, WorkItem__c.TotalLoggedHoursSum__c, WorkLog__c.HoursLoggedNumber__c, WorkLog__c.WorkDateDate__c, NetworkEntity__c.DefaultHourlyRateCurrency__c'
+    },
+    deliveryWatcherSetup: {
+        dataSource:
+            'Calls DeliveryWatcherSetupController.getSettings to load the Watcher digest configuration from DeliveryHubSettings__c, and saveSettings to persist it. Flipping the master toggle stamps EnableWatcherDigestDateTime__c; the recipient list is validated against active Users and stored in WatcherDigestRecipientUserIdsTxt__c; an optional Slack webhook override updates the org-wide webhook used by escalations and forecasts.',
+        description:
+            'Admin form for the daily Watcher digest. Flips the master opt-in, curates the digest recipient list (validated Salesforce User Ids), and optionally overrides the org-wide Slack webhook — so admins no longer need to open Setup → Custom Settings. Shows the next scheduled run and last-saved timestamp.',
+        friendlyName: 'Watcher Digest Setup',
+        keyFields:
+            'DeliveryHubSettings__c.EnableWatcherDigestDateTime__c, DeliveryHubSettings__c.WatcherDigestRecipientUserIdsTxt__c, DeliveryHubSettings__c.SlackWebhookUrl, CronTrigger (scheduled Watcher tick)'
     }
 };
 

--- a/force-app/main/default/lwc/deliveryWatcherSetup/deliveryWatcherSetup.html
+++ b/force-app/main/default/lwc/deliveryWatcherSetup/deliveryWatcherSetup.html
@@ -1,8 +1,9 @@
 <template>
     <lightning-card icon-name="utility:notification" title="Watcher Digest Setup">
-        <span slot="actions">
+        <div slot="actions" class="slds-grid slds-grid_vertical-align-center" style="gap: 0.25rem;">
+            <c-delivery-info-popover component-name="deliveryWatcherSetup"></c-delivery-info-popover>
             <lightning-badge label={enabledBadgeLabel} variant={enabledBadgeVariant}></lightning-badge>
-        </span>
+        </div>
 
         <template lwc:if={isLoading}>
             <div class="slds-p-around_large slds-text-align_center">


### PR DESCRIPTION
## Home-page LWC sweep

Sweeps the two Home FlexiPages (`DeliveryHubHome` + `DeliveryHubAdminHome`) so **every home-page card carries the `deliveryInfoPopover` self-documenting icon**, and audits report/dashboard deep-link coverage.

### Info popover — coverage closed (5 components)

These 5 were missing **both** an `INFO_REGISTRY` entry and the `<c-delivery-info-popover>` icon. Added both for each:

| LWC | Registry entry | Icon in card actions |
|---|:---:|:---:|
| deliveryExecutiveDashboard | ✅ added | ✅ added |
| deliveryFeatureCockpit | ✅ added | ✅ added |
| deliveryFeatureApprovalInbox | ✅ added | ✅ added |
| deliveryHubHealthDashboard | ✅ added | ✅ added |
| deliveryWatcherSetup | ✅ added | ✅ added |

Each `dataSource` / `keyFields` was derived from the component's **actual** Apex imports + field references (not invented). Icons sit in the card's `slot="actions"` using the existing flex-row style (`deliveryBudgetSummary` / `deliveryActivityDashboard`).

`deliveryPacingForecast` is **intentionally untouched** — owned by #869, which already merged to `main` with its own registry entry + popover. (This branch is based off that commit.)

### Report / dashboard deep-links

Audited in **`docs/audits/home-lwc-info-reports-2026-06-04.md`** (full coverage table inside). The four cards that warrant report deep-links **already have them**: `deliveryClientDashboard`, `deliveryBudgetSummary`, `deliveryActivityDashboard`, `deliveryGhostRecorder`. No new deep-links were forced in — the remaining candidates need non-trivial `NavigationMixin` wiring and are listed as recommendations.

**Recommendations (in the doc):**
- **R1** `deliveryReleaseNotes` → `Recently_Completed` (date-ranged) — needs NavigationMixin wiring, deferred.
- **R2** `deliverySyncRetryPanel` → `Failed_Items` — low effort, same pattern as `deliveryBudgetSummary.handleFailedClick`.
- **R3** `deliveryProFormaTimeline` info-icon placement — gantt canvas has no SLDS card/header slot; registry entry exists but icon placement is a design call.
- **R4** seed `DashboardCard__mdt` rows for `deliveryExecutiveDashboard` pointing at existing reports.

**Pacing card (`deliveryPacingForecast`, for #869):** recommend deep-links to `Monthly_Hours`, `Hours_By_Project_By_Month`, and `Budget_Health`. A net-new "forecast" report is **not** warranted — the Apex already computes target/run-rate lines and those three reports cover the drill-downs.

### Tests
- `deliveryFeatureCockpit.test.js` — the 3 failing tests are **pre-existing on `main`** (onboarding-gate toast / `GenerateUrl` mock assertions), verified by stashing the HTML change and re-running; unrelated to this PR. The HTML change adds a popover to `slot="actions"`, which the test's `lightning-button`/`.feature-card` selectors don't touch.
- The other 4 modified components have no jest tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
