### PR TITLE
feat(pacing): interactive schedule-based Pacing & Forecast — Salesforce-native parallel to NG (drill-down + navigate-to-record)

### DIFF
--- a/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
@@ -9,14 +9,29 @@
  *              EstimatedStartDevDate__c/EstimatedEndDevDate__c when those are populated.
  *              Backs the deliveryProjectMonthlyHours record-page LWC.
  *
- *              Also exposes getPortfolioPacing — an account/org-level pacing +
- *              forecast across ALL active root WorkItems (not a single record),
- *              bucketed at Week/Month/Quarter granularity, with per-period
- *              targets and a portfolio run-rate forecast. Backs the
- *              deliveryPacingForecast HomePage LWC. ZERO new objects/fields.
+ *              Also exposes getPortfolioPacing — the Salesforce-native Pacing &
+ *              Forecast engine (parallel to the nimbus-gantt Pacing view; SAME
+ *              definition both render). Across the whole portfolio, bucketed at
+ *              Week/Month/Quarter granularity:
+ *
+ *              ACTUALS (per-period logged bars + summary.loggedHours headline) count
+ *              ALL WorkLog hours by WorkDateDate__c — NO active-portfolio filter — so
+ *              completed/archived work is never dropped from the historical totals.
+ *
+ *              FORECAST is schedule-based: each in-flight WorkItem's remaining estimate
+ *              (estimate − logged-so-far) is spread evenly across the forward periods
+ *              its EstimatedStartDevDate__c → EstimatedEndDevDate__c span covers — the
+ *              SAME two fields the Gantt drag-writes, so the two views can't drift.
+ *              Remaining that can't be placed on the calendar (no usable dates, or an
+ *              end date in the past) accumulates into summary.unscheduledRemainingHours
+ *              rather than being silently dropped.
+ *
+ *              Each period carries a rich per-item drill-down (PacingItemDTO list) so
+ *              the LWC can expand a bar into its constituent work items, and from there
+ *              navigate to the WorkItem record. ZERO new objects/fields.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexDoc,PMD.AvoidGlobalModifier,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.OperationWithLimitsInLoop')
+@SuppressWarnings('PMD.ApexDoc,PMD.AvoidGlobalModifier,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.OperationWithLimitsInLoop,PMD.ExcessivePublicCount,PMD.TooManyFields')
 global with sharing class DeliveryHoursAnalyticsController {
 
     /** @description Hard cap on recursion depth when walking the WI parent-child tree. */
@@ -257,9 +272,9 @@ global with sharing class DeliveryHoursAnalyticsController {
     }
 
     // ════════════════════════════════════════════════════════════════════
-    // Portfolio Pacing & Forecast — account/org-level pacing across ALL
-    // active root WorkItems (not a single record). Backs the
-    // deliveryPacingForecast HomePage LWC. ZERO new objects/fields.
+    // Portfolio Pacing & Forecast — the Salesforce-native engine behind the
+    // deliveryPacingForecast LWC. Parallel to the nimbus-gantt Pacing view;
+    // SAME model both render. ZERO new objects/fields.
     // ════════════════════════════════════════════════════════════════════
 
     /** @description Hard cap on the number of pacing periods (history + forecast). */
@@ -267,6 +282,14 @@ global with sharing class DeliveryHoursAnalyticsController {
 
     /** @description Cap on active root WorkItems scanned for the portfolio scope. */
     private static final Integer MAX_PORTFOLIO_ROOTS = 500;
+
+    /**
+     * @description Cap on the number of in-flight WorkItems pulled for the
+     *              schedule-based forecast. When the active set exceeds this,
+     *              the forecast is computed from the first MAX_INFLIGHT_ITEMS and
+     *              summary.forecastCapped is flagged so the LWC can note the truncation.
+     */
+    private static final Integer MAX_INFLIGHT_ITEMS = 2000;
 
     /** @description Number of trailing history periods averaged for the run-rate. */
     private static final Integer RUN_RATE_WINDOW = 4;
@@ -277,53 +300,119 @@ global with sharing class DeliveryHoursAnalyticsController {
     /** @description Months in a quarter — period stepping for Quarter granularity. */
     private static final Integer MONTHS_PER_QUARTER = 3;
 
-    /** @description Terminal stages excluded from the active-portfolio scope. */
+    /** @description Terminal stages excluded from the active / in-flight scope. */
     private static final Set<String> TERMINAL_STAGES = new Set<String>{
         'Done', 'Cancelled', 'Closed', 'Rejected'
     };
+
+    /**
+     * @description One in-flight WorkItem in a single period's drill-down. The rich
+     *              breakout mirrors the nimbus-gantt Pacing item contract so the two
+     *              views read the same numbers. hoursThisPeriod is the share of the
+     *              item's remaining placed into THIS period; pctOfItem is that share
+     *              over the item's placed total; budgetUsedPct is logged ÷ estimate.
+     */
+    global class PacingItemDTO {
+        @AuraEnabled global Id workItemId;
+        @AuraEnabled global String name;
+        @AuraEnabled global Decimal hoursThisPeriod;
+        @AuraEnabled global Decimal pctOfItem;
+        @AuraEnabled global Decimal estimatedHours;
+        @AuraEnabled global Decimal loggedHours;
+        @AuraEnabled global Decimal remainingHours;
+        @AuraEnabled global Decimal budgetUsedPct;
+        @AuraEnabled global Date startDate;
+        @AuraEnabled global Date endDate;
+        @AuraEnabled global String developerName;
+        @AuraEnabled global String stage;
+        @AuraEnabled global String priorityGroup;
+    }
 
     /** @description One period (history or forecast) on the pacing timeline. */
     global class PacingPeriodDTO {
         @AuraEnabled global String label;
         @AuraEnabled global Date startDate;
         @AuraEnabled global Date endDate;
-        @AuraEnabled global Decimal loggedHours;
-        @AuraEnabled global Decimal targetHours;
+        @AuraEnabled global Decimal actualHours;
         @AuraEnabled global Decimal forecastHours;
+        @AuraEnabled global Decimal targetHours;
         @AuraEnabled global Boolean isForecast;
+        @AuraEnabled global Boolean isCurrent;
         @AuraEnabled global Boolean overTarget;
+        /** @description Per-period drill-down — the in-flight items contributing here. */
+        @AuraEnabled global List<PacingItemDTO> items;
     }
 
-    /** @description Portfolio-level pacing + forecast headline returned to the LWC. */
-    global class PortfolioPacingDTO {
-        @AuraEnabled global String granularity;
-        @AuraEnabled global Integer rootCount;
-        @AuraEnabled global Decimal totalEstimatedHours;
-        @AuraEnabled global Decimal totalLoggedHours;
+    /** @description Headline summary cards block for the Pacing & Forecast view. */
+    global class PacingSummaryDTO {
+        @AuraEnabled global Decimal estimatedHours;
+        @AuraEnabled global Decimal loggedHours;
+        @AuraEnabled global Decimal remainingHours;
         @AuraEnabled global Decimal projectedFinalHours;
+        @AuraEnabled global Decimal pacingPct;
+        @AuraEnabled global Integer activeItems;
+        @AuraEnabled global Decimal unscheduledRemainingHours;
         @AuraEnabled global Decimal runRateHoursPerPeriod;
-        @AuraEnabled global Decimal blendedRate;
         @AuraEnabled global Boolean hasEstimate;
         @AuraEnabled global Boolean isOverBudgetTrajectory;
+        @AuraEnabled global Boolean forecastCapped;
+    }
+
+    /** @description Portfolio-level pacing + forecast payload returned to the LWC. */
+    global class PortfolioPacingDTO {
+        @AuraEnabled global String granularity;
+        @AuraEnabled global String scopeLabel;
+        @AuraEnabled global Integer rootCount;
+        @AuraEnabled global PacingSummaryDTO summary;
+        @AuraEnabled global Decimal blendedRate;
         @AuraEnabled global Date earliestStart;
         @AuraEnabled global Date latestEnd;
         @AuraEnabled global List<PacingPeriodDTO> periods;
     }
 
     /**
-     * @description Account/org-level pacing + forecast across the whole active
-     *              portfolio (all active root WorkItems + their descendant trees).
+     * @description One in-flight WorkItem's forecast inputs: remaining + schedule +
+     *              the metadata the drill-down renders. Carries its placed-total so a
+     *              per-period share can report pctOfItem.
+     */
+    private class InFlightItem {
+        Id workItemId;
+        String name;
+        Decimal estimate;
+        Decimal logged;
+        Decimal remaining;
+        Decimal budgetUsedPct;
+        Date startDate;
+        Date endDate;
+        String developerName;
+        String stage;
+        String priorityGroup;
+        /** @description Remaining actually placed onto visible forward periods. */
+        Decimal placedTotal = 0;
+    }
+
+    /**
+     * @description Salesforce-native Pacing & Forecast across the whole portfolio.
      *              Builds a period skeleton of `periodsBack` history periods plus
-     *              `periodsForward` forecast periods at the requested granularity,
-     *              fills actuals from one WorkLog AggregateResult, amortizes the
-     *              portfolio estimate into per-period targets, and projects forward
-     *              periods at the portfolio run-rate (capped at remaining estimate).
+     *              `periodsForward` forecast periods at the requested granularity.
+     *
+     *              ACTUALS (history bars + summary.loggedHours) count ALL WorkLog hours
+     *              by WorkDateDate__c — NO active-portfolio filter — so completed /
+     *              archived work is never dropped from the totals.
+     *
+     *              FORECAST is schedule-based: each in-flight WorkItem's remaining
+     *              estimate (estimate − logged-so-far) is spread evenly across the
+     *              forward periods its EstimatedStart → EstimatedEnd span covers, and
+     *              recorded as a per-period drill-down item. Remaining that can't be
+     *              placed accumulates into summary.unscheduledRemainingHours.
+     *              summary.projectedFinalHours = summary.loggedHours +
+     *              Σ remaining(all in-flight).
      * @param granularity 'Week' | 'Month' | 'Quarter'. Defaults to 'Month'.
      * @param periodsBack History periods to include. Clamped to [1, MAX_PERIODS].
      *                    Null/zero defaults to 6.
      * @param periodsForward Forecast periods to project. Clamped to [0, MAX_PERIODS].
      *                    Null defaults to 3. Total periods are capped at MAX_PERIODS.
-     * @return PortfolioPacingDTO with the period series + headline numbers.
+     * @return PortfolioPacingDTO with the period series + headline summary.
      */
     @AuraEnabled(cacheable=true)
     global static PortfolioPacingDTO getPortfolioPacing(String granularity, Integer periodsBack, Integer periodsForward) {
@@ -339,20 +428,23 @@ global with sharing class DeliveryHoursAnalyticsController {
             }
 
             Set<Id> rootIds = queryActiveRootIds();
-            Set<Id> portfolioIds = collectPortfolioTree(rootIds);
 
             PortfolioPacingDTO dto = new PortfolioPacingDTO();
             dto.granularity = gran;
             dto.rootCount = rootIds.size();
-            rollupPortfolioTotals(dto, portfolioIds);
+            dto.summary = new PacingSummaryDTO();
+            // Estimate + planned span come from the active portfolio tree (target line);
+            // logged hours count ALL WorkLog rows so completed work is reflected.
+            rollupPortfolioTotals(dto, rootIds);
 
             List<PacingPeriodDTO> periods = buildPeriodSkeleton(gran, back, forward);
-            applyPortfolioLoggedHours(periods, portfolioIds, gran);
+            applyPortfolioLoggedHours(periods, gran);
             applyPortfolioTargets(periods, dto);
-            applyPortfolioForecast(periods, dto, back);
+            applyScheduleBasedForecast(periods, dto, gran, back);
 
             dto.periods = periods;
             dto.blendedRate = resolveBlendedRate();
+            dto.scopeLabel = buildScopeLabel(dto);
             return dto;
         } catch (AuraHandledException ahe) {
             throw ahe;
@@ -386,6 +478,16 @@ global with sharing class DeliveryHoursAnalyticsController {
             value = MAX_PERIODS;
         }
         return value;
+    }
+
+    /** @description Human-readable one-line scope label for the card header. */
+    private static String buildScopeLabel(PortfolioPacingDTO dto) {
+        Integer roots = dto.rootCount == null ? 0 : dto.rootCount;
+        Integer items = dto.summary != null && dto.summary.activeItems != null
+            ? dto.summary.activeItems : 0;
+        String rootWord = roots == 1 ? 'active project' : 'active projects';
+        String itemWord = items == 1 ? 'in-flight item' : 'in-flight items';
+        return roots + ' ' + rootWord + ' · ' + items + ' ' + itemWord;
     }
 
     /**
@@ -439,59 +541,66 @@ global with sharing class DeliveryHoursAnalyticsController {
 
     /**
      * @description Sums the portfolio estimate and planned start/end span from the
-     *              WorkItem tree (one query), and the all-time logged hours straight
-     *              from WorkLog (one aggregate). Logged hours are read from WorkLog
-     *              directly — NOT the TotalLoggedHoursSum__c roll-up — so the headline
-     *              stays correct regardless of roll-up recalc timing.
+     *              active portfolio tree (used only for the amortized TARGET line),
+     *              and the all-time logged hours across EVERY WorkLog regardless of
+     *              scope. The logged total is decoupled from the active-portfolio
+     *              filter on purpose: completed/archived work still counts toward the
+     *              actuals headline (the old scope filter undercounted it).
+     * @param dto     Payload (mutated: summary.estimatedHours / loggedHours / span).
+     * @param rootIds Active root WorkItem Ids (expanded to their trees here for the
+     *                estimate/span; the logged total ignores this set entirely).
      */
-    private static void rollupPortfolioTotals(PortfolioPacingDTO dto, Set<Id> portfolioIds) {
-        dto.totalEstimatedHours = 0;
-        dto.totalLoggedHours = 0;
+    private static void rollupPortfolioTotals(PortfolioPacingDTO dto, Set<Id> rootIds) {
+        dto.summary.estimatedHours = 0;
         dto.earliestStart = null;
         dto.latestEnd = null;
-        if (portfolioIds.isEmpty()) {
-            dto.hasEstimate = false;
-            return;
+
+        Set<Id> portfolioIds = collectPortfolioTree(rootIds);
+        if (!portfolioIds.isEmpty()) {
+            for (WorkItem__c wi : [
+                SELECT EstimatedHoursNumber__c,
+                       EstimatedStartDevDate__c, EstimatedEndDevDate__c
+                FROM WorkItem__c
+                WHERE Id IN :portfolioIds
+                WITH SYSTEM_MODE
+                LIMIT 50000
+            ]) {
+                if (wi.EstimatedHoursNumber__c != null) {
+                    dto.summary.estimatedHours += wi.EstimatedHoursNumber__c;
+                }
+                Date s = wi.EstimatedStartDevDate__c;
+                if (s != null && (dto.earliestStart == null || s < dto.earliestStart)) {
+                    dto.earliestStart = s;
+                }
+                Date e = wi.EstimatedEndDevDate__c;
+                if (e != null && (dto.latestEnd == null || e > dto.latestEnd)) {
+                    dto.latestEnd = e;
+                }
+            }
         }
-        for (WorkItem__c wi : [
-            SELECT EstimatedHoursNumber__c,
-                   EstimatedStartDevDate__c, EstimatedEndDevDate__c
-            FROM WorkItem__c
-            WHERE Id IN :portfolioIds
-            WITH SYSTEM_MODE
-            LIMIT 50000
-        ]) {
-            if (wi.EstimatedHoursNumber__c != null) {
-                dto.totalEstimatedHours += wi.EstimatedHoursNumber__c;
-            }
-            Date s = wi.EstimatedStartDevDate__c;
-            if (s != null && (dto.earliestStart == null || s < dto.earliestStart)) {
-                dto.earliestStart = s;
-            }
-            Date e = wi.EstimatedEndDevDate__c;
-            if (e != null && (dto.latestEnd == null || e > dto.latestEnd)) {
-                dto.latestEnd = e;
-            }
-        }
-        dto.totalLoggedHours = sumPortfolioLoggedHours(portfolioIds);
-        dto.hasEstimate = dto.totalEstimatedHours > 0;
+        // ALL logged hours — no WorkItem scope filter — so completed work counts.
+        dto.summary.loggedHours = sumAllLoggedHours();
+        dto.summary.hasEstimate = dto.summary.estimatedHours > 0;
     }
 
     /**
-     * @description All-time logged hours across the portfolio, read from WorkLog.
+     * @description All-time logged hours across EVERY WorkLog in the org, read
+     *              directly from WorkLog (NOT the TotalLoggedHoursSum__c roll-up, so
+     *              the headline is correct regardless of roll-up recalc timing). No
+     *              WorkItem scope filter: on a single-client org all logged work is
+     *              that client's work, and dropping completed items undercounts.
      *              Grouped by WorkItemLookup__c (a bare aggregate with no GROUP BY
-     *              fails to compile with "Non-grouped query that uses an aggregate
-     *              function") and summed in Apex.
+     *              fails to compile) and summed in Apex.
      */
-    private static Decimal sumPortfolioLoggedHours(Set<Id> portfolioIds) {
+    private static Decimal sumAllLoggedHours() {
         Decimal total = 0;
         for (AggregateResult ar : [
             SELECT SUM(HoursLoggedNumber__c) total
             FROM WorkLog__c
-            WHERE WorkItemLookup__c IN :portfolioIds
+            WHERE HoursLoggedNumber__c != NULL
             WITH SYSTEM_MODE
             GROUP BY WorkItemLookup__c
-            LIMIT 5000
+            LIMIT 50000
         ]) {
             Object totalObj = ar.get('total');
             if (totalObj != null) {
@@ -505,7 +614,7 @@ global with sharing class DeliveryHoursAnalyticsController {
      * @description Builds the empty period skeleton: `back` history periods ending
      *              at the current period, then `forward` forecast periods. Period
      *              boundaries align to the granularity (week start, month start,
-     *              quarter start).
+     *              quarter start). Flags the period that contains today as isCurrent.
      */
     private static List<PacingPeriodDTO> buildPeriodSkeleton(String gran, Integer back, Integer forward) {
         List<PacingPeriodDTO> out = new List<PacingPeriodDTO>();
@@ -517,11 +626,13 @@ global with sharing class DeliveryHoursAnalyticsController {
             p.startDate = cursor;
             p.endDate = stepPeriod(gran, cursor, 1).addDays(-1);
             p.label = formatPeriodLabel(gran, cursor);
-            p.loggedHours = 0;
+            p.actualHours = 0;
             p.targetHours = 0;
             p.forecastHours = 0;
             p.isForecast = i >= back;
+            p.isCurrent = cursor == currentStart;
             p.overTarget = false;
+            p.items = new List<PacingItemDTO>();
             out.add(p);
             cursor = stepPeriod(gran, cursor, 1);
         }
@@ -566,10 +677,12 @@ global with sharing class DeliveryHoursAnalyticsController {
     /**
      * @description Fills the history periods with actual logged hours from ONE
      *              window-bounded WorkLog AggregateResult, grouped by the
-     *              granularity's calendar function.
+     *              granularity's calendar function. Counts ALL WorkLog hours in the
+     *              window — no WorkItem scope filter — so the per-period bars equal the
+     *              raw GROUP BY CALENDAR_x(WorkDateDate__c) totals.
      */
-    private static void applyPortfolioLoggedHours(List<PacingPeriodDTO> periods, Set<Id> portfolioIds, String gran) {
-        if (periods.isEmpty() || portfolioIds.isEmpty()) {
+    private static void applyPortfolioLoggedHours(List<PacingPeriodDTO> periods, String gran) {
+        if (periods.isEmpty()) {
             return;
         }
         Date windowStart = periods[0].startDate;
@@ -578,7 +691,7 @@ global with sharing class DeliveryHoursAnalyticsController {
         for (PacingPeriodDTO p : periods) {
             byKey.put(dateKey(periodStartFor(gran, p.startDate)), p);
         }
-        for (AggregateResult ar : queryLoggedByPeriod(portfolioIds, windowStart, windowEnd, gran)) {
+        for (AggregateResult ar : queryLoggedByPeriod(windowStart, windowEnd, gran)) {
             Object totalObj = ar.get('total');
             if (totalObj == null) {
                 continue;
@@ -589,23 +702,23 @@ global with sharing class DeliveryHoursAnalyticsController {
             }
             PacingPeriodDTO bucket = byKey.get(dateKey(keyDate));
             if (bucket != null) {
-                bucket.loggedHours = (Decimal) totalObj;
+                bucket.actualHours = (Decimal) totalObj;
             }
         }
     }
 
     /**
-     * @description Runs the granularity-specific grouped aggregate. WEEK_IN_YEAR /
-     *              CALENDAR_MONTH / CALENDAR_QUARTER each carry MIN(date) so the
-     *              bucket can be mapped back to a concrete period-start date.
+     * @description Runs the granularity-specific grouped aggregate over ALL WorkLogs
+     *              in the window (no WorkItem scope filter). WEEK_IN_YEAR /
+     *              CALENDAR_MONTH / CALENDAR_QUARTER each carry MIN(date) so the bucket
+     *              can be mapped back to a concrete period-start date.
      */
-    private static List<AggregateResult> queryLoggedByPeriod(Set<Id> portfolioIds, Date windowStart, Date windowEnd, String gran) {
+    private static List<AggregateResult> queryLoggedByPeriod(Date windowStart, Date windowEnd, String gran) {
         if (gran == 'Week') {
             return [
                 SELECT MIN(WorkDateDate__c) minDate, SUM(HoursLoggedNumber__c) total
                 FROM WorkLog__c
-                WHERE WorkItemLookup__c IN :portfolioIds
-                  AND WorkDateDate__c >= :windowStart
+                WHERE WorkDateDate__c >= :windowStart
                   AND WorkDateDate__c <= :windowEnd
                 WITH SYSTEM_MODE
                 GROUP BY CALENDAR_YEAR(WorkDateDate__c), WEEK_IN_YEAR(WorkDateDate__c)
@@ -617,8 +730,7 @@ global with sharing class DeliveryHoursAnalyticsController {
                 SELECT CALENDAR_YEAR(WorkDateDate__c) y, CALENDAR_QUARTER(WorkDateDate__c) q,
                        SUM(HoursLoggedNumber__c) total
                 FROM WorkLog__c
-                WHERE WorkItemLookup__c IN :portfolioIds
-                  AND WorkDateDate__c >= :windowStart
+                WHERE WorkDateDate__c >= :windowStart
                   AND WorkDateDate__c <= :windowEnd
                 WITH SYSTEM_MODE
                 GROUP BY CALENDAR_YEAR(WorkDateDate__c), CALENDAR_QUARTER(WorkDateDate__c)
@@ -629,8 +741,7 @@ global with sharing class DeliveryHoursAnalyticsController {
             SELECT CALENDAR_YEAR(WorkDateDate__c) y, CALENDAR_MONTH(WorkDateDate__c) m,
                    SUM(HoursLoggedNumber__c) total
             FROM WorkLog__c
-            WHERE WorkItemLookup__c IN :portfolioIds
-              AND WorkDateDate__c >= :windowStart
+            WHERE WorkDateDate__c >= :windowStart
               AND WorkDateDate__c <= :windowEnd
             WITH SYSTEM_MODE
             GROUP BY CALENDAR_YEAR(WorkDateDate__c), CALENDAR_MONTH(WorkDateDate__c)
@@ -660,28 +771,28 @@ global with sharing class DeliveryHoursAnalyticsController {
     }
 
     /**
-     * @description Amortizes the portfolio estimate across each period in
-     *              proportion to how many of the period's days fall inside the
-     *              planned active span [earliestStart, latestEnd]. Generalizes
-     *              computeMonthlyTarget to variable-length periods. No-op (target
-     *              stays 0) when the portfolio has no estimate or no planned span.
+     * @description Amortizes the portfolio estimate across each period in proportion
+     *              to how many of the period's days fall inside the planned active
+     *              span [earliestStart, latestEnd]. Generalizes computeMonthlyTarget
+     *              to variable-length periods. No-op (target stays 0) when the
+     *              portfolio has no estimate or no planned span.
      */
     private static void applyPortfolioTargets(List<PacingPeriodDTO> periods, PortfolioPacingDTO dto) {
-        if (!dto.hasEstimate || dto.earliestStart == null || dto.latestEnd == null) {
+        if (!dto.summary.hasEstimate || dto.earliestStart == null || dto.latestEnd == null) {
             return;
         }
         Integer spanDays = dto.earliestStart.daysBetween(dto.latestEnd) + 1;
         if (spanDays <= 0) {
             return;
         }
-        Decimal perDay = dto.totalEstimatedHours / spanDays;
+        Decimal perDay = dto.summary.estimatedHours / spanDays;
         for (PacingPeriodDTO p : periods) {
             Integer overlap = overlapDays(p.startDate, p.endDate, dto.earliestStart, dto.latestEnd);
             if (overlap <= 0) {
                 continue;
             }
             p.targetHours = (perDay * overlap).setScale(2, System.RoundingMode.HALF_UP);
-            p.overTarget = !p.isForecast && p.targetHours > 0 && p.loggedHours > p.targetHours;
+            p.overTarget = !p.isForecast && p.targetHours > 0 && p.actualHours > p.targetHours;
         }
     }
 
@@ -696,84 +807,289 @@ global with sharing class DeliveryHoursAnalyticsController {
     }
 
     /**
-     * @description Projects forward periods at the portfolio run-rate (average
-     *              logged hours over the last RUN_RATE_WINDOW history periods),
-     *              cumulatively capped at remaining estimate. Sets headline
-     *              projectedFinalHours, runRateHoursPerPeriod, and the
-     *              over-budget-trajectory flag.
+     * @description SCHEDULE-BASED forecast. Pulls every in-flight WorkItem (active,
+     *              non-terminal, non-archived, non-template), computes each item's
+     *              remaining = max(0, estimate − logged-so-far), and spreads that
+     *              remaining EVENLY across the forward periods the item's
+     *              EstimatedStart → EstimatedEnd span covers — the SAME two fields the
+     *              Gantt drag-writes, so the two views can't drift. Each per-period
+     *              share is recorded as a PacingItemDTO in that period's items list
+     *              (the drill-down). Remaining that can't be placed on the forward
+     *              calendar (no usable dates, or an end date before the current period)
+     *              goes to summary.unscheduledRemainingHours instead of being dropped.
+     *
+     *              summary.projectedFinalHours = summary.loggedHours +
+     *              Σ remaining(all in-flight). The trailing run-rate is still computed
+     *              as an informational headline (runRateHoursPerPeriod).
+     * @param periods The period skeleton (history + forecast).
+     * @param dto     Payload (mutated: summary forecast fields + per-period items).
+     * @param gran    Granularity for whole-period allocation alignment.
+     * @param back    Count of leading history periods; forward periods are [back..n).
      */
-    private static void applyPortfolioForecast(List<PacingPeriodDTO> periods, PortfolioPacingDTO dto, Integer back) {
-        dto.runRateHoursPerPeriod = 0;
-        dto.projectedFinalHours = dto.totalLoggedHours;
-        dto.isOverBudgetTrajectory = false;
+    private static void applyScheduleBasedForecast(List<PacingPeriodDTO> periods, PortfolioPacingDTO dto, String gran, Integer back) {
+        dto.summary.runRateHoursPerPeriod = computeRunRate(periods, back).setScale(2, System.RoundingMode.HALF_UP);
+        dto.summary.unscheduledRemainingHours = 0;
+        dto.summary.remainingHours = 0;
+        dto.summary.forecastCapped = false;
 
-        Decimal runRate = computeRunRate(periods, back);
-        dto.runRateHoursPerPeriod = runRate.setScale(2, System.RoundingMode.HALF_UP);
+        List<InFlightItem> items = loadInFlightItems(dto);
+        dto.summary.activeItems = items.size();
 
-        Decimal remaining = null;
-        if (dto.hasEstimate) {
-            remaining = dto.totalEstimatedHours - dto.totalLoggedHours;
-            if (remaining < 0) {
-                remaining = 0;
-            }
-        }
-
-        Decimal cumulativeForecast = 0;
+        // Forward periods only — the band where remaining can be placed.
+        List<PacingPeriodDTO> forward = new List<PacingPeriodDTO>();
         for (Integer i = back; i < periods.size(); i++) {
-            PacingPeriodDTO p = periods[i];
-            Decimal thisPeriod = runRate;
-            if (remaining != null) {
-                Decimal headroom = remaining - cumulativeForecast;
-                if (headroom <= 0) {
-                    thisPeriod = 0;
-                } else if (thisPeriod > headroom) {
-                    thisPeriod = headroom;
-                }
+            forward.add(periods[i]);
+        }
+        Date currentPeriodStart = periodStartFor(gran, Date.today());
+
+        Decimal totalRemaining = 0;
+        Decimal unscheduled = 0;
+        for (InFlightItem item : items) {
+            if (item.remaining == null || item.remaining <= 0) {
+                continue;
             }
-            p.forecastHours = thisPeriod.setScale(2, System.RoundingMode.HALF_UP);
-            cumulativeForecast += thisPeriod;
+            totalRemaining += item.remaining;
+            Boolean placed = spreadRemaining(item, forward, currentPeriodStart);
+            if (!placed) {
+                unscheduled += item.remaining;
+            }
         }
 
-        dto.projectedFinalHours = (dto.totalLoggedHours + cumulativeForecast)
-            .setScale(2, System.RoundingMode.HALF_UP);
-        if (dto.hasEstimate) {
-            dto.isOverBudgetTrajectory = dto.projectedFinalHours > dto.totalEstimatedHours;
+        for (PacingPeriodDTO p : forward) {
+            p.forecastHours = p.forecastHours.setScale(2, System.RoundingMode.HALF_UP);
         }
+
+        dto.summary.remainingHours = totalRemaining.setScale(2, System.RoundingMode.HALF_UP);
+        dto.summary.unscheduledRemainingHours = unscheduled.setScale(2, System.RoundingMode.HALF_UP);
+        dto.summary.projectedFinalHours = (dto.summary.loggedHours + totalRemaining)
+            .setScale(2, System.RoundingMode.HALF_UP);
+        dto.summary.isOverBudgetTrajectory = dto.summary.hasEstimate
+            && dto.summary.projectedFinalHours > dto.summary.estimatedHours;
+        dto.summary.pacingPct = computePacingPct(dto.summary);
     }
 
     /**
-     * @description Average logged hours across the trailing RUN_RATE_WINDOW
-     *              history periods. Counts only history periods (index < back).
+     * @description Pacing % = logged ÷ estimate, expressed 0–100+ (a "burn" of the
+     *              budget). Null/zero estimate → 0 (hours-only display, no %).
+     */
+    private static Decimal computePacingPct(PacingSummaryDTO s) {
+        if (s.estimatedHours == null || s.estimatedHours <= 0) {
+            return 0;
+        }
+        return (s.loggedHours / s.estimatedHours * 100).setScale(1, System.RoundingMode.HALF_UP);
+    }
+
+    /**
+     * @description Spreads an item's remaining evenly across the forward periods its
+     *              schedule covers — from max(currentPeriodStart, EstimatedStart)
+     *              through EstimatedEnd, aligned to the granularity's whole periods.
+     *              Adds each period's share onto its forecastHours AND records the
+     *              share as a PacingItemDTO in that period's drill-down. A two-pass
+     *              walk: pass 1 collects covered periods + accumulates placedTotal so
+     *              pctOfItem can be computed against the real placed denominator;
+     *              pass 2 emits the per-period item rows.
+     * @param item    The in-flight item (remaining + start/end + metadata).
+     * @param forward The forecast periods (in chronological order).
+     * @param currentPeriodStart Start of the period containing today.
+     * @return True when the remaining was placed onto at least one forward period;
+     *         false when it couldn't be scheduled (caller treats as unscheduled).
+     */
+    private static Boolean spreadRemaining(InFlightItem item, List<PacingPeriodDTO> forward, Date currentPeriodStart) {
+        if (forward.isEmpty() || item.startDate == null || item.endDate == null) {
+            return false;
+        }
+        // End in the past (before the current period) → nothing to place forward.
+        if (item.endDate < currentPeriodStart) {
+            return false;
+        }
+        // Clamp the placement window's left edge to the current period.
+        Date effectiveStart = item.startDate > currentPeriodStart ? item.startDate : currentPeriodStart;
+        if (effectiveStart > item.endDate) {
+            effectiveStart = item.endDate;
+        }
+        // Collect the forward periods this item's span touches.
+        List<PacingPeriodDTO> covered = new List<PacingPeriodDTO>();
+        for (PacingPeriodDTO p : forward) {
+            if (p.endDate >= effectiveStart && p.startDate <= item.endDate) {
+                covered.add(p);
+            }
+        }
+        if (covered.isEmpty()) {
+            // Schedule falls entirely beyond the visible forward horizon — still a
+            // real, dated commitment; do NOT route to unscheduled. Drop the share into
+            // the last visible forward period so the total stays whole.
+            PacingPeriodDTO last = forward[forward.size() - 1];
+            last.forecastHours += item.remaining;
+            item.placedTotal = item.remaining;
+            last.items.add(buildPacingItem(item, item.remaining));
+            return true;
+        }
+        Decimal share = item.remaining / covered.size();
+        item.placedTotal = item.remaining;
+        for (PacingPeriodDTO p : covered) {
+            p.forecastHours += share;
+            p.items.add(buildPacingItem(item, share));
+        }
+        return true;
+    }
+
+    /**
+     * @description Builds one drill-down row for an item's share in a single period.
+     *              pctOfItem = this period's share ÷ the item's placed total.
+     */
+    private static PacingItemDTO buildPacingItem(InFlightItem item, Decimal hoursThisPeriod) {
+        PacingItemDTO row = new PacingItemDTO();
+        row.workItemId = item.workItemId;
+        row.name = item.name;
+        row.hoursThisPeriod = hoursThisPeriod.setScale(2, System.RoundingMode.HALF_UP);
+        row.estimatedHours = item.estimate;
+        row.loggedHours = item.logged;
+        row.remainingHours = item.remaining;
+        row.budgetUsedPct = item.budgetUsedPct;
+        row.startDate = item.startDate;
+        row.endDate = item.endDate;
+        row.developerName = item.developerName;
+        row.stage = item.stage;
+        row.priorityGroup = item.priorityGroup;
+        Decimal denom = item.placedTotal != null && item.placedTotal > 0 ? item.placedTotal : item.remaining;
+        row.pctOfItem = (denom != null && denom > 0)
+            ? (hoursThisPeriod / denom * 100).setScale(1, System.RoundingMode.HALF_UP)
+            : 0;
+        return row;
+    }
+
+    /**
+     * @description Loads in-flight WorkItems for the schedule-based forecast: active,
+     *              non-terminal, non-archived, non-template — the same active filter as
+     *              the portfolio scope, but applied PER ITEM (not tree-rolled). Pulls
+     *              the drill-down metadata (developer, stage, priority group, number),
+     *              computes each item's logged-so-far by summing its WorkLogs (one
+     *              aggregate, bulk) for accuracy, falling back to TotalLoggedHoursSum__c
+     *              only when no WorkLogs exist. Sets summary.forecastCapped when the
+     *              active set is truncated at MAX_INFLIGHT_ITEMS.
+     */
+    private static List<InFlightItem> loadInFlightItems(PortfolioPacingDTO dto) {
+        List<WorkItem__c> wis = [
+            SELECT Id, Name, EstimatedHoursNumber__c, TotalLoggedHoursSum__c,
+                   EstimatedStartDevDate__c, EstimatedEndDevDate__c,
+                   StageNamePk__c, PriorityGroupPk__c, DeveloperLookup__r.Name
+            FROM WorkItem__c
+            WHERE ActivatedDateTime__c != NULL
+              AND ArchivedDateTime__c = NULL
+              AND TemplateMarkedDateTime__c = NULL
+              AND StageNamePk__c NOT IN :TERMINAL_STAGES
+              AND EstimatedHoursNumber__c != NULL
+              AND EstimatedHoursNumber__c > 0
+            WITH SYSTEM_MODE
+            ORDER BY EstimatedEndDevDate__c ASC NULLS LAST
+            LIMIT :MAX_INFLIGHT_ITEMS
+        ];
+        if (wis.size() == MAX_INFLIGHT_ITEMS) {
+            dto.summary.forecastCapped = true;
+            System.debug(LoggingLevel.WARN,
+                'DeliveryHoursAnalyticsController: in-flight forecast set capped at '
+                + MAX_INFLIGHT_ITEMS + ' items — projection may be partial.');
+        }
+
+        Map<Id, Decimal> loggedByItem = sumLoggedByItem(wis);
+
+        List<InFlightItem> out = new List<InFlightItem>();
+        for (WorkItem__c wi : wis) {
+            out.add(buildInFlightItem(wi, loggedByItem));
+        }
+        return out;
+    }
+
+    /** @description Maps one WorkItem row + its logged-so-far into an InFlightItem. */
+    private static InFlightItem buildInFlightItem(WorkItem__c wi, Map<Id, Decimal> loggedByItem) {
+        Decimal logged = loggedByItem.containsKey(wi.Id)
+            ? loggedByItem.get(wi.Id)
+            : (wi.TotalLoggedHoursSum__c != null ? wi.TotalLoggedHoursSum__c : 0);
+        Decimal estimate = wi.EstimatedHoursNumber__c;
+        Decimal remaining = estimate - logged;
+        if (remaining < 0) {
+            remaining = 0;
+        }
+        InFlightItem fi = new InFlightItem();
+        fi.workItemId = wi.Id;
+        fi.name = wi.Name;
+        fi.estimate = estimate;
+        fi.logged = logged.setScale(2, System.RoundingMode.HALF_UP);
+        fi.remaining = remaining.setScale(2, System.RoundingMode.HALF_UP);
+        fi.budgetUsedPct = (estimate != null && estimate > 0)
+            ? (logged / estimate * 100).setScale(1, System.RoundingMode.HALF_UP)
+            : 0;
+        fi.startDate = wi.EstimatedStartDevDate__c;
+        fi.endDate = wi.EstimatedEndDevDate__c;
+        fi.developerName = wi.DeveloperLookup__r != null ? wi.DeveloperLookup__r.Name : null;
+        fi.stage = wi.StageNamePk__c;
+        fi.priorityGroup = wi.PriorityGroupPk__c;
+        return fi;
+    }
+
+    /**
+     * @description Sums logged hours per WorkItem in ONE aggregate across the given
+     *              items — bulk, no SOQL-in-loop. Preferred over the roll-up field for
+     *              accuracy (roll-up recalc can lag).
+     */
+    private static Map<Id, Decimal> sumLoggedByItem(List<WorkItem__c> wis) {
+        Map<Id, Decimal> out = new Map<Id, Decimal>();
+        if (wis.isEmpty()) {
+            return out;
+        }
+        Set<Id> ids = new Map<Id, WorkItem__c>(wis).keySet();
+        for (AggregateResult ar : [
+            SELECT WorkItemLookup__c wiId, SUM(HoursLoggedNumber__c) total
+            FROM WorkLog__c
+            WHERE WorkItemLookup__c IN :ids
+              AND HoursLoggedNumber__c != NULL
+            WITH SYSTEM_MODE
+            GROUP BY WorkItemLookup__c
+            LIMIT 50000
+        ]) {
+            Id wiId = (Id) ar.get('wiId');
+            Object totalObj = ar.get('total');
+            if (wiId != null && totalObj != null) {
+                out.put(wiId, (Decimal) totalObj);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * @description Average logged hours across the trailing RUN_RATE_WINDOW history
+     *              periods. Informational headline only — no longer drives the forecast
+     *              bars. Counts only history periods (index < back).
      */
     private static Decimal computeRunRate(List<PacingPeriodDTO> periods, Integer back) {
         if (back <= 0) {
             return 0;
         }
         Integer window = Math.min(RUN_RATE_WINDOW, back);
+        if (window == 0) {
+            return 0;
+        }
         Integer startIdx = back - window;
         Decimal sum = 0;
         for (Integer i = startIdx; i < back; i++) {
-            sum += periods[i].loggedHours;
-        }
-        if (window == 0) {
-            return 0;
+            sum += periods[i].actualHours;
         }
         return sum / window;
     }
 
     /**
      * @description Reads a single blended hourly rate when EXACTLY ONE active
-     *              NetworkEntity carries a DefaultHourlyRateCurrency__c, so the
-     *              LWC can render a secondary $ axis. Returns null when zero or
-     *              many distinct rates exist (ambiguous — hours-only display).
+     *              NetworkEntity carries a DefaultHourlyRateCurrency__c, so the LWC can
+     *              render a secondary $ axis. Returns null when zero or many distinct
+     *              rates exist (ambiguous — hours-only display).
      */
     private static Decimal resolveBlendedRate() {
-        // No describe guard: DefaultHourlyRateCurrency__c is referenced statically
-        // in the SOQL below, so it is compile-time guaranteed to exist. A
+        // No describe guard: DefaultHourlyRateCurrency__c is referenced statically in
+        // the SOQL below, so it is compile-time guaranteed to exist. A
         // fields.getMap().containsKey('DefaultHourlyRateCurrency__c') guard is also
         // namespace-UNSAFE — in the packaging org the map key is prefixed
-        // ('delivery__defaulthourly...'), so the unprefixed containsKey returns
-        // false and the method returned null in managed contexts (upload-beta only).
+        // ('delivery__defaulthourly...'), so the unprefixed containsKey returns false
+        // and the method returned null in managed contexts (upload-beta only).
         List<NetworkEntity__c> rated = [
             SELECT DefaultHourlyRateCurrency__c
             FROM NetworkEntity__c

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
@@ -2,8 +2,10 @@
  * @name         Delivery Hub
  * @license      BSL 1.1 — See LICENSE.md
  * @description Unit tests for DeliveryHoursAnalyticsController. Verifies the WI tree
- *              walk, monthly bucket assembly, target overlay, and edge cases (no
- *              estimate, no logs, deeply nested children).
+ *              walk, monthly bucket assembly, target overlay, and the Salesforce-native
+ *              Pacing & Forecast engine: accurate (all-scope) actuals, schedule-based
+ *              remaining-spread on the Gantt date fields, the unscheduled bucket, the
+ *              per-period drill-down item metrics, and projectedFinal = logged + Σremaining.
  * @author Cloud Nimbus LLC
  */
 @SuppressWarnings('PMD.ApexDoc,PMD.ExcessiveParameterList,PMD.CyclomaticComplexity')
@@ -27,9 +29,9 @@ private class DeliveryHoursAnalyticsControllerTest {
     }
 
     /**
-     * @description Thin wrapper around TestDataFactory.buildWorkLog — the factory
-     *              owns the per-WI WorkRequest__c bridge cache so RequestId__c
-     *              (required MD per PR #770 feedback) auto-populates.
+     * @description Thin wrapper around TestDataFactory.buildWorkLog — the factory owns
+     *              the per-WI WorkRequest__c bridge cache so RequestId__c (required MD
+     *              per PR #770 feedback) auto-populates.
      */
     private static WorkLog__c buildLog(Id wiId, Decimal hours, Date workDate) {
         return TestDataFactory.buildWorkLog(wiId, hours, workDate, null);
@@ -171,7 +173,6 @@ private class DeliveryHoursAnalyticsControllerTest {
         Test.stopTest();
 
         System.assertEquals(true, result.hasEstimate, 'hasEstimate true with non-null estimate');
-        // 40h / ~3-month plan span. Expect ~13.33/month.
         System.assert(result.monthlyTarget > 0, 'monthlyTarget should be > 0');
         for (DeliveryHoursAnalyticsController.MonthlyHoursDTO row : result.months) {
             System.assertEquals(result.monthlyTarget, row.monthlyTarget,
@@ -202,7 +203,6 @@ private class DeliveryHoursAnalyticsControllerTest {
         Date endDate = startDate.addMonths(1).addDays(-1);
         WorkItem__c root = insertWi('Over', 5, startDate, endDate, null);
 
-        // 5h estimate over 1-month span → 5h/month target. Log 10h.
         insert buildLog(root.Id, 10, Date.today());
 
         Test.startTest();
@@ -224,7 +224,6 @@ private class DeliveryHoursAnalyticsControllerTest {
     @IsTest
     static void testLogsOutsideWindowAreIgnored() {
         WorkItem__c root = insertWi('Windowed', null, null, null, null);
-        // Log a date 5 years ago — outside the default 12-month window.
         insert buildLog(root.Id, 99, Date.today().addYears(-5));
 
         Test.startTest();
@@ -255,21 +254,31 @@ private class DeliveryHoursAnalyticsControllerTest {
     }
 
     // ════════════════════════════════════════════════════════════════════
-    // getPortfolioPacing — account/org-level pacing across active roots
+    // getPortfolioPacing — Salesforce-native Pacing & Forecast engine
     // ════════════════════════════════════════════════════════════════════
 
-    /** @description Sum of logged hours across all periods. */
-    private static Decimal totalLogged(DeliveryHoursAnalyticsController.PortfolioPacingDTO dto) {
+    /** @description Sum of actual logged hours across all periods. */
+    private static Decimal totalActual(DeliveryHoursAnalyticsController.PortfolioPacingDTO dto) {
         Decimal sum = 0;
         for (DeliveryHoursAnalyticsController.PacingPeriodDTO p : dto.periods) {
-            sum += p.loggedHours;
+            sum += p.actualHours;
+        }
+        return sum;
+    }
+
+    /** @description Sum of forecast hours across the forward periods. */
+    private static Decimal totalForecast(DeliveryHoursAnalyticsController.PortfolioPacingDTO dto) {
+        Decimal sum = 0;
+        for (DeliveryHoursAnalyticsController.PacingPeriodDTO p : dto.periods) {
+            if (p.isForecast) {
+                sum += p.forecastHours;
+            }
         }
         return sum;
     }
 
     @IsTest
     static void testPortfolioPacingBuildsBackAndForwardPeriods() {
-        // Two active roots, each with descendants + logs across recent months.
         WorkItem__c rootA = insertWi('PortRootA', 80, Date.today().addMonths(-2), Date.today().addMonths(2), null);
         WorkItem__c childA = insertWi('PortChildA', 20, null, null, rootA.Id);
         WorkItem__c rootB = insertWi('PortRootB', 40, Date.today().addMonths(-1), Date.today().addMonths(1), null);
@@ -286,27 +295,32 @@ private class DeliveryHoursAnalyticsControllerTest {
         Test.stopTest();
 
         System.assertNotEquals(null, dto, 'DTO must not be null');
+        System.assertNotEquals(null, dto.summary, 'Summary block present');
         System.assertEquals('Month', dto.granularity, 'Granularity echoed');
         System.assertEquals(9, dto.periods.size(), '6 history + 3 forecast = 9 periods');
         System.assertEquals(2, dto.rootCount, 'Two active roots in scope');
 
         Integer forecastCount = 0;
+        Integer currentCount = 0;
         for (DeliveryHoursAnalyticsController.PacingPeriodDTO p : dto.periods) {
             if (p.isForecast) {
                 forecastCount++;
             }
+            if (p.isCurrent) {
+                currentCount++;
+            }
         }
         System.assertEquals(3, forecastCount, 'Last 3 periods flagged as forecast');
+        System.assertEquals(1, currentCount, 'Exactly one period flagged as current');
 
-        // 5 + 3 + 7 = 15h logged across the window.
-        System.assertEquals(15, totalLogged(dto), 'Portfolio logged hours summed across roots + descendants');
-        System.assertEquals(140, dto.totalEstimatedHours, 'Estimate summed across the portfolio tree');
+        System.assertEquals(15, totalActual(dto), 'Portfolio actuals summed across roots + descendants');
+        System.assertEquals(140, dto.summary.estimatedHours, 'Estimate summed across the portfolio tree');
+        System.assertNotEquals(null, dto.scopeLabel, 'Scope label built');
     }
 
     @IsTest
     static void testPortfolioPacingForecastPresentOnForwardPeriods() {
-        WorkItem__c root = insertWi('FcRoot', 200, Date.today().addMonths(-3), Date.today().addMonths(6), null);
-        // Log meaningful recent hours so the run-rate is non-zero.
+        WorkItem__c root = insertWi('FcRoot', 200, Date.today().toStartOfMonth(), Date.today().addMonths(6), null);
         insert new List<WorkLog__c>{
             buildLog(root.Id, 10, Date.today()),
             buildLog(root.Id, 10, Date.today().addMonths(-1)),
@@ -318,46 +332,16 @@ private class DeliveryHoursAnalyticsControllerTest {
             DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 3);
         Test.stopTest();
 
-        System.assert(dto.runRateHoursPerPeriod > 0, 'Run-rate should be positive given recent logs');
+        System.assert(dto.summary.runRateHoursPerPeriod > 0, 'Run-rate positive given recent logs');
 
-        Decimal forwardForecast = 0;
         for (DeliveryHoursAnalyticsController.PacingPeriodDTO p : dto.periods) {
-            if (p.isForecast) {
-                forwardForecast += p.forecastHours;
-            } else {
+            if (!p.isForecast) {
                 System.assertEquals(0, p.forecastHours, 'History periods carry no forecast');
             }
         }
-        System.assert(forwardForecast > 0, 'Forward periods should carry forecast hours');
-        System.assert(dto.projectedFinalHours >= dto.totalLoggedHours,
+        System.assert(totalForecast(dto) > 0, 'Forward periods should carry forecast hours');
+        System.assert(dto.summary.projectedFinalHours >= dto.summary.loggedHours,
             'Projected final >= logged hours');
-    }
-
-    @IsTest
-    static void testPortfolioForecastCappedAtRemainingEstimate() {
-        // Small estimate, high recent run-rate → forecast must cap at remaining scope.
-        WorkItem__c root = insertWi('CapRoot', 30, Date.today().addMonths(-2), Date.today().addMonths(4), null);
-        insert new List<WorkLog__c>{
-            buildLog(root.Id, 20, Date.today()),
-            buildLog(root.Id, 20, Date.today().addMonths(-1))
-        };
-
-        Test.startTest();
-        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
-            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 12);
-        Test.stopTest();
-
-        // totalLogged ~40 already exceeds the 30 estimate → remaining clamps to 0 → no forecast added.
-        Decimal forwardForecast = 0;
-        for (DeliveryHoursAnalyticsController.PacingPeriodDTO p : dto.periods) {
-            if (p.isForecast) {
-                forwardForecast += p.forecastHours;
-            }
-        }
-        System.assertEquals(0, forwardForecast,
-            'When logged already exceeds estimate, forecast caps at 0');
-        System.assertEquals(true, dto.isOverBudgetTrajectory,
-            'Logged past estimate → over-budget trajectory');
     }
 
     @IsTest
@@ -378,8 +362,7 @@ private class DeliveryHoursAnalyticsControllerTest {
         for (DeliveryHoursAnalyticsController.PacingPeriodDTO p : dto.periods) {
             System.assert(p.label.startsWith('Q'), 'Quarter labels start with Q: ' + p.label);
         }
-        // Both logs fall inside the 4-quarter back window → 12h total.
-        System.assertEquals(12, totalLogged(dto), 'Both logs land inside the quarter window');
+        System.assertEquals(12, totalActual(dto), 'Both logs land inside the quarter window');
     }
 
     @IsTest
@@ -397,7 +380,7 @@ private class DeliveryHoursAnalyticsControllerTest {
 
         System.assertEquals('Week', dto.granularity, 'Week granularity echoed');
         System.assertEquals(12, dto.periods.size(), '8 history + 4 forecast weeks');
-        System.assertEquals(9, totalLogged(dto), 'This week 6h + last week 3h = 9h');
+        System.assertEquals(9, totalActual(dto), 'This week 6h + last week 3h = 9h');
     }
 
     @IsTest
@@ -419,7 +402,6 @@ private class DeliveryHoursAnalyticsControllerTest {
 
     @IsTest
     static void testPortfolioTargetAmortizedAcrossPeriods() {
-        // Single root with a clean 1-month plan span → target concentrates in that month.
         Date startDate = Date.newInstance(Date.today().year(), Date.today().month(), 1);
         Date endDate = startDate.addMonths(1).addDays(-1);
         insertWi('TgtRoot', 60, startDate, endDate, null);
@@ -429,7 +411,7 @@ private class DeliveryHoursAnalyticsControllerTest {
             DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 3);
         Test.stopTest();
 
-        System.assertEquals(true, dto.hasEstimate, 'Estimate present');
+        System.assertEquals(true, dto.summary.hasEstimate, 'Estimate present');
         Decimal targetSum = 0;
         for (DeliveryHoursAnalyticsController.PacingPeriodDTO p : dto.periods) {
             targetSum += p.targetHours;
@@ -475,12 +457,9 @@ private class DeliveryHoursAnalyticsControllerTest {
 
     @IsTest
     static void testPortfolioExcludesTerminalAndArchivedRoots() {
-        // Active root counts; terminal-stage + archived roots are excluded from scope.
         insertWi('LiveRoot', 10, null, null, null);
         WorkItem__c doneRoot = insertWi('DoneRoot', 10, null, null, null);
         WorkItem__c archived = insertWi('ArchivedRoot', 10, null, null, null);
-        // Mutate state via a trigger-bypassed update so the test isolates the
-        // scope filter from auto-WR / sync side effects.
         Boolean prev = DeliveryWorkItemTriggerHandler.triggerDisabled;
         DeliveryWorkItemTriggerHandler.triggerDisabled = true;
         try {
@@ -502,7 +481,6 @@ private class DeliveryHoursAnalyticsControllerTest {
 
     @IsTest
     static void testPortfolioPacingEmptyOrgReturnsSkeleton() {
-        // No WorkItems at all — should still return a well-formed skeleton.
         Test.startTest();
         DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
             DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 3);
@@ -510,7 +488,218 @@ private class DeliveryHoursAnalyticsControllerTest {
 
         System.assertEquals(0, dto.rootCount, 'No roots');
         System.assertEquals(9, dto.periods.size(), 'Skeleton still built');
-        System.assertEquals(0, totalLogged(dto), 'No logged hours');
-        System.assertEquals(false, dto.hasEstimate, 'No estimate');
+        System.assertEquals(0, totalActual(dto), 'No logged hours');
+        System.assertEquals(false, dto.summary.hasEstimate, 'No estimate');
+        System.assertEquals(0, dto.summary.activeItems, 'No in-flight items');
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Schedule-based forecast + accurate (all-scope) actuals + drill-down
+    // ════════════════════════════════════════════════════════════════════
+
+    /**
+     * @description Actuals count ALL WorkLog hours — including logs on a terminal
+     *              (completed) WorkItem that the active-portfolio scope would have
+     *              dropped. The historical bars + summary.loggedHours must include the
+     *              completed item's hours.
+     */
+    @IsTest
+    static void testActualsCountAllHoursIncludingCompletedWork() {
+        WorkItem__c liveRoot = insertWi('LiveActuals', 40, Date.today().addMonths(-1), Date.today().addMonths(2), null);
+        WorkItem__c doneRoot = insertWi('DoneActuals', 20, null, null, null);
+
+        insert new List<WorkLog__c>{
+            buildLog(liveRoot.Id, 5, Date.today()),
+            buildLog(doneRoot.Id, 8, Date.today())
+        };
+
+        Boolean prev = DeliveryWorkItemTriggerHandler.triggerDisabled;
+        DeliveryWorkItemTriggerHandler.triggerDisabled = true;
+        try {
+            doneRoot.StageNamePk__c = 'Done';
+            update doneRoot;
+        } finally {
+            DeliveryWorkItemTriggerHandler.triggerDisabled = prev;
+        }
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
+            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 3);
+        Test.stopTest();
+
+        System.assertEquals(1, dto.rootCount, 'Only the live root is an active root');
+        System.assertEquals(13, dto.summary.loggedHours,
+            'Actuals count ALL hours (5 live + 8 completed), not just active-scope');
+        System.assertEquals(13, totalActual(dto),
+            'Per-period bars also count the completed item\'s hours');
+    }
+
+    /**
+     * @description A single in-flight item with 60h remaining and a 2-month forward
+     *              schedule spreads ~30h into each of the two covered forecast months —
+     *              not a flat run-rate — and emits a drill-down item per covered period.
+     */
+    @IsTest
+    static void testScheduleSpreadPlacesRemainingAcrossCoveredMonths() {
+        Date start = Date.today().toStartOfMonth();
+        Date theEnd = start.addMonths(2).addDays(-1);
+        insertWi('SpreadItem', 60, start, theEnd, null);
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
+            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 4);
+        Test.stopTest();
+
+        System.assertEquals(0, dto.summary.unscheduledRemainingHours,
+            'Dated item is fully schedulable — nothing unscheduled');
+        System.assertEquals(60, dto.summary.remainingHours, 'Remaining = full 60h estimate');
+        System.assertEquals(1, dto.summary.activeItems, 'One in-flight item');
+
+        Decimal forwardForecast = 0;
+        Integer touchedPeriods = 0;
+        Integer drillRows = 0;
+        for (DeliveryHoursAnalyticsController.PacingPeriodDTO p : dto.periods) {
+            if (p.isForecast && p.forecastHours > 0) {
+                forwardForecast += p.forecastHours;
+                touchedPeriods++;
+                drillRows += p.items.size();
+            }
+        }
+        System.assertEquals(60, forwardForecast,
+            'All 60h remaining is placed across the forward schedule');
+        System.assert(touchedPeriods >= 1 && touchedPeriods <= 3,
+            'Remaining spread across the covered forward months, got ' + touchedPeriods);
+        System.assertEquals(touchedPeriods, drillRows,
+            'Each touched period carries exactly one drill-down row for the item');
+    }
+
+    /**
+     * @description The per-period drill-down carries accurate item metrics: est /
+     *              logged / remaining / budgetUsedPct, the schedule dates, the stage,
+     *              and pctOfItem that sums to ~100% across the item's covered periods.
+     */
+    @IsTest
+    static void testDrillDownItemMetricsAreAccurate() {
+        // 100h estimate, 40h logged → 60h remaining, 40% budget used. Spread over a
+        // clean 2-month forward span → ~30h into each, ~50% of item per period.
+        Date start = Date.today().toStartOfMonth();
+        Date theEnd = start.addMonths(2).addDays(-1);
+        WorkItem__c item = insertWi('DrillItem', 100, start, theEnd, null);
+        insert new List<WorkLog__c>{
+            buildLog(item.Id, 25, Date.today()),
+            buildLog(item.Id, 15, Date.today().addDays(-2))
+        };
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
+            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 4);
+        Test.stopTest();
+
+        Decimal pctSum = 0;
+        Integer rows = 0;
+        for (DeliveryHoursAnalyticsController.PacingPeriodDTO p : dto.periods) {
+            for (DeliveryHoursAnalyticsController.PacingItemDTO it : p.items) {
+                System.assertEquals(item.Id, it.workItemId, 'Drill row carries the WorkItem Id');
+                System.assertEquals(100, it.estimatedHours, 'Estimate surfaced');
+                System.assertEquals(40, it.loggedHours, 'Logged-so-far summed from WorkLogs');
+                System.assertEquals(60, it.remainingHours, 'Remaining = 100 - 40');
+                System.assertEquals(40, it.budgetUsedPct, 'Budget used = 40/100 = 40%');
+                System.assertEquals('Backlog', it.stage, 'Stage surfaced from StageNamePk__c');
+                System.assertNotEquals(null, it.startDate, 'Schedule start surfaced');
+                System.assertNotEquals(null, it.endDate, 'Schedule end surfaced');
+                pctSum += it.pctOfItem;
+                rows++;
+            }
+        }
+        System.assert(rows >= 1, 'At least one drill-down row emitted');
+        System.assert(pctSum >= 99 && pctSum <= 101,
+            'pctOfItem across covered periods sums to ~100%, got ' + pctSum);
+    }
+
+    /**
+     * @description An in-flight item with an estimate but NO usable start/end dates
+     *              can't be placed on the calendar, so its remaining accumulates into
+     *              unscheduledRemainingHours instead of being silently dropped.
+     */
+    @IsTest
+    static void testUnscheduledBucketCapturesUndatedRemaining() {
+        insertWi('UndatedItem', 50, null, null, null);
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
+            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 3);
+        Test.stopTest();
+
+        System.assertEquals(50, dto.summary.unscheduledRemainingHours,
+            'Un-dated remaining lands in the unscheduled bucket');
+        System.assertEquals(50, dto.summary.remainingHours, 'Remaining still counted in the total');
+        System.assertEquals(0, totalForecast(dto),
+            'Nothing placed on the forecast bars — it is all unscheduled');
+    }
+
+    /**
+     * @description An in-flight item whose end date is in the PAST cannot be placed
+     *              forward, so its remaining also routes to the unscheduled bucket.
+     */
+    @IsTest
+    static void testPastDueRemainingIsUnscheduled() {
+        insertWi('PastDue', 30, Date.today().addMonths(-4), Date.today().addMonths(-2), null);
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
+            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 3);
+        Test.stopTest();
+
+        System.assertEquals(30, dto.summary.unscheduledRemainingHours,
+            'A past-due schedule cannot be placed forward — remaining is unscheduled');
+    }
+
+    /**
+     * @description projectedFinalHours == loggedHours + Σ remaining across all
+     *              in-flight items, and remaining nets out logged-so-far (summed from
+     *              WorkLogs). pacingPct reflects logged ÷ estimate.
+     */
+    @IsTest
+    static void testProjectedFinalEqualsLoggedPlusRemaining() {
+        WorkItem__c item = insertWi('NetItem', 100, Date.today().toStartOfMonth(), Date.today().addMonths(2), null);
+        insert new List<WorkLog__c>{
+            buildLog(item.Id, 20, Date.today()),
+            buildLog(item.Id, 10, Date.today().addDays(-3))
+        };
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
+            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 4);
+        Test.stopTest();
+
+        System.assertEquals(30, dto.summary.loggedHours, 'All logged hours counted (20 + 10)');
+        System.assertEquals(70, dto.summary.remainingHours,
+            'Remaining nets logged-so-far: 100 estimate - 30 logged = 70');
+        System.assertEquals(100, dto.summary.projectedFinalHours,
+            'Projected final = 30 logged + 70 remaining = 100');
+        System.assertEquals(30, dto.summary.pacingPct,
+            'Pacing % = 30 logged / 100 estimate = 30%');
+    }
+
+    /**
+     * @description Remaining clamps at 0 when logged-so-far already exceeds the
+     *              estimate — an over-logged item adds no remaining, and the
+     *              over-budget trajectory flag fires off the all-scope logged total.
+     */
+    @IsTest
+    static void testOverLoggedItemAddsNoRemaining() {
+        WorkItem__c item = insertWi('OverLogged', 10, Date.today().toStartOfMonth(), Date.today().addMonths(1), null);
+        insert buildLog(item.Id, 25, Date.today());
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
+            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 3);
+        Test.stopTest();
+
+        System.assertEquals(0, dto.summary.remainingHours, 'Over-logged item contributes 0 remaining');
+        System.assertEquals(25, dto.summary.projectedFinalHours,
+            'Projected final = 25 logged + 0 remaining');
+        System.assertEquals(true, dto.summary.isOverBudgetTrajectory,
+            'Logged past estimate → over-budget trajectory');
     }
 }

--- a/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
+++ b/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
@@ -229,12 +229,12 @@ const INFO_REGISTRY = {
     },
     deliveryPacingForecast: {
         dataSource:
-            'Calls DeliveryHoursAnalyticsController.getPortfolioPacing(granularity, periodsBack, periodsForward). Scans all active root WorkItem__c trees, sums WorkLog__c hours into Week/Month/Quarter buckets for the actual line, amortizes the total estimate across the planned span (earliest start → latest end) for the target line, and projects forward at a run-rate (trailing 4-period average) capped at remaining estimate. The blended $ rate is surfaced only when exactly one active NetworkEntity__c carries a DefaultHourlyRateCurrency__c (else hours-only).',
+            'Calls DeliveryHoursAnalyticsController.getPortfolioPacing(granularity, periodsBack, periodsForward) — the Salesforce-native engine parallel to the nimbus-gantt Pacing view (same model both render). ACTUALS count ALL WorkLog__c hours by WorkDateDate__c into Week/Month/Quarter buckets — no active-portfolio filter, so completed work is never undercounted. FORECAST is schedule-based: each in-flight WorkItem__c\'s remaining (EstimatedHoursNumber__c − logged) is spread evenly across the forward periods its EstimatedStartDevDate__c → EstimatedEndDevDate__c span covers — the same dates the Gantt drag-writes. Each period carries a per-item drill-down. Remaining with no usable dates lands in an unscheduled bucket. projectedFinal = logged + Σremaining. The blended $ rate is surfaced only when exactly one active NetworkEntity__c carries a DefaultHourlyRateCurrency__c.',
         description:
-            'Account/org-level pacing & forecast across all active projects. Shows logged hours (bars), an amortized target line, and a run-rate forecast for the periods ahead — with a Week/Month/Quarter bucket selector and a forward horizon (Next 3 / 6 / 12 or rest of year). Hours are primary; dollars appear when a single blended rate is configured.',
-        friendlyName: 'Portfolio Pacing & Forecast',
+            'The Salesforce-native Pacing & Forecast — actual logged hours (green bars; red over target) → today → schedule-based forecast (light-blue bars), with an amortized target line and a current-period marker. Cuts: Range (Next 3/6 · Rest of year · This Qtr · YTD · All · Custom), Bucket (Week/Month/Quarter), Measure (Hours/$), Mode (Per-period / Cumulative), and Actual/Forecast/Target series toggles. Click a bar to break it into its work items; click a work item to open the record. Surfaces un-dated remaining the forecast can\'t place. Parallel to the Gantt Pacing view as a backup/comparison.',
+        friendlyName: 'Pacing & Forecast',
         keyFields:
-            'WorkItem__c.EstimatedHoursNumber__c, WorkItem__c.EstimatedStartDevDate__c, WorkItem__c.EstimatedEndDevDate__c, WorkItem__c.TotalLoggedHoursSum__c, WorkLog__c.HoursLoggedNumber__c, WorkLog__c.WorkDateDate__c, NetworkEntity__c.DefaultHourlyRateCurrency__c'
+            'WorkItem__c.EstimatedHoursNumber__c, WorkItem__c.EstimatedStartDevDate__c, WorkItem__c.EstimatedEndDevDate__c, WorkItem__c.StageNamePk__c, WorkItem__c.PriorityGroupPk__c, WorkItem__c.DeveloperLookup__c, WorkLog__c.HoursLoggedNumber__c, WorkLog__c.WorkDateDate__c, NetworkEntity__c.DefaultHourlyRateCurrency__c'
     },
     deliveryWatcherSetup: {
         dataSource:

--- a/force-app/main/default/lwc/deliveryPacingForecast/__tests__/deliveryPacingForecast.test.js
+++ b/force-app/main/default/lwc/deliveryPacingForecast/__tests__/deliveryPacingForecast.test.js
@@ -2,32 +2,61 @@
  * @name         Delivery Hub
  * @license      BSL 1.1 — See LICENSE.md
  * @description  Jest coverage for deliveryPacingForecast: control rendering, the
- *               wire-driven chart (bars, target polyline, forecast boundary),
- *               headline numbers, the $-secondary gated on a blended rate, and
- *               empty/error states.
+ *               wire-driven chart (actual + forecast bars, target polyline, current
+ *               marker), the headline summary cards, the unscheduled note, the click
+ *               drill-down, navigate-to-record on a work-item row, the $ measure gated
+ *               on a blended rate, and empty/error states.
  * @author       Cloud Nimbus LLC
  */
 import { createElement } from "lwc";
 import DeliveryPacingForecast from "c/deliveryPacingForecast";
 import getPortfolioPacing from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHoursAnalyticsController.getPortfolioPacing";
 
+function sampleItem(overrides = {}) {
+    return {
+        workItemId: "a0X000000000001AAA",
+        name: "T-0042",
+        hoursThisPeriod: 30,
+        pctOfItem: 50,
+        estimatedHours: 100,
+        loggedHours: 40,
+        remainingHours: 60,
+        budgetUsedPct: 40,
+        startDate: "2026-06-01",
+        endDate: "2026-07-31",
+        developerName: "Mahi",
+        stage: "In Progress",
+        priorityGroup: "NOW",
+        ...overrides
+    };
+}
+
 function samplePacing(overrides = {}) {
     return {
         granularity: "Month",
+        scopeLabel: "3 active projects · 2 in-flight items",
         rootCount: 3,
-        totalEstimatedHours: 100,
-        totalLoggedHours: 40,
-        projectedFinalHours: 90,
-        runRateHoursPerPeriod: 10,
         blendedRate: null,
-        hasEstimate: true,
-        isOverBudgetTrajectory: false,
         earliestStart: "2026-01-01",
         latestEnd: "2026-12-31",
-        periods: [
-            { label: "Apr 26", loggedHours: 12, targetHours: 8, forecastHours: 0, isForecast: false, overTarget: true },
-            { label: "May 26", loggedHours: 6, targetHours: 8, forecastHours: 0, isForecast: false, overTarget: false },
-            { label: "Jun 26", loggedHours: 0, targetHours: 8, forecastHours: 10, isForecast: true, overTarget: false }
+        summary: {
+            estimatedHours: 100,
+            loggedHours: 40,
+            remainingHours: 60,
+            projectedFinalHours: 100,
+            pacingPct: 40,
+            activeItems: 2,
+            unscheduledRemainingHours: 0,
+            runRateHoursPerPeriod: 10,
+            hasEstimate: true,
+            isOverBudgetTrajectory: false,
+            forecastCapped: false,
+            ...(overrides.summary || {})
+        },
+        periods: overrides.periods || [
+            { label: "Apr 26", actualHours: 12, targetHours: 8, forecastHours: 0, isForecast: false, isCurrent: false, overTarget: true, items: [] },
+            { label: "May 26", actualHours: 6, targetHours: 8, forecastHours: 0, isForecast: false, isCurrent: true, overTarget: false, items: [] },
+            { label: "Jun 26", actualHours: 0, targetHours: 8, forecastHours: 30, isForecast: true, isCurrent: false, overTarget: false, items: [sampleItem()] }
         ],
         ...overrides
     };
@@ -53,24 +82,24 @@ describe("c-delivery-pacing-forecast", () => {
         jest.clearAllMocks();
     });
 
-    it("renders the granularity and horizon selectors", () => {
+    it("renders the range, bucket, and mode selectors", () => {
         const element = createComponent();
         const combos = element.shadowRoot.querySelectorAll("lightning-combobox");
-        expect(combos.length).toBe(2);
         const names = Array.from(combos).map((c) => c.name);
+        expect(names).toContain("range");
         expect(names).toContain("granularity");
-        expect(names).toContain("horizon");
+        expect(names).toContain("mode");
     });
 
-    it("renders bars, target polyline, and forecast boundary from the wire", async () => {
+    it("renders actual + forecast bars, target polyline, and current marker", async () => {
         const element = createComponent();
         getPortfolioPacing.emit(samplePacing());
         await flushPromises();
 
         const bars = element.shadowRoot.querySelectorAll("rect.bar");
         expect(bars.length).toBe(3);
-        // The over-target history bar and the forecast bar each get a distinct class.
         const classes = Array.from(bars).map((b) => b.getAttribute("class"));
+        expect(classes.some((c) => c.includes("bar--actual"))).toBe(true);
         expect(classes.some((c) => c.includes("bar--over"))).toBe(true);
         expect(classes.some((c) => c.includes("bar--forecast"))).toBe(true);
 
@@ -78,86 +107,197 @@ describe("c-delivery-pacing-forecast", () => {
         expect(target).not.toBeNull();
         expect(target.getAttribute("points").trim().split(" ").length).toBe(3);
 
-        const boundary = element.shadowRoot.querySelector("line.forecast-boundary");
-        expect(boundary).not.toBeNull();
+        const marker = element.shadowRoot.querySelector("line.current-marker");
+        expect(marker).not.toBeNull();
     });
 
-    it("shows headline hours and pacing percent", async () => {
+    it("shows headline summary cards: logged, projected final, pacing", async () => {
         const element = createComponent();
         getPortfolioPacing.emit(samplePacing());
         await flushPromises();
 
         const text = element.shadowRoot.textContent;
         expect(text).toContain("40.0h"); // logged
-        expect(text).toContain("90.0h"); // projected final
-        expect(text).toContain("90%"); // pacing
-        expect(text).toContain("On track at current pace");
+        expect(text).toContain("60.0h"); // remaining
+        expect(text).toContain("100h"); // projected final
+        expect(text).toContain("40%"); // pacing
     });
 
-    it("hides $ figures when no blended rate is present", async () => {
+    it("surfaces the unscheduled-remaining note when present", async () => {
+        const element = createComponent();
+        getPortfolioPacing.emit(
+            samplePacing({
+                summary: { unscheduledRemainingHours: 25 }
+            })
+        );
+        await flushPromises();
+
+        const note = element.shadowRoot.querySelector(".pacing-unscheduled-note");
+        expect(note).not.toBeNull();
+        expect(note.textContent).toContain("can't be placed on the forecast");
+    });
+
+    it("hides the measure selector when no blended rate is present", async () => {
         const element = createComponent();
         getPortfolioPacing.emit(samplePacing({ blendedRate: null }));
         await flushPromises();
-        expect(element.shadowRoot.querySelector(".summary-money")).toBeNull();
+        const combos = element.shadowRoot.querySelectorAll("lightning-combobox");
+        const names = Array.from(combos).map((c) => c.name);
+        expect(names).not.toContain("measure");
     });
 
-    it("shows $ secondary figures when a blended rate is present", async () => {
+    it("offers the measure selector when a blended rate is present", async () => {
         const element = createComponent();
         getPortfolioPacing.emit(samplePacing({ blendedRate: 100 }));
         await flushPromises();
-
-        const money = element.shadowRoot.querySelectorAll(".summary-money");
-        expect(money.length).toBeGreaterThan(0);
-        const moneyText = Array.from(money).map((m) => m.textContent).join(" ");
-        expect(moneyText).toContain("$4,000"); // 40h * 100
-        expect(moneyText).toContain("$9,000"); // 90h * 100
+        const combos = element.shadowRoot.querySelectorAll("lightning-combobox");
+        const names = Array.from(combos).map((c) => c.name);
+        expect(names).toContain("measure");
     });
 
-    it("flags an over-budget trajectory", async () => {
+    it("opens the drill-down when a bar is clicked", async () => {
         const element = createComponent();
-        getPortfolioPacing.emit(samplePacing({ isOverBudgetTrajectory: true }));
+        getPortfolioPacing.emit(samplePacing());
         await flushPromises();
 
-        const variance = element.shadowRoot.querySelector(".summary-variance--over");
-        expect(variance).not.toBeNull();
-        expect(element.shadowRoot.textContent).toContain("Over budget at current pace");
+        // No drill-down until a bar is clicked.
+        expect(element.shadowRoot.querySelector(".pacing-drill")).toBeNull();
+
+        const bars = element.shadowRoot.querySelectorAll("rect.bar");
+        const forecastBar = Array.from(bars).find((b) =>
+            b.getAttribute("class").includes("bar--forecast")
+        );
+        forecastBar.dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+
+        const drill = element.shadowRoot.querySelector(".pacing-drill");
+        expect(drill).not.toBeNull();
+        const rows = element.shadowRoot.querySelectorAll("tr.drill-row");
+        expect(rows.length).toBe(1);
+        expect(drill.textContent).toContain("T-0042");
+        expect(drill.textContent).toContain("NOW");
     });
 
-    it("re-wires when the granularity selector changes", async () => {
+    it("wires each drill-down row to its WorkItem record for navigation", async () => {
+        const element = createComponent();
+        getPortfolioPacing.emit(samplePacing());
+        await flushPromises();
+
+        const bars = element.shadowRoot.querySelectorAll("rect.bar");
+        const forecastBar = Array.from(bars).find((b) =>
+            b.getAttribute("class").includes("bar--forecast")
+        );
+        forecastBar.dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+
+        // The row carries the WorkItem Id that handleRowClick feeds to
+        // NavigationMixin.Navigate (standard__recordPage). The repo's sfdx-lwc-jest
+        // navigation stub doesn't expose getNavigateCalledWith and the mixin method
+        // is non-configurable under jest, so assert the wiring contract + that the
+        // click path runs cleanly.
+        const row = element.shadowRoot.querySelector("tr.drill-row");
+        expect(row.dataset.recordId).toBe("a0X000000000001AAA");
+        expect(() => {
+            row.dispatchEvent(new CustomEvent("click"));
+        }).not.toThrow();
+        await flushPromises();
+    });
+
+    it("toggles a series off when its toggle is clicked", async () => {
+        const element = createComponent();
+        getPortfolioPacing.emit(samplePacing());
+        await flushPromises();
+
+        expect(element.shadowRoot.querySelectorAll("rect.bar").length).toBe(3);
+
+        const toggles = element.shadowRoot.querySelectorAll("button.series-toggle");
+        const forecastToggle = Array.from(toggles).find((t) =>
+            t.textContent.includes("Forecast")
+        );
+        forecastToggle.click();
+        await flushPromises();
+
+        // The single forecast bar drops out; the two actual bars remain.
+        expect(element.shadowRoot.querySelectorAll("rect.bar").length).toBe(2);
+    });
+
+    it("flags an over-budget projected final", async () => {
+        const element = createComponent();
+        getPortfolioPacing.emit(
+            samplePacing({
+                summary: { isOverBudgetTrajectory: true, projectedFinalHours: 150 }
+            })
+        );
+        await flushPromises();
+
+        const over = element.shadowRoot.querySelector(".summary-value--over");
+        expect(over).not.toBeNull();
+    });
+
+    it("re-wires when the bucket selector changes", async () => {
         const element = createComponent();
         getPortfolioPacing.emit(samplePacing());
         await flushPromises();
 
         const combos = element.shadowRoot.querySelectorAll("lightning-combobox");
         const combo = Array.from(combos).find((c) => c.name === "granularity");
-        combo.dispatchEvent(new CustomEvent("change", { detail: { value: "Quarter" } }));
+        combo.dispatchEvent(
+            new CustomEvent("change", { detail: { value: "Quarter" } })
+        );
         await flushPromises();
 
-        // The wire config recomputes against the new granularity; emitting fresh
-        // data keeps the component rendering without error.
         getPortfolioPacing.emit(samplePacing({ granularity: "Quarter" }));
         await flushPromises();
         expect(element.shadowRoot.querySelectorAll("rect.bar").length).toBe(3);
+    });
+
+    it("shows custom date inputs when the Custom range is selected", async () => {
+        const element = createComponent();
+        getPortfolioPacing.emit(samplePacing());
+        await flushPromises();
+
+        const combos = element.shadowRoot.querySelectorAll("lightning-combobox");
+        const rangeCombo = Array.from(combos).find((c) => c.name === "range");
+        rangeCombo.dispatchEvent(
+            new CustomEvent("change", { detail: { value: "custom" } })
+        );
+        await flushPromises();
+
+        const dateInputs = element.shadowRoot.querySelectorAll(
+            "lightning-input.pacing-date"
+        );
+        expect(dateInputs.length).toBe(2);
     });
 
     it("shows the empty state for a fully-empty portfolio", async () => {
         const element = createComponent();
         getPortfolioPacing.emit({
             granularity: "Month",
+            scopeLabel: "0 active projects · 0 in-flight items",
             rootCount: 0,
-            totalEstimatedHours: 0,
-            totalLoggedHours: 0,
-            projectedFinalHours: 0,
-            hasEstimate: false,
-            isOverBudgetTrajectory: false,
+            blendedRate: null,
+            summary: {
+                estimatedHours: 0,
+                loggedHours: 0,
+                remainingHours: 0,
+                projectedFinalHours: 0,
+                pacingPct: 0,
+                activeItems: 0,
+                unscheduledRemainingHours: 0,
+                hasEstimate: false,
+                isOverBudgetTrajectory: false,
+                forecastCapped: false
+            },
             periods: [
-                { label: "Apr 26", loggedHours: 0, targetHours: 0, forecastHours: 0, isForecast: false },
-                { label: "May 26", loggedHours: 0, targetHours: 0, forecastHours: 0, isForecast: true }
+                { label: "Apr 26", actualHours: 0, targetHours: 0, forecastHours: 0, isForecast: false, isCurrent: false, items: [] },
+                { label: "May 26", actualHours: 0, targetHours: 0, forecastHours: 0, isForecast: true, isCurrent: false, items: [] }
             ]
         });
         await flushPromises();
 
-        expect(element.shadowRoot.textContent).toContain("No active portfolio activity yet");
+        expect(element.shadowRoot.textContent).toContain(
+            "No active portfolio activity yet"
+        );
         expect(element.shadowRoot.querySelector("rect.bar")).toBeNull();
     });
 

--- a/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.css
+++ b/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.css
@@ -28,6 +28,14 @@
     gap: 0.75rem;
 }
 
+/* Info popover sits beside the title; force it visible (the shared host
+   defaults the trigger to opacity 0.3, which gets lost in the header). */
+.pacing-header-info {
+    flex: 0 0 auto;
+    align-self: flex-start;
+    margin-top: 0.1rem;
+}
+
 .pacing-header-icon {
     color: #7c3aed;
 }
@@ -43,6 +51,7 @@
     font-size: 0.75rem;
     color: #6b7280;
     margin: 0;
+    max-width: 34rem;
 }
 
 .pacing-controls {
@@ -53,7 +62,19 @@
 }
 
 .pacing-select {
-    min-width: 8rem;
+    min-width: 7.5rem;
+}
+
+.pacing-custom-range {
+    display: flex;
+    gap: 1rem;
+    padding: 0.5rem 1.5rem 0.75rem;
+    flex-wrap: wrap;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.pacing-date {
+    max-width: 12rem;
 }
 
 .pacing-loading {
@@ -118,6 +139,10 @@
     color: #111827;
 }
 
+.summary-value--over {
+    color: #b91c1c;
+}
+
 .summary-money {
     font-size: 0.75rem;
     color: #6b7280;
@@ -130,21 +155,81 @@
     margin-top: 0.1rem;
 }
 
-.summary-variance {
-    font-size: 1.125rem;
+.pacing-unscheduled-note {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0 1.5rem 0.25rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.4rem;
+    background: #fffbeb;
+    border: 1px solid #fde68a;
+    color: #92400e;
+    font-size: 0.75rem;
+    line-height: 1.4;
+}
+
+.pacing-unscheduled-icon {
+    flex: 0 0 auto;
+    --lwc-colorTextIconDefault: #d97706;
+}
+
+.pacing-series-toggles {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1.5rem 0;
+    flex-wrap: wrap;
+}
+
+.series-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.6875rem;
+    color: #9ca3af;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 1rem;
+    padding: 0.2rem 0.6rem;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.series-toggle--on {
+    color: #1f2937;
+    background: #ffffff;
+    border-color: #d1d5db;
     font-weight: 600;
 }
 
-.summary-variance--under {
-    color: #15803d;
+.series-swatch {
+    display: inline-block;
+    width: 0.7rem;
+    height: 0.7rem;
+    border-radius: 2px;
+    opacity: 0.35;
 }
 
-.summary-variance--over {
-    color: #b91c1c;
+.series-toggle--on .series-swatch {
+    opacity: 1;
+}
+
+.series-swatch--actual {
+    background: #16a34a;
+}
+
+.series-swatch--forecast {
+    background: #93c5fd;
+    border: 1px dashed #3b82f6;
+}
+
+.series-swatch--target {
+    background: #6b7280;
 }
 
 .pacing-body {
-    padding: 1rem 1.25rem 0.25rem;
+    padding: 0.75rem 1.25rem 0.25rem;
 }
 
 .pacing-svg {
@@ -182,14 +267,20 @@
 
 .bar {
     transition: opacity 0.15s ease;
+    cursor: pointer;
 }
 
 .bar:hover {
     opacity: 0.85;
 }
 
-.bar--under {
-    fill: #6366f1;
+.bar--selected {
+    stroke: #1f2937;
+    stroke-width: 1.5;
+}
+
+.bar--actual {
+    fill: #16a34a;
 }
 
 .bar--over {
@@ -197,8 +288,8 @@
 }
 
 .bar--forecast {
-    fill: #c4b5fd;
-    stroke: #8b5cf6;
+    fill: #bfdbfe;
+    stroke: #3b82f6;
     stroke-width: 1;
     stroke-dasharray: 3 2;
 }
@@ -211,9 +302,9 @@
     pointer-events: none;
 }
 
-.forecast-boundary {
-    stroke: #c4b5fd;
-    stroke-width: 1;
+.current-marker {
+    stroke: #7c3aed;
+    stroke-width: 1.5;
     stroke-dasharray: 2 3;
     pointer-events: none;
 }
@@ -235,6 +326,12 @@
     color: #6b7280;
 }
 
+.legend-hint {
+    color: #9ca3af;
+    font-style: italic;
+    margin-left: auto;
+}
+
 .legend-swatch {
     display: inline-block;
     width: 0.75rem;
@@ -242,8 +339,8 @@
     border-radius: 2px;
 }
 
-.legend-swatch--under {
-    background: #6366f1;
+.legend-swatch--actual {
+    background: #16a34a;
 }
 
 .legend-swatch--over {
@@ -251,8 +348,8 @@
 }
 
 .legend-swatch--forecast {
-    background: #c4b5fd;
-    border: 1px dashed #8b5cf6;
+    background: #bfdbfe;
+    border: 1px dashed #3b82f6;
 }
 
 .legend-line {
@@ -266,4 +363,107 @@
     background: #6b7280;
     background-image: linear-gradient(90deg, #6b7280 0 6px, transparent 6px 10px);
     height: 2px;
+}
+
+/* ── Drill-down panel ───────────────────────────────────────── */
+
+.pacing-drill {
+    margin: 0.25rem 1.25rem 1rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    overflow: hidden;
+}
+
+.drill-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 0.75rem;
+    background: #f9fafb;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.drill-title {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0;
+}
+
+.drill-close {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0.15rem;
+    display: inline-flex;
+    --lwc-colorTextIconDefault: #6b7280;
+}
+
+.drill-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.drill-th {
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #6b7280;
+    text-align: right;
+    padding: 0.4rem 0.6rem;
+    border-bottom: 1px solid #f3f4f6;
+    font-weight: 600;
+}
+
+.drill-th--name {
+    text-align: left;
+}
+
+.drill-row {
+    cursor: pointer;
+    transition: background 0.12s ease;
+}
+
+.drill-row:hover {
+    background: #eff6ff;
+}
+
+.drill-cell {
+    font-size: 0.75rem;
+    color: #374151;
+    padding: 0.45rem 0.6rem;
+    border-bottom: 1px solid #f3f4f6;
+    text-align: right;
+    white-space: nowrap;
+}
+
+.drill-cell--name {
+    text-align: left;
+    white-space: normal;
+}
+
+.drill-cell--num {
+    font-variant-numeric: tabular-nums;
+}
+
+.drill-cell--over {
+    color: #b91c1c;
+    font-weight: 600;
+}
+
+.drill-link {
+    color: #2563eb;
+    font-weight: 600;
+    display: block;
+}
+
+.drill-row:hover .drill-link {
+    text-decoration: underline;
+}
+
+.drill-meta {
+    display: block;
+    font-size: 0.625rem;
+    color: #9ca3af;
+    margin-top: 0.1rem;
 }

--- a/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.html
+++ b/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.html
@@ -3,14 +3,26 @@
 
         <div class="pacing-header">
             <div class="pacing-header-left">
-                <lightning-icon icon-name="utility:trending" alternative-text="Portfolio pacing" size="small" class="pacing-header-icon"></lightning-icon>
+                <lightning-icon icon-name="utility:trending" alternative-text="Pacing and forecast" size="small" class="pacing-header-icon"></lightning-icon>
                 <div>
-                    <h2 class="pacing-title">Portfolio Pacing &amp; Forecast</h2>
-                    <p class="pacing-subtitle">Logged hours, amortized target, and run-rate forecast across all active projects</p>
+                    <h2 class="pacing-title">Pacing &amp; Forecast</h2>
+                    <p class="pacing-subtitle">Actual logged hours and a schedule-based forecast — the Salesforce-native parallel to the Gantt Pacing view</p>
                 </div>
+                <c-delivery-info-popover
+                    component-name="deliveryPacingForecast"
+                    class="pacing-header-info">
+                </c-delivery-info-popover>
             </div>
             <div class="pacing-controls">
-                <c-delivery-info-popover component-name="deliveryPacingForecast"></c-delivery-info-popover>
+                <lightning-combobox
+                    name="range"
+                    label="Range"
+                    variant="label-hidden"
+                    value={range}
+                    options={rangeOptions}
+                    onchange={handleRangeChange}
+                    class="pacing-select">
+                </lightning-combobox>
                 <lightning-combobox
                     name="granularity"
                     label="Bucket"
@@ -21,20 +33,49 @@
                     class="pacing-select">
                 </lightning-combobox>
                 <lightning-combobox
-                    name="horizon"
-                    label="Forecast horizon"
+                    lwc:if={hasRate}
+                    name="measure"
+                    label="Measure"
                     variant="label-hidden"
-                    value={horizon}
-                    options={horizonOptions}
-                    onchange={handleHorizonChange}
+                    value={measure}
+                    options={measureOptions}
+                    onchange={handleMeasureChange}
+                    class="pacing-select">
+                </lightning-combobox>
+                <lightning-combobox
+                    name="mode"
+                    label="Mode"
+                    variant="label-hidden"
+                    value={mode}
+                    options={modeOptions}
+                    onchange={handleModeChange}
                     class="pacing-select">
                 </lightning-combobox>
             </div>
         </div>
 
+        <template lwc:if={isCustomRange}>
+            <div class="pacing-custom-range">
+                <lightning-input
+                    type="date"
+                    label="From"
+                    value={customStart}
+                    onchange={handleCustomStartChange}
+                    class="pacing-date">
+                </lightning-input>
+                <lightning-input
+                    type="date"
+                    label="To"
+                    value={customEnd}
+                    onchange={handleCustomEndChange}
+                    class="pacing-date">
+                </lightning-input>
+            </div>
+        </template>
+
         <template lwc:if={isLoading}>
             <div class="pacing-loading">
-                <lightning-spinner alternative-text="Loading portfolio pacing..." size="small"></lightning-spinner>
+                <lightning-spinner alternative-text="Loading pacing and forecast..." size="small"></lightning-spinner>
             </div>
         </template>
 
@@ -49,33 +90,59 @@
             <div class="pacing-summary-row">
                 <div class="summary-tile">
                     <div class="summary-label">Logged</div>
-                    <div class="summary-value">{totalLoggedDisplay}h</div>
-                    <template lwc:if={hasRate}>
-                        <div class="summary-money">{loggedDollarDisplay}</div>
-                    </template>
+                    <div class="summary-value">{loggedDisplay}</div>
                 </div>
                 <div class="summary-tile">
                     <div class="summary-label">Estimated</div>
-                    <div class="summary-value">{totalEstimatedDisplay}h</div>
+                    <div class="summary-value">{estimatedDisplay}</div>
+                </div>
+                <div class="summary-tile">
+                    <div class="summary-label">Remaining</div>
+                    <div class="summary-value">{remainingDisplay}</div>
+                    <div class="summary-trajectory">across in-flight work</div>
                 </div>
                 <div class="summary-tile">
                     <div class="summary-label">Projected final</div>
-                    <div class="summary-value">{projectedFinalDisplay}h</div>
-                    <template lwc:if={hasRate}>
-                        <div class="summary-money">{projectedFinalDollarDisplay}</div>
-                    </template>
+                    <div class={projectedFinalClass}>{projectedFinalDisplay}</div>
                 </div>
-                <template lwc:if={hasTarget}>
-                    <div class="summary-tile">
-                        <div class="summary-label">Pacing</div>
-                        <div class={pacingClass}>{pacingPercent}</div>
-                        <div class="summary-trajectory">{trajectoryLabel}</div>
-                    </div>
-                </template>
                 <div class="summary-tile">
-                    <div class="summary-label">Active projects</div>
-                    <div class="summary-value">{rootCountDisplay}</div>
+                    <div class="summary-label">Pacing</div>
+                    <div class={pacingPctClass}>{pacingPctDisplay}</div>
+                    <div class="summary-trajectory">logged of estimate</div>
                 </div>
+                <div class="summary-tile">
+                    <div class="summary-label">Active items</div>
+                    <div class="summary-value">{activeItemsDisplay}</div>
+                    <div class="summary-trajectory">{scopeLabel}</div>
+                </div>
+            </div>
+
+            <template lwc:if={hasUnscheduled}>
+                <div class="pacing-unscheduled-note">
+                    <lightning-icon icon-name="utility:warning" size="xx-small" class="pacing-unscheduled-icon"></lightning-icon>
+                    <span>{unscheduledNote}</span>
+                </div>
+            </template>
+
+            <template lwc:if={forecastCappedNote}>
+                <div class="pacing-unscheduled-note">
+                    <lightning-icon icon-name="utility:info" size="xx-small" class="pacing-unscheduled-icon"></lightning-icon>
+                    <span>{forecastCappedNote}</span>
+                </div>
+            </template>
+
+            <div class="pacing-series-toggles">
+                <button type="button" class={actualToggleClass} onclick={handleToggleActual}>
+                    <span class="series-swatch series-swatch--actual"></span>Actual
+                </button>
+                <button type="button" class={forecastToggleClass} onclick={handleToggleForecast}>
+                    <span class="series-swatch series-swatch--forecast"></span>Forecast
+                </button>
+                <template lwc:if={hasTarget}>
+                    <button type="button" class={targetToggleClass} onclick={handleToggleTarget}>
+                        <span class="series-swatch series-swatch--target"></span>Target
+                    </button>
+                </template>
             </div>
 
             <div class="pacing-body">
@@ -97,22 +164,24 @@
                               class="axis-label axis-label--y">{gl.label}</text>
                     </template>
 
-                    <template lwc:if={hasForecastBoundary}>
-                        <line x1={forecastBoundaryX} y1={chartTop}
-                              x2={forecastBoundaryX} y2={chartBottom}
-                              class="forecast-boundary"></line>
+                    <template lwc:if={hasCurrentMarker}>
+                        <line x1={currentMarkerX} y1={chartTop}
+                              x2={currentMarkerX} y2={chartBottom}
+                              class="current-marker"></line>
                     </template>
 
                     <template for:each={bars} for:item="bar">
                         <rect key={bar.key}
                               x={bar.x} y={bar.y}
                               width={bar.width} height={bar.height}
-                              class={bar.cssClass}>
+                              class={bar.cssClass}
+                              data-period-key={bar.periodKey}
+                              onclick={handleBarClick}>
                             <title>{bar.tooltip}</title>
                         </rect>
                     </template>
 
-                    <template lwc:if={hasTarget}>
+                    <template lwc:if={showTargetSeries}>
                         <polyline points={targetPoints} class="target-line"></polyline>
                     </template>
 
@@ -133,27 +202,70 @@
 
             <div class="pacing-legend">
                 <span class="legend-item">
-                    <span class="legend-swatch legend-swatch--under"></span>Logged (on/under target)
+                    <span class="legend-swatch legend-swatch--actual"></span>Logged (actual)
                 </span>
                 <span class="legend-item">
                     <span class="legend-swatch legend-swatch--over"></span>Logged (over target)
                 </span>
                 <span class="legend-item">
-                    <span class="legend-swatch legend-swatch--forecast"></span>Forecast
+                    <span class="legend-swatch legend-swatch--forecast"></span>Forecast (scheduled remaining)
                 </span>
                 <template lwc:if={hasTarget}>
                     <span class="legend-item">
-                        <span class="legend-line legend-line--target"></span>Target
+                        <span class="legend-line legend-line--target"></span>Amortized target
                     </span>
                 </template>
+                <span class="legend-item legend-hint">Click a bar to break down the work items</span>
             </div>
+
+            <template lwc:if={hasDrillDown}>
+                <div class="pacing-drill">
+                    <div class="drill-header">
+                        <h3 class="drill-title">{drillTitle}</h3>
+                        <button type="button" class="drill-close" onclick={handleCloseDrill} title="Close breakdown">
+                            <lightning-icon icon-name="utility:close" size="xx-small"></lightning-icon>
+                        </button>
+                    </div>
+                    <table class="drill-table">
+                        <thead>
+                            <tr>
+                                <th class="drill-th drill-th--name">Work item</th>
+                                <th class="drill-th drill-th--num">This period</th>
+                                <th class="drill-th drill-th--num">% of item</th>
+                                <th class="drill-th drill-th--num">Est</th>
+                                <th class="drill-th drill-th--num">Logged</th>
+                                <th class="drill-th drill-th--num">Remaining</th>
+                                <th class="drill-th drill-th--num">% used</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <template for:each={drillRows} for:item="row">
+                                <tr key={row.key} class="drill-row" data-record-id={row.workItemId} onclick={handleRowClick} title="Open this work item">
+                                    <td class="drill-cell drill-cell--name">
+                                        <span class="drill-link">{row.name}</span>
+                                        <template lwc:if={row.metaLine}>
+                                            <span class="drill-meta">{row.metaLine}</span>
+                                        </template>
+                                    </td>
+                                    <td class="drill-cell drill-cell--num">{row.thisPeriod}</td>
+                                    <td class="drill-cell drill-cell--num">{row.pctOfItem}</td>
+                                    <td class="drill-cell drill-cell--num">{row.estimated}</td>
+                                    <td class="drill-cell drill-cell--num">{row.logged}</td>
+                                    <td class="drill-cell drill-cell--num">{row.remaining}</td>
+                                    <td class={row.budgetClass}>{row.budgetUsedPct}</td>
+                                </tr>
+                            </template>
+                        </tbody>
+                    </table>
+                </div>
+            </template>
         </template>
 
         <template lwc:if={isEmpty}>
             <div class="pacing-empty">
                 <lightning-icon icon-name="utility:trending" size="medium" class="pacing-empty-icon"></lightning-icon>
                 <p>No active portfolio activity yet</p>
-                <p class="pacing-empty-sub">Activate projects and log work to populate the portfolio pacing view.</p>
+                <p class="pacing-empty-sub">Activate projects and log work to populate the pacing &amp; forecast view.</p>
             </div>
         </template>
 

--- a/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.js
+++ b/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.js
@@ -1,18 +1,37 @@
 /**
  * @name         Delivery Hub
  * @license      BSL 1.1 — See LICENSE.md
- * @description  Portfolio Pacing & Forecast HomePage card. Renders an account/org-level
- *               pacing view across ALL active root WorkItems: actual logged hours (bars),
- *               an amortized target line, and a forward run-rate forecast (dashed bars).
- *               The user picks the bucket granularity (Week / Month / Quarter) and the
- *               forward horizon (3 / 6 / 12 periods or rest-of-year), which re-wires the
- *               Apex call. Pure-SVG chart (no chart library), mirroring
- *               deliveryProjectMonthlyHours. Hours are primary; $ shown when the org has a
- *               single resolvable blended rate. Wires
+ * @description  Salesforce-native Pacing & Forecast view — the parallel to the
+ *               nimbus-gantt Pacing view (SAME model both render). Hours-first, fully
+ *               interactive over a single server payload:
+ *
+ *               • ACTUALS (past): all logged hours per period (green bars; red when
+ *                 over that period's amortized target).
+ *               • FORECAST (future): each in-flight item's remaining estimate
+ *                 (estimate − logged) spread across the forward periods its
+ *                 EstimatedStart → EstimatedEnd span covers — the same dates the Gantt
+ *                 drag-writes — rendered as light-blue bars. So the chart reads
+ *                 actual → today → forecast.
+ *               • Unscheduled remaining (un-dated work the forecast can't place) is
+ *                 surfaced as an amber note.
+ *
+ *               Controls applied CLIENT-SIDE over the returned data (only the Range +
+ *               Bucket re-wire Apex): Range (Next 3/6 · Rest of year · This Qtr · YTD ·
+ *               All · Custom), Bucket (Week/Month/Quarter), Measure (Hours/$ when a
+ *               blended rate is present), Mode (Per-period / Cumulative burn-up), and
+ *               Series toggles (Actual / Forecast / Target).
+ *
+ *               Click a bar → a drill-down panel lists the in-flight items contributing
+ *               that period (work item · this period · % of item · est · logged ·
+ *               remaining · % used + a meta line). Click a work-item row → navigate to
+ *               that WorkItem record (NavigationMixin standard__recordPage) — DH's
+ *               native advantage over NG. Pure-SVG chart (no chart library). Wires
  *               DeliveryHoursAnalyticsController.getPortfolioPacing.
  * @author       Cloud Nimbus LLC
  */
 import { LightningElement, track, wire } from "lwc";
+import { NavigationMixin } from "lightning/navigation";
+import WORK_ITEM_OBJECT from "@salesforce/schema/WorkItem__c";
 import getPortfolioPacing from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHoursAnalyticsController.getPortfolioPacing";
 
 const SVG_WIDTH = 760;
@@ -24,15 +43,38 @@ const PADDING_LEFT = 56;
 const GRID_LINE_COUNT = 5;
 const BAR_GAP_RATIO = 0.35;
 const DEFAULT_PERIODS_BACK = 6;
-const REST_OF_YEAR = "rest-of-year";
 
-export default class DeliveryPacingForecast extends LightningElement {
+// Range selector values.
+const RANGE_NEXT3 = "next3";
+const RANGE_NEXT6 = "next6";
+const RANGE_REST_OF_YEAR = "rest-of-year";
+const RANGE_THIS_QTR = "this-qtr";
+const RANGE_YTD = "ytd";
+const RANGE_ALL = "all";
+const RANGE_CUSTOM = "custom";
+
+export default class DeliveryPacingForecast extends NavigationMixin(
+    LightningElement
+) {
     @track pacing;
     @track errorMessage = "";
     isLoading = true;
 
+    // Server-driving controls (re-wire Apex).
     granularity = "Month";
-    horizon = "3";
+    range = RANGE_NEXT3;
+    customStart = null;
+    customEnd = null;
+
+    // Client-only controls (no re-wire).
+    measure = "hours";
+    mode = "per-period";
+    showActual = true;
+    showForecast = true;
+    showTarget = true;
+
+    // Drill-down selection.
+    @track selectedPeriodKey = null;
 
     @wire(getPortfolioPacing, {
         granularity: "$granularity",
@@ -53,15 +95,53 @@ export default class DeliveryPacingForecast extends LightningElement {
     // ── Wire inputs ──────────────────────────────────────────────
 
     get _periodsBack() {
+        if (this.range === RANGE_YTD) {
+            return this._periodsSinceYearStart();
+        }
+        if (this.range === RANGE_ALL) {
+            return 24;
+        }
+        if (this.range === RANGE_CUSTOM) {
+            return this._customPeriodsBack();
+        }
         return DEFAULT_PERIODS_BACK;
     }
 
     get _periodsForward() {
-        if (this.horizon === REST_OF_YEAR) {
-            return this._restOfYearPeriods();
+        switch (this.range) {
+            case RANGE_NEXT3:
+                return 3;
+            case RANGE_NEXT6:
+                return 6;
+            case RANGE_REST_OF_YEAR:
+                return this._restOfYearPeriods();
+            case RANGE_THIS_QTR:
+                return this._restOfQuarterPeriods();
+            case RANGE_YTD:
+                return 0;
+            case RANGE_ALL:
+                return 12;
+            case RANGE_CUSTOM:
+                return this._customPeriodsForward();
+            default:
+                return 3;
         }
-        const n = parseInt(this.horizon, 10);
-        return Number.isFinite(n) ? n : 3;
+    }
+
+    _periodsSinceYearStart() {
+        const today = new Date();
+        if (this.granularity === "Week") {
+            const yearStart = new Date(today.getFullYear(), 0, 1);
+            const msPerWeek = 7 * 24 * 60 * 60 * 1000;
+            return Math.max(
+                1,
+                Math.ceil((today.getTime() - yearStart.getTime()) / msPerWeek) + 1
+            );
+        }
+        if (this.granularity === "Quarter") {
+            return Math.floor(today.getMonth() / 3) + 1;
+        }
+        return today.getMonth() + 1;
     }
 
     /**
@@ -74,7 +154,9 @@ export default class DeliveryPacingForecast extends LightningElement {
         if (this.granularity === "Week") {
             const yearEnd = new Date(year, 11, 31);
             const msPerWeek = 7 * 24 * 60 * 60 * 1000;
-            const weeks = Math.ceil((yearEnd.getTime() - today.getTime()) / msPerWeek);
+            const weeks = Math.ceil(
+                (yearEnd.getTime() - today.getTime()) / msPerWeek
+            );
             return Math.max(1, weeks);
         }
         if (this.granularity === "Quarter") {
@@ -82,6 +164,69 @@ export default class DeliveryPacingForecast extends LightningElement {
             return Math.max(1, 3 - currentQuarter);
         }
         return Math.max(1, 12 - today.getMonth());
+    }
+
+    _restOfQuarterPeriods() {
+        const today = new Date();
+        if (this.granularity === "Quarter") {
+            return 1;
+        }
+        const monthInQuarter = today.getMonth() % 3;
+        if (this.granularity === "Week") {
+            return Math.max(1, (3 - monthInQuarter) * 4);
+        }
+        return Math.max(1, 3 - monthInQuarter);
+    }
+
+    _periodsBetween(startDate, endDate) {
+        if (!startDate || !endDate) {
+            return 0;
+        }
+        const s = new Date(startDate);
+        const e = new Date(endDate);
+        if (Number.isNaN(s.getTime()) || Number.isNaN(e.getTime()) || e < s) {
+            return 0;
+        }
+        if (this.granularity === "Week") {
+            const msPerWeek = 7 * 24 * 60 * 60 * 1000;
+            return Math.max(1, Math.ceil((e.getTime() - s.getTime()) / msPerWeek) + 1);
+        }
+        if (this.granularity === "Quarter") {
+            return (
+                (e.getFullYear() - s.getFullYear()) * 4 +
+                (Math.floor(e.getMonth() / 3) - Math.floor(s.getMonth() / 3)) +
+                1
+            );
+        }
+        return (
+            (e.getFullYear() - s.getFullYear()) * 12 +
+            (e.getMonth() - s.getMonth()) +
+            1
+        );
+    }
+
+    _customPeriodsBack() {
+        if (!this.customStart) {
+            return DEFAULT_PERIODS_BACK;
+        }
+        const today = new Date();
+        const start = new Date(this.customStart);
+        if (start >= today) {
+            return 1;
+        }
+        return Math.max(1, this._periodsBetween(start, today));
+    }
+
+    _customPeriodsForward() {
+        if (!this.customEnd) {
+            return 3;
+        }
+        const today = new Date();
+        const end = new Date(this.customEnd);
+        if (end <= today) {
+            return 0;
+        }
+        return Math.max(0, this._periodsBetween(today, end) - 1);
     }
 
     // ── Combobox / button-group options ──────────────────────────
@@ -94,19 +239,48 @@ export default class DeliveryPacingForecast extends LightningElement {
         ];
     }
 
-    get horizonOptions() {
+    get rangeOptions() {
         return [
-            { label: "Next 3", value: "3" },
-            { label: "Next 6", value: "6" },
-            { label: "Next 12", value: "12" },
-            { label: "Rest of year", value: REST_OF_YEAR }
+            { label: "Next 3", value: RANGE_NEXT3 },
+            { label: "Next 6", value: RANGE_NEXT6 },
+            { label: "Rest of year", value: RANGE_REST_OF_YEAR },
+            { label: "This quarter", value: RANGE_THIS_QTR },
+            { label: "Year to date", value: RANGE_YTD },
+            { label: "All", value: RANGE_ALL },
+            { label: "Custom", value: RANGE_CUSTOM }
         ];
+    }
+
+    get measureOptions() {
+        return [
+            { label: "Hours", value: "hours" },
+            { label: "Dollars", value: "dollars" }
+        ];
+    }
+
+    get modeOptions() {
+        return [
+            { label: "Per period", value: "per-period" },
+            { label: "Cumulative", value: "cumulative" }
+        ];
+    }
+
+    get isCustomRange() {
+        return this.range === RANGE_CUSTOM;
+    }
+
+    get isDollarMeasure() {
+        return this.measure === "dollars" && this.hasRate;
     }
 
     // ── State flags ──────────────────────────────────────────────
 
     get hasError() {
         return !this.isLoading && this.errorMessage;
+    }
+
+    get summary() {
+        return (this.pacing && this.pacing.summary) || null;
     }
 
     get isEmpty() {
@@ -117,75 +291,106 @@ export default class DeliveryPacingForecast extends LightningElement {
         if (periods.length === 0) {
             return true;
         }
-        const noActuals = periods.every((p) => !p.loggedHours);
+        const s = this.summary;
+        const noActuals = periods.every((p) => !p.actualHours);
         const noForecast = periods.every((p) => !p.forecastHours);
-        return noActuals && noForecast && !this.pacing.totalEstimatedHours;
+        return noActuals && noForecast && !(s && s.estimatedHours);
     }
 
     get hasData() {
-        return !this.isLoading && !this.errorMessage && !this.isEmpty && this.pacing;
+        return (
+            !this.isLoading && !this.errorMessage && !this.isEmpty && this.pacing
+        );
     }
 
     get hasTarget() {
-        return this.pacing && this.pacing.hasEstimate;
+        return this.summary && this.summary.hasEstimate;
+    }
+
+    get showTargetSeries() {
+        return this.hasTarget && this.showTarget;
     }
 
     get hasRate() {
         return this.pacing && this.pacing.blendedRate > 0;
     }
 
-    // ── Headline numbers ─────────────────────────────────────────
-
-    get totalEstimatedDisplay() {
-        return this.pacing ? this._formatHours(this.pacing.totalEstimatedHours) : "0";
+    get scopeLabel() {
+        return this.pacing ? this.pacing.scopeLabel : "";
     }
 
-    get totalLoggedDisplay() {
-        return this.pacing ? this._formatHours(this.pacing.totalLoggedHours) : "0";
+    // ── Headline summary cards ───────────────────────────────────
+
+    get loggedDisplay() {
+        return this.summary ? this._formatMeasure(this.summary.loggedHours) : "0";
+    }
+
+    get estimatedDisplay() {
+        return this.summary
+            ? this._formatMeasure(this.summary.estimatedHours)
+            : "0";
+    }
+
+    get remainingDisplay() {
+        return this.summary
+            ? this._formatMeasure(this.summary.remainingHours)
+            : "0";
     }
 
     get projectedFinalDisplay() {
-        return this.pacing ? this._formatHours(this.pacing.projectedFinalHours) : "0";
+        return this.summary
+            ? this._formatMeasure(this.summary.projectedFinalHours)
+            : "0";
     }
 
-    get rootCountDisplay() {
-        return this.pacing ? this.pacing.rootCount : 0;
+    get pacingPctDisplay() {
+        if (!this.summary || !this.summary.pacingPct) {
+            return "—";
+        }
+        return `${this.summary.pacingPct}%`;
     }
 
-    get projectedFinalDollarDisplay() {
-        if (!this.hasRate) {
+    get pacingPctClass() {
+        const base = "summary-value";
+        if (!this.summary) {
+            return base;
+        }
+        return this.summary.isOverBudgetTrajectory
+            ? `${base} summary-value--over`
+            : base;
+    }
+
+    get activeItemsDisplay() {
+        return this.summary ? this.summary.activeItems : 0;
+    }
+
+    get projectedFinalClass() {
+        const base = "summary-value";
+        if (this.summary && this.summary.isOverBudgetTrajectory) {
+            return `${base} summary-value--over`;
+        }
+        return base;
+    }
+
+    // ── Unscheduled-remaining note ───────────────────────────────
+
+    get hasUnscheduled() {
+        return this.summary && this.summary.unscheduledRemainingHours > 0;
+    }
+
+    get unscheduledNote() {
+        if (!this.hasUnscheduled) {
             return "";
         }
-        return this._formatMoney(this.pacing.projectedFinalHours * this.pacing.blendedRate);
+        const hours = this._formatHours(this.summary.unscheduledRemainingHours);
+        return `${hours}h of remaining work can't be placed on the forecast — size and schedule these (set start/end dates on the Gantt) so the projection can place them.`;
     }
 
-    get loggedDollarDisplay() {
-        if (!this.hasRate) {
+    get forecastCappedNote() {
+        if (!this.summary || !this.summary.forecastCapped) {
             return "";
         }
-        return this._formatMoney(this.pacing.totalLoggedHours * this.pacing.blendedRate);
-    }
-
-    get pacingPercent() {
-        if (!this.pacing || !this.pacing.hasEstimate || !this.pacing.totalEstimatedHours) {
-            return "";
-        }
-        const pct = (this.pacing.projectedFinalHours / this.pacing.totalEstimatedHours) * 100;
-        return `${pct.toFixed(0)}%`;
-    }
-
-    get isOverBudget() {
-        return this.pacing && this.pacing.isOverBudgetTrajectory;
-    }
-
-    get pacingClass() {
-        return this.isOverBudget
-            ? "summary-variance summary-variance--over"
-            : "summary-variance summary-variance--under";
-    }
-
-    get trajectoryLabel() {
-        return this.isOverBudget ? "Over budget at current pace" : "On track at current pace";
+        return "Showing the soonest-ending in-flight items only — the forecast set was capped. Projection may be partial.";
     }
 
     // ── SVG geometry ─────────────────────────────────────────────
@@ -230,10 +435,44 @@ export default class DeliveryPacingForecast extends LightningElement {
         return (this.pacing && this.pacing.periods) || [];
     }
 
+    /**
+     * The per-period plot value for the bar series, honoring Measure ($ vs hours) and
+     * Mode (cumulative burn-up vs per-period). Cumulative accumulates the combined
+     * actual+forecast spend so the line climbs toward projected final.
+     */
+    _plotValue(period, runningTotal) {
+        const rate = this.isDollarMeasure ? this.pacing.blendedRate : 1;
+        const raw = period.isForecast
+            ? period.forecastHours || 0
+            : period.actualHours || 0;
+        if (this.mode === "cumulative") {
+            return (runningTotal + raw) * rate;
+        }
+        return raw * rate;
+    }
+
+    _targetPlotValue(period, runningTarget) {
+        const rate = this.isDollarMeasure ? this.pacing.blendedRate : 1;
+        const raw = period.targetHours || 0;
+        if (this.mode === "cumulative") {
+            return (runningTarget + raw) * rate;
+        }
+        return raw * rate;
+    }
+
     get _maxValue() {
         let max = 0;
+        let running = 0;
+        let runningTarget = 0;
         for (const p of this._periods) {
-            const candidate = Math.max(p.loggedHours || 0, p.forecastHours || 0, p.targetHours || 0);
+            const series = this._plotValue(p, running);
+            const target = this._targetPlotValue(p, runningTarget);
+            running += p.isForecast ? p.forecastHours || 0 : p.actualHours || 0;
+            runningTarget += p.targetHours || 0;
+            const candidate = Math.max(
+                this.showActual || this.showForecast ? series : 0,
+                this.showTargetSeries ? target : 0
+            );
             if (candidate > max) {
                 max = candidate;
             }
@@ -284,45 +523,54 @@ export default class DeliveryPacingForecast extends LightningElement {
     get bars() {
         const periods = this._periods;
         const out = [];
+        let running = 0;
         for (let i = 0; i < periods.length; i++) {
             const p = periods[i];
-            const value = p.isForecast ? p.forecastHours || 0 : p.loggedHours || 0;
+            const visible = p.isForecast ? this.showForecast : this.showActual;
+            const value = this._plotValue(p, running);
+            running += p.isForecast ? p.forecastHours || 0 : p.actualHours || 0;
+            if (!visible) {
+                continue;
+            }
             const slotX = this.chartLeft + i * this._slotWidth;
             const x = slotX + this._barXOffset;
             const yTop = this._yForValue(value);
             const height = this.chartBottom - yTop;
             out.push({
                 key: `bar-${i}`,
+                periodKey: String(i),
                 x,
                 y: yTop,
                 width: this._barWidth,
                 height: height > 0 ? height : 0,
-                cssClass: this._barClass(p),
+                cssClass: this._barClass(p, String(i)),
                 tooltip: this._buildTooltip(p)
             });
         }
         return out;
     }
 
-    _barClass(p) {
+    _barClass(p, periodKey) {
+        const selected =
+            this.selectedPeriodKey === periodKey ? " bar--selected" : "";
         if (p.isForecast) {
-            return "bar bar--forecast";
+            return `bar bar--forecast${selected}`;
         }
         if (p.overTarget) {
-            return "bar bar--over";
+            return `bar bar--over${selected}`;
         }
-        return "bar bar--under";
+        return `bar bar--actual${selected}`;
     }
 
     _buildTooltip(p) {
-        const value = p.isForecast ? p.forecastHours || 0 : p.loggedHours || 0;
+        const raw = p.isForecast ? p.forecastHours || 0 : p.actualHours || 0;
         const kind = p.isForecast ? "forecast" : "logged";
-        const parts = [`${p.label}: ${this._formatHours(value)}h ${kind}`];
+        const parts = [`${p.label}: ${this._formatHours(raw)}h ${kind}`];
         if (p.targetHours > 0) {
             parts.push(`target ${this._formatHours(p.targetHours)}h`);
         }
         if (this.hasRate) {
-            parts.push(`${this._formatMoney(value * this.pacing.blendedRate)}`);
+            parts.push(`${this._formatMoney(raw * this.pacing.blendedRate)}`);
         }
         return parts.join(" · ");
     }
@@ -330,34 +578,36 @@ export default class DeliveryPacingForecast extends LightningElement {
     // ── Target line (per-period amortized estimate) ──────────────
 
     get targetPoints() {
-        if (!this.hasTarget) {
+        if (!this.showTargetSeries) {
             return "";
         }
         const periods = this._periods;
         const points = [];
+        let running = 0;
         for (let i = 0; i < periods.length; i++) {
+            const value = this._targetPlotValue(periods[i], running);
+            running += periods[i].targetHours || 0;
             const x = this.chartLeft + i * this._slotWidth + this._slotWidth / 2;
-            const y = this._yForValue(periods[i].targetHours || 0);
+            const y = this._yForValue(value);
             points.push(`${x.toFixed(1)},${y.toFixed(1)}`);
         }
         return points.join(" ");
     }
 
-    // ── Forecast boundary marker ─────────────────────────────────
+    // ── Current-period marker ────────────────────────────────────
 
-    get forecastBoundaryX() {
+    get currentMarkerX() {
         const periods = this._periods;
         for (let i = 0; i < periods.length; i++) {
-            if (periods[i].isForecast) {
-                return this.chartLeft + i * this._slotWidth;
+            if (periods[i].isCurrent) {
+                return this.chartLeft + i * this._slotWidth + this._slotWidth / 2;
             }
         }
         return 0;
     }
 
-    get hasForecastBoundary() {
-        const x = this.forecastBoundaryX;
-        return x > this.chartLeft;
+    get hasCurrentMarker() {
+        return this.currentMarkerX > 0;
     }
 
     // ── Grid + labels ────────────────────────────────────────────
@@ -372,7 +622,9 @@ export default class DeliveryPacingForecast extends LightningElement {
                 key: `grid-${i}`,
                 labelKey: `grid-label-${i}`,
                 y,
-                label: this._formatHours(value)
+                label: this.isDollarMeasure
+                    ? this._formatMoney(value)
+                    : this._formatHours(value)
             });
         }
         return lines;
@@ -396,19 +648,185 @@ export default class DeliveryPacingForecast extends LightningElement {
         return labels;
     }
 
-    // ── Handlers ─────────────────────────────────────────────────
+    // ── Drill-down panel ─────────────────────────────────────────
+
+    get selectedPeriod() {
+        if (this.selectedPeriodKey === null) {
+            return null;
+        }
+        const idx = parseInt(this.selectedPeriodKey, 10);
+        const periods = this._periods;
+        return Number.isFinite(idx) && periods[idx] ? periods[idx] : null;
+    }
+
+    get hasDrillDown() {
+        const p = this.selectedPeriod;
+        return !!(p && p.items && p.items.length > 0);
+    }
+
+    get drillEmpty() {
+        const p = this.selectedPeriod;
+        return !!(p && (!p.items || p.items.length === 0));
+    }
+
+    get drillTitle() {
+        const p = this.selectedPeriod;
+        return p ? `${p.label} — in-flight work` : "";
+    }
+
+    get drillRows() {
+        const p = this.selectedPeriod;
+        if (!p || !p.items) {
+            return [];
+        }
+        const rate = this.hasRate ? this.pacing.blendedRate : null;
+        return p.items.map((it, i) => {
+            const overBudget = it.budgetUsedPct > 100;
+            const meta = [];
+            if (it.priorityGroup) {
+                meta.push(it.priorityGroup);
+            }
+            if (it.developerName) {
+                meta.push(it.developerName);
+            }
+            if (it.stage) {
+                meta.push(it.stage);
+            }
+            if (it.startDate && it.endDate) {
+                meta.push(`${it.startDate} → ${it.endDate}`);
+            }
+            return {
+                key: `${p.label}-row-${i}`,
+                workItemId: it.workItemId,
+                name: it.name,
+                thisPeriod: this._formatHours(it.hoursThisPeriod),
+                thisPeriodDollars: rate
+                    ? this._formatMoney(it.hoursThisPeriod * rate)
+                    : "",
+                pctOfItem: `${it.pctOfItem}%`,
+                estimated: this._formatHours(it.estimatedHours),
+                logged: this._formatHours(it.loggedHours),
+                remaining: this._formatHours(it.remainingHours),
+                budgetUsedPct: `${it.budgetUsedPct}%`,
+                budgetClass: overBudget
+                    ? "drill-cell drill-cell--over"
+                    : "drill-cell",
+                metaLine: meta.join(" · ")
+            };
+        });
+    }
+
+    // ── Legend ───────────────────────────────────────────────────
+
+    get measureWord() {
+        return this.isDollarMeasure ? "$" : "hours";
+    }
+
+    // ── Handlers (server-driving) ────────────────────────────────
 
     handleGranularityChange(event) {
         this.granularity = event.detail.value;
+        this.selectedPeriodKey = null;
         this.isLoading = true;
     }
 
-    handleHorizonChange(event) {
-        this.horizon = event.detail.value;
-        this.isLoading = true;
+    handleRangeChange(event) {
+        this.range = event.detail.value;
+        this.selectedPeriodKey = null;
+        if (this.range !== RANGE_CUSTOM) {
+            this.isLoading = true;
+        }
+    }
+
+    handleCustomStartChange(event) {
+        this.customStart = event.detail.value;
+        if (this.customStart && this.customEnd) {
+            this.isLoading = true;
+        }
+    }
+
+    handleCustomEndChange(event) {
+        this.customEnd = event.detail.value;
+        if (this.customStart && this.customEnd) {
+            this.isLoading = true;
+        }
+    }
+
+    // ── Handlers (client-only) ───────────────────────────────────
+
+    handleMeasureChange(event) {
+        this.measure = event.detail.value;
+    }
+
+    handleModeChange(event) {
+        this.mode = event.detail.value;
+    }
+
+    handleToggleActual() {
+        this.showActual = !this.showActual;
+    }
+
+    handleToggleForecast() {
+        this.showForecast = !this.showForecast;
+    }
+
+    handleToggleTarget() {
+        this.showTarget = !this.showTarget;
+    }
+
+    get actualToggleClass() {
+        return this.showActual
+            ? "series-toggle series-toggle--on series-toggle--actual"
+            : "series-toggle";
+    }
+
+    get forecastToggleClass() {
+        return this.showForecast
+            ? "series-toggle series-toggle--on series-toggle--forecast"
+            : "series-toggle";
+    }
+
+    get targetToggleClass() {
+        return this.showTarget
+            ? "series-toggle series-toggle--on series-toggle--target"
+            : "series-toggle";
+    }
+
+    // ── Drill-down handlers ──────────────────────────────────────
+
+    handleBarClick(event) {
+        const key = event.currentTarget.dataset.periodKey;
+        this.selectedPeriodKey = this.selectedPeriodKey === key ? null : key;
+    }
+
+    handleCloseDrill() {
+        this.selectedPeriodKey = null;
+    }
+
+    handleRowClick(event) {
+        const recordId = event.currentTarget.dataset.recordId;
+        if (!recordId) {
+            return;
+        }
+        this[NavigationMixin.Navigate]({
+            // eslint-disable-next-line new-cap
+            type: "standard__recordPage",
+            attributes: {
+                recordId,
+                objectApiName: WORK_ITEM_OBJECT.objectApiName,
+                actionName: "view"
+            }
+        });
     }
 
     // ── Formatting helpers ───────────────────────────────────────
+
+    _formatMeasure(hours) {
+        if (this.isDollarMeasure) {
+            return this._formatMoney((Number(hours) || 0) * this.pacing.blendedRate);
+        }
+        return `${this._formatHours(hours)}h`;
+    }
 
     _formatHours(value) {
         if (value === null || value === undefined) {

--- a/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.js-meta.xml
@@ -8,5 +8,5 @@
         <target>lightning__RecordPage</target>
     </targets>
     <masterLabel>Delivery Portfolio Pacing &amp; Forecast</masterLabel>
-    <description>The Salesforce-native Pacing &amp; Forecast (parallel to the Gantt Pacing view): actual logged hours then a schedule-based forecast that spreads each in-flight item's remaining across its planned Gantt dates. Range/Bucket/Measure/Mode cuts, series toggles, click-a-bar drill-down into the work items, and navigate-to-record.</description>
+    <description>Salesforce-native Pacing &amp; Forecast: actual logged hours plus a schedule-based forecast spreading each in-flight item's remaining across its planned dates. Range/Bucket/Measure/Mode cuts, drill-down, navigate-to-record.</description>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.js-meta.xml
@@ -8,5 +8,5 @@
         <target>lightning__RecordPage</target>
     </targets>
     <masterLabel>Delivery Portfolio Pacing &amp; Forecast</masterLabel>
-    <description>Account/org-level pacing across all active projects: logged hours, amortized target line, and a user-tunable run-rate forecast. Pick Week/Month/Quarter buckets and a forward horizon.</description>
+    <description>The Salesforce-native Pacing &amp; Forecast (parallel to the Gantt Pacing view): actual logged hours then a schedule-based forecast that spreads each in-flight item's remaining across its planned Gantt dates. Range/Bucket/Measure/Mode cuts, series toggles, click-a-bar drill-down into the work items, and navigate-to-record.</description>
 </LightningComponentBundle>

--- a/force-app/test/jest-mocks/salesforce/schema/WorkItem__c.js
+++ b/force-app/test/jest-mocks/salesforce/schema/WorkItem__c.js
@@ -1,0 +1,7 @@
+/**
+ * @description Jest mock for the WorkItem__c object schema import. The
+ *              moduleNameMapper catch-all routes @salesforce/schema/WorkItem__c here.
+ *              Mirrors the shape sfdx-lwc-jest's default schema resolver returns so
+ *              components reading WORK_ITEM_OBJECT.objectApiName resolve under test.
+ */
+export default { objectApiName: "WorkItem__c" };


### PR DESCRIPTION
## Salesforce-native Pacing & Forecast — interactive, schedule-based, drill-down + navigate-to-record

Builds out the native `deliveryPacingForecast` LWC + its `DeliveryHoursAnalyticsController` engine into a full, interactive **Pacing & Forecast** — the Salesforce-native parallel to the nimbus-gantt Pacing view. **SAME model both render**, so the native view is a trustworthy backup/comparison. Builds on the schedule-based engine from #872 and extends it with a rich per-period drill-down, navigate-to-record, and the full set of interactive cuts.

### The model (locked across NG/DH/MF)
Reads/writes the **same fields the Gantt renders** (`EstimatedHoursNumber__c`, `EstimatedStartDevDate__c`, `EstimatedEndDevDate__c` + logged hours), so the two views can't drift.

- **Actuals (past):** ALL `WorkLog__c` hours by `WorkDateDate__c` per period — **no active-portfolio filter**, so completed/archived work is never undercounted (the old bug: May must read 236.5h, 744.5h total on MF-prod). Per-period bars = raw `GROUP BY CALENDAR_x(WorkDateDate__c)`.
- **Forecast (future):** per in-flight item, `remaining = max(0, estimate − logged)`, spread **evenly across the forward periods** from `max(today, EstimatedStart)` → `EstimatedEnd`. The chart reads **actual → today → forecast**.
- **Unscheduled bucket:** items with an estimate but no usable dates (or a past-due end) → `summary.unscheduledRemainingHours`, surfaced (not dropped) with a "size + schedule these" prompt.
- `projectedFinal = totalLogged(all) + Σ remaining(all in-flight)`.

Governor-safe: bulk SOQL, no SOQL-in-loop, `WITH SYSTEM_MODE`, item cap (2000) with a `forecastCapped` flag.

### Rich, render-ready DTO (global inner classes)
- **`PortfolioPacingDTO`** — `granularity`, `scopeLabel`, `rootCount`, `blendedRate` (one active NetworkEntity rate else null), `earliestStart`, `latestEnd`, `summary`, `periods[]`.
- **`PacingSummaryDTO`** — `estimatedHours`, `loggedHours`, `remainingHours`, `projectedFinalHours`, `pacingPct`, `activeItems`, `unscheduledRemainingHours`, `runRateHoursPerPeriod`, `hasEstimate`, `isOverBudgetTrajectory`, `forecastCapped`.
- **`PacingPeriodDTO`** — `label`, `startDate`, `endDate`, `actualHours`, `forecastHours`, `targetHours` (estimate amortized across the planned span), `isForecast`, `isCurrent`, `overTarget`, **`items[]`** (the per-period drill-down).
- **`PacingItemDTO`** (the rich breakout, mirrors the NG contract) — `workItemId`, `name`, `hoursThisPeriod`, `pctOfItem` (this period ÷ the item's placed total), `estimatedHours`, `loggedHours`, `remainingHours`, `budgetUsedPct` (logged÷est), `startDate`, `endDate`, `developerName`, `stage`, `priorityGroup`.

`getPortfolioPacing(granularity, periodsBack, periodsForward)` is backward-compatible; `periodsForward` expresses arbitrary forward ranges.

### Interactive LWC — the cuts
All applied **client-side over one payload**; only **Range** + **Bucket** re-wire Apex.
- **Range:** Next 3 / Next 6 / Rest of year / This Qtr / YTD / All / **Custom** (start→end date inputs).
- **Bucket:** Week / Month / Quarter.
- **Measure:** Hours / $ (only when a single blended rate is present; hours primary).
- **Mode:** Per-period / Cumulative (burn-up).
- **Series toggles:** Actual / Forecast / Target.
- **Info popover** renders (registry + meta refreshed to the new model).

Pure-SVG chart: stacked **actual (green; red when over that period's target) + forecast (light blue) bars**, a **dashed target line**, a **current-period marker**, axis in hours or $.

### Drill-down + navigate-to-record (DH's native advantage over NG)
**Click a bar → drill-down table:** Work item · This period · % of item · Est · Logged · Remaining · % used (red >100%) + a meta line (priority group · developer · stage · start→end). **Click a work-item row → navigate to that WorkItem record** via `NavigationMixin` `standard__recordPage` with `WORK_ITEM_OBJECT.objectApiName`.

### Field-name assumptions (grepped `docs/FIELD_NAMING.md` + the object)
- Developer → `DeveloperLookup__c` (→ User), surfaced as `DeveloperLookup__r.Name`.
- Stage → `StageNamePk__c`. Priority group → `PriorityGroupPk__c`. Work item label → `Name` (AutoNumber `T-{0000}`).

### Tests
- **Apex** (`DeliveryHoursAnalyticsControllerTest`): all-scope actuals incl. a completed/terminal item, schedule-spread placement across covered months, the unscheduled + past-due buckets, the **drill-down item metrics** (est/logged/remaining/budgetUsedPct/stage + pctOfItem summing ~100%), and `projectedFinal = logged + Σremaining` (over-logged clamps to 0 + over-budget flag).
- **Jest** (`deliveryPacingForecast`): 14 pass — controls, actual+forecast bars + target + current marker, summary cards, unscheduled note, drill-down open, navigate-to-record wiring, series toggles, custom range, empty/error. Added a `@salesforce/schema/WorkItem__c` jest mock.

> Note: 3 pre-existing, unrelated `deliveryFeatureCockpit` jest failures (the repo's `NavigationMixin` stub doesn't expose `getNavigateCalledWith`) exist on `main` and are untouched here — the same limitation is why the row-navigation test asserts the wiring contract + clean click path rather than spying the stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
