### PR TITLE
feat(cart): procurement Checkout Cart over WorkItem state — zero new objects

### DIFF
--- a/docs/plans/checkout-cart-procurement-2026-06-05.md
+++ b/docs/plans/checkout-cart-procurement-2026-06-05.md
@@ -1,0 +1,148 @@
+# Checkout Cart — procurement-side ordering inside Delivery Hub
+
+**Date:** 2026-06-05
+**Thesis fit:** DH = Salesforce-native **procurement** (self-serve), cloudnimbus = white-label
+**fulfillment**, bidirectional sync is the spine. The cart is the *procurement* surface made
+literal: a client assembles a basket of scoped work, it auto-**sizes** and auto-**sequences**,
+and checkout routes it into the existing delivery pipeline.
+
+> Origin: 2026-06-04/05 MF billing-call arc. Jose/Jared want no-surprises visibility into
+> hours + what's coming. The cart lets a purchaser say "I want these, in this order" and lets
+> Glen review the basket in a meeting as a ready-to-action proposal.
+
+**Scope (locked 2026-06-05):** **one org-wide cart** (not per-client, not per-purchaser,
+not multiple). **Zero new objects.** The cart is a *state* over existing WorkItems.
+
+---
+
+## 1. Persistence — the cart is already in the schema (`ClientIntentionPk__c`)
+
+No new object, no new cart fields. The cart = WorkItems carrying a client-intent state:
+
+| `ClientIntentionPk__c` (existing) | Cart meaning |
+|-----------------------------------|--------------|
+| `Will Do`     | **committed cart** — checkout candidate |
+| `Sizing Only` | **in cart, exploring** — wants the estimate, not committed |
+| `Deferred` / `On Hold` | not in the active cart |
+
+- **Org-wide cart** = all `WorkItem__c` where `ClientIntentionPk__c ∈ {Will Do, Sizing Only}`
+  **and** `ActivatedDateTime__c == NULL`. One basket for the whole org.
+- **Checkout = stamp `ActivatedDateTime__c`** on the `Will Do` lines → they cross into the
+  live pipeline and inherit forecast (PR #873 keys in-flight on `ActivatedDateTime != NULL`),
+  gantt, sync, and invoicing **for free**. No copy/convert, no parallel data model.
+- Per-line sizing already exists: `EstimatedHoursNumber__c`; on the WorkRequest
+  `QuotedHoursNumber__c × HourlyRateCurrency__c = ProjectedCostCurrency__c`.
+- Per-line order already exists: `PriorityGroupPk__c` / `PriorityPk__c` + `FeatureDependency__c`.
+
+> **Multi-cart is a clean future upgrade, deferred:** because lines are already real WorkItems,
+> adding a thin `Cart__c` header + `CartLookup__c` later is purely additive — zero rework of
+> anything below. Don't build it until multiple concurrent carts are a real need.
+
+---
+
+## 2. Experience config — capability flags resolved per actor (org-level primary)
+
+The experience is **orthogonal capabilities**, so any client is a *combination*, never a named
+"mode." New client shapes = new flag combinations, **zero new code**.
+
+| Capability     | Mechanism                              | MF        | Self-serve client |
+|----------------|----------------------------------------|-----------|-------------------|
+| `showDollars`  | `EnableCartDollarsDateTime__c` (Settings) | **off** | on                |
+| `checkoutMode` | `CheckoutModeTxt__c` (Approve\|Invoice\|Stripe — Text, validated in Apex) | `Invoice` | `Stripe` |
+| `selfServe`    | `EnableCartSelfServeDateTime__c`       | off (Glen assembles) | on |
+
+> **`checkoutMode` is `CheckoutModeTxt__c` (Text), NOT a Picklist/GVS.** It lives on
+> `DeliveryHubSettings__c`, which is a **Custom Setting** — Custom Settings cannot hold
+> Picklist fields (primitive types only). The value is one of `Approve | Invoice | Stripe`,
+> validated and normalized in Apex (`CartExperienceProfile.normalizeMode`); blank defaults to
+> `Invoice`. This supersedes the original "via GVS" sizing note in §4 below.
+
+**Resolution:** **`DeliveryHubSettings__c` org defaults** are primary (one org-wide cart →
+org-level config). `NetworkEntity__c` override stays *available* (it already hosts the
+`EnableBillingDateTime__c` pattern) but is optional/future. Role (admin vs client) gates which
+surface a user sees — same split as the Home pages (#869/#870).
+
+Flags are **DateTime stamps + a Text mode, never booleans** (house pattern), so they stay
+queryable/reportable. **Only genuinely new metadata in this whole plan = these ~3 config fields.**
+One Apex resolver returns a `CartExperienceProfile`; both LWCs are a pure function of
+`(cartData, profile)` — MF and a self-serve client run **identical bytes** (same "never fork the
+renderer" lesson as the gantt + the NG pacing `controls`/`defaults`).
+
+---
+
+## 3. Two surfaces (one config-driven LWC each)
+
+### A. `deliveryCartBuilder` (client / purchaser) — "add to cart"
+- Browse catalog (`Feature__c` via the `deliveryFeatureCockpit` pattern; cascade via
+  `deliveryFeatureCascadePreview`) and/or freeform request (`deliveryQuickRequest` pattern).
+- Add → sets `ClientIntentionPk__c = Sizing Only` (exploring) or `Will Do` (committed) on a
+  pre-activation WorkItem.
+- Running total: Σ hours, **Σ $ only when `showDollars`** (reuses the pacing dollar gate).
+- Timeline impact: call the forecast engine on the cart's lines → "this lands across these months."
+- Reorder (drag priority) → writes `PriorityPk__c`.
+
+### B. `deliveryCartCheckout` (Glen's meeting / review surface) — "review the checkout"
+- The org-wide basket, auto-**sized** (hrs + $ per profile) and auto-**sequenced**
+  (priority + dependency) — recommendations-to-action in order.
+- One control → **checkout**, branching on `checkoutMode`:
+  - `Invoice` (MF) → stamp `Will Do` lines active + generate proposal/agreement via
+    `DeliveryDocGenerationService` (retainer/fixed-bid/hourly clauses already shipped).
+  - `Stripe` (self-serve) → activate + hand off to `DeliveryStripePaymentHandler` (seam).
+  - `Approve` → activate + route through the approval rails (seam).
+
+---
+
+## 4. Build steps — sized & ordered
+
+| # | Step | Size | Notes |
+|---|------|------|-------|
+| 1 | ~3 config fields on `DeliveryHubSettings__c` (`EnableCartDollarsDateTime__c`, `EnableCartSelfServeDateTime__c`, `CheckoutModeTxt__c` — **Text, not GVS**: Custom Settings can't hold picklists) | S | the only new metadata |
+| 2 | `CartExperienceProfile` resolver + `DeliveryCartService` (add/remove/reorder/checkout over `ClientIntentionPk__c` + `ActivatedDateTime__c`) | M | checkout = activate `Will Do` lines |
+| 3 | `deliveryCartCheckout` LWC (review surface) — sized + sequenced + checkout control | M | reuses forecast engine, DocGen, Stripe, approval |
+| 4 | `deliveryCartBuilder` LWC (add-to-cart) — catalog + freeform + running total | M | reuses Feature cockpit + cascade + quick-request patterns |
+| 5 | FlexiPage placement (cart tab + checkout-review on AdminHome) + info popovers | S | **place on FlexiPages in-package** (lesson #869) |
+| 6 | Apex + Jest tests; profile matrix (MF hours-only vs self-serve $/Stripe) | M | upload-beta-safe (namespaced describe, ≤40-char identifiers, global DTOs) |
+
+**Order:** 1 → 2 → 3 (review surface first — it's the meeting need and proves sizing/sequencing)
+→ 4 → 5 → 6. Steps 3 and 4 parallelize once 2 lands.
+
+---
+
+## 5. Open decisions (greenlight before build) — RESOLVED 2026-06-05
+1. **`Will Do` vs `Sizing Only` as the checkout line** — *Locked: checkout activates `Will Do`
+   only; `Sizing Only` stays in the cart as "priced but not committed."*
+2. **Checkout-review placement** — *Locked: a `Cart` tab (the org's single basket) hosting
+   `deliveryCartCheckout` + an "Open cart" summary card on AdminHome.*
+3. **`showDollars` default** — *Locked: off by default org-wide (MF behavior); self-serve orgs
+   opt in.*
+
+---
+
+## 6. What this reuses (nothing rebuilt)
+`ClientIntentionPk__c` (cart state) · forecast engine (sizing, PR #873) · priority +
+`FeatureDependency__c` (order) · `DeliveryDocGenerationService` + agreement clauses (proposal) ·
+approval rails (`DeliveryFeatureApprovalService`, multi-step) · `DeliveryStripePaymentHandler`
+(paid checkout) · `Feature__c` catalog + `deliveryFeatureCockpit`/`deliveryFeatureCascadePreview`
+(browse/add) · bidirectional sync (a cart line syncs like any work). The cart is **assembly +
+~3 config fields + two screens** on top of machinery that already exists — the deplatformer
+thesis in miniature.
+
+---
+
+## 7. As-built notes / TODO seams (2026-06-05)
+- **Stripe checkout is a seam.** `DeliveryStripePaymentHandler` is an *inbound* webhook event
+  handler (charge.succeeded → `DeliveryTransaction__c`), not an outbound payment initiator.
+  `checkout()` in `Stripe` mode activates the `Will Do` lines and returns a clearly-marked
+  message; a real Checkout Session / Payment Link callout is a follow-up. No payment behavior
+  is faked.
+- **Approve checkout is a seam.** The shipped approval rails (`DeliveryFeatureApprovalService`)
+  key on `Feature__c` toggle requests, not on a basket of WorkItems. `Approve` mode activates
+  the lines and notes the seam; a WorkItem-basket approval flow is a follow-up.
+- **Invoice proposal generation** is wired when the committed lines share exactly one client
+  `NetworkEntity__c` (`ClientNetworkEntityLookup__c`); it generates a `Client_Agreement` via
+  `DeliveryDocGenerationService.generateDocument`. When the lines span zero or many client
+  entities, activation stands and the result notes that no single-client proposal was generated
+  (no fabricated document).
+- **Forecast month-spread** on the review surface reuses
+  `DeliveryHoursAnalyticsController.getPortfolioPacing` (the active-portfolio forecast). The
+  exact cart-only month spread folds into that view once lines are activated.

--- a/force-app/main/default/applications/DeliveryHub.app-meta.xml
+++ b/force-app/main/default/applications/DeliveryHub.app-meta.xml
@@ -214,6 +214,7 @@
     <tabs>WorkItem__c</tabs>
     <tabs>WorkItemComment__c</tabs>
     <tabs>Delivery_Guide</tabs>
+    <tabs>Delivery_Cart</tabs>
     <uiType>Lightning</uiType>
     <utilityBar>DeliveryHubUtilityBar</utilityBar>
 </CustomApplication>

--- a/force-app/main/default/applications/DeliveryHubAdmin.app-meta.xml
+++ b/force-app/main/default/applications/DeliveryHubAdmin.app-meta.xml
@@ -225,6 +225,7 @@
     <tabs>Delivery_Permission_Analyzer</tabs>
     <tabs>DeliveryHubSettings</tabs>
     <tabs>Delivery_Guide</tabs>
+    <tabs>Delivery_Cart</tabs>
     <tabs>standard-report</tabs>
     <uiType>Lightning</uiType>
     <utilityBar>DeliveryHubAdmin_UtilityBar</utilityBar>

--- a/force-app/main/default/classes/CartExperienceProfile.cls
+++ b/force-app/main/default/classes/CartExperienceProfile.cls
@@ -1,0 +1,104 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Resolved Checkout Cart experience capabilities for the running org.
+ *               The cart UI is a pure function of (cartData, profile): MF and a
+ *               self-serve client run identical bytes — only this profile differs.
+ *               Capabilities are orthogonal flags resolved from DeliveryHubSettings__c
+ *               org defaults (DateTime != null => true; CheckoutModeTxt default 'Invoice'
+ *               when blank). showDollars additionally requires a resolvable blended rate.
+ *               Global so it can be returned across the @AuraEnabled boundary and
+ *               reused as a return/param type by other global classes.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
+global with sharing class CartExperienceProfile {
+
+    /** @description Canonical checkout-mode value: stamp active + generate a proposal/agreement. */
+    global static final String MODE_INVOICE = 'Invoice';
+    /** @description Canonical checkout-mode value: stamp active + route through paid (Stripe) checkout. */
+    global static final String MODE_STRIPE = 'Stripe';
+    /** @description Canonical checkout-mode value: route through the approval rails first. */
+    global static final String MODE_APPROVE = 'Approve';
+
+    /** @description True when the cart should render dollar amounts (hours + $). */
+    @AuraEnabled global Boolean showDollars { get; set; }
+
+    /** @description True when clients self-serve the cart; false = admin assembles. */
+    @AuraEnabled global Boolean selfServe { get; set; }
+
+    /** @description One of Approve | Invoice | Stripe. Drives the checkout button + routing. */
+    @AuraEnabled global String checkoutMode { get; set; }
+
+    /** @description Single resolvable blended hourly rate, or null when ambiguous/absent. */
+    @AuraEnabled global Decimal blendedRate { get; set; }
+
+    /**
+     * @description Resolves the experience profile from DeliveryHubSettings__c org
+     *              defaults. DateTime fields map to Booleans (non-null => true);
+     *              CheckoutModeTxt__c is validated against the three known modes and
+     *              defaults to Invoice when blank/unrecognized. showDollars is gated on
+     *              BOTH the EnableCartDollarsDateTime__c opt-in AND a resolvable blended
+     *              rate (mirrors the pacing dollar gate — no rate => hours-only).
+     * @return A fully populated CartExperienceProfile.
+     */
+    global static CartExperienceProfile resolve() {
+        CartExperienceProfile profile = new CartExperienceProfile();
+
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        Boolean dollarsOptIn = settings != null && settings.EnableCartDollarsDateTime__c != null;
+        profile.selfServe = settings != null && settings.EnableCartSelfServeDateTime__c != null;
+        profile.checkoutMode = normalizeMode(settings == null ? null : settings.CheckoutModeTxt__c);
+
+        profile.blendedRate = resolveBlendedRate();
+        // Dollars require BOTH the opt-in AND a single resolvable rate.
+        profile.showDollars = dollarsOptIn && profile.blendedRate != null && profile.blendedRate > 0;
+
+        return profile;
+    }
+
+    /**
+     * @description Validates a raw checkout-mode string against the three known modes.
+     *              Case-insensitive; blank or unrecognized => Invoice (the default).
+     * @param raw The raw CheckoutModeTxt__c value (may be null/blank).
+     * @return One of MODE_APPROVE, MODE_INVOICE, MODE_STRIPE.
+     */
+    global static String normalizeMode(String raw) {
+        if (String.isBlank(raw)) {
+            return MODE_INVOICE;
+        }
+        String v = raw.trim().toLowerCase();
+        if (v == 'approve') {
+            return MODE_APPROVE;
+        }
+        if (v == 'stripe') {
+            return MODE_STRIPE;
+        }
+        return MODE_INVOICE;
+    }
+
+    /**
+     * @description Reads a single blended hourly rate when EXACTLY ONE active
+     *              NetworkEntity carries a DefaultHourlyRateCurrency__c. Returns null
+     *              when zero or many distinct rates exist (ambiguous — hours-only).
+     *              Mirrors DeliveryHoursAnalyticsController.resolveBlendedRate. Field is
+     *              referenced statically in the SOQL so it is compile-time guaranteed
+     *              to exist (no namespace-unsafe describe guard).
+     * @return The blended rate, or null.
+     */
+    global static Decimal resolveBlendedRate() {
+        List<NetworkEntity__c> rated = [
+            SELECT DefaultHourlyRateCurrency__c
+            FROM NetworkEntity__c
+            WHERE DefaultHourlyRateCurrency__c != NULL
+              AND DefaultHourlyRateCurrency__c > 0
+              AND StatusPk__c = 'Active'
+            WITH SYSTEM_MODE
+            LIMIT 2
+        ];
+        if (rated.size() == 1) {
+            return rated[0].DefaultHourlyRateCurrency__c;
+        }
+        return null;
+    }
+}

--- a/force-app/main/default/classes/CartExperienceProfile.cls-meta.xml
+++ b/force-app/main/default/classes/CartExperienceProfile.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryCartService.cls
+++ b/force-app/main/default/classes/DeliveryCartService.cls
@@ -161,7 +161,7 @@ global with sharing class DeliveryCartService {
                    StageNamePk__c, EstimatedStartDevDate__c, EstimatedEndDevDate__c,
                    DeveloperLookup__r.Name,
                    (SELECT Id, ProjectedCostCurrency__c, QuotedHoursNumber__c
-                    FROM Requests
+                    FROM Requests__r
                     ORDER BY CreatedDate DESC
                     LIMIT 1)
             FROM WorkItem__c
@@ -191,8 +191,8 @@ global with sharing class DeliveryCartService {
         if (wi.DeveloperLookup__r != null) {
             line.developerName = wi.DeveloperLookup__r.Name;
         }
-        if (wi.Requests != null && !wi.Requests.isEmpty()) {
-            line.projectedCost = wi.Requests[0].ProjectedCostCurrency__c;
+        if (wi.Requests__r != null && !wi.Requests__r.isEmpty()) {
+            line.projectedCost = wi.Requests__r[0].ProjectedCostCurrency__c;
         }
         return line;
     }

--- a/force-app/main/default/classes/DeliveryCartService.cls
+++ b/force-app/main/default/classes/DeliveryCartService.cls
@@ -1,0 +1,437 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Procurement-side Checkout Cart service. The cart is a STATE over
+ *               existing WorkItem__c records — ZERO new objects:
+ *
+ *                 cart = WorkItem__c WHERE ClientIntentionPk__c IN
+ *                        {Will Do, Sizing Only} AND ActivatedDateTime__c == NULL
+ *
+ *               'Will Do' = committed (checkout candidate); 'Sizing Only' = priced but
+ *               not committed; 'Deferred'/'On Hold' = not in the cart. Checkout stamps
+ *               ActivatedDateTime__c on the Will Do lines so they cross into the live
+ *               pipeline (forecast / gantt / sync / invoicing) with no copy/convert.
+ *
+ *               Per-line sizing is EstimatedHoursNumber__c; the projected cost comes
+ *               from the child WorkRequest__c (QuotedHoursNumber__c x HourlyRateCurrency__c
+ *               = ProjectedCostCurrency__c, an existing formula). Per-line order is
+ *               PriorityPk__c.
+ *
+ *               Global + all inner DTOs global so the @AuraEnabled boundary and any
+ *               global caller can use them as return types. SOQL is WITH SYSTEM_MODE
+ *               (namespaced package test context). ClientIntentionPk__c is unrestricted
+ *               with no trigger enforcement (CLAUDE.md) — safe known values are passed
+ *               directly and validated in Apex.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexDoc,PMD.AvoidGlobalModifier,PMD.CyclomaticComplexity')
+global with sharing class DeliveryCartService {
+
+    /** @description Cart intent: committed — included at checkout. */
+    @TestVisible private static final String INTENT_WILL_DO = 'Will Do';
+    /** @description Cart intent: exploring — priced, NOT included at checkout. */
+    @TestVisible private static final String INTENT_SIZING_ONLY = 'Sizing Only';
+    /** @description Out-of-cart intent. */
+    @TestVisible private static final String INTENT_DEFERRED = 'Deferred';
+    /** @description Out-of-cart intent. */
+    @TestVisible private static final String INTENT_ON_HOLD = 'On Hold';
+
+    /** @description Intent values accepted by add/remove. */
+    private static final Set<String> VALID_INTENTIONS = new Set<String>{
+        INTENT_WILL_DO, INTENT_SIZING_ONLY, INTENT_DEFERRED, INTENT_ON_HOLD
+    };
+
+    /** @description Intent values that constitute the active cart. */
+    private static final Set<String> CART_INTENTIONS = new Set<String>{
+        INTENT_WILL_DO, INTENT_SIZING_ONLY
+    };
+
+    /** @description Hard cap on cart lines scanned. */
+    private static final Integer MAX_CART_LINES = 2000;
+
+    // ── DTOs ─────────────────────────────────────────────────────────────
+
+    /** @description One render-ready cart line (a non-activated WorkItem). */
+    global class CartLineDTO {
+        @AuraEnabled global Id workItemId;
+        @AuraEnabled global String name;
+        @AuraEnabled global String intention;
+        @AuraEnabled global Decimal estimatedHours;
+        @AuraEnabled global Decimal projectedCost;
+        @AuraEnabled global String priority;
+        @AuraEnabled global String priorityGroup;
+        @AuraEnabled global String stage;
+        @AuraEnabled global String developerName;
+        @AuraEnabled global Date estimatedStart;
+        @AuraEnabled global Date estimatedEnd;
+        @AuraEnabled global Boolean isCommitted;
+    }
+
+    /** @description Cart summary header. */
+    global class CartSummaryDTO {
+        @AuraEnabled global Integer count;
+        @AuraEnabled global Integer willDoCount;
+        @AuraEnabled global Integer sizingOnlyCount;
+        @AuraEnabled global Decimal willDoHours;
+        @AuraEnabled global Decimal sizingOnlyHours;
+        @AuraEnabled global Decimal willDoCost;
+    }
+
+    /** @description Full cart payload returned to the LWC. */
+    global class CartDTO {
+        @AuraEnabled global List<CartLineDTO> lines;
+        @AuraEnabled global CartSummaryDTO summary;
+        @AuraEnabled global CartExperienceProfile profile;
+    }
+
+    /** @description Result of a checkout call. */
+    global class CheckoutResultDTO {
+        @AuraEnabled global Integer activatedCount;
+        @AuraEnabled global String checkoutMode;
+        @AuraEnabled global Id documentId;
+        @AuraEnabled global String message;
+    }
+
+    // ── Read ─────────────────────────────────────────────────────────────
+
+    /**
+     * @description Returns the org-wide cart (Will Do + Sizing Only, non-activated
+     *              WorkItems), sequenced by priority + dependency, plus a summary
+     *              header and the resolved CartExperienceProfile.
+     * @return CartDTO render-ready payload.
+     */
+    @AuraEnabled
+    global static CartDTO getCart() {
+        try {
+            CartExperienceProfile profile = CartExperienceProfile.resolve();
+            List<WorkItem__c> rows = queryCartItems();
+
+            CartDTO cart = new CartDTO();
+            cart.profile = profile;
+            cart.lines = new List<CartLineDTO>();
+            CartSummaryDTO summary = newSummary();
+
+            for (WorkItem__c wi : rows) {
+                CartLineDTO line = toLine(wi);
+                cart.lines.add(line);
+                accumulate(summary, line);
+            }
+            summary.count = cart.lines.size();
+            cart.summary = summary;
+            return cart;
+        } catch (Exception e) {
+            throw toAura(e);
+        }
+    }
+
+    private static CartSummaryDTO newSummary() {
+        CartSummaryDTO s = new CartSummaryDTO();
+        s.count = 0;
+        s.willDoCount = 0;
+        s.sizingOnlyCount = 0;
+        s.willDoHours = 0;
+        s.sizingOnlyHours = 0;
+        s.willDoCost = 0;
+        return s;
+    }
+
+    private static void accumulate(CartSummaryDTO s, CartLineDTO line) {
+        Decimal hours = line.estimatedHours == null ? 0 : line.estimatedHours;
+        Decimal cost = line.projectedCost == null ? 0 : line.projectedCost;
+        if (line.isCommitted) {
+            s.willDoCount++;
+            s.willDoHours += hours;
+            s.willDoCost += cost;
+        } else {
+            s.sizingOnlyCount++;
+            s.sizingOnlyHours += hours;
+        }
+    }
+
+    /**
+     * @description Queries the non-activated cart WorkItems, sequenced by priority
+     *              group then priority then planned start. The child WorkRequest's
+     *              ProjectedCostCurrency__c is pulled via the Requests subquery for
+     *              per-line cost.
+     */
+    private static List<WorkItem__c> queryCartItems() {
+        return [
+            SELECT Id, Name, BriefDescriptionTxt__c, ClientIntentionPk__c,
+                   EstimatedHoursNumber__c, PriorityPk__c, PriorityGroupPk__c,
+                   StageNamePk__c, EstimatedStartDevDate__c, EstimatedEndDevDate__c,
+                   DeveloperLookup__r.Name,
+                   (SELECT Id, ProjectedCostCurrency__c, QuotedHoursNumber__c
+                    FROM Requests
+                    ORDER BY CreatedDate DESC
+                    LIMIT 1)
+            FROM WorkItem__c
+            WHERE ClientIntentionPk__c IN :CART_INTENTIONS
+              AND ActivatedDateTime__c = NULL
+              AND ArchivedDateTime__c = NULL
+              AND TemplateMarkedDateTime__c = NULL
+            WITH SYSTEM_MODE
+            ORDER BY PriorityGroupPk__c NULLS LAST, PriorityPk__c NULLS LAST,
+                     EstimatedStartDevDate__c NULLS LAST, CreatedDate
+            LIMIT :MAX_CART_LINES
+        ];
+    }
+
+    private static CartLineDTO toLine(WorkItem__c wi) {
+        CartLineDTO line = new CartLineDTO();
+        line.workItemId = wi.Id;
+        line.name = String.isNotBlank(wi.BriefDescriptionTxt__c) ? wi.BriefDescriptionTxt__c : wi.Name;
+        line.intention = wi.ClientIntentionPk__c;
+        line.isCommitted = wi.ClientIntentionPk__c == INTENT_WILL_DO;
+        line.estimatedHours = wi.EstimatedHoursNumber__c;
+        line.priority = wi.PriorityPk__c;
+        line.priorityGroup = wi.PriorityGroupPk__c;
+        line.stage = wi.StageNamePk__c;
+        line.estimatedStart = wi.EstimatedStartDevDate__c;
+        line.estimatedEnd = wi.EstimatedEndDevDate__c;
+        if (wi.DeveloperLookup__r != null) {
+            line.developerName = wi.DeveloperLookup__r.Name;
+        }
+        if (wi.Requests != null && !wi.Requests.isEmpty()) {
+            line.projectedCost = wi.Requests[0].ProjectedCostCurrency__c;
+        }
+        return line;
+    }
+
+    // ── Mutations ────────────────────────────────────────────────────────
+
+    /**
+     * @description Sets ClientIntentionPk__c on a WorkItem to place it in (or pull it
+     *              out of) the cart. Intention is validated against the four known
+     *              values; the field is unrestricted with no trigger enforcement so
+     *              safe known values are written directly.
+     * @param workItemId The WorkItem to update.
+     * @param intention One of Will Do, Sizing Only, Deferred, On Hold.
+     */
+    @AuraEnabled
+    global static void addToCart(Id workItemId, String intention) {
+        try {
+            if (workItemId == null) {
+                throw new AuraHandledException('workItemId is required.');
+            }
+            if (!VALID_INTENTIONS.contains(intention)) {
+                throw new AuraHandledException('Invalid cart intention: ' + intention);
+            }
+            updateIntention(workItemId, intention);
+        } catch (Exception e) {
+            throw toAura(e);
+        }
+    }
+
+    /**
+     * @description Removes a WorkItem from the cart by setting ClientIntentionPk__c
+     *              to Deferred (out-of-cart). The line is not deleted — it stays a real
+     *              WorkItem, just no longer part of the active basket.
+     * @param workItemId The WorkItem to remove.
+     */
+    @AuraEnabled
+    global static void removeFromCart(Id workItemId) {
+        try {
+            if (workItemId == null) {
+                throw new AuraHandledException('workItemId is required.');
+            }
+            updateIntention(workItemId, INTENT_DEFERRED);
+        } catch (Exception e) {
+            throw toAura(e);
+        }
+    }
+
+    /**
+     * @description Reorders a cart line by writing PriorityPk__c.
+     * @param workItemId The WorkItem to reorder.
+     * @param priority The new PriorityPk__c value (passed through as a known value).
+     */
+    @AuraEnabled
+    global static void reorder(Id workItemId, String priority) {
+        try {
+            if (workItemId == null) {
+                throw new AuraHandledException('workItemId is required.');
+            }
+            WorkItem__c wi = new WorkItem__c(Id = workItemId, PriorityPk__c = priority);
+            persist(wi);
+        } catch (Exception e) {
+            throw toAura(e);
+        }
+    }
+
+    /**
+     * @description Freeform-adds a NEW pre-activation WorkItem to the cart. Creates a
+     *              WorkItem with the given description + estimated hours, the chosen cart
+     *              intention, and ActivatedDateTime__c left NULL (so it is a cart line,
+     *              not a live-pipeline item). Safe known StatusPk__c/StageNamePk__c values
+     *              are passed directly (unrestricted fields, no trigger enforcement).
+     * @param description The brief description / line name (required).
+     * @param estimatedHours Optional per-line sizing.
+     * @param intention Will Do (commit) or Sizing Only (explore). Other values rejected.
+     * @return The new WorkItem Id.
+     */
+    @AuraEnabled
+    global static Id createCartItem(String description, Decimal estimatedHours, String intention) {
+        try {
+            if (String.isBlank(description)) {
+                throw new AuraHandledException('A description is required.');
+            }
+            if (!CART_INTENTIONS.contains(intention)) {
+                throw new AuraHandledException('Cart adds must be Will Do or Sizing Only.');
+            }
+            WorkItem__c wi = new WorkItem__c(
+                BriefDescriptionTxt__c = description,
+                ClientIntentionPk__c = intention,
+                EstimatedHoursNumber__c = estimatedHours,
+                StatusPk__c = 'Active',
+                StageNamePk__c = 'Backlog'
+                // ActivatedDateTime__c intentionally left NULL — cart line, not live.
+            );
+            SObjectAccessDecision decision = Security.stripInaccessible(
+                AccessType.CREATABLE, new List<WorkItem__c>{ wi });
+            insert decision.getRecords();
+            return decision.getRecords()[0].Id;
+        } catch (Exception e) {
+            throw toAura(e);
+        }
+    }
+
+    private static void updateIntention(Id workItemId, String intention) {
+        WorkItem__c wi = new WorkItem__c(Id = workItemId, ClientIntentionPk__c = intention);
+        persist(wi);
+    }
+
+    private static void persist(WorkItem__c wi) {
+        SObjectAccessDecision decision = Security.stripInaccessible(
+            AccessType.UPDATABLE, new List<WorkItem__c>{ wi });
+        update decision.getRecords();
+    }
+
+    // ── Checkout ─────────────────────────────────────────────────────────
+
+    /**
+     * @description Checks out the cart: stamps ActivatedDateTime__c = now() on the
+     *              non-activated Will Do lines (ONLY — Sizing Only stays in the cart),
+     *              then branches on the resolved checkoutMode:
+     *                Invoice  -> also generate a Client_Agreement proposal via
+     *                            DeliveryDocGenerationService when the committed lines
+     *                            share one client NetworkEntity (else: activate only,
+     *                            noted in the result).
+     *                Stripe   -> activate; paid-checkout wiring is a clearly-marked
+     *                            seam (DeliveryStripePaymentHandler is an inbound
+     *                            webhook handler, not an outbound initiator — see TODO).
+     *                Approve  -> activate; approval routing seam (the approval rails
+     *                            key on Feature__c, not WorkItems — see TODO).
+     * @return CheckoutResultDTO with the activated count, mode, optional doc id, and a message.
+     */
+    @AuraEnabled
+    global static CheckoutResultDTO checkout() {
+        try {
+            CartExperienceProfile profile = CartExperienceProfile.resolve();
+            String mode = profile.checkoutMode;
+
+            List<WorkItem__c> willDo = [
+                SELECT Id, ClientNetworkEntityLookup__c
+                FROM WorkItem__c
+                WHERE ClientIntentionPk__c = :INTENT_WILL_DO
+                  AND ActivatedDateTime__c = NULL
+                  AND ArchivedDateTime__c = NULL
+                  AND TemplateMarkedDateTime__c = NULL
+                WITH SYSTEM_MODE
+                LIMIT :MAX_CART_LINES
+            ];
+
+            CheckoutResultDTO result = new CheckoutResultDTO();
+            result.checkoutMode = mode;
+            result.activatedCount = 0;
+
+            if (willDo.isEmpty()) {
+                result.message = 'No committed (Will Do) lines to check out.';
+                return result;
+            }
+
+            Datetime now = Datetime.now();
+            List<WorkItem__c> toActivate = new List<WorkItem__c>();
+            for (WorkItem__c wi : willDo) {
+                toActivate.add(new WorkItem__c(Id = wi.Id, ActivatedDateTime__c = now));
+            }
+            SObjectAccessDecision decision = Security.stripInaccessible(
+                AccessType.UPDATABLE, toActivate);
+            update decision.getRecords();
+            result.activatedCount = toActivate.size();
+
+            routeCheckout(mode, willDo, result);
+            return result;
+        } catch (Exception e) {
+            throw toAura(e);
+        }
+    }
+
+    /**
+     * @description Mode-specific post-activation routing. Activation already happened;
+     *              this layers the proposal/payment/approval step on top.
+     */
+    private static void routeCheckout(String mode, List<WorkItem__c> willDo, CheckoutResultDTO result) {
+        if (mode == CartExperienceProfile.MODE_INVOICE) {
+            generateProposal(willDo, result);
+            return;
+        }
+        if (mode == CartExperienceProfile.MODE_STRIPE) {
+            // TODO(seam): paid checkout. DeliveryStripePaymentHandler is an INBOUND
+            // webhook event handler (charge.succeeded -> DeliveryTransaction__c), not an
+            // outbound payment initiator. A real Stripe checkout needs a Checkout Session
+            // / Payment Link callout that does not exist yet. Activation is the real,
+            // load-bearing behavior; the payment hand-off is intentionally not faked.
+            result.message = 'Lines activated. Stripe paid-checkout hand-off is a pending integration seam.';
+            return;
+        }
+        // Approve
+        // TODO(seam): approval routing. The shipped approval rails
+        // (DeliveryFeatureApprovalService.submit) key on Feature__c toggle requests, not
+        // on a basket of WorkItems. A WorkItem-basket approval object/flow does not exist
+        // yet. Activation is the real behavior; the approval hand-off is a noted seam.
+        result.message = 'Lines activated. Approval routing for a WorkItem basket is a pending seam.';
+    }
+
+    /**
+     * @description Generates a Client_Agreement proposal for the committed lines when
+     *              they share exactly one client NetworkEntity. When the lines span
+     *              zero or many client entities (ambiguous), activation stands and the
+     *              result notes that no single-client proposal was generated — no
+     *              fabricated document.
+     */
+    private static void generateProposal(List<WorkItem__c> willDo, CheckoutResultDTO result) {
+        Set<Id> entityIds = new Set<Id>();
+        for (WorkItem__c wi : willDo) {
+            if (wi.ClientNetworkEntityLookup__c != null) {
+                entityIds.add(wi.ClientNetworkEntityLookup__c);
+            }
+        }
+        if (entityIds.size() != 1) {
+            result.message = 'Lines activated. Proposal not generated — committed lines span '
+                + entityIds.size() + ' client entities (need exactly one).';
+            return;
+        }
+        Id entityId = new List<Id>(entityIds)[0];
+        Date today = Date.today();
+        try {
+            result.documentId = DeliveryDocGenerationService.generateDocument(
+                entityId, 'Client_Agreement', today, today, null);
+            result.message = 'Lines activated and a Client Agreement proposal was generated.';
+        } catch (Exception docEx) {
+            // Don't roll back the activation if proposal generation fails — the cart
+            // crossing into the pipeline is the primary effect.
+            result.message = 'Lines activated. Proposal generation failed: ' + docEx.getMessage();
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private static AuraHandledException toAura(Exception e) {
+        if (e instanceof AuraHandledException) {
+            return (AuraHandledException) e;
+        }
+        AuraHandledException ahe = new AuraHandledException(e.getMessage());
+        ahe.setMessage(e.getMessage());
+        return ahe;
+    }
+}

--- a/force-app/main/default/classes/DeliveryCartService.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryCartService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryCartServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryCartServiceTest.cls
@@ -1,0 +1,215 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for DeliveryCartService + CartExperienceProfile. Covers the
+ *               cart query (Will Do + Sizing Only, excludes activated / Deferred /
+ *               On Hold), add/remove/reorder, freeform create, checkout (activates
+ *               Will Do ONLY — not Sizing Only), and the profile resolution matrix
+ *               (dollars off by default; on when EnableCartDollarsDateTime__c set AND a
+ *               rate exists; checkoutMode default Invoice). Never asserts on
+ *               AuraHandledException.getMessage() (generic in managed package). SOQL is
+ *               WITH SYSTEM_MODE; TestDataFactory defaults are allowlist-compliant.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryCartServiceTest {
+
+    /**
+     * @description Helper: a non-activated cart WorkItem with the given intention.
+     * @param intention The ClientIntentionPk__c value to set.
+     * @param hours The EstimatedHoursNumber__c value to set.
+     * @return The inserted WorkItem__c.
+     */
+    private static WorkItem__c cartItem(String intention, Decimal hours) {
+        return TestDataFactory.createWorkItem(new Map<String, Object>{
+            'ClientIntentionPk__c' => intention,
+            'EstimatedHoursNumber__c' => hours,
+            'ActivatedDateTime__c' => null,
+            'StageNamePk__c' => 'Backlog'
+        });
+    }
+
+    @IsTest
+    static void getCartReturnsOnlyNonActivatedCartIntentions() {
+        WorkItem__c willDo = cartItem('Will Do', 10);
+        WorkItem__c sizing = cartItem('Sizing Only', 5);
+        // Excluded: Deferred, On Hold, and an activated Will Do.
+        cartItem('Deferred', 8);
+        cartItem('On Hold', 8);
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'ClientIntentionPk__c' => 'Will Do',
+            'EstimatedHoursNumber__c' => 99,
+            'ActivatedDateTime__c' => Datetime.now()
+        });
+
+        Test.startTest();
+        DeliveryCartService.CartDTO cart = DeliveryCartService.getCart();
+        Test.stopTest();
+
+        System.assertEquals(2, cart.lines.size(), 'Only the 2 non-activated cart lines should return.');
+        System.assertEquals(2, cart.summary.count, 'Summary count should match line count.');
+        System.assertEquals(1, cart.summary.willDoCount, 'One Will Do line.');
+        System.assertEquals(1, cart.summary.sizingOnlyCount, 'One Sizing Only line.');
+        System.assertEquals(10, cart.summary.willDoHours, 'Will Do hours roll up.');
+        System.assertEquals(5, cart.summary.sizingOnlyHours, 'Sizing Only hours roll up.');
+
+        Set<Id> ids = new Set<Id>();
+        for (DeliveryCartService.CartLineDTO line : cart.lines) {
+            ids.add(line.workItemId);
+        }
+        System.assert(ids.contains(willDo.Id), 'Will Do line present.');
+        System.assert(ids.contains(sizing.Id), 'Sizing Only line present.');
+    }
+
+    @IsTest
+    static void addRemoveAndReorderUpdateIntentionAndPriority() {
+        WorkItem__c wi = cartItem('Sizing Only', 4);
+
+        Test.startTest();
+        DeliveryCartService.addToCart(wi.Id, 'Will Do');
+        DeliveryCartService.reorder(wi.Id, 'High');
+        Test.stopTest();
+
+        WorkItem__c after = [
+            SELECT ClientIntentionPk__c, PriorityPk__c FROM WorkItem__c WHERE Id = :wi.Id
+        ];
+        System.assertEquals('Will Do', after.ClientIntentionPk__c, 'Intention promoted to Will Do.');
+        System.assertEquals('High', after.PriorityPk__c, 'Priority reordered.');
+
+        DeliveryCartService.removeFromCart(wi.Id);
+        WorkItem__c removed = [SELECT ClientIntentionPk__c FROM WorkItem__c WHERE Id = :wi.Id];
+        System.assertEquals('Deferred', removed.ClientIntentionPk__c, 'Remove sets Deferred (out of cart).');
+    }
+
+    @IsTest
+    static void addToCartRejectsInvalidIntention() {
+        WorkItem__c wi = cartItem('Sizing Only', 4);
+        Boolean threw = false;
+        Test.startTest();
+        try {
+            DeliveryCartService.addToCart(wi.Id, 'Bogus');
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        Test.stopTest();
+        System.assert(threw, 'Invalid intention should throw.');
+    }
+
+    @IsTest
+    static void createCartItemAddsNonActivatedLine() {
+        Test.startTest();
+        Id newId = DeliveryCartService.createCartItem('New cart work', 7, 'Sizing Only');
+        Test.stopTest();
+
+        WorkItem__c created = [
+            SELECT ClientIntentionPk__c, EstimatedHoursNumber__c, ActivatedDateTime__c,
+                   BriefDescriptionTxt__c
+            FROM WorkItem__c WHERE Id = :newId
+        ];
+        System.assertEquals('Sizing Only', created.ClientIntentionPk__c, 'Intention set.');
+        System.assertEquals(7, created.EstimatedHoursNumber__c, 'Hours set.');
+        System.assertEquals(null, created.ActivatedDateTime__c, 'Cart line not activated.');
+        System.assertEquals('New cart work', created.BriefDescriptionTxt__c, 'Description set.');
+    }
+
+    @IsTest
+    static void createCartItemRejectsOutOfCartIntention() {
+        Boolean threw = false;
+        Test.startTest();
+        try {
+            DeliveryCartService.createCartItem('x', 1, 'Deferred');
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        Test.stopTest();
+        System.assert(threw, 'Deferred is not a valid add intention.');
+    }
+
+    @IsTest
+    static void checkoutActivatesWillDoOnlyNotSizingOnly() {
+        WorkItem__c willDo = cartItem('Will Do', 12);
+        WorkItem__c sizing = cartItem('Sizing Only', 6);
+
+        Test.startTest();
+        DeliveryCartService.CheckoutResultDTO result = DeliveryCartService.checkout();
+        Test.stopTest();
+
+        System.assertEquals(1, result.activatedCount, 'Only the Will Do line activates.');
+
+        WorkItem__c willDoAfter = [SELECT ActivatedDateTime__c FROM WorkItem__c WHERE Id = :willDo.Id];
+        WorkItem__c sizingAfter = [SELECT ActivatedDateTime__c FROM WorkItem__c WHERE Id = :sizing.Id];
+        System.assertNotEquals(null, willDoAfter.ActivatedDateTime__c, 'Will Do line activated.');
+        System.assertEquals(null, sizingAfter.ActivatedDateTime__c, 'Sizing Only stays in the cart.');
+    }
+
+    @IsTest
+    static void checkoutWithNoWillDoLinesIsNoOp() {
+        cartItem('Sizing Only', 6);
+        Test.startTest();
+        DeliveryCartService.CheckoutResultDTO result = DeliveryCartService.checkout();
+        Test.stopTest();
+        System.assertEquals(0, result.activatedCount, 'Nothing to check out.');
+    }
+
+    @IsTest
+    static void profileDefaultsDollarsOffModeInvoice() {
+        // No settings, no rate.
+        Test.startTest();
+        CartExperienceProfile profile = CartExperienceProfile.resolve();
+        Test.stopTest();
+        System.assertEquals(false, profile.showDollars, 'Dollars off by default.');
+        System.assertEquals(false, profile.selfServe, 'Self-serve off by default.');
+        System.assertEquals('Invoice', profile.checkoutMode, 'Mode defaults to Invoice.');
+    }
+
+    @IsTest
+    static void profileDollarsOnWhenOptInAndRateExists() {
+        // A single active rated NetworkEntity -> resolvable blended rate.
+        TestDataFactory.createNetworkEntity(new Map<String, Object>{
+            'DefaultHourlyRateCurrency__c' => 90,
+            'StatusPk__c' => 'Active'
+        });
+        DeliveryHubSettings__c settings = new DeliveryHubSettings__c(
+            SetupOwnerId = UserInfo.getOrganizationId(),
+            EnableCartDollarsDateTime__c = Datetime.now(),
+            EnableCartSelfServeDateTime__c = Datetime.now(),
+            CheckoutModeTxt__c = 'Stripe'
+        );
+        insert settings;
+
+        Test.startTest();
+        CartExperienceProfile profile = CartExperienceProfile.resolve();
+        Test.stopTest();
+
+        System.assertEquals(true, profile.showDollars, 'Dollars on with opt-in + rate.');
+        System.assertEquals(90, profile.blendedRate, 'Blended rate resolved.');
+        System.assertEquals(true, profile.selfServe, 'Self-serve on.');
+        System.assertEquals('Stripe', profile.checkoutMode, 'Mode honored.');
+    }
+
+    @IsTest
+    static void profileDollarsOffWhenOptInButNoRate() {
+        DeliveryHubSettings__c settings = new DeliveryHubSettings__c(
+            SetupOwnerId = UserInfo.getOrganizationId(),
+            EnableCartDollarsDateTime__c = Datetime.now()
+        );
+        insert settings;
+
+        Test.startTest();
+        CartExperienceProfile profile = CartExperienceProfile.resolve();
+        Test.stopTest();
+
+        System.assertEquals(false, profile.showDollars, 'No rate => hours-only even with opt-in.');
+        System.assertEquals(null, profile.blendedRate, 'No single rate resolvable.');
+    }
+
+    @IsTest
+    static void normalizeModeValidatesValues() {
+        System.assertEquals('Invoice', CartExperienceProfile.normalizeMode(null), 'Blank => Invoice.');
+        System.assertEquals('Invoice', CartExperienceProfile.normalizeMode(''), 'Empty => Invoice.');
+        System.assertEquals('Invoice', CartExperienceProfile.normalizeMode('whatever'), 'Unknown => Invoice.');
+        System.assertEquals('Approve', CartExperienceProfile.normalizeMode('approve'), 'Case-insensitive Approve.');
+        System.assertEquals('Stripe', CartExperienceProfile.normalizeMode('STRIPE'), 'Case-insensitive Stripe.');
+        System.assertEquals('Invoice', CartExperienceProfile.normalizeMode('Invoice'), 'Invoice passes through.');
+    }
+}

--- a/force-app/main/default/classes/DeliveryCartServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryCartServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryHubSettingsController.cls
+++ b/force-app/main/default/classes/DeliveryHubSettingsController.cls
@@ -148,6 +148,18 @@ global with sharing class DeliveryHubSettingsController {
         @AuraEnabled public Boolean invoiceGenerationEnabled { get; set; }
         /** @description Formatted date when invoice generation was activated */
         @AuraEnabled public String invoiceGenerationActivatedAt { get; set; }
+
+        // ── Checkout Cart settings ─────────────────────────────────────────
+        /** @description Show dollars in the Checkout Cart (computed from DateTime) */
+        @AuraEnabled public Boolean cartDollarsEnabled { get; set; }
+        /** @description Formatted date when cart dollars were activated */
+        @AuraEnabled public String cartDollarsActivatedAt { get; set; }
+        /** @description Clients self-serve the Checkout Cart (computed from DateTime) */
+        @AuraEnabled public Boolean cartSelfServeEnabled { get; set; }
+        /** @description Formatted date when cart self-serve was activated */
+        @AuraEnabled public String cartSelfServeActivatedAt { get; set; }
+        /** @description Checkout routing mode: Approve | Invoice | Stripe (blank = Invoice) */
+        @AuraEnabled public String checkoutMode { get; set; }
     }
 
     /**
@@ -343,6 +355,14 @@ global with sharing class DeliveryHubSettingsController {
             dto.invoiceGenerationEnabled = settings.EnableInvoiceGenerationDateTime__c != null;
             dto.invoiceGenerationActivatedAt = formatActivationDate(settings.EnableInvoiceGenerationDateTime__c);
 
+            // Checkout Cart settings
+            dto.cartDollarsEnabled = settings.EnableCartDollarsDateTime__c != null;
+            dto.cartDollarsActivatedAt = formatActivationDate(settings.EnableCartDollarsDateTime__c);
+            dto.cartSelfServeEnabled = settings.EnableCartSelfServeDateTime__c != null;
+            dto.cartSelfServeActivatedAt = formatActivationDate(settings.EnableCartSelfServeDateTime__c);
+            dto.checkoutMode = String.isNotBlank(settings.CheckoutModeTxt__c)
+                ? settings.CheckoutModeTxt__c : 'Invoice';
+
             // Enterprise / API settings
             dto.syncApiRateLimit = settings.SyncApiRateLimitNumber__c != null
                 ? Integer.valueOf(settings.SyncApiRateLimitNumber__c) : null;
@@ -388,6 +408,11 @@ global with sharing class DeliveryHubSettingsController {
             dto.overdueRemindersEnabled = false;
             dto.overdueReminderSchedule = '1,7,14,30';
             dto.resourceTitleAutoFillEnabled = false;
+            // Checkout Cart defaults — dollars off org-wide (MF behavior), admin
+            // assembles, Invoice routing.
+            dto.cartDollarsEnabled = false;
+            dto.cartSelfServeEnabled = false;
+            dto.checkoutMode = 'Invoice';
         }
         return dto;
     }
@@ -483,6 +508,11 @@ global with sharing class DeliveryHubSettingsController {
             settings.EnableAutoCreateWorkRequestDateTime__c = dto.autoCreateWorkRequest ? (settings.EnableAutoCreateWorkRequestDateTime__c != null ? settings.EnableAutoCreateWorkRequestDateTime__c : Datetime.now()) : null;
             settings.RequireWorkLogApprovalDateTime__c = dto.requireWorkLogApproval ? (settings.RequireWorkLogApprovalDateTime__c != null ? settings.RequireWorkLogApprovalDateTime__c : Datetime.now()) : null;
             settings.EnableInvoiceGenerationDateTime__c = dto.invoiceGenerationEnabled == true ? (settings.EnableInvoiceGenerationDateTime__c != null ? settings.EnableInvoiceGenerationDateTime__c : Datetime.now()) : null;
+
+            // Checkout Cart toggles (DateTime-based) + mode (Text, validated)
+            settings.EnableCartDollarsDateTime__c = dto.cartDollarsEnabled == true ? (settings.EnableCartDollarsDateTime__c != null ? settings.EnableCartDollarsDateTime__c : Datetime.now()) : null;
+            settings.EnableCartSelfServeDateTime__c = dto.cartSelfServeEnabled == true ? (settings.EnableCartSelfServeDateTime__c != null ? settings.EnableCartSelfServeDateTime__c : Datetime.now()) : null;
+            settings.CheckoutModeTxt__c = CartExperienceProfile.normalizeMode(dto.checkoutMode);
 
             // Enterprise feature toggles
             settings.EnableExternalNotificationsDateTime__c = dto.externalNotificationsEnabled == true ? (settings.EnableExternalNotificationsDateTime__c != null ? settings.EnableExternalNotificationsDateTime__c : Datetime.now()) : null;

--- a/force-app/main/default/flexipages/DeliveryHubAdminHome.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryHubAdminHome.flexipage-meta.xml
@@ -23,6 +23,12 @@
                 <identifier>c_deliveryPacingForecast</identifier>
             </componentInstance>
         </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentName>deliveryCartCheckout</componentName>
+                <identifier>c_deliveryCartCheckout</identifier>
+            </componentInstance>
+        </itemInstances>
         <name>top</name>
         <type>Region</type>
     </flexiPageRegions>

--- a/force-app/main/default/lwc/deliveryCartBuilder/__tests__/deliveryCartBuilder.test.js
+++ b/force-app/main/default/lwc/deliveryCartBuilder/__tests__/deliveryCartBuilder.test.js
@@ -1,0 +1,152 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryCartBuilder: the running total, the
+ *               freeform-add form (Sizing Only vs Will Do), the dollars gate, inline
+ *               line actions (commit / remove / reorder), and the empty state.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from "lwc";
+import DeliveryCartBuilder from "c/deliveryCartBuilder";
+import getCart from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.getCart";
+import createCartItem from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.createCartItem";
+import addToCart from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.addToCart";
+
+function sampleCart(overrides = {}) {
+    return {
+        lines: [
+            {
+                workItemId: "a01000000000001",
+                name: "Existing sizing line",
+                intention: "Sizing Only",
+                isCommitted: false,
+                estimatedHours: 5,
+                projectedCost: 450,
+                priority: "Medium"
+            }
+        ],
+        summary: {
+            count: 1,
+            willDoCount: 0,
+            sizingOnlyCount: 1,
+            willDoHours: 0,
+            sizingOnlyHours: 5,
+            willDoCost: 0
+        },
+        profile: {
+            showDollars: false,
+            selfServe: true,
+            checkoutMode: "Invoice",
+            blendedRate: 90
+        },
+        ...overrides
+    };
+}
+
+function createComponent() {
+    const element = createElement("c-delivery-cart-builder", {
+        is: DeliveryCartBuilder
+    });
+    document.body.appendChild(element);
+    return element;
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("c-delivery-cart-builder", () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it("renders the running total and current lines", async () => {
+        const element = createComponent();
+        getCart.emit(sampleCart());
+        await flushPromises();
+
+        const text = element.shadowRoot.textContent;
+        expect(text).toContain("5.00h"); // running total (5 hours)
+        expect(text).toContain("Existing sizing line");
+    });
+
+    it("hides dollars on the total when showDollars is false", async () => {
+        const element = createComponent();
+        getCart.emit(sampleCart());
+        await flushPromises();
+        expect(element.shadowRoot.textContent).not.toContain("$450");
+    });
+
+    it("shows dollars on the total when showDollars is true", async () => {
+        const element = createComponent();
+        getCart.emit(sampleCart({
+            profile: { showDollars: true, selfServe: true, checkoutMode: "Invoice", blendedRate: 90 }
+        }));
+        await flushPromises();
+        // 5 total hours * 90 = $450
+        expect(element.shadowRoot.textContent).toContain("$450");
+    });
+
+    it("freeform-adds a Sizing Only line", async () => {
+        createCartItem.mockResolvedValue("a01000000000099");
+        getCart.mockResolvedValue(sampleCart());
+
+        const element = createComponent();
+        getCart.emit(sampleCart());
+        await flushPromises();
+
+        // Type into the description input — the change handler reads event.target.value.
+        const desc = element.shadowRoot.querySelectorAll("lightning-input")[0];
+        desc.value = "Brand new work";
+        desc.dispatchEvent(new CustomEvent("change"));
+        await flushPromises();
+
+        // Click "Add to size".
+        const buttons = element.shadowRoot.querySelectorAll("lightning-button");
+        const sizeBtn = Array.from(buttons).find((b) => b.label === "Add to size");
+        sizeBtn.dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+
+        expect(createCartItem).toHaveBeenCalledWith({
+            description: "Brand new work",
+            estimatedHours: null,
+            intention: "Sizing Only"
+        });
+    });
+
+    it("commits a line inline via addToCart", async () => {
+        addToCart.mockResolvedValue(undefined);
+        getCart.mockResolvedValue(sampleCart());
+
+        const element = createComponent();
+        getCart.emit(sampleCart());
+        await flushPromises();
+
+        const commitBtn = element.shadowRoot.querySelector(
+            'lightning-button-icon[title="Commit (Will Do)"]'
+        );
+        expect(commitBtn).not.toBeNull();
+        commitBtn.dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+
+        expect(addToCart).toHaveBeenCalledWith({
+            workItemId: "a01000000000001",
+            intention: "Will Do"
+        });
+    });
+
+    it("shows the empty hint when the cart has no lines", async () => {
+        const element = createComponent();
+        getCart.emit({
+            lines: [],
+            summary: { count: 0, willDoCount: 0, sizingOnlyCount: 0, willDoHours: 0, sizingOnlyHours: 0, willDoCost: 0 },
+            profile: { showDollars: false, selfServe: true, checkoutMode: "Invoice", blendedRate: 90 }
+        });
+        await flushPromises();
+
+        expect(element.shadowRoot.textContent).toContain("No items in the cart yet");
+    });
+});

--- a/force-app/main/default/lwc/deliveryCartBuilder/deliveryCartBuilder.css
+++ b/force-app/main/default/lwc/deliveryCartBuilder/deliveryCartBuilder.css
@@ -1,0 +1,166 @@
+.builder-card {
+    padding: 1rem 1.25rem 1.25rem;
+}
+
+.builder-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.builder-header-left {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+}
+
+.builder-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    margin: 0;
+}
+
+.builder-subtitle {
+    font-size: 0.78rem;
+    color: #5c5c5c;
+    margin: 0.1rem 0 0;
+}
+
+.builder-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.builder-total {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    padding: 0.5rem 0;
+    border-top: 1px solid #ececec;
+    border-bottom: 1px solid #ececec;
+    margin-bottom: 0.75rem;
+}
+
+.builder-total-value {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: #0b5cab;
+}
+
+.builder-total-cost {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #0b5cab;
+}
+
+.builder-total-label {
+    font-size: 0.75rem;
+    color: #706e6b;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.builder-form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: flex-end;
+    margin-bottom: 0.5rem;
+}
+
+.builder-input {
+    flex: 1 1 12rem;
+}
+
+.builder-input--hours {
+    flex: 0 0 8rem;
+}
+
+.builder-form-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.builder-status {
+    margin: 0.25rem 0 0.5rem;
+    font-size: 0.8rem;
+    color: #2e844a;
+}
+
+.builder-error {
+    color: #c23934;
+    padding: 0.5rem 0;
+}
+
+.builder-loading,
+.builder-empty {
+    text-align: center;
+    color: #706e6b;
+    padding: 0.75rem;
+}
+
+.builder-line {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.5rem 0.25rem;
+    border-bottom: 1px solid #f1f1f1;
+}
+
+.builder-line-main {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.builder-line-name {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.builder-line-tag {
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    font-weight: 700;
+}
+
+.builder-line-tag--commit {
+    color: #2e844a;
+}
+
+.builder-line-tag--sizing {
+    color: #706e6b;
+}
+
+.builder-line-figures {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    white-space: nowrap;
+}
+
+.builder-line-hours {
+    font-weight: 700;
+}
+
+.builder-line-cost {
+    font-size: 0.78rem;
+    color: #0b5cab;
+}
+
+.builder-line-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.builder-priority {
+    width: 7rem;
+}

--- a/force-app/main/default/lwc/deliveryCartBuilder/deliveryCartBuilder.html
+++ b/force-app/main/default/lwc/deliveryCartBuilder/deliveryCartBuilder.html
@@ -1,0 +1,118 @@
+<template>
+    <div class="builder-card">
+
+        <div class="builder-header">
+            <div class="builder-header-left">
+                <lightning-icon icon-name="utility:add" alternative-text="Add to cart" size="small" class="builder-header-icon"></lightning-icon>
+                <div>
+                    <h2 class="builder-title">Cart Builder</h2>
+                    <p class="builder-subtitle">Assemble the basket — add scoped work to size or commit.</p>
+                </div>
+            </div>
+            <div class="builder-controls">
+                <c-delivery-info-popover component-name="deliveryCartBuilder"></c-delivery-info-popover>
+            </div>
+        </div>
+
+        <!-- Running total -->
+        <div class="builder-total">
+            <span class="builder-total-value">{totalHoursLabel}h</span>
+            <template lwc:if={showDollars}>
+                <span class="builder-total-cost">{totalCostLabel}</span>
+            </template>
+            <span class="builder-total-label">in cart ({cartCountLabel})</span>
+        </div>
+
+        <!-- Freeform add -->
+        <div class="builder-form">
+            <lightning-input
+                type="text"
+                label="What do you want to add?"
+                value={newDescription}
+                onchange={handleDescriptionChange}
+                class="builder-input"></lightning-input>
+            <lightning-input
+                type="number"
+                label="Estimated hours"
+                value={newHours}
+                min="0"
+                step="0.25"
+                onchange={handleHoursChange}
+                class="builder-input builder-input--hours"></lightning-input>
+            <div class="builder-form-actions">
+                <lightning-button
+                    variant="neutral"
+                    label="Add to size"
+                    disabled={addDisabled}
+                    onclick={handleAddSizing}></lightning-button>
+                <lightning-button
+                    variant="brand"
+                    label="Add &amp; commit"
+                    disabled={addDisabled}
+                    onclick={handleAddWillDo}></lightning-button>
+            </div>
+        </div>
+
+        <template lwc:if={statusMessage}>
+            <p class="builder-status">{statusMessage}</p>
+        </template>
+
+        <template lwc:if={hasError}>
+            <div class="builder-error">{errorMessage}</div>
+        </template>
+
+        <template lwc:if={isLoading}>
+            <div class="builder-loading">
+                <lightning-spinner alternative-text="Loading cart" size="small"></lightning-spinner>
+            </div>
+        </template>
+
+        <template lwc:if={isEmpty}>
+            <p class="builder-empty">No items in the cart yet — add one above.</p>
+        </template>
+
+        <!-- Current cart lines -->
+        <template for:each={lines} for:item="line">
+            <div key={line.workItemId} class="builder-line">
+                <div class="builder-line-main">
+                    <span class="builder-line-name">{line.name}</span>
+                    <span class={line.intentionClass}>{line.intention}</span>
+                </div>
+                <div class="builder-line-figures">
+                    <span class="builder-line-hours">{line.hoursLabel}h</span>
+                    <template lwc:if={showDollars}>
+                        <span class="builder-line-cost">{line.costLabel}</span>
+                    </template>
+                </div>
+                <div class="builder-line-actions">
+                    <lightning-combobox
+                        name="priority"
+                        label="Priority"
+                        variant="label-hidden"
+                        value={line.priority}
+                        options={priorityOptions}
+                        data-record-id={line.workItemId}
+                        onchange={handleReorder}
+                        class="builder-priority"></lightning-combobox>
+                    <template lwc:if={line.canCommit}>
+                        <lightning-button-icon
+                            icon-name="utility:check"
+                            variant="bare"
+                            alternative-text="Commit"
+                            title="Commit (Will Do)"
+                            data-record-id={line.workItemId}
+                            onclick={handleCommit}></lightning-button-icon>
+                    </template>
+                    <lightning-button-icon
+                        icon-name="utility:close"
+                        variant="bare"
+                        alternative-text="Remove"
+                        title="Remove from cart"
+                        data-record-id={line.workItemId}
+                        onclick={handleRemove}></lightning-button-icon>
+                </div>
+            </div>
+        </template>
+
+    </div>
+</template>

--- a/force-app/main/default/lwc/deliveryCartBuilder/deliveryCartBuilder.js
+++ b/force-app/main/default/lwc/deliveryCartBuilder/deliveryCartBuilder.js
@@ -1,0 +1,235 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Add-to-cart surface for the procurement Checkout Cart. A purchaser
+ *               freeform-adds scoped work (description + estimated hours) as either
+ *               Sizing Only (exploring) or Will Do (committed) — each creates a
+ *               pre-activation WorkItem carrying ClientIntentionPk__c. A running total
+ *               (Σ hours, Σ $ only when profile.showDollars) reflects the org-wide cart,
+ *               and lines can be promoted/removed/reordered inline. Pure function of
+ *               (cartData, profile). Wires DeliveryCartService.getCart / createCartItem /
+ *               addToCart / removeFromCart / reorder.
+ * @author       Cloud Nimbus LLC
+ */
+import { LightningElement, track, wire } from "lwc";
+import { refreshApex } from "@salesforce/apex";
+import getCart from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.getCart";
+import createCartItem from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.createCartItem";
+import addToCart from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.addToCart";
+import removeFromCart from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.removeFromCart";
+import reorder from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.reorder";
+
+export default class DeliveryCartBuilder extends LightningElement {
+    @track cart;
+    @track errorMessage = "";
+    @track statusMessage = "";
+    isLoading = true;
+    isBusy = false;
+
+    // Freeform-add form state.
+    newDescription = "";
+    newHours = null;
+
+    _wiredCart;
+
+    @wire(getCart)
+    wiredCart(result) {
+        this._wiredCart = result;
+        this.isLoading = false;
+        if (result.data) {
+            this.cart = result.data;
+            this.errorMessage = "";
+        } else if (result.error) {
+            this.errorMessage = this._extractError(result.error);
+            this.cart = null;
+        }
+    }
+
+    // ── State flags ──────────────────────────────────────────────
+
+    get profile() {
+        return this.cart ? this.cart.profile : null;
+    }
+
+    get showDollars() {
+        return !!(this.profile && this.profile.showDollars);
+    }
+
+    get summary() {
+        return this.cart ? this.cart.summary : null;
+    }
+
+    get hasError() {
+        return !this.isLoading && this.errorMessage;
+    }
+
+    get isEmpty() {
+        return !!(this.cart && (!this.cart.lines || this.cart.lines.length === 0));
+    }
+
+    get addDisabled() {
+        return this.isBusy || !this.newDescription || !this.newDescription.trim();
+    }
+
+    // ── Running total ────────────────────────────────────────────
+
+    get totalHoursLabel() {
+        if (!this.summary) {
+            return "0";
+        }
+        const total = (this.summary.willDoHours || 0) + (this.summary.sizingOnlyHours || 0);
+        return this._formatHours(total);
+    }
+
+    get totalCostLabel() {
+        if (!this.showDollars || !this.summary || !this.profile) {
+            return "";
+        }
+        // Cost across the basket = (willDo + sizingOnly) hours x blended rate; the
+        // committed cost is already known, the exploring lines are valued at the rate.
+        const totalHours =
+            (this.summary.willDoHours || 0) + (this.summary.sizingOnlyHours || 0);
+        const rate = this.profile.blendedRate || 0;
+        return this._formatMoney(totalHours * rate);
+    }
+
+    get cartCountLabel() {
+        return this.summary ? this.summary.count : 0;
+    }
+
+    // ── Line list ────────────────────────────────────────────────
+
+    get lines() {
+        if (!this.cart || !this.cart.lines) {
+            return [];
+        }
+        return this.cart.lines.map((l) => ({
+            ...l,
+            hoursLabel: this._formatHours(l.estimatedHours),
+            costLabel: this.showDollars ? this._formatMoney(l.projectedCost) : "",
+            intentionClass: l.isCommitted
+                ? "builder-line-tag builder-line-tag--commit"
+                : "builder-line-tag builder-line-tag--sizing",
+            canCommit: !l.isCommitted
+        }));
+    }
+
+    // ── Form handlers ────────────────────────────────────────────
+
+    handleDescriptionChange(event) {
+        this.newDescription = event.target.value;
+    }
+
+    handleHoursChange(event) {
+        const v = event.target.value;
+        this.newHours = v === "" || v === null ? null : Number(v);
+    }
+
+    handleAddSizing() {
+        this._add("Sizing Only");
+    }
+
+    handleAddWillDo() {
+        this._add("Will Do");
+    }
+
+    async _add(intention) {
+        if (this.addDisabled) {
+            return;
+        }
+        this.isBusy = true;
+        this.statusMessage = "";
+        try {
+            await createCartItem({
+                description: this.newDescription.trim(),
+                estimatedHours: this.newHours,
+                intention
+            });
+            this.newDescription = "";
+            this.newHours = null;
+            this.statusMessage = `Added to cart as ${intention}.`;
+            await refreshApex(this._wiredCart);
+        } catch (e) {
+            this.statusMessage = this._extractError(e);
+        } finally {
+            this.isBusy = false;
+        }
+    }
+
+    // ── Line handlers ────────────────────────────────────────────
+
+    async handleCommit(event) {
+        const workItemId = event.currentTarget.dataset.recordId;
+        await this._mutate(() => addToCart({ workItemId, intention: "Will Do" }), "Committed.");
+    }
+
+    async handleRemove(event) {
+        const workItemId = event.currentTarget.dataset.recordId;
+        await this._mutate(() => removeFromCart({ workItemId }), "Removed from cart.");
+    }
+
+    async handleReorder(event) {
+        const workItemId = event.currentTarget.dataset.recordId;
+        const priority = event.detail.value;
+        await this._mutate(() => reorder({ workItemId, priority }), "Reordered.");
+    }
+
+    async _mutate(action, okMessage) {
+        this.isBusy = true;
+        this.statusMessage = "";
+        try {
+            await action();
+            this.statusMessage = okMessage;
+            await refreshApex(this._wiredCart);
+        } catch (e) {
+            this.statusMessage = this._extractError(e);
+        } finally {
+            this.isBusy = false;
+        }
+    }
+
+    get priorityOptions() {
+        return [
+            { label: "High", value: "High" },
+            { label: "Medium", value: "Medium" },
+            { label: "Low", value: "Low" }
+        ];
+    }
+
+    // ── Formatting helpers ───────────────────────────────────────
+
+    _formatHours(value) {
+        const num = Number(value);
+        if (!Number.isFinite(num)) {
+            return "0";
+        }
+        if (Math.abs(num) >= 100) {
+            return num.toFixed(0);
+        }
+        if (Math.abs(num) >= 10) {
+            return num.toFixed(1);
+        }
+        return num.toFixed(2);
+    }
+
+    _formatMoney(value) {
+        const num = Number(value);
+        if (!Number.isFinite(num)) {
+            return "";
+        }
+        return `$${num.toLocaleString(undefined, {
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 0
+        })}`;
+    }
+
+    _extractError(error) {
+        if (error && error.body && error.body.message) {
+            return error.body.message;
+        }
+        if (error && error.message) {
+            return error.message;
+        }
+        return "Something went wrong.";
+    }
+}

--- a/force-app/main/default/lwc/deliveryCartBuilder/deliveryCartBuilder.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryCartBuilder/deliveryCartBuilder.js-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <target>lightning__RecordPage</target>
+    </targets>
+    <masterLabel>Delivery Cart Builder</masterLabel>
+    <description>Add-to-cart surface for the procurement Checkout Cart. Freeform-add scoped work as Sizing Only or Will Do, with a running hours/dollars total and inline commit, remove, and priority reorder for each cart line.</description>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/deliveryCartCheckout/__tests__/deliveryCartCheckout.test.js
+++ b/force-app/main/default/lwc/deliveryCartCheckout/__tests__/deliveryCartCheckout.test.js
@@ -1,0 +1,160 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryCartCheckout: Will Do vs Sizing Only
+ *               sectioning, the hours/$ gate on profile.showDollars, the summary
+ *               header, the checkout-mode-driven button label, row navigation, and
+ *               empty/error states.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from "lwc";
+import DeliveryCartCheckout from "c/deliveryCartCheckout";
+import getCart from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.getCart";
+import checkout from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.checkout";
+
+function sampleCart(overrides = {}) {
+    return {
+        lines: [
+            {
+                workItemId: "a01000000000001",
+                name: "Build the thing",
+                intention: "Will Do",
+                isCommitted: true,
+                estimatedHours: 12,
+                projectedCost: 1080,
+                priority: "High",
+                priorityGroup: "NOW",
+                stage: "Backlog",
+                developerName: "Dev One",
+                estimatedStart: null,
+                estimatedEnd: null
+            },
+            {
+                workItemId: "a01000000000002",
+                name: "Maybe explore this",
+                intention: "Sizing Only",
+                isCommitted: false,
+                estimatedHours: 5,
+                projectedCost: 450,
+                priority: "Medium",
+                priorityGroup: "NEXT",
+                stage: "Backlog",
+                developerName: null,
+                estimatedStart: null,
+                estimatedEnd: null
+            }
+        ],
+        summary: {
+            count: 2,
+            willDoCount: 1,
+            sizingOnlyCount: 1,
+            willDoHours: 12,
+            sizingOnlyHours: 5,
+            willDoCost: 1080
+        },
+        profile: {
+            showDollars: false,
+            selfServe: false,
+            checkoutMode: "Invoice",
+            blendedRate: 90
+        },
+        ...overrides
+    };
+}
+
+function createComponent() {
+    const element = createElement("c-delivery-cart-checkout", {
+        is: DeliveryCartCheckout
+    });
+    document.body.appendChild(element);
+    return element;
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("c-delivery-cart-checkout", () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it("renders Will Do and Sizing Only sections from the wire", async () => {
+        const element = createComponent();
+        getCart.emit(sampleCart());
+        await flushPromises();
+
+        const text = element.shadowRoot.textContent;
+        expect(text).toContain("Will Do — committed");
+        expect(text).toContain("Sizing Only — exploring");
+        expect(text).toContain("Build the thing");
+        expect(text).toContain("Maybe explore this");
+    });
+
+    it("hides dollars when profile.showDollars is false", async () => {
+        const element = createComponent();
+        getCart.emit(sampleCart());
+        await flushPromises();
+
+        const text = element.shadowRoot.textContent;
+        expect(text).not.toContain("$1,080");
+        expect(text).toContain("12.0h"); // hours still shown
+    });
+
+    it("shows dollars when profile.showDollars is true", async () => {
+        const element = createComponent();
+        getCart.emit(sampleCart({
+            profile: { showDollars: true, selfServe: false, checkoutMode: "Invoice", blendedRate: 90 }
+        }));
+        await flushPromises();
+
+        expect(element.shadowRoot.textContent).toContain("$1,080");
+    });
+
+    it("labels the checkout button per checkout mode", async () => {
+        const element = createComponent();
+        getCart.emit(sampleCart({
+            profile: { showDollars: false, selfServe: true, checkoutMode: "Stripe", blendedRate: 90 }
+        }));
+        await flushPromises();
+
+        const button = element.shadowRoot.querySelector("lightning-button");
+        expect(button.label).toBe("Checkout & Pay");
+    });
+
+    it("invokes checkout and surfaces the result message", async () => {
+        checkout.mockResolvedValue({ activatedCount: 1, checkoutMode: "Invoice", message: "Lines activated." });
+        getCart.mockResolvedValue(sampleCart());
+
+        const element = createComponent();
+        getCart.emit(sampleCart());
+        await flushPromises();
+
+        const button = element.shadowRoot.querySelector("lightning-button");
+        button.dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+        await flushPromises();
+
+        expect(checkout).toHaveBeenCalled();
+        expect(element.shadowRoot.textContent).toContain("Lines activated.");
+    });
+
+    it("shows the empty state for an empty cart", async () => {
+        const element = createComponent();
+        getCart.emit({ lines: [], summary: { count: 0, willDoCount: 0, sizingOnlyCount: 0, willDoHours: 0, sizingOnlyHours: 0, willDoCost: 0 }, profile: { showDollars: false, checkoutMode: "Invoice" } });
+        await flushPromises();
+
+        expect(element.shadowRoot.textContent).toContain("The cart is empty");
+    });
+
+    it("shows an error when the wire errors", async () => {
+        const element = createComponent();
+        getCart.error();
+        await flushPromises();
+
+        expect(element.shadowRoot.querySelector(".cart-error")).not.toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/deliveryCartCheckout/deliveryCartCheckout.css
+++ b/force-app/main/default/lwc/deliveryCartCheckout/deliveryCartCheckout.css
@@ -1,0 +1,171 @@
+.cart-card {
+    padding: 1rem 1.25rem 1.25rem;
+}
+
+.cart-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.cart-header-left {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+}
+
+.cart-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    margin: 0;
+}
+
+.cart-subtitle {
+    font-size: 0.78rem;
+    color: #5c5c5c;
+    margin: 0.1rem 0 0;
+}
+
+.cart-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.cart-loading,
+.cart-empty,
+.cart-error {
+    padding: 1rem;
+    text-align: center;
+    color: #5c5c5c;
+}
+
+.cart-error {
+    color: #c23934;
+}
+
+.cart-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    padding: 0.75rem 0;
+    border-top: 1px solid #ececec;
+    border-bottom: 1px solid #ececec;
+    margin-bottom: 0.75rem;
+}
+
+.cart-summary-metric {
+    display: flex;
+    flex-direction: column;
+}
+
+.cart-summary-value {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: #0b5cab;
+}
+
+.cart-summary-value--muted {
+    color: #706e6b;
+}
+
+.cart-summary-label {
+    font-size: 0.72rem;
+    color: #706e6b;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.cart-forecast {
+    font-size: 0.82rem;
+    color: #444;
+    font-style: italic;
+    margin: 0 0 0.75rem;
+}
+
+.cart-section {
+    margin-bottom: 0.75rem;
+}
+
+.cart-section-title {
+    font-size: 0.78rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin: 0 0 0.4rem;
+}
+
+.cart-section-title--commit {
+    color: #2e844a;
+}
+
+.cart-section-title--sizing {
+    color: #706e6b;
+}
+
+.cart-line {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.5rem 0.4rem;
+    border-radius: 0.25rem;
+    cursor: pointer;
+}
+
+.cart-line:hover {
+    background: #f3f7fb;
+}
+
+.cart-line--muted {
+    opacity: 0.85;
+}
+
+.cart-line-main {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.cart-line-name {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.cart-line-meta {
+    font-size: 0.72rem;
+    color: #706e6b;
+}
+
+.cart-line-figures {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    white-space: nowrap;
+}
+
+.cart-line-hours {
+    font-weight: 700;
+}
+
+.cart-line-cost {
+    font-size: 0.78rem;
+    color: #0b5cab;
+}
+
+.cart-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+}
+
+.cart-checkout-message {
+    margin: 0.5rem 0 0;
+    font-size: 0.82rem;
+    color: #2e844a;
+}

--- a/force-app/main/default/lwc/deliveryCartCheckout/deliveryCartCheckout.html
+++ b/force-app/main/default/lwc/deliveryCartCheckout/deliveryCartCheckout.html
@@ -1,0 +1,117 @@
+<template>
+    <div class="cart-card">
+
+        <div class="cart-header">
+            <div class="cart-header-left">
+                <lightning-icon icon-name="utility:cart" alternative-text="Checkout cart" size="small" class="cart-header-icon"></lightning-icon>
+                <div>
+                    <h2 class="cart-title">Checkout Cart</h2>
+                    <p class="cart-subtitle">The org-wide basket — review, sequence, and check out committed work.</p>
+                </div>
+            </div>
+            <div class="cart-controls">
+                <c-delivery-info-popover component-name="deliveryCartCheckout"></c-delivery-info-popover>
+            </div>
+        </div>
+
+        <template lwc:if={isLoading}>
+            <div class="cart-loading">
+                <lightning-spinner alternative-text="Loading cart" size="small"></lightning-spinner>
+            </div>
+        </template>
+
+        <template lwc:if={hasError}>
+            <div class="cart-error">{errorMessage}</div>
+        </template>
+
+        <template lwc:if={isEmpty}>
+            <div class="cart-empty">The cart is empty. Add work via the Cart Builder to get started.</div>
+        </template>
+
+        <template lwc:if={hasData}>
+
+            <!-- Summary header -->
+            <div class="cart-summary">
+                <div class="cart-summary-metric">
+                    <span class="cart-summary-value">{willDoHoursLabel}h</span>
+                    <span class="cart-summary-label">Will Do hours ({willDoCountLabel})</span>
+                </div>
+                <template lwc:if={showDollars}>
+                    <div class="cart-summary-metric">
+                        <span class="cart-summary-value">{willDoCostLabel}</span>
+                        <span class="cart-summary-label">Will Do cost</span>
+                    </div>
+                </template>
+                <div class="cart-summary-metric">
+                    <span class="cart-summary-value cart-summary-value--muted">{sizingOnlyHoursLabel}h</span>
+                    <span class="cart-summary-label">Sizing Only hours ({sizingOnlyCountLabel})</span>
+                </div>
+            </div>
+
+            <template lwc:if={hasMonthSpread}>
+                <p class="cart-forecast">{monthSpreadLabel}</p>
+            </template>
+
+            <!-- Will Do (committed) section -->
+            <template lwc:if={hasWillDo}>
+                <div class="cart-section">
+                    <h3 class="cart-section-title cart-section-title--commit">Will Do — committed</h3>
+                    <template for:each={willDoLines} for:item="line">
+                        <div key={line.workItemId} class="cart-line" data-record-id={line.workItemId} onclick={handleRowClick}>
+                            <div class="cart-line-main">
+                                <span class="cart-line-name">{line.name}</span>
+                                <span class="cart-line-meta">{line.stageLabel} · Priority {line.priorityLabel} · {line.developerLabel}</span>
+                            </div>
+                            <div class="cart-line-figures">
+                                <span class="cart-line-hours">{line.hoursLabel}h</span>
+                                <template lwc:if={showDollars}>
+                                    <span class="cart-line-cost">{line.costLabel}</span>
+                                </template>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+            </template>
+
+            <!-- Sizing Only (exploring) section -->
+            <template lwc:if={hasSizingOnly}>
+                <div class="cart-section">
+                    <h3 class="cart-section-title cart-section-title--sizing">Sizing Only — exploring</h3>
+                    <template for:each={sizingOnlyLines} for:item="line">
+                        <div key={line.workItemId} class="cart-line cart-line--muted" data-record-id={line.workItemId} onclick={handleRowClick}>
+                            <div class="cart-line-main">
+                                <span class="cart-line-name">{line.name}</span>
+                                <span class="cart-line-meta">{line.stageLabel} · {line.priorityLabel} · {line.developerLabel}</span>
+                            </div>
+                            <div class="cart-line-figures">
+                                <span class="cart-line-hours">{line.hoursLabel}h</span>
+                                <template lwc:if={showDollars}>
+                                    <span class="cart-line-cost">{line.costLabel}</span>
+                                </template>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+            </template>
+
+            <!-- Checkout control -->
+            <div class="cart-actions">
+                <lightning-button
+                    variant="brand"
+                    label={checkoutLabel}
+                    disabled={checkoutDisabled}
+                    onclick={handleCheckout}
+                    class="cart-checkout-button">
+                </lightning-button>
+                <template lwc:if={isCheckingOut}>
+                    <lightning-spinner alternative-text="Checking out" size="small"></lightning-spinner>
+                </template>
+            </div>
+
+            <template lwc:if={checkoutMessage}>
+                <p class="cart-checkout-message">{checkoutMessage}</p>
+            </template>
+
+        </template>
+    </div>
+</template>

--- a/force-app/main/default/lwc/deliveryCartCheckout/deliveryCartCheckout.js
+++ b/force-app/main/default/lwc/deliveryCartCheckout/deliveryCartCheckout.js
@@ -1,0 +1,259 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Checkout-review surface for the procurement Checkout Cart. Renders the
+ *               org-wide basket — Will Do (committed) vs Sizing Only (exploring) sections,
+ *               each line sequenced by priority + dependency, with hours (and $ only when
+ *               profile.showDollars). A summary header shows total Will Do hours/$ and a
+ *               forecast "lands across these months" line sourced from the portfolio pacing
+ *               engine. One Checkout button activates the Will Do lines (label/behavior
+ *               reflect profile.checkoutMode). Pure function of (cartData, profile). Wires
+ *               DeliveryCartService.getCart / checkout and
+ *               DeliveryHoursAnalyticsController.getPortfolioPacing for the month spread.
+ * @author       Cloud Nimbus LLC
+ */
+import { LightningElement, track, wire } from "lwc";
+import { NavigationMixin } from "lightning/navigation";
+import { refreshApex } from "@salesforce/apex";
+import WORK_ITEM_OBJECT from "@salesforce/schema/WorkItem__c";
+import getCart from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.getCart";
+import checkout from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.checkout";
+import getPortfolioPacing from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHoursAnalyticsController.getPortfolioPacing";
+
+export default class DeliveryCartCheckout extends NavigationMixin(LightningElement) {
+    @track cart;
+    @track pacing;
+    @track errorMessage = "";
+    @track checkoutMessage = "";
+    isLoading = true;
+    isCheckingOut = false;
+
+    _wiredCart;
+
+    @wire(getCart)
+    wiredCart(result) {
+        this._wiredCart = result;
+        this.isLoading = false;
+        if (result.data) {
+            this.cart = result.data;
+            this.errorMessage = "";
+        } else if (result.error) {
+            this.errorMessage = this._extractError(result.error);
+            this.cart = null;
+        }
+    }
+
+    // Forecast month-spread for the "lands across these months" line. Reuses the
+    // portfolio pacing DTO; the cart's hours fold into the same active-portfolio
+    // forecast once checked out. Best-effort — failure leaves the spread hidden.
+    @wire(getPortfolioPacing, { granularity: "Month", periodsBack: 1, periodsForward: 6 })
+    wiredPacing({ data }) {
+        if (data) {
+            this.pacing = data;
+        }
+    }
+
+    // ── State flags ──────────────────────────────────────────────
+
+    get hasError() {
+        return !this.isLoading && this.errorMessage;
+    }
+
+    get profile() {
+        return this.cart ? this.cart.profile : null;
+    }
+
+    get showDollars() {
+        return !!(this.profile && this.profile.showDollars);
+    }
+
+    get summary() {
+        return this.cart ? this.cart.summary : null;
+    }
+
+    get isEmpty() {
+        if (this.isLoading || this.errorMessage || !this.cart) {
+            return false;
+        }
+        return !this.cart.lines || this.cart.lines.length === 0;
+    }
+
+    get hasData() {
+        return !this.isLoading && !this.errorMessage && !this.isEmpty && this.cart;
+    }
+
+    // ── Line sections ────────────────────────────────────────────
+
+    get willDoLines() {
+        if (!this.cart || !this.cart.lines) {
+            return [];
+        }
+        return this.cart.lines
+            .filter((l) => l.isCommitted)
+            .map((l) => this._decorateLine(l));
+    }
+
+    get sizingOnlyLines() {
+        if (!this.cart || !this.cart.lines) {
+            return [];
+        }
+        return this.cart.lines
+            .filter((l) => !l.isCommitted)
+            .map((l) => this._decorateLine(l));
+    }
+
+    get hasWillDo() {
+        return this.willDoLines.length > 0;
+    }
+
+    get hasSizingOnly() {
+        return this.sizingOnlyLines.length > 0;
+    }
+
+    _decorateLine(line) {
+        return {
+            ...line,
+            hoursLabel: this._formatHours(line.estimatedHours),
+            costLabel: this.showDollars ? this._formatMoney(line.projectedCost) : "",
+            priorityLabel: line.priority || "—",
+            stageLabel: line.stage || "—",
+            developerLabel: line.developerName || "Unassigned"
+        };
+    }
+
+    // ── Summary header ───────────────────────────────────────────
+
+    get willDoHoursLabel() {
+        return this.summary ? this._formatHours(this.summary.willDoHours) : "0";
+    }
+
+    get sizingOnlyHoursLabel() {
+        return this.summary ? this._formatHours(this.summary.sizingOnlyHours) : "0";
+    }
+
+    get willDoCostLabel() {
+        if (!this.showDollars || !this.summary) {
+            return "";
+        }
+        return this._formatMoney(this.summary.willDoCost);
+    }
+
+    get willDoCountLabel() {
+        return this.summary ? this.summary.willDoCount : 0;
+    }
+
+    get sizingOnlyCountLabel() {
+        return this.summary ? this.summary.sizingOnlyCount : 0;
+    }
+
+    // ── Forecast month spread ────────────────────────────────────
+
+    get hasMonthSpread() {
+        return !!(this.pacing && this.pacing.periods && this.pacing.periods.length > 0);
+    }
+
+    get monthSpreadLabel() {
+        if (!this.hasMonthSpread) {
+            return "";
+        }
+        const labels = this.pacing.periods
+            .filter((p) => p.isForecast || p.forecastHours > 0)
+            .map((p) => p.label);
+        if (labels.length === 0) {
+            return "";
+        }
+        if (labels.length === 1) {
+            return `Lands in ${labels[0]} at the current run-rate.`;
+        }
+        return `Lands across ${labels[0]} – ${labels[labels.length - 1]} at the current run-rate.`;
+    }
+
+    // ── Checkout control ─────────────────────────────────────────
+
+    get checkoutMode() {
+        return this.profile ? this.profile.checkoutMode : "Invoice";
+    }
+
+    get checkoutLabel() {
+        const mode = this.checkoutMode;
+        if (mode === "Stripe") {
+            return "Checkout & Pay";
+        }
+        if (mode === "Approve") {
+            return "Submit for Approval";
+        }
+        return "Checkout & Generate Proposal";
+    }
+
+    get checkoutDisabled() {
+        return this.isCheckingOut || !this.summary || this.summary.willDoCount === 0;
+    }
+
+    async handleCheckout() {
+        this.isCheckingOut = true;
+        this.checkoutMessage = "";
+        try {
+            const result = await checkout();
+            this.checkoutMessage = result && result.message ? result.message : "Checkout complete.";
+            await refreshApex(this._wiredCart);
+        } catch (e) {
+            this.checkoutMessage = this._extractError(e);
+        } finally {
+            this.isCheckingOut = false;
+        }
+    }
+
+    // ── Row navigation ───────────────────────────────────────────
+
+    handleRowClick(event) {
+        const recordId = event.currentTarget.dataset.recordId;
+        if (!recordId) {
+            return;
+        }
+        this[NavigationMixin.Navigate]({ // eslint-disable-line new-cap
+            attributes: {
+                actionName: "view",
+                objectApiName: WORK_ITEM_OBJECT.objectApiName,
+                recordId
+            },
+            type: "standard__recordPage"
+        });
+    }
+
+    // ── Formatting helpers ───────────────────────────────────────
+
+    _formatHours(value) {
+        const num = Number(value);
+        if (!Number.isFinite(num)) {
+            return "0";
+        }
+        if (Math.abs(num) >= 100) {
+            return num.toFixed(0);
+        }
+        if (Math.abs(num) >= 10) {
+            return num.toFixed(1);
+        }
+        return num.toFixed(2);
+    }
+
+    _formatMoney(value) {
+        const num = Number(value);
+        if (!Number.isFinite(num)) {
+            return "";
+        }
+        return `$${num.toLocaleString(undefined, {
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 0
+        })}`;
+    }
+
+    _extractError(error) {
+        if (error && error.body && error.body.message) {
+            return error.body.message;
+        }
+        if (error && error.message) {
+            return error.message;
+        }
+        return "Something went wrong.";
+    }
+}

--- a/force-app/main/default/lwc/deliveryCartCheckout/deliveryCartCheckout.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryCartCheckout/deliveryCartCheckout.js-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <target>lightning__RecordPage</target>
+    </targets>
+    <masterLabel>Delivery Checkout Cart</masterLabel>
+    <description>Org-wide procurement basket review: Will Do (committed) vs Sizing Only lines with hours (and dollars when enabled), a forecast month-spread, and a Checkout button that activates the committed lines per the configured checkout mode.</description>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/deliveryCartCheckout/deliveryCartCheckout.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryCartCheckout/deliveryCartCheckout.js-meta.xml
@@ -6,6 +6,7 @@
         <target>lightning__AppPage</target>
         <target>lightning__HomePage</target>
         <target>lightning__RecordPage</target>
+        <target>lightning__Tab</target>
     </targets>
     <masterLabel>Delivery Checkout Cart</masterLabel>
     <description>Org-wide procurement basket review: Will Do (committed) vs Sizing Only lines with hours (and dollars when enabled), a forecast month-spread, and a Checkout button that activates the committed lines per the configured checkout mode.</description>

--- a/force-app/main/default/lwc/deliveryGeneralSettingsCard/deliveryGeneralSettingsCard.html
+++ b/force-app/main/default/lwc/deliveryGeneralSettingsCard/deliveryGeneralSettingsCard.html
@@ -648,6 +648,45 @@
                 </div>
             </div>
 
+            <div class="form-section">
+                <h3 class="slds-text-heading_small slds-p-horizontal_small slds-p-top_small">Checkout Cart</h3>
+                <div class="slds-grid slds-wrap slds-gutters_small" style="padding: 0.75rem;">
+                    <div class="slds-col slds-size_1-of-2 slds-p-bottom_small">
+                        <lightning-input
+                            type="toggle"
+                            label="Show dollars in cart"
+                            checked={cartDollarsEnabled}
+                            onchange={handleCartDollarsChange}>
+                        </lightning-input>
+                        <p class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
+                            Show dollar amounts in the Checkout Cart (requires a single resolvable blended rate). Off = hours-only.
+                        </p>
+                    </div>
+                    <div class="slds-col slds-size_1-of-2 slds-p-bottom_small">
+                        <lightning-input
+                            type="toggle"
+                            label="Clients self-serve the cart"
+                            checked={cartSelfServeEnabled}
+                            onchange={handleCartSelfServeChange}>
+                        </lightning-input>
+                        <p class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
+                            Let clients assemble and check out their own cart. Off = admin assembles.
+                        </p>
+                    </div>
+                    <div class="slds-col slds-size_1-of-2 slds-p-bottom_small">
+                        <lightning-combobox
+                            label="Checkout mode"
+                            value={checkoutMode}
+                            options={checkoutModeOptions}
+                            onchange={handleCheckoutModeChange}>
+                        </lightning-combobox>
+                        <p class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
+                            How checkout routes committed lines once they are activated.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
             <div class="form-section" style="padding: 0 0.75rem;">
                 <lightning-input
                     type="text"

--- a/force-app/main/default/lwc/deliveryGeneralSettingsCard/deliveryGeneralSettingsCard.js
+++ b/force-app/main/default/lwc/deliveryGeneralSettingsCard/deliveryGeneralSettingsCard.js
@@ -37,6 +37,13 @@ export default class DeliveryGeneralSettingsCard extends LightningElement {
     @track requireWorkLogApproval = false;
     @track invoiceGenerationEnabled = false;
 
+    // ── Checkout Cart settings ──────────────────────────────────────────
+    @track cartDollarsEnabled = false;
+    @track cartDollarsActivatedAt = null;
+    @track cartSelfServeEnabled = false;
+    @track cartSelfServeActivatedAt = null;
+    @track checkoutMode = 'Invoice';
+
     // ── Activation-date display strings ─────────────────────────────────
     @track notificationsActivatedAt = null;
     @track autoSyncActivatedAt = null;
@@ -144,6 +151,13 @@ export default class DeliveryGeneralSettingsCard extends LightningElement {
                 this.autoCreateWorkRequestActivatedAt = data.autoCreateWorkRequestActivatedAt || null;
                 this.requireWorkLogApprovalActivatedAt = data.requireWorkLogApprovalActivatedAt || null;
                 this.invoiceGenerationActivatedAt = data.invoiceGenerationActivatedAt || null;
+
+                // Checkout Cart settings
+                this.cartDollarsEnabled = data.cartDollarsEnabled || false;
+                this.cartDollarsActivatedAt = data.cartDollarsActivatedAt || null;
+                this.cartSelfServeEnabled = data.cartSelfServeEnabled || false;
+                this.cartSelfServeActivatedAt = data.cartSelfServeActivatedAt || null;
+                this.checkoutMode = data.checkoutMode || 'Invoice';
 
                 // Enterprise settings
                 this.externalNotificationsEnabled = data.externalNotificationsEnabled || false;
@@ -400,6 +414,29 @@ export default class DeliveryGeneralSettingsCard extends LightningElement {
         this.saveExtended();
     }
 
+    handleCartDollarsChange(event) {
+        this.cartDollarsEnabled = event.target.checked;
+        this.saveExtended();
+    }
+
+    handleCartSelfServeChange(event) {
+        this.cartSelfServeEnabled = event.target.checked;
+        this.saveExtended();
+    }
+
+    handleCheckoutModeChange(event) {
+        this.checkoutMode = event.detail.value;
+        this.saveExtended();
+    }
+
+    get checkoutModeOptions() {
+        return [
+            { label: 'Invoice — generate a proposal/agreement', value: 'Invoice' },
+            { label: 'Stripe — paid checkout', value: 'Stripe' },
+            { label: 'Approve — route through approval', value: 'Approve' }
+        ];
+    }
+
     handleStatusPageTokenChange(event) {
         this.statusPageToken = event.target.value;
     }
@@ -477,7 +514,10 @@ export default class DeliveryGeneralSettingsCard extends LightningElement {
                     syncApiRateLimit: this.syncApiRateLimit,
                     publicApiRateLimit: this.publicApiRateLimit,
                     invoiceHourLockoutDay: this.invoiceHourLockoutDay,
-                    invoiceHourLockoutTime: this.invoiceHourLockoutTime
+                    invoiceHourLockoutTime: this.invoiceHourLockoutTime,
+                    cartDollarsEnabled: this.cartDollarsEnabled,
+                    cartSelfServeEnabled: this.cartSelfServeEnabled,
+                    checkoutMode: this.checkoutMode
                 })
             });
 

--- a/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
+++ b/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
@@ -236,6 +236,24 @@ const INFO_REGISTRY = {
         keyFields:
             'WorkItem__c.EstimatedHoursNumber__c, WorkItem__c.EstimatedStartDevDate__c, WorkItem__c.EstimatedEndDevDate__c, WorkItem__c.TotalLoggedHoursSum__c, WorkLog__c.HoursLoggedNumber__c, WorkLog__c.WorkDateDate__c, NetworkEntity__c.DefaultHourlyRateCurrency__c'
     },
+    deliveryCartCheckout: {
+        dataSource:
+            'Calls DeliveryCartService.getCart, which returns the org-wide cart — WorkItem__c rows where ClientIntentionPk__c is Will Do or Sizing Only AND ActivatedDateTime__c is null — sequenced by PriorityGroupPk__c then PriorityPk__c. Per-line projected cost comes from the child WorkRequest__c ProjectedCostCurrency__c (QuotedHoursNumber__c x HourlyRateCurrency__c). The forecast month-spread reuses DeliveryHoursAnalyticsController.getPortfolioPacing. Checkout calls DeliveryCartService.checkout, which stamps ActivatedDateTime__c on the Will Do lines only and branches on the configured checkout mode (Invoice / Stripe / Approve).',
+        description:
+            'The org-wide procurement basket review surface. Shows committed (Will Do) vs exploring (Sizing Only) lines with hours — and dollars when the org opts in — a summary header, and a forecast of which months the work lands in. One Checkout button activates the committed lines into the live pipeline.',
+        friendlyName: 'Checkout Cart',
+        keyFields:
+            'WorkItem__c.ClientIntentionPk__c, WorkItem__c.ActivatedDateTime__c, WorkItem__c.EstimatedHoursNumber__c, WorkItem__c.PriorityPk__c, WorkItem__c.PriorityGroupPk__c, WorkRequest__c.ProjectedCostCurrency__c, DeliveryHubSettings__c.EnableCartDollarsDateTime__c, DeliveryHubSettings__c.CheckoutModeTxt__c'
+    },
+    deliveryCartBuilder: {
+        dataSource:
+            'Calls DeliveryCartService.getCart for the running total and current lines, and DeliveryCartService.createCartItem to freeform-add a new pre-activation WorkItem__c carrying ClientIntentionPk__c (Sizing Only or Will Do) with ActivatedDateTime__c left null. Inline actions call addToCart (promote to Will Do), removeFromCart (set Deferred), and reorder (write PriorityPk__c). Dollars on the running total appear only when a single blended NetworkEntity__c rate is resolvable and the org has opted in.',
+        description:
+            'The add-to-cart surface. A purchaser adds scoped work as Sizing Only (explore) or Will Do (commit), watches a running hours/dollars total, and promotes, removes, or reorders cart lines inline — all without leaving the procurement basket.',
+        friendlyName: 'Cart Builder',
+        keyFields:
+            'WorkItem__c.ClientIntentionPk__c, WorkItem__c.ActivatedDateTime__c, WorkItem__c.EstimatedHoursNumber__c, WorkItem__c.PriorityPk__c, WorkItem__c.BriefDescriptionTxt__c, NetworkEntity__c.DefaultHourlyRateCurrency__c'
+    },
     deliveryWatcherSetup: {
         dataSource:
             'Calls DeliveryWatcherSetupController.getSettings to load the Watcher digest configuration from DeliveryHubSettings__c, and saveSettings to persist it. Flipping the master toggle stamps EnableWatcherDigestDateTime__c; the recipient list is validated against active Users and stored in WatcherDigestRecipientUserIdsTxt__c; an optional Slack webhook override updates the org-wide webhook used by escalations and forecasts.',

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/CheckoutModeTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/CheckoutModeTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>CheckoutModeTxt__c</fullName>
+    <description>Checkout routing mode for the Checkout Cart. One of: Approve, Invoice, Stripe (validated in Apex — Custom Settings cannot hold Picklist fields, so this is stored as Text). Blank defaults to Invoice. Invoice = stamp active + generate a proposal/agreement document; Stripe = paid checkout via DeliveryStripePaymentHandler (seam); Approve = route through the approval rails.</description>
+    <inlineHelpText>Enter Approve, Invoice, or Stripe. Blank defaults to Invoice.</inlineHelpText>
+    <label>Checkout Mode</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableCartDollarsDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableCartDollarsDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnableCartDollarsDateTime__c</fullName>
+    <description>When non-null, the Checkout Cart surfaces dollar amounts ($ per line + totals) in addition to hours, provided a single blended rate is resolvable. Null = hours-only (default; MF behavior). Self-serve orgs opt in.</description>
+    <inlineHelpText>Set to show dollars in the Checkout Cart (requires a single resolvable blended rate). Leave blank for hours-only.</inlineHelpText>
+    <label>Enable Cart Dollars</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableCartSelfServeDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableCartSelfServeDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnableCartSelfServeDateTime__c</fullName>
+    <description>When non-null, clients self-serve the Checkout Cart (browse + add + checkout). Null = Glen/admin assembles the cart on the client's behalf (default; MF behavior).</description>
+    <inlineHelpText>Set to let clients self-serve the cart. Leave blank for admin-assembled carts.</inlineHelpText>
+    <label>Enable Cart Self-Serve</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
@@ -1459,6 +1459,10 @@
         <visibility>Visible</visibility>
     </tabSettings>
     <tabSettings>
+        <tab>Delivery_Cart</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
+    <tabSettings>
         <tab>Delivery_Guide</tab>
         <visibility>Visible</visibility>
     </tabSettings>

--- a/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
@@ -1466,6 +1466,10 @@
         <visibility>Visible</visibility>
     </tabSettings>
     <tabSettings>
+        <tab>Delivery_Cart</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
+    <tabSettings>
         <tab>Delivery_Guide</tab>
         <visibility>Visible</visibility>
     </tabSettings>

--- a/force-app/main/default/tabs/Delivery_Cart.tab-meta.xml
+++ b/force-app/main/default/tabs/Delivery_Cart.tab-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Delivery Hub Checkout Cart — the org-wide procurement basket review surface.</description>
+    <label>Cart</label>
+    <lwcComponent>deliveryCartCheckout</lwcComponent>
+    <motif>Custom25: Cart</motif>
+</CustomTab>

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.addToCart.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.addToCart.js
@@ -1,0 +1,4 @@
+/**
+ * Mock for DeliveryCartService.addToCart (imperative).
+ */
+module.exports = { default: jest.fn() };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.checkout.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.checkout.js
@@ -1,0 +1,4 @@
+/**
+ * Mock for DeliveryCartService.checkout (imperative).
+ */
+module.exports = { default: jest.fn() };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.createCartItem.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.createCartItem.js
@@ -1,0 +1,4 @@
+/**
+ * Mock for DeliveryCartService.createCartItem (imperative).
+ */
+module.exports = { default: jest.fn() };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.getCart.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.getCart.js
@@ -1,0 +1,8 @@
+/**
+ * Wire adapter mock for DeliveryCartService.getCart.
+ * Used by the c-delivery-cart-checkout and c-delivery-cart-builder jest tests.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+
+const getCart = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getCart };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.removeFromCart.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.removeFromCart.js
@@ -1,0 +1,4 @@
+/**
+ * Mock for DeliveryCartService.removeFromCart (imperative).
+ */
+module.exports = { default: jest.fn() };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.reorder.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryCartService.reorder.js
@@ -1,0 +1,4 @@
+/**
+ * Mock for DeliveryCartService.reorder (imperative).
+ */
+module.exports = { default: jest.fn() };


### PR DESCRIPTION
## Delivery Hub "Checkout Cart" — procurement-side ordering

Implements `docs/plans/checkout-cart-procurement-2026-06-05.md`. The cart makes the procurement thesis literal: a purchaser assembles a basket of scoped work, it auto-sizes + auto-sequences, and checkout routes it into the existing delivery pipeline.

### The zero-new-object design
The cart is a **STATE over existing `WorkItem__c`** — no new objects, no new cart fields:
- **Cart** = `WorkItem__c` where `ClientIntentionPk__c ∈ {Will Do, Sizing Only}` AND `ActivatedDateTime__c == NULL` (these picklist values already exist on the field).
- `Will Do` = committed (checkout candidate); `Sizing Only` = priced but exploring; `Deferred`/`On Hold` = out of cart.
- **Checkout = stamp `ActivatedDateTime__c`** on the `Will Do` lines → they cross into the live pipeline (forecast/gantt/sync/invoice) with no copy/convert.
- Per-line sizing reuses `EstimatedHoursNumber__c`; cost reuses the child `WorkRequest__c.ProjectedCostCurrency__c` formula; order reuses `PriorityPk__c`/`PriorityGroupPk__c`.

### The only new metadata — 3 config fields on `DeliveryHubSettings__c`
`DeliveryHubSettings__c` is a **Custom Setting** (primitive types only — no Picklist):
- `EnableCartDollarsDateTime__c` (DateTime) — null = hours-only (default/MF); set = show $.
- `EnableCartSelfServeDateTime__c` (DateTime) — null = admin assembles (default); set = client self-serves.
- `CheckoutModeTxt__c` (**Text**, not GVS — Custom Settings can't hold picklists) — `Approve | Invoice | Stripe`, validated/normalized in Apex; blank → `Invoice`.

All three surfaced in the settings UI allowlist (`DeliveryHubSettingsController` SettingsDTO + `getSettings` + `saveExtendedSettings`) and rendered in `deliveryGeneralSettingsCard`.

### Apex
- **`CartExperienceProfile`** (global DTO + resolver): `showDollars` (gated on opt-in AND a single resolvable blended rate — mirrors the pacing dollar gate), `selfServe`, `checkoutMode` (default Invoice), `blendedRate` (reuses the `resolveBlendedRate` pattern).
- **`DeliveryCartService`** (global, all DTOs global, SOQL `WITH SYSTEM_MODE`): `getCart`, `addToCart`, `removeFromCart`, `reorder`, `createCartItem`, `checkout`. Checkout activates **`Will Do` only** (Sizing Only stays in cart) then branches on mode.

### Two surfaces (each a pure function of `(cartData, profile)`)
- **`deliveryCartCheckout`** — the review surface: Will Do vs Sizing Only sections, hours (+ $ only when `showDollars`), summary header, forecast "lands across these months" line (reuses `getPortfolioPacing`), and a checkout button whose label/behavior reflect `checkoutMode`. Row click → `standard__recordPage` via `WORK_ITEM_OBJECT.objectApiName` + `data-record-id`.
- **`deliveryCartBuilder`** — the add-to-cart surface: freeform add as Sizing Only / Will Do, running hours/$ total, inline commit/remove/reorder.

### Placement (in-package)
- New **`Cart`** Lightning tab (`Delivery_Cart`) hosting `deliveryCartCheckout`, wired into `DeliveryHub` + `DeliveryHubAdmin` apps and both permsets.
- "Open cart" card added to `DeliveryHubAdminHome.flexipage-meta.xml`.
- Both LWCs registered in `deliveryInfoPopover` `INFO_REGISTRY` with `<c-delivery-info-popover>` in each card header.

### Locked decisions honored
1. Checkout activates `Will Do` only; `Sizing Only` stays in the cart.
2. Dedicated `Cart` tab + an AdminHome summary card.
3. `showDollars` OFF by default org-wide; self-serve orgs opt in.

### TODO seams (clearly marked — not faked, per Data Integrity rules)
- **Stripe** paid-checkout: `DeliveryStripePaymentHandler` is an *inbound* webhook event handler, not an outbound initiator. `Stripe` mode activates the lines and returns a marked message; a Checkout Session / Payment Link callout is a follow-up.
- **Approve** routing: the shipped approval rails key on `Feature__c` toggle requests, not WorkItem baskets. `Approve` mode activates the lines and notes the seam.
- **Invoice** proposal: generates a `Client_Agreement` via `DeliveryDocGenerationService` when the committed lines share exactly one client `NetworkEntity__c`; otherwise activation stands and the result notes no single-client proposal was generated.

### Tests
- `DeliveryCartServiceTest`: cart query (Will Do + Sizing Only; excludes activated/Deferred/On Hold), add/remove/reorder, freeform create, checkout activates Will Do only, profile matrix (dollars off default; on with opt-in + rate; mode default Invoice), `normalizeMode` validation.
- Jest for both LWCs (13 tests). Full local jest suite passes except one **pre-existing** unrelated failure in `deliveryFeatureCockpit` (confirmed failing on clean `main`).
- PMD clean on all new/modified Apex + new field metadata (FIELD_NAMING).

### Not verified without org auth
No deploy/install performed (per instructions). The namespaced upload-beta feature-test runs in CI. `NS_PREFIX`/managed-install behaviors (tab visibility, `WORK_ITEM_OBJECT.objectApiName` resolution) could not be checked against a live managed org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)