### PR TITLE
fix(pacing): match forecast active-item count to the gantt board (99 -> 95)

### DIFF
--- a/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
@@ -411,25 +411,54 @@ global with sharing class DeliveryHoursAnalyticsController {
     }
 
     /**
-     * @description Expands the active roots into their full descendant trees via
-     *              a level-by-level BFS (capped at MAX_TREE_DEPTH), bulk across all
+     * @description Expands the active roots into their descendant trees via a
+     *              level-by-level BFS (capped at MAX_TREE_DEPTH), bulk across all
      *              roots so each depth level is ONE query — no per-root loop.
+     *
+     *              Descendants are filtered to the board's canonical "Active"
+     *              definition — `ActivatedDateTime__c != NULL AND
+     *              TemplateMarkedDateTime__c = NULL` — so the pacing item
+     *              universe matches exactly what the gantt board draws
+     *              (DeliveryGanttController.getProFormaTimelineData with
+     *              showCompleted=false). Before this gate, the BFS pulled in
+     *              EVERY child regardless of activation/template state, so the
+     *              forecast's active-item universe drifted ABOVE the board count
+     *              (e.g. 99 in Pacing vs 95 on the board on MF prod) — the extra
+     *              records were non-activated / template descendants the board
+     *              never shows. The number the forecast totals + the consumer's
+     *              activeItems count are derived from must equal the client-
+     *              visible board, or it raises questions in the client review.
+     *
+     *              Note: traversal of the frontier uses the raw parent link
+     *              (every child is followed so the walk is never cut short by a
+     *              non-active mid-tree parent), but a child is only ADDED to the
+     *              returned scope when it is itself board-active. This keeps an
+     *              activated grandchild reachable under a non-activated parent —
+     *              matching the board's flat (parent-state-independent) view —
+     *              while excluding the non-active records themselves.
      */
     private static Set<Id> collectPortfolioTree(Set<Id> rootIds) {
         Set<Id> collected = new Set<Id>(rootIds);
+        Set<Id> visited = new Set<Id>(rootIds);
         Set<Id> frontier = new Set<Id>(rootIds);
         for (Integer depth = 0; depth < MAX_TREE_DEPTH && !frontier.isEmpty(); depth++) {
             Set<Id> next = new Set<Id>();
             for (WorkItem__c child : [
-                SELECT Id
+                SELECT Id, ActivatedDateTime__c, TemplateMarkedDateTime__c
                 FROM WorkItem__c
                 WHERE ParentWorkItemLookup__c IN :frontier
                 WITH SYSTEM_MODE
                 LIMIT 50000
             ]) {
-                if (!collected.contains(child.Id)) {
+                if (visited.contains(child.Id)) {
+                    continue;
+                }
+                visited.add(child.Id);
+                next.add(child.Id);
+                // Board-active gate: only activated, non-template descendants
+                // join the scope — mirrors getProFormaTimelineData(false).
+                if (child.ActivatedDateTime__c != null && child.TemplateMarkedDateTime__c == null) {
                     collected.add(child.Id);
-                    next.add(child.Id);
                 }
             }
             frontier = next;

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
@@ -501,6 +501,92 @@ private class DeliveryHoursAnalyticsControllerTest {
     }
 
     @IsTest
+    static void testPortfolioScopeExcludesNonActiveAndTemplateDescendants() {
+        // The pacing item universe must match the board's canonical "Active"
+        // definition (DeliveryGanttController.getProFormaTimelineData with
+        // showCompleted=false): ActivatedDateTime__c != null AND
+        // TemplateMarkedDateTime__c = null. Before the collectPortfolioTree
+        // gate, the BFS pulled in EVERY descendant regardless of activation /
+        // template state, inflating the forecast's active-item universe above
+        // the board count (the live 99-vs-95 drift on MF prod).
+        WorkItem__c root = insertWi('ScopeRoot', 50, Date.today().addMonths(-1), Date.today().addMonths(1), null);
+        // Activated, non-template child — IN scope (counts toward totals).
+        WorkItem__c activeChild = insertWi('ScopeActiveChild', 20, null, null, root.Id);
+        // Non-activated child — the board never draws it, so it must be OUT.
+        WorkItem__c inactiveChild = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'ScopeInactiveChild',
+            'EstimatedHoursNumber__c' => 999,
+            'ParentWorkItemLookup__c' => root.Id,
+            'ActivatedDateTime__c' => null
+        });
+        // Template-marked child — also OUT regardless of activation.
+        WorkItem__c templateChild = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'ScopeTemplateChild',
+            'EstimatedHoursNumber__c' => 777,
+            'ParentWorkItemLookup__c' => root.Id,
+            'TemplateMarkedDateTime__c' => Datetime.now()
+        });
+
+        insert new List<WorkLog__c>{
+            buildLog(root.Id, 4, Date.today()),
+            buildLog(activeChild.Id, 6, Date.today()),
+            // Logs on the excluded children must NOT surface in the portfolio.
+            buildLog(inactiveChild.Id, 50, Date.today()),
+            buildLog(templateChild.Id, 50, Date.today())
+        };
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
+            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 3);
+        Test.stopTest();
+
+        // Only root (50) + activeChild (20) estimate is in scope = 70.
+        // The 999 + 777 from the non-active / template children are excluded.
+        System.assertEquals(70, dto.totalEstimatedHours,
+            'Estimate must exclude non-activated + template descendants');
+        // Only root (4) + activeChild (6) logged = 10. The 50 + 50 are excluded.
+        System.assertEquals(10, dto.totalLoggedHours,
+            'Logged hours must exclude non-activated + template descendants');
+        System.assertEquals(10, totalLogged(dto),
+            'Per-period logged hours must exclude the off-scope children too');
+        // Root is the only active root in scope.
+        System.assertEquals(1, dto.rootCount, 'One active root in scope');
+    }
+
+    @IsTest
+    static void testPortfolioScopeKeepsActivatedGrandchildUnderInactiveParent() {
+        // The walk follows EVERY child link (so traversal is never cut by a
+        // non-active mid-tree parent), but only board-active descendants join
+        // the scope. An activated grandchild under a non-activated parent stays
+        // reachable — mirroring the board's flat, parent-state-independent view.
+        WorkItem__c root = insertWi('GcRoot', 10, null, null, null);
+        WorkItem__c inactiveParent = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'GcInactiveParent',
+            'EstimatedHoursNumber__c' => 999,
+            'ParentWorkItemLookup__c' => root.Id,
+            'ActivatedDateTime__c' => null
+        });
+        // Activated grandchild — board would draw it; must be IN scope.
+        WorkItem__c activeGrandchild = insertWi('GcActiveGrandchild', 15, null, null, inactiveParent.Id);
+
+        insert new List<WorkLog__c>{
+            buildLog(root.Id, 2, Date.today()),
+            buildLog(activeGrandchild.Id, 5, Date.today())
+        };
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
+            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 3);
+        Test.stopTest();
+
+        // root (10) + activeGrandchild (15) = 25; the inactive parent's 999 is out.
+        System.assertEquals(25, dto.totalEstimatedHours,
+            'Activated grandchild stays in scope; inactive mid-tree parent stays out');
+        System.assertEquals(7, dto.totalLoggedHours,
+            'root 2h + grandchild 5h = 7h; inactive parent contributes nothing');
+    }
+
+    @IsTest
     static void testPortfolioPacingEmptyOrgReturnsSkeleton() {
         // No WorkItems at all — should still return a well-formed skeleton.
         Test.startTest();


### PR DESCRIPTION
## Why

Cowork saw MF prod show **95 scheduled items on the gantt board** but **99 "active items" in the Pacing/Forecast view**. The forecast total must equal the client-visible board number, or it raises questions in front of the client.

## Diagnosis: why 99 vs 95

The two sides scope their item universe differently:

- **Board (95)** — `DeliveryGanttController.getProFormaTimelineData(showCompleted:false)` returns a **flat** query: every `WorkItem__c` where `TemplateMarkedDateTime__c = null AND ActivatedDateTime__c != null`. Parents and children each count as one row. No tree walk, no terminal/archived filter — activation IS the gate.
- **Pacing (99)** — `DeliveryHoursAnalyticsController.getPortfolioPacing` scopes via `collectPortfolioTree(queryActiveRootIds())`. Roots are filtered (activated, non-template, non-archived, non-terminal), but the descendant BFS pulled in **every** child with **no per-item filter** — so it included **non-activated descendants** and **template-marked descendants** that the board never draws. Those extra records (the +4) inflated the forecast totals and the consumer-rendered `activeItems` count above the board.

The record set that differs: activated/non-template items are in both; **non-activated and template-marked descendants are in Pacing only**. That gap is the 99 - 95.

## Fix

Gate the descendant BFS in `collectPortfolioTree` to the board's canonical Active definition (`ActivatedDateTime__c != null AND TemplateMarkedDateTime__c = null`). Traversal still follows every child link, so an activated grandchild under a non-activated mid-tree parent stays reachable (matching the board's flat, parent-state-independent view) — but only board-active descendants join the scope.

- **Forced equality toward the board** per the brief ("lean toward matching the board, since that's the number the client sees"). The +4 was non-displayed records, not a legitimate forecast inclusion, so excluding them is correct, not a forecast-hiding compromise.
- **No DTO / PacingData shape change** — logic only. The pinned `PortfolioPacingDTO` / `PacingData` contract is untouched (could not add an `activeItems` field even though that's where the consumer reads the count; instead the underlying scope now matches, so every derived number — totals, forecast, and the consumer's `activeItems` — aligns to the board).
- `rootCount` ("Active **projects**", a deliberately different headline) is left unchanged.

## Tests

Two new tests in `DeliveryHoursAnalyticsControllerTest`:
- `testPortfolioScopeExcludesNonActiveAndTemplateDescendants` — non-activated + template-marked children (and their logs) must not roll into portfolio estimate / logged totals.
- `testPortfolioScopeKeepsActivatedGrandchildUnderInactiveParent` — an activated grandchild under a non-activated parent stays in scope (flat-view parity); the inactive mid-tree parent stays out.

## Flagged for human review

One residual, opposite-direction scoping difference (pre-existing, **not** the reported symptom): the board shows activated items org-wide including any under terminal/archived roots, whereas Pacing only starts from non-terminal/non-archived active roots. On MF the drift was Pacing **higher** (99 > 95), so this case isn't currently biting; if a future count shows Pacing **lower** than the board, this root-scope philosophy is the place to look.

