### PR TITLE
fix(forecast): exclude terminal-stage descendants from remaining/forecast

### DIFF
--- a/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
@@ -550,6 +550,11 @@ global with sharing class DeliveryHoursAnalyticsController {
             }
         }
         for (ForecastItemAccum acc : accs) {
+            // Drop drill-down rows that contribute 0h (or less) to this period — they're
+            // noise in the bucket's items[] list.
+            if (acc.hoursThisPeriod == null || acc.hoursThisPeriod <= 0) {
+                continue;
+            }
             ItemSchedule s = acc.sched;
             Decimal est = numOrZero(s.estimate);
             Decimal logged = numOrZero(s.logged);
@@ -718,11 +723,20 @@ global with sharing class DeliveryHoursAnalyticsController {
             WITH SYSTEM_MODE
             LIMIT 50000
         ]) {
+            // Terminal-stage items (Done/Cancelled/Closed/Rejected) are dead work: their
+            // already-LOGGED hours are real history (kept in totalLoggedHours + the actual
+            // series, both sourced from WorkLog independent of stage), but their REMAINING
+            // (estimate − logged) must NOT contribute to totalRemainingHours / forecast /
+            // projectedFinal / the schedule-based spread / the unscheduled bucket. We skip
+            // their remaining here and in spreadScheduleBasedForecast via the same stage
+            // flag (carried on ItemSchedule.stage).
+            Boolean isTerminal = String.isNotBlank(wi.StageNamePk__c)
+                && TERMINAL_STAGES.contains(wi.StageNamePk__c);
             Decimal estimate = (wi.EstimatedHoursNumber__c == null) ? 0 : wi.EstimatedHoursNumber__c;
             dto.totalEstimatedHours += estimate;
             Decimal logged = loggedByItem.containsKey(wi.Id) ? loggedByItem.get(wi.Id) : 0;
             Decimal itemRemaining = estimate - logged;
-            if (itemRemaining > 0) {
+            if (!isTerminal && itemRemaining > 0) {
                 totalRemainingHours += itemRemaining;
             }
             // Capture per-item schedule + work + meta for the schedule-based forecast
@@ -1039,6 +1053,11 @@ global with sharing class DeliveryHoursAnalyticsController {
         Date today = Date.today();
         Decimal unscheduled = 0;
         for (ItemSchedule sched : portfolioItemSchedules) {
+            // Terminal-stage items contribute 0 remaining — never spread onto a forecast
+            // bar and never pushed into the unscheduled bucket (dead work isn't forecast).
+            if (String.isNotBlank(sched.stage) && TERMINAL_STAGES.contains(sched.stage)) {
+                continue;
+            }
             Decimal itemRemaining = sched.estimate - sched.logged;
             if (itemRemaining == null || itemRemaining <= 0) {
                 continue;

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
@@ -898,6 +898,127 @@ private class DeliveryHoursAnalyticsControllerTest {
             'Σ item hoursThisPeriod ≈ placed remaining (60h), got ' + totalItemHours);
     }
 
+    // ────────────────────────────────────────────────────────────────────
+    // Terminal-stage descendants — dead work must NOT contribute remaining /
+    // forecast / projectedFinal, but its already-logged actuals stay counted.
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Flips a WorkItem's stage via a trigger-bypassed update so the test
+     *              isolates the analytics from auto-WR / sync side effects (mirrors the
+     *              pattern in testPortfolioExcludesTerminalAndArchivedRoots).
+     */
+    private static void setStage(WorkItem__c wi, String stage) {
+        Boolean prev = DeliveryWorkItemTriggerHandler.triggerDisabled;
+        DeliveryWorkItemTriggerHandler.triggerDisabled = true;
+        try {
+            wi.StageNamePk__c = stage;
+            update wi;
+        } finally {
+            DeliveryWorkItemTriggerHandler.triggerDisabled = prev;
+        }
+    }
+
+    @IsTest
+    static void testTerminalDescendantContributesNoRemainingOrForecast() {
+        // Active root (Backlog) with a future-dated active child AND a Cancelled child
+        // that has POSITIVE remaining (estimate 50 > logged 10). The Cancelled child's
+        // 50h estimate / 40h remaining is dead work — it must NOT inflate
+        // totalRemainingHours, projectedFinalHours, the forecast bars, or unscheduled —
+        // but its 10h LOGGED is real history and must stay in totalLoggedHours + the
+        // actual series.
+        Date nextMonthStart = Date.today().toStartOfMonth().addMonths(1);
+        Date spanEnd = nextMonthStart.addMonths(2).addDays(-1);
+        WorkItem__c root = insertWi('TermRoot', 100, nextMonthStart, spanEnd, null);
+        WorkItem__c activeChild = insertWi('TermActiveChild', 60, nextMonthStart, spanEnd, root.Id);
+        // Cancelled child: scheduled in the future with positive remaining, so absent the
+        // fix it WOULD spread 40h onto the forecast bars.
+        WorkItem__c cancelledChild = insertWi('TermCancelledChild', 50, nextMonthStart, spanEnd, root.Id);
+
+        insert new List<WorkLog__c>{
+            buildLog(activeChild.Id, 10, Date.today()),
+            buildLog(cancelledChild.Id, 10, Date.today())
+        };
+        setStage(cancelledChild, 'Cancelled');
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
+            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 4);
+        Test.stopTest();
+
+        // LOGGED actuals: both children's 10h logged stays counted (20h total) — the
+        // Cancelled child's history is NOT dropped.
+        System.assertEquals(20, dto.totalLoggedHours,
+            'Terminal child logged actuals stay counted: 10 (active) + 10 (cancelled) = 20');
+        System.assertEquals(20, totalLogged(dto),
+            'Both children appear in the actual series (period logged sum)');
+
+        // REMAINING / forecast / projected: only the ACTIVE child contributes remaining.
+        // Active child remaining = 60 - 10 = 50; Cancelled child remaining (40) excluded.
+        // Projected = logged(20) + remaining(50) = 70.
+        System.assertEquals(70, dto.projectedFinalHours,
+            'Projected = logged(20) + active-child remaining(50); cancelled remaining excluded');
+
+        // Forecast bars: spread the 50h ACTIVE remaining only (not 90 = 50+40).
+        Decimal placed = totalForecast(dto);
+        System.assert(placed >= 49.8 && placed <= 50.2,
+            'Forecast bars spread ONLY the active child remaining (~50h), not the ' +
+            'cancelled child (would be ~90h with the bug), got ' + placed);
+        System.assertEquals(0, dto.unscheduledRemainingHours,
+            'Both children are future-dated; cancelled remaining is excluded, not unscheduled');
+    }
+
+    @IsTest
+    static void testTerminalRootSiblingExcludedFromForecastButLoggedKept() {
+        // Belt-and-suspenders at the per-item-stage level: a terminal-stage item that
+        // somehow enters the portfolio id set (here as a Done CHILD under an active root)
+        // still has its logged kept and its remaining zeroed.
+        WorkItem__c root = insertWi('DoneChildRoot', 0, null, null, null);
+        WorkItem__c doneChild = insertWi('DoneChild', 80,
+            Date.today().toStartOfMonth().addMonths(1),
+            Date.today().toStartOfMonth().addMonths(3).addDays(-1), root.Id);
+        insert buildLog(doneChild.Id, 15, Date.today());
+        setStage(doneChild, 'Done');
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
+            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 4);
+        Test.stopTest();
+
+        System.assertEquals(15, dto.totalLoggedHours, 'Done child 15h logged stays counted');
+        System.assertEquals(0, totalForecast(dto),
+            'Done child contributes no forecast bars (dead remaining)');
+        System.assertEquals(0, dto.unscheduledRemainingHours,
+            'Done child remaining is excluded, not pushed to unscheduled');
+        // Projected = logged(15) + remaining(0) = 15. Root has 0 estimate.
+        System.assertEquals(15, dto.projectedFinalHours,
+            'Projected = logged only; no remaining from the Done child');
+    }
+
+    @IsTest
+    static void testNoDrillDownItemHasZeroOrNegativeHours() {
+        // Every items[] drill-down row across every bucket must carry hours > 0 — no
+        // 0h noise rows (the second fix).
+        Date nextMonthStart = Date.today().toStartOfMonth().addMonths(1);
+        Date spanEnd = nextMonthStart.addMonths(3).addDays(-1);
+        insertWi('DrillNonZero', 90, nextMonthStart, spanEnd, null);
+
+        Test.startTest();
+        String pacingJson = DeliveryHoursAnalyticsController.getPacing('Month', 6, 4);
+        Test.stopTest();
+
+        Integer rowsSeen = 0;
+        for (Object o : bucketsOf(pacingJson)) {
+            for (Object io : (List<Object>) ((Map<String, Object>) o).get('items')) {
+                Decimal hrs = (Decimal) ((Map<String, Object>) io).get('hours');
+                System.assert(hrs != null && hrs > 0,
+                    'No drill-down item may have this-period hours <= 0, got ' + hrs);
+                rowsSeen++;
+            }
+        }
+        System.assert(rowsSeen > 0, 'Sanity: the scheduled item produced at least one drill row');
+    }
+
     @IsTest
     static void testUnscheduledItemNeverAppearsInAnyBucketItems() {
         // A no-date item with remaining work is unscheduled — it must NOT show up in


### PR DESCRIPTION
## Problem

The portfolio forecast (`getPortfolioPacing` / `getPacing` in `DeliveryHoursAnalyticsController`) was counting **terminal-stage descendant** work items in its REMAINING / forecast / projected numbers.

`queryActiveRootIds` filters **roots** by stage:

```sql
WHERE ... AND StageNamePk__c NOT IN :TERMINAL_STAGES   -- {Done, Cancelled, Closed, Rejected}
```

but `collectPortfolioTree` (the descendant BFS that builds the full portfolio id set) pulls children with **no stage filter**:

```sql
SELECT Id FROM WorkItem__c WHERE ParentWorkItemLookup__c IN :frontier WITH SYSTEM_MODE LIMIT 50000
```

So a `Cancelled`/`Done` child under an active root entered `portfolioIds`, and its remaining (`estimate − logged`) got spread into `totalRemainingHours`, the schedule-based forecast bars, `projectedFinalHours`, and the unscheduled bucket. Live-confirmed on MF prod: a "CF 2.0 — two-journey form · Cancelled" child contributed 15h to a forecast bucket.

## Fix — remaining-only exclusion (preserves logged actuals)

Terminal-stage items must not contribute **remaining / forecast / projected**, but their already-LOGGED hours are real history. Logged actuals come from `WorkLog__c` aggregated over the portfolio id set, **independent of stage** (`loggedHoursByItem` → `dto.totalLoggedHours`; `applyPortfolioLoggedHours` → the actual series). Dropping terminal descendants from the id set entirely would also drop their logged history — so this uses the **remaining-only** approach instead:

- `rollupPortfolioTotals`: a terminal item's remaining is **skipped** from `totalRemainingHours` (its logged is still summed into `totalLoggedHours`).
- `spreadScheduleBasedForecast`: terminal items are **skipped** before placement, so they never spread onto a forecast bar and never fall into the unscheduled bucket. The stage flag is read from `ItemSchedule.stage`, which the SELECT already populated.
- `projectedFinalHours = totalLoggedHours + totalRemainingHours` is therefore fixed automatically.

`totalEstimatedHours` and the target amortization are intentionally **left unchanged** (out of scope — changing the estimate would alter `applyPortfolioTargets`, which the brief said not to touch).

## Also: drop 0h drill-down rows

`buildBucketItems` now skips items whose this-period hours `<= 0` (noise in a bucket's `items[]`).

## Expected effect on headline numbers

Remaining, the forecast bars, Projected Final, and the unscheduled total all **drop** by the dead-work remaining that was previously included. Estimated and the logged/actual series are unchanged.

## Tests (added to `DeliveryHoursAnalyticsControllerTest`)

- `testTerminalDescendantContributesNoRemainingOrForecast` — a Cancelled child with positive remaining under an active root contributes **0** to forecast bars / `projectedFinalHours`, while its logged stays in `totalLoggedHours` and the actual series.
- `testTerminalRootSiblingExcludedFromForecastButLoggedKept` — a Done child: logged kept, remaining zeroed (no bars, no unscheduled).
- `testNoDrillDownItemHasZeroOrNegativeHours` — asserts no `items[]` row has this-period hours `<= 0`.

## Scope

Only `DeliveryHoursAnalyticsController.cls` + its test. No LWC / static-resource / model changes. **Do not merge** — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
