### PR TITLE
feat(forecast): cohort-split stacked forecast — feed NG PacingData.segments (0.268, stacks #882)

### DIFF
--- a/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
@@ -60,6 +60,10 @@ global with sharing class DeliveryHoursAnalyticsController {
         Decimal logged;
         Date startDate;
         Date endDate;
+        /** 0.268 — the stacked-forecast commitment tier (PacingSegment.id) this item
+         *  belongs to, derived once from PriorityGroupPk__c via tierForGroup(). Drives
+         *  both the per-bucket `segments` sums and each drill-down item's `tier`. */
+        String tier;
     }
 
     /**
@@ -336,6 +340,62 @@ global with sharing class DeliveryHoursAnalyticsController {
         'Done', 'Cancelled', 'Closed', 'Rejected'
     };
 
+    /**
+     * @description Maps a WorkItem `PriorityGroupPk__c` lane onto the NG stacked-forecast
+     *              commitment tier (PacingSegment.id). Mirrors NG's PACING_LANE_TO_SEGMENT
+     *              (packages/app/src/renderers/pacing.ts) 1:1 so DH's AUTHORITATIVE per-tier
+     *              split reconciles with NG's task-derived PREVIEW split — same lane, same
+     *              tier, no drift. DH's lane values (top-priority/active/follow-on/proposed/
+     *              deferred — see DeliveryGanttController) ARE NG's keys, so no translation.
+     *              Fallbacks preserve the "no work silently vanishes" invariant: every
+     *              forecasted item lands in a tier, so the per-bucket segments always sum to
+     *              the bucket forecast (NG renders bar = actual + Σ segments and ignores
+     *              `forecast` once segments are present). Blank/unknown → 'greenlit' (matches
+     *              NG); 'deferred' (on-hold) → 'ready' (the speculative/dotted upside tier)
+     *              rather than NG's exclude, because DH's schedule spread already counts
+     *              on-hold remaining and dropping its tier would shrink the bar.
+     */
+    private static final Map<String, String> PRIORITY_GROUP_TO_TIER = new Map<String, String>{
+        'top-priority' => 'greenlit',
+        'active'       => 'greenlit',
+        'follow-on'    => 'predicted',
+        'proposed'     => 'ready',
+        'deferred'     => 'ready'
+    };
+
+    /** @description Fallback tier for blank/unknown lanes (no-vanish — see above). */
+    private static final String DEFAULT_TIER = 'greenlit';
+
+    /**
+     * @description The DH-declared stacked-forecast tier definitions, in stack order, in
+     *              NG's PacingSegment shape. Colors/style match NG's PACING_SEGMENT_DEFAULTS
+     *              (and the MF prototype: committed green / predicted blue / ready amber-
+     *              dotted) so the legend, palette, and tier-grouped drill-down render
+     *              identically whether DH feeds segments or NG falls back to its preview.
+     *              toPacingData only advertises the tiers that actually carry hours.
+     */
+    private static final Map<String, Map<String, Object>> SEGMENT_DEFS = new Map<String, Map<String, Object>>{
+        'greenlit'  => new Map<String, Object>{ 'id' => 'greenlit',  'label' => 'Committed',         'color' => '#059669', 'style' => 'solid',   'order' => 0 },
+        'predicted' => new Map<String, Object>{ 'id' => 'predicted', 'label' => 'Predicted',         'color' => '#2563eb', 'style' => 'solid',   'order' => 1 },
+        'ready'     => new Map<String, Object>{ 'id' => 'ready',     'label' => 'Ready to approve',  'color' => '#d97706', 'style' => 'dotted',  'order' => 2 },
+        'recurring' => new Map<String, Object>{ 'id' => 'recurring', 'label' => 'Recurring intake',  'color' => '#7c3aed', 'style' => 'hatched', 'order' => 3 }
+    };
+
+    /** @description Tier order for emitting the segment-def array (matches SEGMENT_DEFS order). */
+    private static final List<String> TIER_ORDER = new List<String>{ 'greenlit', 'predicted', 'ready', 'recurring' };
+
+    /**
+     * @description Resolves a WorkItem lane to its forecast tier (see PRIORITY_GROUP_TO_TIER).
+     * @param lane The WorkItem `PriorityGroupPk__c` value (may be blank).
+     * @return A PacingSegment.id — never null (blank/unknown fall back to DEFAULT_TIER).
+     */
+    private static String tierForGroup(String lane) {
+        if (String.isNotBlank(lane) && PRIORITY_GROUP_TO_TIER.containsKey(lane)) {
+            return PRIORITY_GROUP_TO_TIER.get(lane);
+        }
+        return DEFAULT_TIER;
+    }
+
     /** @description One period (history or forecast) on the pacing timeline. */
     global class PacingPeriodDTO {
         @AuraEnabled global String label;
@@ -470,6 +530,10 @@ global with sharing class DeliveryHoursAnalyticsController {
         Decimal logged = numOrZero(dto == null ? null : dto.totalLoggedHours);
 
         List<Object> buckets = new List<Object>();
+        // 0.268 — accumulate which commitment tiers actually carry hours so the top-level
+        // segments[] defs only advertise non-empty tiers (mirrors NG's own legend filter).
+        Set<String> tiersWithHours = new Set<String>();
+        Decimal recurring = resolveRecurringHoursPerPeriod();
         if (dto != null && dto.periods != null) {
             for (Integer idx = 0; idx < dto.periods.size(); idx++) {
                 PacingPeriodDTO p = dto.periods[idx];
@@ -491,6 +555,18 @@ global with sharing class DeliveryHoursAnalyticsController {
                 };
                 if (p.startDate != null) {
                     b.put('startMs', dateToMs(p.startDate));
+                }
+                // 0.268 — per-period commitment-tier split (the stacked hockey-stick).
+                // Only forecast buckets have scheduled work; recurring rides on forecast
+                // buckets as a synthetic tier (inert until resolveRecurringHoursPerPeriod
+                // returns > 0).
+                Map<String, Decimal> segs = buildBucketSegments(idx);
+                if (isForecast && recurring > 0) {
+                    segs.put('recurring', recurring);
+                }
+                if (!segs.isEmpty()) {
+                    b.put('segments', segs);
+                    tiersWithHours.addAll(segs.keySet());
                 }
                 buckets.add(b);
             }
@@ -514,6 +590,20 @@ global with sharing class DeliveryHoursAnalyticsController {
             'summary' => summary,
             'authoritative' => true
         };
+        // 0.268 — declare the stacked-forecast tier definitions (NG PacingData.segments),
+        // in stack order, for only the tiers that carry hours. NG renders the legend + the
+        // tier-grouped drill-down from these; absent → NG falls back to its preview split.
+        if (!tiersWithHours.isEmpty()) {
+            List<Object> segmentDefs = new List<Object>();
+            for (String t : TIER_ORDER) {
+                if (tiersWithHours.contains(t) && SEGMENT_DEFS.containsKey(t)) {
+                    segmentDefs.add(SEGMENT_DEFS.get(t));
+                }
+            }
+            if (!segmentDefs.isEmpty()) {
+                out.put('segments', segmentDefs);
+            }
+        }
         if (dto != null && dto.blendedRate != null) {
             out.put('rate', dto.blendedRate);
         }
@@ -586,9 +676,59 @@ global with sharing class DeliveryHoursAnalyticsController {
             if (String.isNotBlank(s.assignee)) {
                 item.put('assignee', s.assignee);
             }
+            if (String.isNotBlank(s.tier)) {
+                item.put('tier', s.tier);
+            }
             items.add(item);
         }
         return items;
+    }
+
+    /**
+     * @description Sums a forecast period's scheduled hours BY COMMITMENT TIER, from the
+     *              same per-period accumulator that backs buildBucketItems. Produces NG's
+     *              `PacingBucket.segments` map (segId → hours) so the forecast bar renders
+     *              as a STACKED hockey-stick (Committed / Predicted / Ready). Because every
+     *              forecasted item carries a tier (tierForGroup never returns null), these
+     *              per-tier sums add up to the bucket's `forecast` total — NG draws the bar
+     *              as actual + Σ segments and ignores `forecast` when segments are present,
+     *              so the stack height equals the un-split bar (no regression). History
+     *              periods have no accumulator entries → empty map (no segments emitted).
+     * @param periodIndex Index into forecastItemsByPeriod (parallel to dto.periods).
+     * @return Map of PacingSegment.id → hours for this period (rounded; empty for history).
+     */
+    private static Map<String, Decimal> buildBucketSegments(Integer periodIndex) {
+        Map<String, Decimal> segs = new Map<String, Decimal>();
+        if (forecastItemsByPeriod == null
+            || periodIndex < 0 || periodIndex >= forecastItemsByPeriod.size()) {
+            return segs;
+        }
+        for (ForecastItemAccum acc : forecastItemsByPeriod[periodIndex].values()) {
+            if (acc.hoursThisPeriod == null || acc.hoursThisPeriod <= 0) {
+                continue;
+            }
+            String tier = String.isNotBlank(acc.sched.tier) ? acc.sched.tier : DEFAULT_TIER;
+            Decimal running = segs.containsKey(tier) ? segs.get(tier) : 0;
+            segs.put(tier, running + acc.hoursThisPeriod);
+        }
+        for (String k : new List<String>(segs.keySet())) {
+            segs.put(k, segs.get(k).setScale(2, System.RoundingMode.HALF_UP));
+        }
+        return segs;
+    }
+
+    /**
+     * @description Hours per forecast period for the SYNTHETIC 'recurring' steady-state
+     *              intake tier — the ~N small inbounds that always land regardless of the
+     *              dated backlog. Added uniformly to every forecast bucket as its own tier
+     *              so the curve extends to the right beyond scheduled work.
+     *              SEAM: returns 0 today (tier absent, prod unchanged). Wire MF's
+     *              history-derived run-rate here once it lands — scaling it to the chosen
+     *              granularity (per-week vs per-month vs per-quarter) at the call site.
+     * @return Recurring hours per forecast period (0 = tier off).
+     */
+    private static Decimal resolveRecurringHoursPerPeriod() {
+        return 0;
     }
 
     /**
@@ -716,7 +856,7 @@ global with sharing class DeliveryHoursAnalyticsController {
         Map<Id, Decimal> loggedByItem = loggedHoursByItem(portfolioIds);
         for (WorkItem__c wi : [
             SELECT Id, BriefDescriptionTxt__c, StageNamePk__c, DeveloperLookup__r.Name,
-                   EstimatedHoursNumber__c,
+                   EstimatedHoursNumber__c, PriorityGroupPk__c,
                    EstimatedStartDevDate__c, EstimatedEndDevDate__c
             FROM WorkItem__c
             WHERE Id IN :portfolioIds
@@ -750,6 +890,7 @@ global with sharing class DeliveryHoursAnalyticsController {
             sched.logged = logged;
             sched.startDate = wi.EstimatedStartDevDate__c;
             sched.endDate = wi.EstimatedEndDevDate__c;
+            sched.tier = tierForGroup(wi.PriorityGroupPk__c);
             portfolioItemSchedules.add(sched);
             Date s = wi.EstimatedStartDevDate__c;
             if (s != null && (dto.earliestStart == null || s < dto.earliestStart)) {

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
@@ -550,6 +550,11 @@ global with sharing class DeliveryHoursAnalyticsController {
             }
         }
         for (ForecastItemAccum acc : accs) {
+            // Drop drill-down rows that contribute 0h (or less) to this period — they're
+            // noise in the bucket's items[] list.
+            if (acc.hoursThisPeriod == null || acc.hoursThisPeriod <= 0) {
+                continue;
+            }
             ItemSchedule s = acc.sched;
             Decimal est = numOrZero(s.estimate);
             Decimal logged = numOrZero(s.logged);
@@ -718,11 +723,20 @@ global with sharing class DeliveryHoursAnalyticsController {
             WITH SYSTEM_MODE
             LIMIT 50000
         ]) {
+            // Terminal-stage items (Done/Cancelled/Closed/Rejected) are dead work: their
+            // already-LOGGED hours are real history (kept in totalLoggedHours + the actual
+            // series, both sourced from WorkLog independent of stage), but their REMAINING
+            // (estimate − logged) must NOT contribute to totalRemainingHours / forecast /
+            // projectedFinal / the schedule-based spread / the unscheduled bucket. We skip
+            // their remaining here and in spreadScheduleBasedForecast via the same stage
+            // flag (carried on ItemSchedule.stage).
+            Boolean isTerminal = String.isNotBlank(wi.StageNamePk__c)
+                && TERMINAL_STAGES.contains(wi.StageNamePk__c);
             Decimal estimate = (wi.EstimatedHoursNumber__c == null) ? 0 : wi.EstimatedHoursNumber__c;
             dto.totalEstimatedHours += estimate;
             Decimal logged = loggedByItem.containsKey(wi.Id) ? loggedByItem.get(wi.Id) : 0;
             Decimal itemRemaining = estimate - logged;
-            if (itemRemaining > 0) {
+            if (!isTerminal && itemRemaining > 0) {
                 totalRemainingHours += itemRemaining;
             }
             // Capture per-item schedule + work + meta for the schedule-based forecast
@@ -1039,6 +1053,11 @@ global with sharing class DeliveryHoursAnalyticsController {
         Date today = Date.today();
         Decimal unscheduled = 0;
         for (ItemSchedule sched : portfolioItemSchedules) {
+            // Terminal-stage items contribute 0 remaining — never spread onto a forecast
+            // bar and never pushed into the unscheduled bucket (dead work isn't forecast).
+            if (String.isNotBlank(sched.stage) && TERMINAL_STAGES.contains(sched.stage)) {
+                continue;
+            }
             Decimal itemRemaining = sched.estimate - sched.logged;
             if (itemRemaining == null || itemRemaining <= 0) {
                 continue;

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
@@ -899,6 +899,143 @@ private class DeliveryHoursAnalyticsControllerTest {
     }
 
     // ────────────────────────────────────────────────────────────────────
+    // getPacing — cohort/commitment-tier split (the stacked hockey-stick).
+    // PriorityGroupPk__c → segment id: active/top-priority→greenlit,
+    // follow-on→predicted, proposed/deferred→ready. Per-bucket `segments`
+    // sum to forecast; items carry `tier`; top-level segments[] advertises
+    // only tiers that carry hours.
+    // ────────────────────────────────────────────────────────────────────
+
+    /** @description Active future-dated root WorkItem with an explicit priority lane. */
+    private static WorkItem__c insertTieredWi(String briefDesc, Decimal estimate, Date startDate, Date endDate, String priorityGroup) {
+        return TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => briefDesc,
+            'EstimatedHoursNumber__c' => estimate,
+            'EstimatedStartDevDate__c' => startDate,
+            'EstimatedEndDevDate__c' => endDate,
+            'PriorityGroupPk__c' => priorityGroup,
+            'ActivatedDateTime__c' => System.now()
+        });
+    }
+
+    /** @description Pulls the top-level segments[] defs out of a getPacing payload. */
+    private static List<Object> segmentDefsOf(String pacingJson) {
+        Map<String, Object> data = (Map<String, Object>) JSON.deserializeUntyped(pacingJson);
+        return (List<Object>) data.get('segments');
+    }
+
+    @IsTest
+    static void testCohortSplitTiersBucketsAndItems() {
+        // Three active roots over the SAME future window → their forecast buckets carry
+        // all three commitment tiers, mapped from PriorityGroupPk__c.
+        Date nextMonthStart = Date.today().toStartOfMonth().addMonths(1);
+        Date spanEnd = nextMonthStart.addMonths(3).addDays(-1);
+        insertTieredWi('CommittedWI', 90, nextMonthStart, spanEnd, 'active');     // → greenlit
+        insertTieredWi('PredictedWI', 60, nextMonthStart, spanEnd, 'follow-on');  // → predicted
+        insertTieredWi('ProposedWI',  30, nextMonthStart, spanEnd, 'proposed');   // → ready
+
+        Test.startTest();
+        String pacingJson = DeliveryHoursAnalyticsController.getPacing('Month', 6, 4);
+        Test.stopTest();
+
+        // Top-level segment defs: greenlit/predicted/ready present, in stack order, no recurring.
+        List<Object> defs = segmentDefsOf(pacingJson);
+        System.assertNotEquals(null, defs, 'segments[] defs are emitted when tiers carry hours');
+        List<String> ids = new List<String>();
+        for (Object o : defs) {
+            ids.add((String) ((Map<String, Object>) o).get('id'));
+        }
+        System.assertEquals(new List<String>{ 'greenlit', 'predicted', 'ready' }, ids,
+            'segment defs are the three non-empty tiers in stack order (no recurring — seam off)');
+        Map<String, Object> firstDef = (Map<String, Object>) defs[0];
+        System.assertEquals('Committed', firstDef.get('label'), 'greenlit labelled Committed');
+        System.assertEquals('#059669', firstDef.get('color'), 'greenlit color matches NG default');
+
+        // A forecast bucket overlapping the span: segments map sums to the bucket forecast,
+        // and every drill-down item carries the tier its lane maps to.
+        Boolean checkedABucket = false;
+        for (Object o : bucketsOf(pacingJson)) {
+            Map<String, Object> b = (Map<String, Object>) o;
+            Decimal forecast = (Decimal) b.get('forecast');
+            if (forecast == null || forecast <= 0) {
+                continue;
+            }
+            Map<String, Object> segs = (Map<String, Object>) b.get('segments');
+            System.assertNotEquals(null, segs, 'a forecast bucket carries a segments map');
+            Decimal segSum = 0;
+            for (Object v : segs.values()) {
+                segSum += (Decimal) v;
+            }
+            System.assert(Math.abs(segSum - forecast) <= 0.2,
+                'Σ per-tier segment hours (' + segSum + ') ≈ bucket forecast (' + forecast + ')');
+            System.assert(segs.containsKey('greenlit') && segs.containsKey('predicted')
+                && segs.containsKey('ready'), 'all three tiers contribute to the overlapping bucket');
+
+            for (Object io : (List<Object>) b.get('items')) {
+                Map<String, Object> item = (Map<String, Object>) io;
+                String name = (String) item.get('name');
+                String tier = (String) item.get('tier');
+                if (name == 'CommittedWI') {
+                    System.assertEquals('greenlit', tier, 'active lane → greenlit');
+                } else if (name == 'PredictedWI') {
+                    System.assertEquals('predicted', tier, 'follow-on lane → predicted');
+                } else if (name == 'ProposedWI') {
+                    System.assertEquals('ready', tier, 'proposed lane → ready');
+                }
+            }
+            checkedABucket = true;
+        }
+        System.assert(checkedABucket, 'at least one forecast bucket was asserted');
+    }
+
+    @IsTest
+    static void testBlankLaneFallsBackToGreenlitNoVanish() {
+        // A future-dated item with NO priority lane must still land in a tier (greenlit),
+        // so its forecast hours never vanish from the stack (Σ segments == forecast).
+        Date nextMonthStart = Date.today().toStartOfMonth().addMonths(1);
+        Date spanEnd = nextMonthStart.addMonths(2).addDays(-1);
+        insertTieredWi('NoLaneWI', 50, nextMonthStart, spanEnd, null);
+
+        Test.startTest();
+        String pacingJson = DeliveryHoursAnalyticsController.getPacing('Month', 6, 4);
+        Test.stopTest();
+
+        List<String> ids = new List<String>();
+        for (Object o : segmentDefsOf(pacingJson)) {
+            ids.add((String) ((Map<String, Object>) o).get('id'));
+        }
+        System.assertEquals(new List<String>{ 'greenlit' }, ids,
+            'blank lane folds into the single greenlit tier (no-vanish fallback)');
+        for (Object o : bucketsOf(pacingJson)) {
+            Map<String, Object> b = (Map<String, Object>) o;
+            Decimal forecast = (Decimal) b.get('forecast');
+            if (forecast != null && forecast > 0) {
+                Map<String, Object> segs = (Map<String, Object>) b.get('segments');
+                System.assertEquals(forecast, (Decimal) segs.get('greenlit'),
+                    'all forecast hours land in greenlit when no lane is set');
+            }
+        }
+    }
+
+    @IsTest
+    static void testHistoryBucketsCarryNoSegments() {
+        // History (non-forecast) buckets must not emit a segments map — actuals aren't tiered.
+        insertTieredWi('HistWI', 40, Date.today().addMonths(-1), Date.today().addMonths(2), 'active');
+
+        Test.startTest();
+        String pacingJson = DeliveryHoursAnalyticsController.getPacing('Month', 6, 4);
+        Test.stopTest();
+
+        for (Object o : bucketsOf(pacingJson)) {
+            Map<String, Object> b = (Map<String, Object>) o;
+            if (((Boolean) b.get('isPast')) == true) {
+                System.assertEquals(null, b.get('segments'),
+                    'history/past buckets carry no segments map');
+            }
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
     // Terminal-stage descendants — dead work must NOT contribute remaining /
     // forecast / projectedFinal, but its already-logged actuals stay counted.
     // ────────────────────────────────────────────────────────────────────

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
@@ -898,6 +898,127 @@ private class DeliveryHoursAnalyticsControllerTest {
             'Σ item hoursThisPeriod ≈ placed remaining (60h), got ' + totalItemHours);
     }
 
+    // ────────────────────────────────────────────────────────────────────
+    // Terminal-stage descendants — dead work must NOT contribute remaining /
+    // forecast / projectedFinal, but its already-logged actuals stay counted.
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Flips a WorkItem's stage via a trigger-bypassed update so the test
+     *              isolates the analytics from auto-WR / sync side effects (mirrors the
+     *              pattern in testPortfolioExcludesTerminalAndArchivedRoots).
+     */
+    private static void setStage(WorkItem__c wi, String stage) {
+        Boolean prev = DeliveryWorkItemTriggerHandler.triggerDisabled;
+        DeliveryWorkItemTriggerHandler.triggerDisabled = true;
+        try {
+            wi.StageNamePk__c = stage;
+            update wi;
+        } finally {
+            DeliveryWorkItemTriggerHandler.triggerDisabled = prev;
+        }
+    }
+
+    @IsTest
+    static void testTerminalDescendantContributesNoRemainingOrForecast() {
+        // Active root (Backlog) with a future-dated active child AND a Cancelled child
+        // that has POSITIVE remaining (estimate 50 > logged 10). The Cancelled child's
+        // 50h estimate / 40h remaining is dead work — it must NOT inflate
+        // totalRemainingHours, projectedFinalHours, the forecast bars, or unscheduled —
+        // but its 10h LOGGED is real history and must stay in totalLoggedHours + the
+        // actual series.
+        Date nextMonthStart = Date.today().toStartOfMonth().addMonths(1);
+        Date spanEnd = nextMonthStart.addMonths(2).addDays(-1);
+        WorkItem__c root = insertWi('TermRoot', 100, nextMonthStart, spanEnd, null);
+        WorkItem__c activeChild = insertWi('TermActiveChild', 60, nextMonthStart, spanEnd, root.Id);
+        // Cancelled child: scheduled in the future with positive remaining, so absent the
+        // fix it WOULD spread 40h onto the forecast bars.
+        WorkItem__c cancelledChild = insertWi('TermCancelledChild', 50, nextMonthStart, spanEnd, root.Id);
+
+        insert new List<WorkLog__c>{
+            buildLog(activeChild.Id, 10, Date.today()),
+            buildLog(cancelledChild.Id, 10, Date.today())
+        };
+        setStage(cancelledChild, 'Cancelled');
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
+            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 4);
+        Test.stopTest();
+
+        // LOGGED actuals: both children's 10h logged stays counted (20h total) — the
+        // Cancelled child's history is NOT dropped.
+        System.assertEquals(20, dto.totalLoggedHours,
+            'Terminal child logged actuals stay counted: 10 (active) + 10 (cancelled) = 20');
+        System.assertEquals(20, totalLogged(dto),
+            'Both children appear in the actual series (period logged sum)');
+
+        // REMAINING / forecast / projected: only the ACTIVE child contributes remaining.
+        // Active child remaining = 60 - 10 = 50; Cancelled child remaining (40) excluded.
+        // Projected = logged(20) + remaining(50) = 70.
+        System.assertEquals(70, dto.projectedFinalHours,
+            'Projected = logged(20) + active-child remaining(50); cancelled remaining excluded');
+
+        // Forecast bars: spread the 50h ACTIVE remaining only (not 90 = 50+40).
+        Decimal placed = totalForecast(dto);
+        System.assert(placed >= 49.8 && placed <= 50.2,
+            'Forecast bars spread ONLY the active child remaining (~50h), not the ' +
+            'cancelled child (would be ~90h with the bug), got ' + placed);
+        System.assertEquals(0, dto.unscheduledRemainingHours,
+            'Both children are future-dated; cancelled remaining is excluded, not unscheduled');
+    }
+
+    @IsTest
+    static void testTerminalRootSiblingExcludedFromForecastButLoggedKept() {
+        // Belt-and-suspenders at the per-item-stage level: a terminal-stage item that
+        // somehow enters the portfolio id set (here as a Done CHILD under an active root)
+        // still has its logged kept and its remaining zeroed.
+        WorkItem__c root = insertWi('DoneChildRoot', 0, null, null, null);
+        WorkItem__c doneChild = insertWi('DoneChild', 80,
+            Date.today().toStartOfMonth().addMonths(1),
+            Date.today().toStartOfMonth().addMonths(3).addDays(-1), root.Id);
+        insert buildLog(doneChild.Id, 15, Date.today());
+        setStage(doneChild, 'Done');
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
+            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 4);
+        Test.stopTest();
+
+        System.assertEquals(15, dto.totalLoggedHours, 'Done child 15h logged stays counted');
+        System.assertEquals(0, totalForecast(dto),
+            'Done child contributes no forecast bars (dead remaining)');
+        System.assertEquals(0, dto.unscheduledRemainingHours,
+            'Done child remaining is excluded, not pushed to unscheduled');
+        // Projected = logged(15) + remaining(0) = 15. Root has 0 estimate.
+        System.assertEquals(15, dto.projectedFinalHours,
+            'Projected = logged only; no remaining from the Done child');
+    }
+
+    @IsTest
+    static void testNoDrillDownItemHasZeroOrNegativeHours() {
+        // Every items[] drill-down row across every bucket must carry hours > 0 — no
+        // 0h noise rows (the second fix).
+        Date nextMonthStart = Date.today().toStartOfMonth().addMonths(1);
+        Date spanEnd = nextMonthStart.addMonths(3).addDays(-1);
+        insertWi('DrillNonZero', 90, nextMonthStart, spanEnd, null);
+
+        Test.startTest();
+        String pacingJson = DeliveryHoursAnalyticsController.getPacing('Month', 6, 4);
+        Test.stopTest();
+
+        Integer rowsSeen = 0;
+        for (Object o : bucketsOf(pacingJson)) {
+            for (Object io : (List<Object>) ((Map<String, Object>) o).get('items')) {
+                Decimal hrs = (Decimal) ((Map<String, Object>) io).get('hours');
+                System.assert(hrs != null && hrs > 0,
+                    'No drill-down item may have this-period hours <= 0, got ' + hrs);
+                rowsSeen++;
+            }
+        }
+        System.assert(rowsSeen > 0, 'Sanity: the scheduled item produced at least one drill row');
+    }
+
     @IsTest
     static void testUnscheduledItemNeverAppearsInAnyBucketItems() {
         // A no-date item with remaining work is unscheduled — it must NOT show up in


### PR DESCRIPTION
## What

Splits the schedule-based portfolio forecast into **commitment tiers** so the NG Pacing view renders the stacked **"hockey-stick"** (Committed / Predicted / Ready) instead of one flat forecast bar. DH is the forecast brain — this feeds the NG **0.200.0+** contract the shipped renderer already consumes:

- `PacingData.segments[]` — tier defs (id/label/color/style/order)
- `PacingBucket.segments{segId→hours}` — per-period per-tier hours
- `PacingBucketItem.tier` — each drill-down row's cohort

## How

- **Classification** — each in-scope `WorkItem__c` is tagged by `PriorityGroupPk__c` via `PRIORITY_GROUP_TO_TIER`, mirroring NG's `PACING_LANE_TO_SEGMENT` **1:1** (active/top-priority→greenlit, follow-on→predicted, proposed/deferred→ready). DH's lane values **are** NG's keys, so the authoritative split reconciles with NG's task-derived preview split — no drift.
- **No-vanish invariant** — blank/unknown lanes fall back to `greenlit`, so every forecasted item lands in a tier. Per-bucket segments therefore **sum to the bucket forecast**, and since NG draws the bar as `actual + Σ segments` (ignoring `forecast` once segments are present), the stack height equals the un-split bar — **no regression**.
- **Emission** — `buildBucketSegments()` sums each forecast period's hours by tier; `buildBucketItems()` adds `tier` to each row; `toPacingData()` emits top-level `segments[]` for only the tiers that carry hours (colors/style match NG defaults + the MF prototype: committed green / predicted blue / ready amber-dotted).
- **Recurring seam** — the synthetic steady-state `recurring` tier is wired but **inert** (`resolveRecurringHoursPerPeriod()` returns 0). MF's history-derived run-rate drops in here without a signature change; prod behavior is unchanged until it's set.

## Tests

`DeliveryHoursAnalyticsControllerTest`:
- Tier mapping (active→greenlit, follow-on→predicted, proposed→ready) on items + top-level defs in stack order.
- Per-bucket `segments` sum ≈ bucket `forecast`.
- Blank-lane no-vanish fallback → all hours in `greenlit`.
- History/past buckets carry no `segments` map.

## Release / batching

⚠️ **Stacks on #882** — this branch was cut from `fix/forecast-terminal-stage-descendants`, so it **carries #882's terminal-stage commit** (`69005566`). Merging this to main lands both; #882 becomes redundant and can be closed. Intended as the **0.268** batch (terminal-stage + cohort-split). A parent/child double-count fix in `rollupPortfolioTotals` is a known follow-up that can join the same release.

## Verification owed (headless-unverifiable)

NG bundle is already at 0.201.0 (renderer shipped). After install, **eyeball** that the Pacing forecast renders as a stacked 3-tier hockey-stick with the per-tier legend toggles + tier-grouped drill-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
