### PR TITLE
fix(forecast,cart): unblock 0.268 upload-beta (#882 test-data) + Cart cacheable wire

### DIFF
--- a/force-app/main/default/classes/DeliveryCartService.cls
+++ b/force-app/main/default/classes/DeliveryCartService.cls
@@ -100,7 +100,7 @@ global with sharing class DeliveryCartService {
      *              header and the resolved CartExperienceProfile.
      * @return CartDTO render-ready payload.
      */
-    @AuraEnabled
+    @AuraEnabled(cacheable=true)
     global static CartDTO getCart() {
         try {
             CartExperienceProfile profile = CartExperienceProfile.resolve();

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
@@ -1066,7 +1066,12 @@ private class DeliveryHoursAnalyticsControllerTest {
         // actual series.
         Date nextMonthStart = Date.today().toStartOfMonth().addMonths(1);
         Date spanEnd = nextMonthStart.addMonths(2).addDays(-1);
-        WorkItem__c root = insertWi('TermRoot', 100, nextMonthStart, spanEnd, null);
+        // 0-estimate container root (its work lives in the children) — mirrors the
+        // sibling testTerminalRootSiblingExcludedFromForecastButLoggedKept pattern. A
+        // non-zero root estimate would contribute its own remaining and is orthogonal to
+        // what this test isolates (terminal-stage exclusion); the projected math below
+        // assumes the root adds nothing.
+        WorkItem__c root = insertWi('TermRoot', 0, nextMonthStart, spanEnd, null);
         WorkItem__c activeChild = insertWi('TermActiveChild', 60, nextMonthStart, spanEnd, root.Id);
         // Cancelled child: scheduled in the future with positive remaining, so absent the
         // fix it WOULD spread 40h onto the forecast bars.


### PR DESCRIPTION
## Why
0.268's `upload-beta` **failed** on an Apex test from the batched #882, blocking the forecast release. This unblocks it + folds in the live Cart-page fix.

## 1. Unblock — #882 test-data typo
`testTerminalDescendantContributesNoRemainingOrForecast` set the **container root's own estimate to 100**, but its expected math (`projected = logged 20 + active-child remaining 50 = 70`) assumes the root adds nothing. Code correctly returns **170** (root 100 + active 50 + logged 20). The Cancelled child's 40h **is** excluded — so **terminal-stage exclusion works**; only the root estimate was wrong. The sibling `testTerminalRootSiblingExcludedFromForecastButLoggedKept` already uses a 0-estimate root on purpose. Fix: `TermRoot` estimate → **0**, isolating terminal-stage exclusion from the separate/deferred parent-rollup question. Slipped past #882's PR scratch run; `upload-beta` runs the full package suite and caught it.

## 2. Cart cacheable wire
`DeliveryCartService.getCart()` is `@wire`d by `deliveryCartCheckout` + `deliveryCartBuilder` but was `@AuraEnabled` **without** `cacheable=true` → the live Cart page threw *"Apex methods that are to be cached must be marked as @AuraEnabled(cacheable=true)"*. `getCart` is a pure read (profile resolve + SOQL, no DML), so `cacheable=true` is safe and is what the `@wire`+`refreshApex` pattern requires.

## Not included (deliberate)
- **Recurring tier wire** — `69h/mo` is **MF-specific**; hardcoding it would inject phantom recurring work into every subscriber org's forecast. Needs a per-org `DeliveryHubSettings__c` config field (default 0), shipping as a separate small PR.
- **Parent/child rollup double-count** — still the deferred, data-verified P3 question.

Re-cuts **0.268** on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)