### PR TITLE
feat(forecast): leaf-only counting (kill double-count) + recurring tier via setting (0.269)

### DIFF
--- a/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
@@ -533,7 +533,7 @@ global with sharing class DeliveryHoursAnalyticsController {
         // 0.268 — accumulate which commitment tiers actually carry hours so the top-level
         // segments[] defs only advertise non-empty tiers (mirrors NG's own legend filter).
         Set<String> tiersWithHours = new Set<String>();
-        Decimal recurring = resolveRecurringHoursPerPeriod();
+        Decimal recurring = resolveRecurringHoursPerPeriod(bucketSize);
         if (dto != null && dto.periods != null) {
             for (Integer idx = 0; idx < dto.periods.size(); idx++) {
                 PacingPeriodDTO p = dto.periods[idx];
@@ -722,13 +722,28 @@ global with sharing class DeliveryHoursAnalyticsController {
      *              intake tier — the ~N small inbounds that always land regardless of the
      *              dated backlog. Added uniformly to every forecast bucket as its own tier
      *              so the curve extends to the right beyond scheduled work.
-     *              SEAM: returns 0 today (tier absent, prod unchanged). Wire MF's
-     *              history-derived run-rate here once it lands — scaling it to the chosen
-     *              granularity (per-week vs per-month vs per-quarter) at the call site.
+     *              Sourced per-org from DeliveryHubSettings__c.RecurringHoursPerMonthNumber__c
+     *              (a MONTHLY rate), scaled here to the requested bucket. Default/blank/<=0 =
+     *              tier off (prod unchanged until an org sets it) — so MF can set ~69 without
+     *              injecting phantom recurring work into other subscriber orgs' forecasts.
+     * @param bucketSize 'week' | 'month' | 'quarter' — the period the hours are scaled to.
      * @return Recurring hours per forecast period (0 = tier off).
      */
-    private static Decimal resolveRecurringHoursPerPeriod() {
-        return 0;
+    private static Decimal resolveRecurringHoursPerPeriod(String bucketSize) {
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        Decimal perMonth = (settings == null || settings.RecurringHoursPerMonthNumber__c == null)
+            ? 0 : settings.RecurringHoursPerMonthNumber__c;
+        if (perMonth <= 0) {
+            return 0;
+        }
+        if (bucketSize == 'week') {
+            // 12 months / 52 weeks — average monthly rate spread per week.
+            return (perMonth * 12 / 52).setScale(2, System.RoundingMode.HALF_UP);
+        }
+        if (bucketSize == 'quarter') {
+            return (perMonth * MONTHS_PER_QUARTER).setScale(2, System.RoundingMode.HALF_UP);
+        }
+        return perMonth.setScale(2, System.RoundingMode.HALF_UP);
     }
 
     /**
@@ -854,15 +869,35 @@ global with sharing class DeliveryHoursAnalyticsController {
             return;
         }
         Map<Id, Decimal> loggedByItem = loggedHoursByItem(portfolioIds);
-        for (WorkItem__c wi : [
+        List<WorkItem__c> items = [
             SELECT Id, BriefDescriptionTxt__c, StageNamePk__c, DeveloperLookup__r.Name,
-                   EstimatedHoursNumber__c, PriorityGroupPk__c,
+                   EstimatedHoursNumber__c, PriorityGroupPk__c, ParentWorkItemLookup__c,
                    EstimatedStartDevDate__c, EstimatedEndDevDate__c
             FROM WorkItem__c
             WHERE Id IN :portfolioIds
             WITH SYSTEM_MODE
             LIMIT 50000
-        ]) {
+        ];
+        // 0.269 — LEAF-ONLY counting. A WorkItem that is the PARENT of another in-scope item
+        // is a CONTAINER whose EstimatedHoursNumber__c is a planning rollup of its children
+        // (verified on MF-Prod: RR-ENGINE-PARENT 200h == its children RR-ENG-1/2/3 = 80+70+50).
+        // Counting BOTH the parent and its children double-counts the same work, inflating
+        // estimate / remaining / forecast above the real total (the Pacing-2,640h-vs-board-
+        // 1,460h credibility gap). So estimate, remaining, and the schedule-based spread count
+        // LEAVES only (items with no in-scope child). Logged stays INCLUSIVE — a WorkLog is
+        // recorded against one specific item (never a parent↔child rollup), so it can't
+        // double-count, and dropping a parent's direct logs would lose real history.
+        Set<Id> parentIds = new Set<Id>();
+        for (WorkItem__c wi : items) {
+            if (wi.ParentWorkItemLookup__c != null) {
+                parentIds.add(wi.ParentWorkItemLookup__c);
+            }
+        }
+        for (WorkItem__c wi : items) {
+            // Skip container parents — their work is counted via their (leaf) children.
+            if (parentIds.contains(wi.Id)) {
+                continue;
+            }
             // Terminal-stage items (Done/Cancelled/Closed/Rejected) are dead work: their
             // already-LOGGED hours are real history (kept in totalLoggedHours + the actual
             // series, both sourced from WorkLog independent of stage), but their REMAINING

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
@@ -298,9 +298,13 @@ private class DeliveryHoursAnalyticsControllerTest {
         }
         System.assertEquals(3, forecastCount, 'Last 3 periods flagged as forecast');
 
-        // 5 + 3 + 7 = 15h logged across the window.
+        // 5 + 3 + 7 = 15h logged across the window (logged stays INCLUSIVE — real WorkLog
+        // history is never a parent↔child rollup, so it isn't leaf-filtered).
         System.assertEquals(15, totalLogged(dto), 'Portfolio logged hours summed across roots + descendants');
-        System.assertEquals(140, dto.totalEstimatedHours, 'Estimate summed across the portfolio tree');
+        // Leaf-only (0.269): rootA (80h) is a CONTAINER parent of childA, so its rollup
+        // estimate is excluded; only leaves count = childA(20) + rootB(40) = 60.
+        System.assertEquals(60, dto.totalEstimatedHours,
+            'Leaf-only: container parent rootA excluded; childA 20 + rootB 40 = 60');
     }
 
     @IsTest
@@ -1032,6 +1036,107 @@ private class DeliveryHoursAnalyticsControllerTest {
                 System.assertEquals(null, b.get('segments'),
                     'history/past buckets carry no segments map');
             }
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Leaf-only counting — a container parent's rollup estimate must NOT be
+    // double-counted with its children's estimates.
+    // ────────────────────────────────────────────────────────────────────
+
+    @IsTest
+    static void testLeafOnlyExcludesParentRollupEstimate() {
+        // Container parent (200h) whose three leaf children sum to the same 200h — the
+        // live MF-Prod RR-ENGINE-PARENT shape. Counting both = 400h double-count.
+        Date start = Date.today().toStartOfMonth().addMonths(1);
+        Date spanEnd = start.addMonths(2).addDays(-1);
+        WorkItem__c parent = insertWi('RollupParent', 200, start, spanEnd, null);
+        insertWi('Leaf1', 80, start, spanEnd, parent.Id);
+        insertWi('Leaf2', 70, start, spanEnd, parent.Id);
+        insertWi('Leaf3', 50, start, spanEnd, parent.Id);
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
+            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 4);
+        Test.stopTest();
+
+        System.assertEquals(200, dto.totalEstimatedHours,
+            'Leaf-only: 3 children (80+70+50) count; parent rollup excluded — not 400');
+        System.assertEquals(200, dto.projectedFinalHours,
+            'Projected = 0 logged + 200 leaf remaining; parent 200 not double-counted');
+        Decimal placed = totalForecast(dto);
+        System.assert(placed >= 199.5 && placed <= 200.5,
+            'Forecast bars spread the 200h of leaf work once, got ' + placed);
+    }
+
+    @IsTest
+    static void testParentWithNoChildrenStillCounts() {
+        // A childless root is itself a leaf — its estimate must still count (the fix only
+        // strips parents that HAVE in-scope children).
+        Date start = Date.today().toStartOfMonth().addMonths(1);
+        insertWi('SoloLeaf', 90, start, start.addMonths(2).addDays(-1), null);
+
+        Test.startTest();
+        DeliveryHoursAnalyticsController.PortfolioPacingDTO dto =
+            DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 4);
+        Test.stopTest();
+
+        System.assertEquals(90, dto.totalEstimatedHours,
+            'A childless item is a leaf — its estimate is counted, not dropped');
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Recurring tier — synthetic steady-state intake from the per-org setting.
+    // ────────────────────────────────────────────────────────────────────
+
+    @IsTest
+    static void testRecurringTierFromSettingScaledByBucket() {
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        settings.RecurringHoursPerMonthNumber__c = 69;
+        upsert settings;
+        Date start = Date.today().toStartOfMonth().addMonths(1);
+        insertTieredWi('RecBase', 40, start, start.addMonths(2).addDays(-1), 'active');
+
+        Test.startTest();
+        String monthJson = DeliveryHoursAnalyticsController.getPacing('Month', 6, 4);
+        Test.stopTest();
+
+        Boolean sawRecurringDef = false;
+        for (Object o : segmentDefsOf(monthJson)) {
+            if ('recurring' == (String) ((Map<String, Object>) o).get('id')) {
+                sawRecurringDef = true;
+            }
+        }
+        System.assert(sawRecurringDef, 'recurring tier advertised when the setting is > 0');
+        Boolean sawRecurringBucket = false;
+        for (Object o : bucketsOf(monthJson)) {
+            Map<String, Object> b = (Map<String, Object>) o;
+            if (((Boolean) b.get('isPast')) == true) {
+                continue;
+            }
+            Map<String, Object> segs = (Map<String, Object>) b.get('segments');
+            if (segs != null && segs.containsKey('recurring')) {
+                System.assertEquals(69, (Decimal) segs.get('recurring'),
+                    'Month bucket recurring = the monthly rate (69)');
+                sawRecurringBucket = true;
+            }
+        }
+        System.assert(sawRecurringBucket, 'at least one forecast bucket carries the recurring tier');
+    }
+
+    @IsTest
+    static void testRecurringTierAbsentWhenSettingZero() {
+        // Default (no setting) → recurring tier off, prod behavior unchanged.
+        Date start = Date.today().toStartOfMonth().addMonths(1);
+        insertTieredWi('NoRec', 40, start, start.addMonths(2).addDays(-1), 'active');
+
+        Test.startTest();
+        String json = DeliveryHoursAnalyticsController.getPacing('Month', 6, 4);
+        Test.stopTest();
+
+        for (Object o : segmentDefsOf(json)) {
+            System.assertNotEquals('recurring', (String) ((Map<String, Object>) o).get('id'),
+                'recurring tier absent when the setting is unset/0');
         }
     }
 

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/RecurringHoursPerMonthNumber__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/RecurringHoursPerMonthNumber__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RecurringHoursPerMonthNumber__c</fullName>
+    <description>Synthetic steady-state intake hours per MONTH for the forecast's "Recurring" commitment tier — the ongoing small inbounds that always land regardless of the dated backlog. Per-org: 0 (default) hides the tier; set it to your historical monthly intake rate to extend the forecast curve to the right. Scaled to the chosen bucket (week/month/quarter) at render time.</description>
+    <externalId>false</externalId>
+    <label>Recurring Hours / Month</label>
+    <precision>9</precision>
+    <required>false</required>
+    <scale>2</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## Why
Two forecast-correctness fixes from the MF-Prod live QA — the credibility blocker + the recurring tier, done tenant-safe.

## 1. Leaf-only counting — kills the parent/child double-count
A WorkItem that is the **parent** of another in-scope item is a **container** whose `EstimatedHoursNumber__c` is a planning rollup of its children — **verified live**: `RR-ENGINE-PARENT 200h` == its children `RR-ENG-1/2/3` = 80+70+50. Counting both double-counts the same work (the Pacing **2,640h** vs board **1,460h** gap).

`rollupPortfolioTotals` now counts **estimate, remaining, and the schedule spread for leaves only** (items with no in-scope child). **Logged stays inclusive** — a `WorkLog` is recorded against one specific item (never a parent↔child rollup), so it can't double-count, and dropping a parent's direct logs would lose real history. Per-bucket `segments` still sum to `forecast` (the spread is leaf-only too).
- Updated `testPortfolioPacingBuildsBackAndForwardPeriods`: container parent `rootA` excluded → 60h (childA 20 + rootB 40), not 140h.

## 2. Recurring tier — synthetic intake, **tenant-safe**
New `DeliveryHubSettings__c.RecurringHoursPerMonthNumber__c` (Number, **default 0**). `resolveRecurringHoursPerPeriod` reads it per-org and scales to the bucket (week = x·12/52, month = x, quarter = x·3), feeding the `recurring` segment wired inert in 0.268. **Default 0 = tier off everywhere** (prod unchanged) — MF sets ~69 **without** injecting phantom recurring work into other subscriber orgs' forecasts.

## Tests
Leaf-only excludes a container parent's rollup (200h parent + 3 children ≠ 400h); a childless item still counts; recurring tier appears scaled when set and is absent at 0. Regression-audited every existing getPortfolioPacing assertion for tree setups (only the one above needed updating).

## Net effect on the live forecast (after install)
Pacing estimate collapses toward the 1,460h board envelope; Stats↔Pacing reconcile; the stacked hockey-stick stays correct (segments sum to forecast). MF setting `RecurringHoursPerMonth = 69` lights up the 4th band.

Ships as **0.269**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)