### PR TITLE
chore: gitignore local .mfdata/ MF data export cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,10 @@ mf-active-workitems.csv
 MORNING_*.md
 mfp-dump/
 
+# Local MF data export/build cache (SQLite db + CSV extracts + build script;
+# contains real org record data — must never be committed)
+.mfdata/
+
 # Dated planning / session docs (belong in private notes, not the public repo)
 docs/*_2026-*.md
 docs/*_2027-*.md


### PR DESCRIPTION
## What

Adds `.mfdata/` to `.gitignore`.

## Why

`.mfdata/` is a **local-only** data export / build cache that surfaces as untracked at the repo root. It contains:
- `mf.db` — SQLite database
- `wr.csv` / `wi.csv` / `wl.csv` / `ne.csv` — CSV extracts of **real MF-Prod** WorkRequest / WorkItem / WorkLog / numbered-entity records (with live org record IDs)
- `mf_mapping.yml`, `build_dataset.py`, `load.log`, `verify.log`

Per CLAUDE.md, **MF-Prod data dumps must never be committed**. This slots into the existing "MF-Prod data dumps (must never be committed)" block in `.gitignore`.

## Scope / safety

- One-line-block `.gitignore` addition only.
- **No tracked files removed** — `.mfdata/` was never tracked, so there's nothing to `git rm`.
- Verified the pattern correctly ignores `.mfdata/` contents.
- Did **not** touch `force-app/`, `.github/`, `docs/`, `.claude/`, stashes, or worktrees.

### Noted but intentionally left alone
Several untracked stray docs exist under `docs/` (e.g. `docs/feature-status-0264-for-bots.md`, `docs/handoffs/*`, `docs/plans/*`). These are **out of scope** (constraint: do not touch `docs/`) and may be intentional documentation, so they were left for human review. The existing `docs/*_2026-*.md` ignore rule does not match them because they use hyphenated (`-2026-` / `-0606`) rather than underscore (`_2026-`) date patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)