### PR TITLE
PR2: approval queue LWC — Jose's pending-approval queue on DH Home

### DIFF
--- a/force-app/main/default/flexipages/DeliveryHubAdminHome.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryHubAdminHome.flexipage-meta.xml
@@ -25,6 +25,12 @@
         </itemInstances>
         <itemInstances>
             <componentInstance>
+                <componentName>deliveryApprovalQueue</componentName>
+                <identifier>c_deliveryApprovalQueue</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
                 <componentName>deliveryCartCheckout</componentName>
                 <identifier>c_deliveryCartCheckout</identifier>
             </componentInstance>

--- a/force-app/main/default/flexipages/DeliveryHubHome.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryHubHome.flexipage-meta.xml
@@ -41,6 +41,12 @@
         </itemInstances>
         <itemInstances>
             <componentInstance>
+                <componentName>deliveryApprovalQueue</componentName>
+                <identifier>c_deliveryApprovalQueue</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
                 <componentName>deliveryFeatureCockpit</componentName>
                 <identifier>c_deliveryFeatureCockpit_home</identifier>
             </componentInstance>

--- a/force-app/main/default/lwc/deliveryApprovalQueue/__tests__/deliveryApprovalQueue.test.js
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/__tests__/deliveryApprovalQueue.test.js
@@ -1,0 +1,161 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryApprovalQueue: wire-driven rows
+ *               (label fallback, increase badge, headline totals), the
+ *               imperative approve flow (apex call + success toast + wire
+ *               refresh), the inline decline flow, and the caught-up empty
+ *               state.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from "lwc";
+import DeliveryApprovalQueue from "c/deliveryApprovalQueue";
+import getPendingForApprover from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.getPendingForApprover";
+import approve from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.approve";
+import decline from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.decline";
+
+const REQUEST_ONE = "a0G000000000001AAA";
+const REQUEST_TWO = "a0G000000000002AAA";
+
+function samplePending() {
+    return [
+        {
+            requestId: REQUEST_ONE,
+            workItemId: "a42000000000001AAA",
+            workItemName: "T-1001",
+            workItemLabel: "Build the approval queue",
+            quotedHours: 12,
+            requestedIncrease: null,
+            requestStatus: "Offer Sent",
+            submittedAt: new Date().toISOString(),
+            approverUserId: "005000000000001AAA"
+        },
+        {
+            requestId: REQUEST_TWO,
+            workItemId: "a42000000000002AAA",
+            workItemName: "T-1002",
+            workItemLabel: null,
+            quotedHours: 4,
+            requestedIncrease: 4,
+            requestStatus: "Offer Sent",
+            submittedAt: new Date(Date.now() - 3 * 86400000).toISOString(),
+            approverUserId: null
+        }
+    ];
+}
+
+function createComponent() {
+    const element = createElement("c-delivery-approval-queue", {
+        is: DeliveryApprovalQueue
+    });
+    document.body.appendChild(element);
+    return element;
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function findButtonByLabel(element, label) {
+    return Array.from(element.shadowRoot.querySelectorAll("lightning-button")).find(
+        (b) => b.label === label
+    );
+}
+
+describe("c-delivery-approval-queue", () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it("renders rows from the wire with label fallback and increase badge", async () => {
+        const element = createComponent();
+        getPendingForApprover.emit(samplePending());
+        await flushPromises();
+
+        const rows = element.shadowRoot.querySelectorAll(".queue-row");
+        expect(rows.length).toBe(2);
+
+        const text = element.shadowRoot.textContent;
+        expect(text).toContain("Build the approval queue"); // workItemLabel
+        expect(text).toContain("T-1002"); // workItemName fallback when label null
+
+        const badges = element.shadowRoot.querySelectorAll(".queue-increase-badge");
+        expect(badges.length).toBe(1);
+        expect(badges[0].textContent).toContain("increase +4");
+
+        // Headline: 2 pending, 16h quoted total.
+        expect(text).toContain("16.0h");
+    });
+
+    it("approve button calls apex with the request id and refreshes via a success toast", async () => {
+        approve.mockResolvedValue(undefined);
+        const element = createComponent();
+
+        const toastHandler = jest.fn();
+        element.addEventListener("lightning__showtoast", toastHandler);
+
+        getPendingForApprover.emit(samplePending());
+        await flushPromises();
+
+        const approveButton = findButtonByLabel(element, "Approve");
+        approveButton.dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+        await flushPromises();
+
+        expect(approve).toHaveBeenCalledWith({
+            workRequestId: REQUEST_ONE,
+            approvedHours: null,
+            note: null
+        });
+        expect(toastHandler).toHaveBeenCalled();
+        const toastDetail = toastHandler.mock.calls[0][0].detail;
+        expect(toastDetail.variant).toBe("success");
+    });
+
+    it("decline requires a reason then calls apex", async () => {
+        decline.mockResolvedValue(undefined);
+        const element = createComponent();
+        getPendingForApprover.emit(samplePending());
+        await flushPromises();
+
+        findButtonByLabel(element, "Decline").dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+
+        const reasonInput = Array.from(
+            element.shadowRoot.querySelectorAll("lightning-input")
+        ).find((i) => i.label === "Decline reason");
+        expect(reasonInput).toBeTruthy();
+        reasonInput.value = "Budget exhausted for this quarter";
+        reasonInput.dispatchEvent(new CustomEvent("change"));
+        await flushPromises();
+
+        findButtonByLabel(element, "Confirm decline").dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+        await flushPromises();
+
+        expect(decline).toHaveBeenCalledWith({
+            workRequestId: REQUEST_ONE,
+            reason: "Budget exhausted for this quarter"
+        });
+    });
+
+    it("shows the caught-up empty state when nothing is pending", async () => {
+        const element = createComponent();
+        getPendingForApprover.emit([]);
+        await flushPromises();
+
+        expect(element.shadowRoot.textContent).toContain("Nothing pending");
+        expect(element.shadowRoot.querySelector(".queue-row")).toBeNull();
+    });
+
+    it("shows an error when the wire errors", async () => {
+        const element = createComponent();
+        getPendingForApprover.error();
+        await flushPromises();
+
+        expect(element.shadowRoot.querySelector(".queue-error")).not.toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.css
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.css
@@ -1,0 +1,223 @@
+:host {
+    display: block;
+}
+
+.queue-card {
+    background: #ffffff;
+    border-radius: 0.75rem;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    font-size: 0.8125rem;
+}
+
+.queue-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.125rem 1.5rem;
+    border-bottom: 1px solid #e5e7eb;
+    background: linear-gradient(135deg, #eff6ff 0%, #f5f3ff 100%);
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.queue-header-left {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.queue-header-icon {
+    color: #7c3aed;
+}
+
+.queue-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0 0 0.15rem 0;
+}
+
+.queue-subtitle {
+    font-size: 0.75rem;
+    color: #6b7280;
+    margin: 0;
+}
+
+.queue-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.queue-loading {
+    padding: 2rem;
+    display: flex;
+    justify-content: center;
+}
+
+.queue-error {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 1rem 1.5rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    background: #fef2f2;
+    border: 1px solid #fca5a5;
+    color: #991b1b;
+}
+
+.queue-summary-row {
+    display: flex;
+    gap: 1rem;
+    padding: 0.75rem 1.5rem;
+    flex-wrap: wrap;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.summary-tile {
+    flex: 0 1 9rem;
+    min-width: 6.5rem;
+}
+
+.summary-label {
+    font-size: 0.6875rem;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.15rem;
+}
+
+.summary-value {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #111827;
+}
+
+.queue-list {
+    list-style: none;
+    margin: 0;
+    padding: 0.25rem 0;
+}
+
+.queue-row {
+    padding: 0.875rem 1.5rem;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.queue-row:last-child {
+    border-bottom: none;
+}
+
+.queue-row-main {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.queue-row-info {
+    min-width: 14rem;
+    flex: 1 1 14rem;
+}
+
+.queue-item-link {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #4338ca;
+    text-align: left;
+}
+
+.queue-item-link:hover {
+    text-decoration: underline;
+    color: #312e81;
+}
+
+.queue-row-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: 0.25rem;
+    flex-wrap: wrap;
+}
+
+.queue-hours {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #374151;
+}
+
+.queue-increase-badge {
+    display: inline-block;
+    padding: 0.1rem 0.5rem;
+    border-radius: 9999px;
+    background: #fef3c7;
+    border: 1px solid #f59e0b;
+    color: #92400e;
+    font-size: 0.6875rem;
+    font-weight: 600;
+}
+
+.queue-age {
+    font-size: 0.6875rem;
+    color: #9ca3af;
+}
+
+.queue-row-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+}
+
+.queue-inline {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    flex-wrap: wrap;
+}
+
+.queue-inline-input {
+    min-width: 8rem;
+}
+
+.queue-inline-input--wide {
+    flex: 1 1 14rem;
+}
+
+.queue-inline-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.queue-empty {
+    padding: 3rem 2rem;
+    text-align: center;
+    color: #6b7280;
+}
+
+.queue-empty-icon {
+    color: #a7f3d0;
+    margin-bottom: 0.75rem;
+}
+
+.queue-empty-sub {
+    font-size: 0.75rem;
+    color: #9ca3af;
+    margin-top: 0.25rem;
+}

--- a/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.html
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.html
@@ -1,0 +1,164 @@
+<template>
+    <div class="queue-card">
+
+        <div class="queue-header">
+            <div class="queue-header-left">
+                <lightning-icon icon-name="standard:approval" alternative-text="Approval queue" size="small" class="queue-header-icon"></lightning-icon>
+                <div>
+                    <h2 class="queue-title">Pending Work Approvals</h2>
+                    <p class="queue-subtitle">Offer-Sent work requests awaiting your decision</p>
+                </div>
+            </div>
+            <div class="queue-controls">
+                <c-delivery-info-popover component-name="deliveryApprovalQueue"></c-delivery-info-popover>
+                <lightning-button-icon
+                    icon-name="utility:refresh"
+                    variant="border-filled"
+                    alternative-text="Refresh"
+                    title="Refresh"
+                    onclick={handleRefresh}>
+                </lightning-button-icon>
+            </div>
+        </div>
+
+        <template lwc:if={isLoading}>
+            <div class="queue-loading">
+                <lightning-spinner alternative-text="Loading approval queue..." size="small"></lightning-spinner>
+            </div>
+        </template>
+
+        <template lwc:if={hasError}>
+            <div class="queue-error">
+                <lightning-icon icon-name="utility:error" size="x-small"></lightning-icon>
+                <span>{errorMessage}</span>
+            </div>
+        </template>
+
+        <template lwc:if={hasRows}>
+            <div class="queue-summary-row">
+                <div class="summary-tile">
+                    <div class="summary-label">Pending</div>
+                    <div class="summary-value">{pendingCountDisplay}</div>
+                </div>
+                <div class="summary-tile">
+                    <div class="summary-label">Hours quoted</div>
+                    <div class="summary-value">{totalQuotedDisplay}h</div>
+                </div>
+            </div>
+
+            <ul class="queue-list">
+                <template for:each={rows} for:item="row">
+                    <li key={row.key} class="queue-row">
+                        <div class="queue-row-main">
+                            <div class="queue-row-info">
+                                <button class="queue-item-link"
+                                        data-work-item-id={row.workItemId}
+                                        onclick={handleItemClick}>{row.label}</button>
+                                <div class="queue-row-meta">
+                                    <span class="queue-hours">{row.quotedDisplay}</span>
+                                    <template lwc:if={row.hasIncrease}>
+                                        <span class="queue-increase-badge">{row.increaseBadge}</span>
+                                    </template>
+                                    <span class="queue-age">{row.ageDisplay}</span>
+                                </div>
+                            </div>
+                            <div class="queue-row-actions">
+                                <lightning-button
+                                    variant="brand"
+                                    label="Approve"
+                                    data-request-id={row.key}
+                                    disabled={isSaving}
+                                    onclick={handleApprove}>
+                                </lightning-button>
+                                <lightning-button
+                                    variant="neutral"
+                                    label="Approve w/ change"
+                                    data-request-id={row.key}
+                                    disabled={isSaving}
+                                    onclick={handleOpenChange}>
+                                </lightning-button>
+                                <lightning-button
+                                    variant="destructive-text"
+                                    label="Decline"
+                                    data-request-id={row.key}
+                                    disabled={isSaving}
+                                    onclick={handleOpenDecline}>
+                                </lightning-button>
+                            </div>
+                        </div>
+
+                        <template lwc:if={row.isChangeOpen}>
+                            <div class="queue-inline">
+                                <lightning-input
+                                    type="number"
+                                    label="Approved hours"
+                                    step="0.25"
+                                    min="0"
+                                    value={draftHours}
+                                    onchange={handleHoursChange}
+                                    class="queue-inline-input">
+                                </lightning-input>
+                                <lightning-input
+                                    type="text"
+                                    label="Note (optional)"
+                                    value={draftNote}
+                                    onchange={handleNoteChange}
+                                    class="queue-inline-input queue-inline-input--wide">
+                                </lightning-input>
+                                <div class="queue-inline-actions">
+                                    <lightning-button
+                                        variant="brand"
+                                        label="Confirm"
+                                        data-request-id={row.key}
+                                        disabled={isSaving}
+                                        onclick={handleConfirmChange}>
+                                    </lightning-button>
+                                    <lightning-button
+                                        variant="neutral"
+                                        label="Cancel"
+                                        onclick={handleCancelInline}>
+                                    </lightning-button>
+                                </div>
+                            </div>
+                        </template>
+
+                        <template lwc:if={row.isDeclineOpen}>
+                            <div class="queue-inline">
+                                <lightning-input
+                                    type="text"
+                                    label="Decline reason"
+                                    value={draftReason}
+                                    onchange={handleReasonChange}
+                                    class="queue-inline-input queue-inline-input--wide">
+                                </lightning-input>
+                                <div class="queue-inline-actions">
+                                    <lightning-button
+                                        variant="destructive"
+                                        label="Confirm decline"
+                                        data-request-id={row.key}
+                                        disabled={isSaving}
+                                        onclick={handleConfirmDecline}>
+                                    </lightning-button>
+                                    <lightning-button
+                                        variant="neutral"
+                                        label="Cancel"
+                                        onclick={handleCancelInline}>
+                                    </lightning-button>
+                                </div>
+                            </div>
+                        </template>
+                    </li>
+                </template>
+            </ul>
+        </template>
+
+        <template lwc:if={isEmpty}>
+            <div class="queue-empty">
+                <lightning-icon icon-name="utility:success" size="medium" class="queue-empty-icon"></lightning-icon>
+                <p>Nothing pending &mdash; you&rsquo;re caught up</p>
+                <p class="queue-empty-sub">New work requests submitted for approval will appear here.</p>
+            </div>
+        </template>
+
+    </div>
+</template>

--- a/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.js
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.js
@@ -1,0 +1,282 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Pending work-approval queue card for DH Home (PR2 of the
+ *               work-approval queue). Wires
+ *               DeliveryWorkApprovalService.getPendingForApprover and renders
+ *               each Offer-Sent WorkRequest__c with inline Approve /
+ *               Approve-with-change / Decline actions. After any decision the
+ *               wire is refreshed and a toast confirms the outcome using OUR
+ *               labels (AuraHandledException messages come back generic inside
+ *               the managed package). Clicking the item name navigates to the
+ *               WorkItem__c record via NavigationMixin + @salesforce/schema so
+ *               the object API name stays namespace-safe.
+ * @author       Cloud Nimbus LLC
+ */
+import { LightningElement, wire } from "lwc";
+import { NavigationMixin } from "lightning/navigation";
+import { refreshApex } from "@salesforce/apex";
+import { ShowToastEvent } from "lightning/platformShowToastEvent";
+import WORK_ITEM_OBJECT from "@salesforce/schema/WorkItem__c";
+import getPendingForApprover from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.getPendingForApprover";
+import approveApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.approve";
+import declineApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.decline";
+
+const MS_PER_DAY = 86400000;
+const MODE_CHANGE = "change";
+const MODE_DECLINE = "decline";
+
+export default class DeliveryApprovalQueue extends NavigationMixin(LightningElement) {
+    pendingRaw = [];
+    errorMessage = "";
+    isLoading = true;
+    isSaving = false;
+
+    // One inline panel open at a time: the row + which panel.
+    activeRequestId = null;
+    activeMode = "";
+    draftHours = null;
+    draftNote = "";
+    draftReason = "";
+
+    wiredResult;
+
+    @wire(getPendingForApprover, { userId: null })
+    wiredPending(result) {
+        this.wiredResult = result;
+        if (result.data) {
+            this.pendingRaw = result.data;
+            this.errorMessage = "";
+            this.isLoading = false;
+        } else if (result.error) {
+            this.errorMessage = this._errorText(result.error, "Unable to load the approval queue.");
+            this.pendingRaw = [];
+            this.isLoading = false;
+        }
+    }
+
+    // ── Row shaping (templates can't do ternaries — precompute) ──
+
+    get rows() {
+        return this.pendingRaw.map((dto) => {
+            const isActive = dto.requestId === this.activeRequestId;
+            return {
+                key: dto.requestId,
+                workItemId: dto.workItemId,
+                label: dto.workItemLabel || dto.workItemName || "(unnamed item)",
+                quotedDisplay: `${this._formatHours(dto.quotedHours)}h quoted`,
+                hasIncrease: dto.requestedIncrease > 0,
+                increaseBadge: `increase +${this._formatHours(dto.requestedIncrease)}h`,
+                ageDisplay: this._ageDisplay(dto.submittedAt),
+                isChangeOpen: isActive && this.activeMode === MODE_CHANGE,
+                isDeclineOpen: isActive && this.activeMode === MODE_DECLINE
+            };
+        });
+    }
+
+    // ── State flags ──────────────────────────────────────────────
+
+    get hasRows() {
+        return !this.isLoading && !this.errorMessage && this.pendingRaw.length > 0;
+    }
+
+    get isEmpty() {
+        return !this.isLoading && !this.errorMessage && this.pendingRaw.length === 0;
+    }
+
+    get hasError() {
+        return !this.isLoading && this.errorMessage.length > 0;
+    }
+
+    // ── Headline numbers ─────────────────────────────────────────
+
+    get pendingCountDisplay() {
+        return this.pendingRaw.length;
+    }
+
+    get totalQuotedDisplay() {
+        let total = 0;
+        for (const dto of this.pendingRaw) {
+            total += dto.quotedHours || 0;
+        }
+        return this._formatHours(total);
+    }
+
+    // ── Navigation ───────────────────────────────────────────────
+
+    handleItemClick(event) {
+        const workItemId = event.currentTarget.dataset.workItemId;
+        if (!workItemId) {
+            return;
+        }
+        this[NavigationMixin.Navigate]({
+            type: "standard__recordPage",
+            attributes: {
+                recordId: workItemId,
+                objectApiName: WORK_ITEM_OBJECT.objectApiName,
+                actionName: "view"
+            }
+        });
+    }
+
+    // ── Decision actions ─────────────────────────────────────────
+
+    handleApprove(event) {
+        const requestId = event.currentTarget.dataset.requestId;
+        if (!requestId || this.isSaving) {
+            return;
+        }
+        this._decide(
+            approveApex({ workRequestId: requestId, approvedHours: null, note: null }),
+            "Approved",
+            "The request was approved at the quoted hours."
+        );
+    }
+
+    handleOpenChange(event) {
+        this._openInline(event.currentTarget.dataset.requestId, MODE_CHANGE);
+    }
+
+    handleOpenDecline(event) {
+        this._openInline(event.currentTarget.dataset.requestId, MODE_DECLINE);
+    }
+
+    handleCancelInline() {
+        this._closeInline();
+    }
+
+    handleHoursChange(event) {
+        this.draftHours = event.target.value;
+    }
+
+    handleNoteChange(event) {
+        this.draftNote = event.target.value;
+    }
+
+    handleReasonChange(event) {
+        this.draftReason = event.target.value;
+    }
+
+    handleConfirmChange(event) {
+        const requestId = event.currentTarget.dataset.requestId;
+        const hours = parseFloat(this.draftHours);
+        if (!Number.isFinite(hours) || hours <= 0) {
+            this._toast("Enter the approved hours", "Approved hours must be a number greater than zero.", "error");
+            return;
+        }
+        const note = (this.draftNote || "").trim();
+        this._decide(
+            approveApex({ workRequestId: requestId, approvedHours: hours, note: note.length > 0 ? note : null }),
+            "Approved with change",
+            `The request was approved at ${this._formatHours(hours)}h.`
+        );
+    }
+
+    handleConfirmDecline(event) {
+        const requestId = event.currentTarget.dataset.requestId;
+        const reason = (this.draftReason || "").trim();
+        if (reason.length === 0) {
+            this._toast("Enter a reason", "A decline reason is required.", "error");
+            return;
+        }
+        this._decide(
+            declineApex({ workRequestId: requestId, reason }),
+            "Declined",
+            "The request was declined."
+        );
+    }
+
+    handleRefresh() {
+        if (this.wiredResult) {
+            refreshApex(this.wiredResult);
+        }
+    }
+
+    // ── Internals ────────────────────────────────────────────────
+
+    _openInline(requestId, mode) {
+        if (!requestId) {
+            return;
+        }
+        this.activeRequestId = requestId;
+        this.activeMode = mode;
+        this.draftHours = null;
+        this.draftNote = "";
+        this.draftReason = "";
+    }
+
+    _closeInline() {
+        this.activeRequestId = null;
+        this.activeMode = "";
+        this.draftHours = null;
+        this.draftNote = "";
+        this.draftReason = "";
+    }
+
+    _decide(apexPromise, successTitle, successMessage) {
+        this.isSaving = true;
+        apexPromise
+            .then(() => {
+                this.isSaving = false;
+                this._closeInline();
+                this._toast(successTitle, successMessage, "success");
+                return refreshApex(this.wiredResult);
+            })
+            .catch((err) => {
+                this.isSaving = false;
+                this._toast(
+                    "Decision failed",
+                    this._errorText(err, "The decision could not be recorded."),
+                    "error"
+                );
+            });
+    }
+
+    _toast(title, message, variant) {
+        this.dispatchEvent(new ShowToastEvent({ title, message, variant }));
+    }
+
+    _errorText(err, fallback) {
+        // Display-only: managed-package AuraHandledException messages are
+        // generic, so never branch on the text — just surface it when present.
+        if (err && err.body && err.body.message) {
+            return err.body.message;
+        }
+        return fallback;
+    }
+
+    _ageDisplay(submittedAt) {
+        if (!submittedAt) {
+            return "";
+        }
+        const submitted = new Date(submittedAt).getTime();
+        if (!Number.isFinite(submitted)) {
+            return "";
+        }
+        const days = Math.max(0, Math.floor((Date.now() - submitted) / MS_PER_DAY));
+        if (days === 0) {
+            return "in queue today";
+        }
+        if (days === 1) {
+            return "1 day in queue";
+        }
+        return `${days} days in queue`;
+    }
+
+    _formatHours(value) {
+        if (value === null || value === undefined) {
+            return "0";
+        }
+        const num = Number(value);
+        if (!Number.isFinite(num)) {
+            return "0";
+        }
+        if (Math.abs(num) >= 100) {
+            return num.toFixed(0);
+        }
+        if (Math.abs(num) >= 10) {
+            return num.toFixed(1);
+        }
+        return num.toFixed(2);
+    }
+}

--- a/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.js-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__HomePage</target>
+        <target>lightning__AppPage</target>
+        <target>lightning__Tab</target>
+    </targets>
+    <masterLabel>Delivery Approval Queue</masterLabel>
+    <description>Pending work-approval queue: every Offer-Sent work request awaiting the approver, with inline Approve / Approve-with-change / Decline actions and click-through to the WorkItem.</description>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
+++ b/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
@@ -254,6 +254,15 @@ const INFO_REGISTRY = {
         keyFields:
             'WorkItem__c.ClientIntentionPk__c, WorkItem__c.ActivatedDateTime__c, WorkItem__c.EstimatedHoursNumber__c, WorkItem__c.PriorityPk__c, WorkItem__c.BriefDescriptionTxt__c, NetworkEntity__c.DefaultHourlyRateCurrency__c'
     },
+    deliveryApprovalQueue: {
+        dataSource:
+            'Wires DeliveryWorkApprovalService.getPendingForApprover — every WorkRequest__c at StatusPk__c=Offer Sent assigned to the running user (plus unassigned requests), oldest first. Approve / Approve-with-change / Decline call the service imperatively; approve stamps the decision on the request and lands ClientPreApprovedHoursNumber__c on the WorkItem (a budget INCREASE raises the existing cap by the approved delta), decline stands the request down and parks the item only when nothing was previously approved.',
+        description:
+            'The approver\'s pending-work queue. Each Offer-Sent work request shows the item, quoted hours, any requested budget increase, and time in queue — with one-click Approve, an Approve-with-change inline hours/note form, and an inline-reason Decline. Item names click through to the Work Item record.',
+        friendlyName: 'Pending Work Approvals',
+        keyFields:
+            'WorkRequest__c.StatusPk__c, WorkRequest__c.QuotedHoursNumber__c, WorkRequest__c.RequestedBudgetIncreaseNumber__c, WorkRequest__c.ApproverUserLookup__c, WorkRequest__c.DecisionDateTime__c, WorkItem__c.ClientPreApprovedHoursNumber__c, WorkItem__c.StageNamePk__c'
+    },
     deliveryWatcherSetup: {
         dataSource:
             'Calls DeliveryWatcherSetupController.getSettings to load the Watcher digest configuration from DeliveryHubSettings__c, and saveSettings to persist it. Flipping the master toggle stamps EnableWatcherDigestDateTime__c; the recipient list is validated against active Users and stored in WatcherDigestRecipientUserIdsTxt__c; an optional Slack webhook override updates the org-wide webhook used by escalations and forecasts.',

--- a/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
@@ -221,6 +221,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryWorkApprovalService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryWorkItemController</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
@@ -221,6 +221,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryWorkApprovalService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryWorkItemController</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.approve.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.approve.js
@@ -1,0 +1,4 @@
+/**
+ * Mock for DeliveryWorkApprovalService.approve (imperative).
+ */
+module.exports = { default: jest.fn() };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.decline.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.decline.js
@@ -1,0 +1,4 @@
+/**
+ * Mock for DeliveryWorkApprovalService.decline (imperative).
+ */
+module.exports = { default: jest.fn() };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.getPendingForApprover.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.getPendingForApprover.js
@@ -1,0 +1,8 @@
+/**
+ * Wire adapter mock for DeliveryWorkApprovalService.getPendingForApprover.
+ * Used by the c-delivery-approval-queue jest tests.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+
+const getPendingForApprover = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getPendingForApprover };


### PR DESCRIPTION
﻿## What this renders

`deliveryApprovalQueue` — Jose's pending-approval queue card on DH Home. Wires `DeliveryWorkApprovalService.getPendingForApprover` (Offer-Sent `WorkRequest__c` rows for the running user + unassigned) and renders:

- Header with **pending count** and **total quoted hours**, refresh button, info popover (registered in `deliveryInfoPopover`'s INFO_REGISTRY).
- Per-row: `workItemLabel` (falls back to `workItemName`), quoted hours, an **"increase +Nh"** badge when `requestedIncrease` is present, and age-in-queue (days since `submittedAt`).
- Item name click-through navigates to the WorkItem record via `NavigationMixin` + `WORK_ITEM_OBJECT.objectApiName` from `@salesforce/schema/WorkItem__c` (no hardcoded object names).

## Decision actions

- **Approve** — imperative `approve(workRequestId, null, null)` (quoted-hours fallback in apex).
- **Approve w/ change** — inline hours input + optional note, then `approve(workRequestId, hours, note)`.
- **Decline** — inline required reason, then `decline(workRequestId, reason)`.
- After any decision: success/error toast with our own labels (managed-package `AuraHandledException` messages are generic — body message is display-only) + `refreshApex` of the wire.
- Empty state ("Nothing pending — you're caught up") and error state; visual idiom mirrors `deliveryPacingForecast` (card, gradient header, summary tiles).

## Placement (in package metadata)

- `DeliveryHubHome.flexipage-meta.xml` — directly under the pacing forecast card.
- `DeliveryHubAdminHome.flexipage-meta.xml` — same position.

## classAccesses fix (PR1 gap)

PR1 shipped `DeliveryWorkApprovalService` without permset class access. Added `<classAccesses>` (enabled) to **both** `DeliveryHubApp` and `DeliveryHubAdmin_App`, alphabetically before `DeliveryWorkItemController`.

## Tests

5 jest tests (`__tests__/deliveryApprovalQueue.test.js`) + 3 apex mocks under `force-app/test/jest-mocks/apex/` following the repo's `moduleNameMapper` catch-all idiom. All pass locally. Note: `deliveryFeatureCockpit` jest suite has 3 pre-existing failures on the base branch (reproduced with this diff stashed) — untouched here. Repo has no `lint` npm script (`test:lwc` only), so no eslint run.

## What PR3 adds

The 4 agenda reports (Hours Approved / Pending / Approved & In-Progress / Deployed-to-Prod awaiting verification), the `deliveryApprovalSummaryCard` tile card with report click-throughs, and the Deploy-to-Prod custom notification + assignment on stage entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
