### PR TITLE
fix(test): align #879 scope test with 0.269 leaf-only counting (unblocks beta)

### DIFF
--- a/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
@@ -615,10 +615,13 @@ private class DeliveryHoursAnalyticsControllerTest {
             DeliveryHoursAnalyticsController.getPortfolioPacing('Month', 6, 3);
         Test.stopTest();
 
-        // Only root (50) + activeChild (20) estimate is in scope = 70.
-        // The 999 + 777 from the non-active / template children are excluded.
-        System.assertEquals(70, dto.totalEstimatedHours,
-            'Estimate must exclude non-activated + template descendants');
+        // Scope = root + activeChild, but the 0.269 LEAF-ONLY rule counts only
+        // items with no in-scope child — the root is a container parent of the
+        // in-scope activeChild, so its 50 is a planning rollup and contributes
+        // nothing. In-scope leaves = activeChild = 20. The 999 + 777 from the
+        // non-active / template children stay fully excluded.
+        System.assertEquals(20, dto.totalEstimatedHours,
+            'Estimate counts in-scope leaves only and excludes non-activated + template descendants');
         // Only root (4) + activeChild (6) logged = 10. The 50 + 50 are excluded.
         System.assertEquals(10, dto.totalLoggedHours,
             'Logged hours must exclude non-activated + template descendants');


### PR DESCRIPTION
## Why

`upload-beta` has failed on every `beta_create` run since #879 merged — blocking the release that carries the approval-queue arc (#891/#892/#893).

**Root cause is a semantic merge conflict, not a code bug:** #879 branched 6/6, before 0.269's leaf-only estimate counting landed 6/8. Its new test asserts `totalEstimatedHours = 70` (root 50 + activeChild 20), but under leaf-only the root is a container parent of an in-scope child and contributes nothing — correct result is **20**. #879's PR CI ran green against its own pre-leaf-only branch; the textually-clean merge produced a test that contradicts shipped semantics, and only the packaging org's full test run caught it.

## Change

One assertion + comment in `DeliveryHoursAnalyticsControllerTest.testPortfolioScopeExcludesNonActiveAndTemplateDescendants`: expected 70 → 20. Controller untouched. The sibling grandchild test (25) is already leaf-only consistent.

## After merge

beta_create re-fires; upload-beta should go green → promote the beta carrying #879 + the approval-queue arc for the MF-Prod install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)