### PR TITLE
feat(pacing): de-clutter default Pacing view (suppress measure/mode/breakout)

### DIFF
--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -896,7 +896,19 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             config: {
                 pacing: {
                     data: this._pacingData || undefined,
-                    controls: { dollars: false },
+                    // 6/11 de-clutter (Glen: the default Pacing view is "overwhelming /
+                    // disorienting"): suppress the pill groups that add decisions without
+                    // adding demo value, so row 2 collapses to just the Pace dial.
+                    //   measure:false  — MF is hours-only; a one-option Hours/$ group is noise
+                    //   mode:false     — Per-period/Cumulative flattening confuses the ramp story
+                    //   breakout:false — Cohort/Epic/Owner/Item restructures the whole chart +
+                    //                    legend + drill-down on each toggle; off by default until
+                    //                    a client asks (NG keeps full capability; this is config)
+                    // Range/Bucket presets + the Series legend stay (the legend doubles as the
+                    // color key). The remaining density (6-7 KPI cards, scope-banner alarm
+                    // styling, actual-vs-greenlit color collision) is NG-substrate work, not
+                    // host config — dispatched separately.
+                    controls: { dollars: false, measure: false, mode: false, breakout: false },
                     // 0.271 — make Pacing drill-down rows clickable. NG fires onOpenItem
                     // with the WorkItem id; navigate to the record (same path the gantt
                     // bar/right-click menu uses). Without this the drill-down rows render


### PR DESCRIPTION
Glen's 6/10-11 feedback: the DH-hosted Pacing view feels overwhelming vs
the curated CN modeled page. Diagnosis (6/10 render-path read): ~24
identically-styled control pills across two rows bury the one control
that matters (Pace), and breakout/cumulative toggles restructure the
chart mid-read.

Host-config-only change per the substrate/consumer rule — NG keeps full
capability; DH curates the default surface:
- measure:false (MF is hours-only; one-option group is noise)
- mode:false (cumulative flattening confuses the ramp story)
- breakout:false (until a client asks)
Row 2 collapses to the Pace dial. Range/Bucket and the Series legend
(the color key) stay.

Remaining density is NG-substrate work (KPI card count, scope-banner
alarm styling, actual-vs-greenlit green collision) — dispatched to NG
separately, not forked here.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
