### PR TITLE
docs(readme): pin install to 0.273.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ It is open source under the [BSL 1.1 license](LICENSE.md) and ships as an unlock
 
 ## Install
 
-**Current release**: [`release/0.271.0.1`](https://github.com/Nimba-Solutions/Delivery-Hub/releases) (production-promoted 2026-06-09). Carries the cohort stacked-forecast + leaf-only counting + capacity-leveling (NimbusGantt 0.202.0 bundle). See [GitHub Releases](https://github.com/Nimba-Solutions/Delivery-Hub/releases) for the full version history.
+**Current release**: [`release/0.273.0.2`](https://github.com/Nimba-Solutions/Delivery-Hub/releases) (production-promoted 2026-06-11). Carries the work-approval queue (estimate → approve → cap rails, pending-approval queue on Home, approval reports + agenda card, Deployed-to-Prod ship loop), forecast/board scope parity, and NimbusGantt 0.204.0 (pace-aware auto-schedule, unified click-through, search + axis fixes) with a de-cluttered default Pacing view. See [GitHub Releases](https://github.com/Nimba-Solutions/Delivery-Hub/releases) for the full version history.
 
 | Environment | Link |
 |---|---|
-| **Production** | [![Install in Production](https://img.shields.io/badge/Install-Production-0070d2?logo=salesforce&style=for-the-badge)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000Vw9NIAS) |
-| **Sandbox** | [![Install in Sandbox](https://img.shields.io/badge/Install-Sandbox-3e8b3e?logo=salesforce&style=for-the-badge)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000Vw9NIAS) |
+| **Production** | [![Install in Production](https://img.shields.io/badge/Install-Production-0070d2?logo=salesforce&style=for-the-badge)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000Vxi9IAC) |
+| **Sandbox** | [![Install in Sandbox](https://img.shields.io/badge/Install-Sandbox-3e8b3e?logo=salesforce&style=for-the-badge)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000Vxi9IAC) |
 
 **Quickstart (≈5 minutes):**
 


### PR DESCRIPTION
Catches the pin up from 0.271.0.1 across 0.272.0.1 (approval-queue arc:
rails + queue LWC + reports/agenda card + ship loop; forecast/board
scope parity) and 0.273.0.2 (NG 0.204.0 Gate 2 both-bundle adoption +
pacing de-clutter + rescued docs).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
