### PR TITLE
PR4: approval pings — submit notifies the approver, decisions notify the dev

### DIFF
--- a/force-app/main/default/classes/DeliveryNotificationService.cls
+++ b/force-app/main/default/classes/DeliveryNotificationService.cls
@@ -228,6 +228,180 @@ global with sharing class DeliveryNotificationService {
     }
 
     // ────────────────────────────────────────────────────────────────────
+    // WORK APPROVAL (WorkRequest__c queue — PR4)
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Work submitted for client approval — ping each approver
+     *              with ONE summarized bell per transaction ("Approval
+     *              needed: N item(s)") instead of a per-row storm. Loads the
+     *              Offer-Sent requests, groups them by
+     *              ApproverUserLookup__c (unassigned rows fall back to the
+     *              configured org-default approver), sums the quoted hours
+     *              per approver, and deep-links each approver's first
+     *              request's work item. Rows with no assigned approver AND
+     *              no configured default skip silently — approver
+     *              assignment is settings-optional in the approval queue.
+     * @param workRequestIds The WorkRequest__c ids that just moved to
+     *        'Offer Sent' in this transaction (auto-approved requests
+     *        should not be passed — they never queue for a human).
+     */
+    global static void notifyWorkApprovalSubmitted(List<Id> workRequestIds) {
+        if (workRequestIds == null || workRequestIds.isEmpty()) {
+            return;
+        }
+        try {
+            List<WorkRequest__c> rows = [
+                SELECT Id, QuotedHoursNumber__c, ApproverUserLookup__c, WorkItemId__c
+                FROM WorkRequest__c
+                WHERE Id IN :workRequestIds
+                  AND StatusPk__c = :DeliveryWorkApprovalService.REQUEST_OFFER_SENT
+                WITH SYSTEM_MODE
+                ORDER BY CreatedDate ASC
+                LIMIT 200
+            ];
+            if (rows.isEmpty()) {
+                return;
+            }
+            Map<Id, List<WorkRequest__c>> byApprover = groupRequestsByApprover(rows);
+            for (Id approverId : byApprover.keySet()) {
+                sendApproverDigest(approverId, byApprover.get(approverId));
+            }
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryNotificationService.notifyWorkApprovalSubmitted] failed: '
+                + e.getMessage());
+        }
+    }
+
+    /**
+     * @description Buckets pending requests by their target approver:
+     *              ApproverUserLookup__c when assigned, the configured
+     *              org-default approver otherwise. Rows with neither are
+     *              dropped (skip silently — approver assignment is
+     *              settings-optional).
+     * @param rows Offer-Sent WorkRequest__c rows to bucket.
+     * @return Requests keyed by the approver to ping.
+     */
+    private static Map<Id, List<WorkRequest__c>> groupRequestsByApprover(
+        List<WorkRequest__c> rows
+    ) {
+        Id fallbackApproverId = resolveConfiguredApproverId();
+        Map<Id, List<WorkRequest__c>> byApprover = new Map<Id, List<WorkRequest__c>>();
+        for (WorkRequest__c req : rows) {
+            Id approverId = req.ApproverUserLookup__c != null
+                ? req.ApproverUserLookup__c
+                : fallbackApproverId;
+            if (approverId == null) {
+                continue; // unassigned + no configured default — skip silently
+            }
+            if (!byApprover.containsKey(approverId)) {
+                byApprover.put(approverId, new List<WorkRequest__c>());
+            }
+            byApprover.get(approverId).add(req);
+        }
+        return byApprover;
+    }
+
+    /**
+     * @description Sends ONE summarized "Approval needed" bell to a single
+     *              approver: item count + summed quoted hours, deep-linked
+     *              to the first request's work item.
+     * @param approverId The approver to ping.
+     * @param bucket That approver's pending requests (never null / empty).
+     */
+    private static void sendApproverDigest(Id approverId, List<WorkRequest__c> bucket) {
+        Decimal totalHours = 0;
+        for (WorkRequest__c req : bucket) {
+            if (req.QuotedHoursNumber__c != null) {
+                totalHours += req.QuotedHoursNumber__c;
+            }
+        }
+        String title = 'Approval needed: ' + bucket.size() + ' item(s)';
+        String body = bucket.size() + ' work item(s) totaling ' + totalHours
+            + ' quoted hours are pending your approval.';
+        sendQueueable(new Set<Id>{ approverId }, title, body, bucket.get(0).WorkItemId__c);
+    }
+
+    /**
+     * @description Work-approval decision landed — notify the work item's
+     *              assigned developer (WorkItem__c.DeveloperLookup__c) so dev
+     *              work starts (or stands down) without anyone polling the
+     *              queue. Approved → "capped at N hours, ready for
+     *              development"; declined → includes the stand-down reason
+     *              when one was recorded. Skips silently when the item has
+     *              no assigned developer — assignment is optional and a
+     *              missing dev must never block the decision DML.
+     * @param workRequestId The WorkRequest__c that was just decided.
+     * @param approved True for an approve decision, false for a decline.
+     */
+    global static void notifyWorkApprovalDecided(Id workRequestId, Boolean approved) {
+        if (workRequestId == null || approved == null) {
+            return;
+        }
+        try {
+            List<WorkRequest__c> rows = [
+                SELECT Id, PreApprovedHoursNumber__c, StandDownReasonTxt__c,
+                       WorkItemId__c, WorkItemId__r.DeveloperLookup__c,
+                       WorkItemId__r.Name, WorkItemId__r.BriefDescriptionTxt__c
+                FROM WorkRequest__c
+                WHERE Id = :workRequestId
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ];
+            if (rows.isEmpty()) {
+                return;
+            }
+            WorkRequest__c req = rows.get(0);
+            Id devId = req.WorkItemId__r == null ? null : req.WorkItemId__r.DeveloperLookup__c;
+            if (devId == null) {
+                return; // no developer assigned — skip silently
+            }
+            String label = resolveWorkItemLabel(req);
+            String approverName = resolveUserName(UserInfo.getUserId());
+            String title;
+            String body;
+            if (approved) {
+                title = 'Approved: ' + label;
+                String tail = req.PreApprovedHoursNumber__c == null
+                    ? 'ready for development.'
+                    : 'capped at ' + req.PreApprovedHoursNumber__c
+                        + ' hours, ready for development.';
+                body = approverName + ' approved ' + label + ' ' + '\u2014' + ' ' + tail;
+            } else {
+                title = 'Declined: ' + label;
+                body = approverName + ' declined ' + label + '.';
+                if (String.isNotBlank(req.StandDownReasonTxt__c)) {
+                    body += ' Reason: ' + req.StandDownReasonTxt__c;
+                }
+            }
+            sendQueueable(new Set<Id>{ devId }, title, body, req.WorkItemId__c);
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryNotificationService.notifyWorkApprovalDecided] failed: '
+                + e.getMessage());
+        }
+    }
+
+    /**
+     * @description Builds the human label for a work-approval notification
+     *              from the joined work item: BriefDescriptionTxt__c first,
+     *              the auto-number Name next, generic last — same fallback
+     *              ladder the approval-queue DTO uses.
+     * @param req WorkRequest__c loaded with the WorkItemId__r join.
+     * @return Best-available human label, never null / blank.
+     */
+    private static String resolveWorkItemLabel(WorkRequest__c req) {
+        if (req == null || req.WorkItemId__r == null) {
+            return 'Work item';
+        }
+        if (String.isNotBlank(req.WorkItemId__r.BriefDescriptionTxt__c)) {
+            return req.WorkItemId__r.BriefDescriptionTxt__c;
+        }
+        return String.isBlank(req.WorkItemId__r.Name) ? 'Work item' : req.WorkItemId__r.Name;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
     // ONBOARDING
     // ────────────────────────────────────────────────────────────────────
 

--- a/force-app/main/default/classes/DeliveryWorkApprovalService.cls
+++ b/force-app/main/default/classes/DeliveryWorkApprovalService.cls
@@ -298,7 +298,9 @@ public with sharing class DeliveryWorkApprovalService {
 
     /**
      * @description Batched DML for submit: upsert the requests, update the
-     *              items, and write one audit row per Auto short-circuit.
+     *              items, write one audit row per Auto short-circuit, and
+     *              fire the summarized approver ping for the requests that
+     *              queued for a human decision (PR4).
      * @param requests Requests to save (mixed insert/update).
      * @param itemUpdates WorkItem stage/cap updates.
      * @param results DTOs to backfill with request ids.
@@ -317,12 +319,19 @@ public with sharing class DeliveryWorkApprovalService {
                 + e.getMessage());
             throw new AuraHandledException('Unable to submit for approval.');
         }
+        List<Id> pendingRequestIds = new List<Id>();
         for (Integer i = 0; i < results.size(); i++) {
             results[i].workRequestId = requests[i].Id;
             if (results[i].autoApproved) {
                 writeAuditRow(results[i].workItemId, 'Auto_Approve', requests[i].Id, null);
+            } else {
+                pendingRequestIds.add(requests[i].Id);
             }
         }
+        // Fire-and-forget approver ping for the requests that actually queued
+        // for a human — the notification service is null-safe and never
+        // throws back into this transaction.
+        DeliveryNotificationService.notifyWorkApprovalSubmitted(pendingRequestIds);
     }
 
     // ────────────────────────────────────────────────────────────────────
@@ -373,6 +382,8 @@ public with sharing class DeliveryWorkApprovalService {
             throw new AuraHandledException('Unable to approve the request.');
         }
         writeAuditRow(req.WorkItemId__c, isIncrease ? 'Approve_Increase' : 'Approve', req.Id, note);
+        // Fire-and-forget dev ping — null-safe, never throws back here.
+        DeliveryNotificationService.notifyWorkApprovalDecided(req.Id, true);
     }
 
     // ────────────────────────────────────────────────────────────────────
@@ -411,6 +422,8 @@ public with sharing class DeliveryWorkApprovalService {
             throw new AuraHandledException('Unable to decline the request.');
         }
         writeAuditRow(req.WorkItemId__c, 'Decline', req.Id, reason);
+        // Fire-and-forget dev ping — null-safe, never throws back here.
+        DeliveryNotificationService.notifyWorkApprovalDecided(req.Id, false);
     }
 
     // ────────────────────────────────────────────────────────────────────

--- a/force-app/main/default/classes/DeliveryWorkApprovalServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkApprovalServiceTest.cls
@@ -710,4 +710,185 @@ private class DeliveryWorkApprovalServiceTest {
         Decimal total = DeliveryWorkApprovalService.sumAutoApprovedHoursThisMonth();
         System.assertEquals(7.5, total, 'seeded auto-approved hours counted against the cap');
     }
+
+    // ────────────────────────────────────────────────────────────────────
+    // NOTIFICATIONS (PR4) — Apex tests cannot assert
+    // Messaging.CustomNotification.send() directly (the managed test runner
+    // short-circuits delivery — see DeliveryShipVerificationTest /
+    // DeliveryNotificationServiceTest). The contract asserted here is the
+    // trackable decision state PLUS the notification path completing without
+    // exception; Test.stopTest() drains the queueable.
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Over-threshold submit runs the approver ping path
+     *              (summarized "Approval needed" bell to the configured
+     *              approver) without exception — the request still lands as
+     *              an assigned Offer-Sent row and the submit DML is never
+     *              blocked by the notification fanout.
+     */
+    @IsTest
+    static void testSubmitOverThresholdPingsApproverWithoutException() {
+        configureSettings(8, 40, UserInfo.getUserId());
+        WorkItem__c wi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 20
+        });
+
+        Test.startTest();
+        List<DeliveryWorkApprovalService.SubmitResultDTO> results =
+            DeliveryWorkApprovalService.submitForApproval(new Set<Id>{ wi.Id });
+        Test.stopTest();
+
+        // Reaching here = the ping path (and the drained queueable) did not
+        // throw. Sanity-check the trackable side effects are intact.
+        WorkRequest__c req = [
+            SELECT StatusPk__c, ApproverUserLookup__c
+            FROM WorkRequest__c WHERE Id = :results[0].workRequestId
+        ];
+        System.assertEquals('Offer Sent', req.StatusPk__c,
+            'offer still goes out with the ping path wired in');
+        System.assertEquals(UserInfo.getUserId(), req.ApproverUserLookup__c,
+            'configured approver assigned — the ping targets this user');
+    }
+
+    /**
+     * @description Approve fires the decided ping to the work item's
+     *              assigned developer without exception; the decision state
+     *              and canonical cap land exactly as before.
+     */
+    @IsTest
+    static void testApprovePingsAssignedDev() {
+        configureSettings(null, null, UserInfo.getUserId());
+        WorkItem__c wi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 20,
+            'DeveloperLookup__c' => UserInfo.getUserId()
+        });
+        List<DeliveryWorkApprovalService.SubmitResultDTO> results =
+            DeliveryWorkApprovalService.submitForApproval(new Set<Id>{ wi.Id });
+
+        Test.startTest();
+        DeliveryWorkApprovalService.approve(results[0].workRequestId, 25, 'go');
+        Test.stopTest();
+
+        WorkRequest__c req = [
+            SELECT StatusPk__c, PreApprovedHoursNumber__c
+            FROM WorkRequest__c WHERE Id = :results[0].workRequestId
+        ];
+        System.assertEquals('Accepted', req.StatusPk__c,
+            'approve decision lands with the dev ping wired in');
+        System.assertEquals(25, req.PreApprovedHoursNumber__c,
+            'granted hours stamped — the ping body reads this cap');
+    }
+
+    /**
+     * @description Decline fires the decided ping (with the stand-down
+     *              reason in the body) to the assigned developer without
+     *              exception; the stand-down state lands exactly as before.
+     */
+    @IsTest
+    static void testDeclinePingsAssignedDevWithReason() {
+        configureSettings(null, null, UserInfo.getUserId());
+        WorkItem__c wi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 20,
+            'DeveloperLookup__c' => UserInfo.getUserId()
+        });
+        List<DeliveryWorkApprovalService.SubmitResultDTO> results =
+            DeliveryWorkApprovalService.submitForApproval(new Set<Id>{ wi.Id });
+
+        Test.startTest();
+        DeliveryWorkApprovalService.decline(results[0].workRequestId, 'Budget freeze');
+        Test.stopTest();
+
+        WorkRequest__c req = [
+            SELECT StatusPk__c, StandDownReasonTxt__c
+            FROM WorkRequest__c WHERE Id = :results[0].workRequestId
+        ];
+        System.assertEquals('Inactive', req.StatusPk__c,
+            'decline decision lands with the dev ping wired in');
+        System.assertEquals('Budget freeze', req.StandDownReasonTxt__c,
+            'reason stored — the ping body carries it');
+    }
+
+    /**
+     * @description No developer assigned on the work item = the decided
+     *              ping skips silently: the approve succeeds and no
+     *              notification queueable is enqueued.
+     */
+    @IsTest
+    static void testDecidedPingSkipsSilentlyWhenNoDevAssigned() {
+        configureSettings(null, null, null);
+        WorkItem__c wi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 20
+        }); // no DeveloperLookup__c
+        List<DeliveryWorkApprovalService.SubmitResultDTO> results =
+            DeliveryWorkApprovalService.submitForApproval(new Set<Id>{ wi.Id });
+
+        Test.startTest();
+        Integer asyncBefore = [SELECT COUNT() FROM AsyncApexJob WHERE JobType = 'Queueable'];
+        DeliveryWorkApprovalService.approve(results[0].workRequestId, 20, null);
+        Integer asyncAfter = [SELECT COUNT() FROM AsyncApexJob WHERE JobType = 'Queueable'];
+        Test.stopTest();
+
+        System.assertEquals(asyncBefore, asyncAfter,
+            'unassigned dev must not enqueue a decided notification');
+        WorkRequest__c req = [
+            SELECT StatusPk__c FROM WorkRequest__c WHERE Id = :results[0].workRequestId
+        ];
+        System.assertEquals('Accepted', req.StatusPk__c,
+            'the decision itself must never be blocked by the silent skip');
+    }
+
+    /**
+     * @description Blank approver setting + unassigned request = the submit
+     *              ping skips silently: nothing to target, no exception, no
+     *              queueable, and the offer still goes out.
+     */
+    @IsTest
+    static void testSubmitPingSkipsSilentlyWhenNoApproverAnywhere() {
+        configureSettings(null, null, null); // no default approver, Auto off
+        WorkItem__c wi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 20
+        });
+
+        Test.startTest();
+        Integer asyncBefore = [SELECT COUNT() FROM AsyncApexJob WHERE JobType = 'Queueable'];
+        List<DeliveryWorkApprovalService.SubmitResultDTO> results =
+            DeliveryWorkApprovalService.submitForApproval(new Set<Id>{ wi.Id });
+        Integer asyncAfter = [SELECT COUNT() FROM AsyncApexJob WHERE JobType = 'Queueable'];
+        Test.stopTest();
+
+        System.assertEquals(asyncBefore, asyncAfter,
+            'no assigned approver and no configured default = no submit ping');
+        WorkRequest__c req = [
+            SELECT StatusPk__c, ApproverUserLookup__c
+            FROM WorkRequest__c WHERE Id = :results[0].workRequestId
+        ];
+        System.assertEquals('Offer Sent', req.StatusPk__c,
+            'the offer itself must never be blocked by the silent skip');
+        System.assertEquals(null, req.ApproverUserLookup__c, 'request is unassigned');
+    }
+
+    /**
+     * @description The two PR4 notification entry points are documented
+     *              null-safe no-ops: null / empty inputs and a non-existent
+     *              request id must never throw or enqueue.
+     */
+    @IsTest
+    static void testNotificationEntryPointsNullSafety() {
+        Test.startTest();
+        Integer asyncBefore = [SELECT COUNT() FROM AsyncApexJob WHERE JobType = 'Queueable'];
+        DeliveryNotificationService.notifyWorkApprovalSubmitted(null);
+        DeliveryNotificationService.notifyWorkApprovalSubmitted(new List<Id>());
+        DeliveryNotificationService.notifyWorkApprovalDecided(null, true);
+        DeliveryNotificationService.notifyWorkApprovalDecided(null, null);
+        // Real-shaped but non-existent request id — loader returns no rows.
+        DeliveryNotificationService.notifyWorkApprovalDecided(
+            WorkRequest__c.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED)
+                .getKeyPrefix() + '000000000000', false);
+        Integer asyncAfter = [SELECT COUNT() FROM AsyncApexJob WHERE JobType = 'Queueable'];
+        Test.stopTest();
+
+        System.assertEquals(asyncBefore, asyncAfter,
+            'null, empty, and missing-record inputs must never enqueue or throw');
+    }
 }


### PR DESCRIPTION
## Summary

PR4 of the work-approval queue: the two missing bell notifications, built on the shipped PR #891/#893 flow.

### `DeliveryNotificationService` (new global entry points, mirroring `notifyDeployedToProd`'s idiom — null-safe, try/catch WARN logging, `sendQueueable`, never blocks the caller)

- **`notifyWorkApprovalSubmitted(List<Id> workRequestIds)`** — batch-aware approver digest. Loads the Offer-Sent requests, groups by `ApproverUserLookup__c` with `resolveConfiguredApproverId()` as the fallback for unassigned rows, and sends **ONE notification per approver per transaction**: title `Approval needed: N item(s)`, body `N work item(s) totaling M quoted hours are pending your approval.`, deep-linked to the first request's `WorkItemId__c`. Rows with no assigned approver and no configured default skip silently.
- **`notifyWorkApprovalDecided(Id workRequestId, Boolean approved)`** — pings the work item's assigned developer (`WorkItemId__r.DeveloperLookup__c`; silent skip when unassigned). Approved → `Approved: <label>` / `<approver> approved <label> — capped at N hours, ready for development.` Declined → `Declined: <label>`, body carries the stand-down reason when present. Label ladder: `BriefDescriptionTxt__c` → `Name` → generic.
- Helper extraction (`groupRequestsByApprover` / `sendApproverDigest`) keeps the new method under PMD's CognitiveComplexity method threshold; remaining scanner findings on these files pre-exist on main.

### `DeliveryWorkApprovalService` call sites (next to the existing `writeAuditRow` positions, fire-and-forget after DML)

- End of `persistSubmit` — collects the **non-auto** request ids → `notifyWorkApprovalSubmitted` (auto-approved requests never queue for a human, so they never ping).
- End of `approve()` → `notifyWorkApprovalDecided(req.Id, true)`.
- End of `decline()` → `notifyWorkApprovalDecided(req.Id, false)`.

### Tests (`DeliveryWorkApprovalServiceTest`: 19 → 25)

- Over-threshold submit runs the approver ping path without exception (assigned Offer-Sent row intact).
- Approve and decline fire the decided path (decision state + cap/reason intact, `Test.stopTest()` drains the queueable).
- Unassigned dev = silent skip (queueable count unchanged, decision still lands).
- Blank approver setting + unassigned request = silent skip (queueable count unchanged, offer still goes out).
- Null/empty/missing-record inputs on both new entry points never throw or enqueue.

`Messaging.CustomNotification.send()` cannot be asserted directly (the managed test runner short-circuits delivery) — same contract as `DeliveryShipVerificationTest`: trackable side effects + the path completing cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)