### PR TITLE
PR5: approval-cap enforcement at WorkLog time — flag by default, hard-block by setting

### DIFF
--- a/force-app/main/default/classes/DeliveryWorkCapEnforcementService.cls
+++ b/force-app/main/default/classes/DeliveryWorkCapEnforcementService.cls
@@ -1,0 +1,458 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  PR5 (billing close-out) of the work-approval queue: enforces
+ *               the client-approved hours cap (WorkItem__c.
+ *               ClientPreApprovedHoursNumber__c, stamped by
+ *               DeliveryWorkApprovalService) at WorkLog__c time.
+ *
+ *               Two postures, gated by DeliveryHubSettings__c.
+ *               EnforceApprovalCapDateTime__c:
+ *
+ *               FLAG MODE (the default — setting is null): an over-cap log
+ *               still SAVES, but the item's newest Accepted WorkRequest__c
+ *               moves to StatusPk__c='Budget Hold' and one bell notification
+ *               goes to the org-default approver (ApproverUserIdTxt__c) plus
+ *               the item's assigned developer. Flag mode never throws — every
+ *               side effect is WARN-logged on failure.
+ *
+ *               ENFORCE MODE (setting populated): the offending row gets
+ *               addError() in the BEFORE context, so the over-cap log never
+ *               commits. The unblock path is the shipped
+ *               DeliveryWorkApprovalService.requestIncrease(...) → approve(...)
+ *               flow, which raises the cap by the approved delta only.
+ *
+ *               Execution is split across trigger contexts because addError
+ *               only works BEFORE the DML while the flag-mode side effects
+ *               (request update + queueable) must run AFTER the WorkLog row is
+ *               in the database: checkInserts/checkUpdates run in before
+ *               insert/update and stash flag-mode work in a static buffer;
+ *               processPendingFlags() drains that buffer in after
+ *               insert/update.
+ *
+ *               Logged totals are summed LIVE from WorkLog__c —
+ *               WorkItem__c.TotalLoggedHoursSum__c is a rollup and cannot be
+ *               trusted mid-transaction. Items with a null/zero cap are
+ *               uncapped and never evaluated. All SOQL is WITH SYSTEM_MODE per
+ *               CLAUDE.md (WITH USER_MODE breaks in namespaced package test
+ *               context).
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.CognitiveComplexity')
+public with sharing class DeliveryWorkCapEnforcementService {
+
+    /** WorkRequest__c lifecycle value consumed by the flag path (verified picklist value). */
+    public static final String REQUEST_ACCEPTED = 'Accepted';
+
+    /** WorkRequest__c lifecycle value written by the flag path (verified picklist value). */
+    public static final String REQUEST_BUDGET_HOLD = 'Budget Hold';
+
+    /** Hard cap on existing-log rows scanned per evaluation. */
+    private static final Integer MAX_LOG_ROWS = 10000;
+
+    /** Hard cap on Accepted-request rows scanned by the flag path. */
+    private static final Integer MAX_REQUEST_ROWS = 1000;
+
+    /**
+     * Before-context stash keyed by WorkItem id (one flag per item per
+     * transaction chunk), drained by processPendingFlags() in after context.
+     */
+    private static Map<Id, PendingFlag> pendingFlags = new Map<Id, PendingFlag>();
+
+    /**
+     * @description One over-cap work item flagged in the before context,
+     *              awaiting its after-commit side effects (Budget Hold +
+     *              notification). Internal carrier only.
+     */
+    private class PendingFlag {
+        private Id workItemId;
+        private String itemLabel;
+        private Decimal cap;
+        private Decimal total;
+        private Id developerId;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // BEFORE-CONTEXT ENTRY POINTS
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Evaluates WorkLog__c rows being INSERTED against their
+     *              parent items' client-approved caps. Enforce mode addErrors
+     *              the offending rows; flag mode stashes after-commit work.
+     *              Call from BEFORE INSERT.
+     * @param rows Trigger.new in before insert (no ids yet).
+     */
+    public static void checkInserts(List<WorkLog__c> rows) {
+        evaluate(rows, null);
+    }
+
+    /**
+     * @description Evaluates WorkLog__c rows being UPDATED against their
+     *              parent items' client-approved caps. Only rows whose hours
+     *              or parent item changed are evaluated, so unrelated edits to
+     *              an already-over-cap log are never blocked. Call from
+     *              BEFORE UPDATE.
+     * @param rows Trigger.new in before update.
+     * @param oldMap Trigger.oldMap (pre-update values).
+     */
+    public static void checkUpdates(List<WorkLog__c> rows, Map<Id, WorkLog__c> oldMap) {
+        evaluate(rows, oldMap);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // AFTER-CONTEXT ENTRY POINT
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Drains the flag-mode buffer AFTER the WorkLog DML has
+     *              committed: moves each flagged item's newest Accepted
+     *              WorkRequest__c to 'Budget Hold' and enqueues one
+     *              DeliveryNotificationQueueable per item to the org-default
+     *              approver + the item's assigned developer. Never throws —
+     *              flag mode must not abort the caller's save; failures are
+     *              WARN-logged. Honors DeliveryTriggerControl.runAfterLogic
+     *              like sibling after-handlers (the buffer is still cleared so
+     *              suppressed flags cannot leak into a later DML). Call from
+     *              AFTER INSERT / AFTER UPDATE.
+     */
+    public static void processPendingFlags() {
+        if (pendingFlags.isEmpty()) {
+            return;
+        }
+        Map<Id, PendingFlag> flags = pendingFlags;
+        pendingFlags = new Map<Id, PendingFlag>();
+        if (!DeliveryTriggerControl.runAfterLogic) {
+            return;
+        }
+        moveAcceptedRequestsToBudgetHold(flags.keySet());
+        notifyOverCap(flags.values());
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // EVALUATION CORE
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Shared bulkified evaluation: loads each parent item's cap
+     *              (skipping uncapped items), sums existing logged hours live
+     *              from WorkLog__c (excluding the in-flight rows themselves),
+     *              then walks the incoming rows accumulating a running total
+     *              per item so several rows in ONE batch cannot collectively
+     *              sneak past the cap. Inbound-sync DML is exempt — relayed
+     *              logs were already evaluated at their origin org and must
+     *              not be blocked mid-sync.
+     * @param rows The WorkLog__c rows being saved.
+     * @param oldMap Pre-update values (null on insert).
+     */
+    private static void evaluate(List<WorkLog__c> rows, Map<Id, WorkLog__c> oldMap) {
+        if (rows == null || rows.isEmpty() || DeliveryTriggerControl.inboundSyncContext) {
+            return;
+        }
+        List<WorkLog__c> candidates = collectCandidates(rows, oldMap);
+        if (candidates.isEmpty()) {
+            return;
+        }
+        Map<Id, WorkItem__c> cappedItems = loadCappedItems(candidateItemIds(candidates));
+        if (cappedItems.isEmpty()) {
+            return;
+        }
+
+        Map<Id, Decimal> runningTotals =
+            sumExistingLoggedHours(cappedItems.keySet(), candidateLogIds(candidates));
+        applyCapRules(candidates, cappedItems, runningTotals);
+    }
+
+    /**
+     * @description Walks the candidate rows in batch order, accumulating a
+     *              running per-item total (live DB sum + committing deltas) so
+     *              several rows in ONE batch cannot collectively sneak past
+     *              the cap. Over-cap rows are addError'd in enforce mode
+     *              (blocked rows stay OUT of the running total — a later
+     *              under-cap row in the same batch still passes) or stashed
+     *              for after-commit flagging in flag mode.
+     * @param candidates The rows requiring cap evaluation.
+     * @param cappedItems The capped parent items by id (uncapped absent).
+     * @param runningTotals Per-item persisted totals, mutated as rows commit.
+     */
+    private static void applyCapRules(
+        List<WorkLog__c> candidates, Map<Id, WorkItem__c> cappedItems, Map<Id, Decimal> runningTotals
+    ) {
+        Boolean enforce = isEnforcementOn();
+        for (WorkLog__c wl : candidates) {
+            WorkItem__c item = cappedItems.get(wl.WorkItemLookup__c);
+            if (item == null) {
+                continue; // uncapped item — never enforced
+            }
+            Decimal cap = item.ClientPreApprovedHoursNumber__c;
+            Decimal logged = runningTotals.containsKey(item.Id) ? runningTotals.get(item.Id) : 0;
+            Decimal delta = wl.HoursLoggedNumber__c == null ? 0 : wl.HoursLoggedNumber__c;
+            Decimal newTotal = logged + delta;
+
+            if (newTotal <= cap) {
+                runningTotals.put(item.Id, newTotal);
+                continue;
+            }
+            if (enforce) {
+                // Blocked row never commits — keep it OUT of the running total
+                // so a later under-cap row in the same batch still passes.
+                wl.addError('Logged hours would exceed the client-approved cap of ' + cap
+                    + 'h (currently ' + logged
+                    + 'h logged). Request a budget increase to continue.');
+                continue;
+            }
+            // Flag mode: the row WILL commit — count it and stash the
+            // after-commit side effects (one flag per item, newest total wins).
+            runningTotals.put(item.Id, newTotal);
+            stashFlag(item, newTotal);
+        }
+    }
+
+    /**
+     * @description Filters the trigger batch down to rows that can move a
+     *              capped total: parented rows whose hours or parent changed
+     *              (inserts always qualify). Rows whose update touches neither
+     *              are skipped, so their old (= new) hours stay in the DB sum.
+     * @param rows Trigger.new.
+     * @param oldMap Trigger.oldMap (null on insert).
+     * @return The rows requiring cap evaluation, in batch order.
+     */
+    private static List<WorkLog__c> collectCandidates(List<WorkLog__c> rows, Map<Id, WorkLog__c> oldMap) {
+        List<WorkLog__c> candidates = new List<WorkLog__c>();
+        for (WorkLog__c wl : rows) {
+            if (wl.WorkItemLookup__c == null) {
+                continue;
+            }
+            if (oldMap != null && !isRelevantChange(wl, oldMap.get(wl.Id))) {
+                continue;
+            }
+            candidates.add(wl);
+        }
+        return candidates;
+    }
+
+    /**
+     * @description Distinct parent WorkItem ids across the candidate rows.
+     * @param candidates The rows requiring cap evaluation.
+     * @return Set of parent WorkItem__c ids.
+     */
+    private static Set<Id> candidateItemIds(List<WorkLog__c> candidates) {
+        Set<Id> itemIds = new Set<Id>();
+        for (WorkLog__c wl : candidates) {
+            itemIds.add(wl.WorkItemLookup__c);
+        }
+        return itemIds;
+    }
+
+    /**
+     * @description Ids of candidate rows already in the database (updates).
+     *              These are excluded from the live DB sum — in the before
+     *              context the database still holds their OLD hours, and
+     *              their NEW hours re-enter as the incoming delta instead.
+     *              Inserts have no id yet and are naturally absent.
+     * @param candidates The rows requiring cap evaluation.
+     * @return Set of in-flight WorkLog__c ids to omit from the DB sum.
+     */
+    private static Set<Id> candidateLogIds(List<WorkLog__c> candidates) {
+        Set<Id> logIds = new Set<Id>();
+        for (WorkLog__c wl : candidates) {
+            if (wl.Id != null) {
+                logIds.add(wl.Id);
+            }
+        }
+        return logIds;
+    }
+
+    /**
+     * @description Records one flag-mode entry for an over-cap item in the
+     *              before-context buffer (one per item — the newest running
+     *              total wins), to be drained by processPendingFlags().
+     * @param item The capped parent WorkItem__c (label/developer loaded).
+     * @param newTotal The item's logged total INCLUDING the committing rows.
+     */
+    private static void stashFlag(WorkItem__c item, Decimal newTotal) {
+        PendingFlag flag = new PendingFlag();
+        flag.workItemId = item.Id;
+        flag.itemLabel = String.isNotBlank(item.BriefDescriptionTxt__c)
+            ? item.BriefDescriptionTxt__c : item.Name;
+        flag.cap = item.ClientPreApprovedHoursNumber__c;
+        flag.total = newTotal;
+        flag.developerId = item.DeveloperLookup__c;
+        pendingFlags.put(item.Id, flag);
+    }
+
+    /**
+     * @description Update-path relevance filter: only a change to the logged
+     *              hours or a reparenting to another work item can move a
+     *              total, so everything else (status flips, description edits)
+     *              skips evaluation entirely.
+     * @param wl The new row.
+     * @param old The pre-update row (null-safe).
+     * @return true when the row must be (re)evaluated.
+     */
+    private static Boolean isRelevantChange(WorkLog__c wl, WorkLog__c old) {
+        return old == null
+            || wl.HoursLoggedNumber__c != old.HoursLoggedNumber__c
+            || wl.WorkItemLookup__c != old.WorkItemLookup__c;
+    }
+
+    /**
+     * @description Loads the parent work items that actually carry a cap.
+     *              Items with a null/zero ClientPreApprovedHoursNumber__c are
+     *              uncapped and intentionally absent from the result.
+     * @param itemIds Parent WorkItem__c ids from the incoming rows.
+     * @return Map of capped WorkItem__c by id (cap, label, developer loaded).
+     */
+    private static Map<Id, WorkItem__c> loadCappedItems(Set<Id> itemIds) {
+        Map<Id, WorkItem__c> out = new Map<Id, WorkItem__c>();
+        for (WorkItem__c wi : [
+            SELECT Id, Name, BriefDescriptionTxt__c,
+                   ClientPreApprovedHoursNumber__c, DeveloperLookup__c
+            FROM WorkItem__c
+            WHERE Id IN :itemIds
+            AND ClientPreApprovedHoursNumber__c > 0
+            WITH SYSTEM_MODE
+        ]) {
+            out.put(wi.Id, wi);
+        }
+        return out;
+    }
+
+    /**
+     * @description Sums each capped item's ALREADY-PERSISTED logged hours live
+     *              from WorkLog__c. The rows currently in flight are excluded
+     *              by id (updates) or naturally absent (inserts have no id in
+     *              the before context). TotalLoggedHoursSum__c is deliberately
+     *              NOT used — rollups are stale mid-transaction.
+     * @param cappedItemIds Items whose totals are needed.
+     * @param excludeLogIds In-flight WorkLog ids to leave out of the DB sum.
+     * @return Map of WorkItem id → persisted logged-hours total (absent = 0).
+     */
+    private static Map<Id, Decimal> sumExistingLoggedHours(Set<Id> cappedItemIds, Set<Id> excludeLogIds) {
+        Map<Id, Decimal> totals = new Map<Id, Decimal>();
+        for (WorkLog__c wl : [
+            SELECT WorkItemLookup__c, HoursLoggedNumber__c
+            FROM WorkLog__c
+            WHERE WorkItemLookup__c IN :cappedItemIds
+            AND Id NOT IN :excludeLogIds
+            WITH SYSTEM_MODE
+            LIMIT :MAX_LOG_ROWS
+        ]) {
+            Decimal current = totals.containsKey(wl.WorkItemLookup__c)
+                ? totals.get(wl.WorkItemLookup__c) : 0;
+            totals.put(wl.WorkItemLookup__c,
+                current + (wl.HoursLoggedNumber__c == null ? 0 : wl.HoursLoggedNumber__c));
+        }
+        return totals;
+    }
+
+    /**
+     * @description Whether hard-block enforcement is on: true when
+     *              DeliveryHubSettings__c.EnforceApprovalCapDateTime__c is
+     *              populated (DateTime-not-Boolean toggle pattern). Null =
+     *              flag mode, the shipping default.
+     * @return true when over-cap rows must be blocked with addError.
+     */
+    private static Boolean isEnforcementOn() {
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        return settings != null && settings.EnforceApprovalCapDateTime__c != null;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // FLAG-MODE SIDE EFFECTS (after context)
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Moves each flagged item's NEWEST Accepted WorkRequest__c to
+     *              'Budget Hold' so the over-cap state is visible on the
+     *              request lifecycle. Items with no Accepted request are
+     *              skipped silently. Never throws — WARN-logs failures.
+     * @param itemIds The flagged WorkItem__c ids.
+     */
+    private static void moveAcceptedRequestsToBudgetHold(Set<Id> itemIds) {
+        try {
+            Map<Id, WorkRequest__c> newestAcceptedByItem = new Map<Id, WorkRequest__c>();
+            for (WorkRequest__c req : [
+                SELECT Id, WorkItemId__c
+                FROM WorkRequest__c
+                WHERE WorkItemId__c IN :itemIds
+                AND StatusPk__c = :REQUEST_ACCEPTED
+                WITH SYSTEM_MODE
+                ORDER BY CreatedDate DESC
+                LIMIT :MAX_REQUEST_ROWS
+            ]) {
+                if (!newestAcceptedByItem.containsKey(req.WorkItemId__c)) {
+                    req.StatusPk__c = REQUEST_BUDGET_HOLD;
+                    newestAcceptedByItem.put(req.WorkItemId__c, req);
+                }
+            }
+            if (!newestAcceptedByItem.isEmpty()) {
+                Database.update(newestAcceptedByItem.values(), AccessLevel.SYSTEM_MODE);
+            }
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryWorkCapEnforcementService.moveAcceptedRequestsToBudgetHold] failed: '
+                + e.getMessage());
+        }
+    }
+
+    /**
+     * @description Enqueues ONE DeliveryNotificationQueueable per flagged item
+     *              targeting the org-default approver (parsed from
+     *              ApproverUserIdTxt__c, same resolver shape as the shipped
+     *              approval service) plus the item's assigned developer.
+     *              No-ops per item when neither target resolves. Never throws.
+     * @param flags The drained flag-mode buffer entries.
+     */
+    @SuppressWarnings('PMD.OperationWithLimitsInLoop') // one queueable per flagged ITEM (already deduped); a flag batch is a handful of items, nowhere near the 50-job trigger limit, and each enqueue is individually guarded so one failure cannot starve the rest
+    private static void notifyOverCap(List<PendingFlag> flags) {
+        Id approverId = resolveDefaultApproverId();
+        for (PendingFlag flag : flags) {
+            try {
+                Set<Id> targets = new Set<Id>();
+                if (approverId != null) {
+                    targets.add(approverId);
+                }
+                if (flag.developerId != null) {
+                    targets.add(flag.developerId);
+                }
+                if (targets.isEmpty()) {
+                    continue;
+                }
+                System.enqueueJob(new DeliveryNotificationQueueable(
+                    targets,
+                    'Over approved cap',
+                    flag.itemLabel + ': ' + flag.total + 'h logged vs ' + flag.cap
+                        + 'h approved — needs a budget increase.',
+                    flag.workItemId));
+            } catch (Exception e) {
+                System.debug(LoggingLevel.WARN,
+                    '[DeliveryWorkCapEnforcementService.notifyOverCap] enqueue failed for '
+                    + flag.workItemId + ': ' + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * @description Resolves the org-default approver from
+     *              DeliveryHubSettings__c.ApproverUserIdTxt__c — a private
+     *              copy of the shipped services' resolver (the approval
+     *              service is owned by a parallel change and must not be
+     *              touched). Bad/blank ids resolve to null with a WARN.
+     * @return The configured approver's user id, or null when unset/invalid.
+     */
+    private static Id resolveDefaultApproverId() {
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        if (settings == null || String.isBlank(settings.ApproverUserIdTxt__c)) {
+            return null;
+        }
+        try {
+            return Id.valueOf(settings.ApproverUserIdTxt__c.trim());
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryWorkCapEnforcementService.resolveDefaultApproverId] bad id in settings: '
+                + e.getMessage());
+            return null;
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryWorkCapEnforcementService.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryWorkCapEnforcementService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryWorkCapEnforcementServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkCapEnforcementServiceTest.cls
@@ -1,0 +1,277 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for the PR5 client-approved-cap gate at WorkLog time:
+ *               under-cap logging passes untouched; over-cap logging is
+ *               hard-blocked when EnforceApprovalCapDateTime__c is set and
+ *               allowed-but-flagged (newest Accepted request → Budget Hold)
+ *               when it is null (the default); uncapped items are never
+ *               evaluated; bulk batches only error the offending rows; and the
+ *               shipped requestIncrease → approve flow raises the cap so the
+ *               same insert passes afterwards.
+ *
+ *               Seeds data via TestDataFactory (createWorkItem /
+ *               createWorkRequest / createWorkLog) and configures the gate
+ *               through DeliveryHubSettings__c org defaults — the same
+ *               settings idiom as DeliveryWorkApprovalServiceTest.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryWorkCapEnforcementServiceTest {
+
+    private static final Decimal CAP = 10;
+
+    /**
+     * @description Writes the cap-gate org-default settings.
+     * @param enforceOn true stamps EnforceApprovalCapDateTime__c (hard-block
+     *        mode); false leaves it null (flag mode, the shipping default).
+     * @param approverId Default approver User ID (null = no approver target).
+     */
+    private static void configureSettings(Boolean enforceOn, Id approverId) {
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        settings.EnforceApprovalCapDateTime__c = enforceOn ? Datetime.now() : null;
+        settings.ApproverUserIdTxt__c = approverId == null ? null : String.valueOf(approverId);
+        upsert settings;
+    }
+
+    /**
+     * @description Seeds a WorkItem carrying the standard 10h client-approved cap.
+     * @return The inserted capped WorkItem__c.
+     */
+    private static WorkItem__c cappedItem() {
+        return TestDataFactory.createWorkItem(new Map<String, Object>{
+            'ClientPreApprovedHoursNumber__c' => CAP
+        });
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // ENFORCE MODE
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description An under-cap insert passes untouched even with hard
+     *              enforcement on — no error, no Budget Hold side effect.
+     */
+    @IsTest
+    static void testUnderCapInsertPasses() {
+        configureSettings(true, null);
+        WorkItem__c wi = cappedItem();
+
+        Test.startTest();
+        TestDataFactory.createWorkLog(wi.Id, 4, null, null);
+        Test.stopTest();
+
+        System.assertEquals(1, [
+            SELECT COUNT() FROM WorkLog__c WHERE WorkItemLookup__c = :wi.Id
+        ], 'under-cap log saves normally');
+        System.assertEquals(0, [
+            SELECT COUNT() FROM WorkRequest__c
+            WHERE WorkItemId__c = :wi.Id
+            AND StatusPk__c = :DeliveryWorkCapEnforcementService.REQUEST_BUDGET_HOLD
+        ], 'no Budget Hold side effect for an under-cap log');
+    }
+
+    /**
+     * @description With enforcement ON, an insert that pushes the live total
+     *              over the cap is blocked with addError — the row never
+     *              commits and the message points at the budget-increase path.
+     */
+    @IsTest
+    static void testOverCapInsertBlockedWhenEnforcementOn() {
+        configureSettings(true, null);
+        WorkItem__c wi = cappedItem();
+        TestDataFactory.createWorkLog(wi.Id, 8, null, null); // 8 of 10
+
+        Boolean threw = false;
+        String message;
+        Test.startTest();
+        try {
+            TestDataFactory.createWorkLog(wi.Id, 5, null, null); // would be 13 of 10
+        } catch (DmlException e) {
+            threw = true;
+            message = e.getMessage();
+        }
+        Test.stopTest();
+
+        System.assert(threw, 'over-cap insert must be blocked when enforcement is on');
+        System.assert(message.contains('client-approved cap'),
+            'error explains the cap: ' + message);
+        System.assert(message.contains('budget increase'),
+            'error points at the requestIncrease unblock path: ' + message);
+        System.assertEquals(1, [
+            SELECT COUNT() FROM WorkLog__c WHERE WorkItemLookup__c = :wi.Id
+        ], 'the blocked row never committed');
+    }
+
+    /**
+     * @description With enforcement ON, raising an existing log's hours past
+     *              the cap is blocked in before update.
+     */
+    @IsTest
+    static void testOverCapUpdateBlockedWhenEnforcementOn() {
+        configureSettings(true, null);
+        WorkItem__c wi = cappedItem();
+        WorkLog__c log = TestDataFactory.createWorkLog(wi.Id, 8, null, null);
+
+        Boolean threw = false;
+        Test.startTest();
+        try {
+            log.HoursLoggedNumber__c = 12;
+            update log;
+        } catch (DmlException e) {
+            threw = true;
+        }
+        Test.stopTest();
+
+        System.assert(threw, 'raising hours past the cap must be blocked on update');
+        System.assertEquals(8, [
+            SELECT HoursLoggedNumber__c FROM WorkLog__c WHERE Id = :log.Id
+        ].HoursLoggedNumber__c, 'the original hours survive the blocked update');
+    }
+
+    /**
+     * @description Items with a null cap are uncapped — never evaluated, even
+     *              with enforcement on and a huge log.
+     */
+    @IsTest
+    static void testUncappedItemNeverEnforced() {
+        configureSettings(true, null);
+        WorkItem__c wi = TestDataFactory.createWorkItem(null); // no cap
+
+        Test.startTest();
+        TestDataFactory.createWorkLog(wi.Id, 100, null, null);
+        Test.stopTest();
+
+        System.assertEquals(1, [
+            SELECT COUNT() FROM WorkLog__c WHERE WorkItemLookup__c = :wi.Id
+        ], 'uncapped items take any hours — null cap means unenforced');
+    }
+
+    /**
+     * @description Bulk partial save: a mixed batch only errors the rows that
+     *              push their item over the cap — under-cap rows on the same
+     *              item and rows on uncapped items still save. The running
+     *              total accumulates WITHIN the batch (6h passes, the second
+     *              6h on the same 10h item fails).
+     */
+    @IsTest
+    static void testBulkMixedBatchOnlyErrorsOffendingRows() {
+        configureSettings(true, null);
+        WorkItem__c capped = cappedItem();
+        WorkItem__c uncapped = TestDataFactory.createWorkItem(null);
+        List<WorkLog__c> rows = new List<WorkLog__c>{
+            TestDataFactory.buildWorkLog(capped.Id, 6, null, null),
+            TestDataFactory.buildWorkLog(capped.Id, 6, null, null),  // 12 of 10 → blocked
+            TestDataFactory.buildWorkLog(uncapped.Id, 20, null, null)
+        };
+
+        Test.startTest();
+        List<Database.SaveResult> results = Database.insert(rows, false);
+        Test.stopTest();
+
+        System.assertEquals(true, results[0].isSuccess(),
+            'first 6h on the 10h item fits and saves');
+        System.assertEquals(false, results[1].isSuccess(),
+            'second 6h on the same item breaches the cap and is blocked');
+        System.assert(results[1].getErrors()[0].getMessage().contains('client-approved cap'),
+            'the offending row carries the cap error');
+        System.assertEquals(true, results[2].isSuccess(),
+            'uncapped-item row is untouched by the gate');
+        System.assertEquals(1, [
+            SELECT COUNT() FROM WorkLog__c WHERE WorkItemLookup__c = :capped.Id
+        ], 'only the fitting row committed on the capped item');
+    }
+
+    /**
+     * @description The acceptance loop: a blocked insert passes after the
+     *              shipped requestIncrease → approve flow raises the cap by
+     *              the approved delta (the budget increase re-enters the queue
+     *              for the delta only).
+     */
+    @IsTest
+    static void testIncreaseThenApprovePassesAfterCapRaise() {
+        configureSettings(true, null);
+        WorkItem__c wi = cappedItem();
+        TestDataFactory.createWorkLog(wi.Id, 8, null, null); // 8 of 10
+
+        Boolean threwBefore = false;
+        try {
+            TestDataFactory.createWorkLog(wi.Id, 5, null, null);
+        } catch (DmlException e) {
+            threwBefore = true;
+        }
+        System.assert(threwBefore, 'insert is blocked while the cap is 10h');
+
+        Test.startTest();
+        Id increaseId = DeliveryWorkApprovalService.requestIncrease(
+            wi.Id, 10, 'Cap reached — need the delta to finish');
+        DeliveryWorkApprovalService.approve(increaseId, null, 'granting the delta');
+        TestDataFactory.createWorkLog(wi.Id, 5, null, null); // 13 of 20 now
+        Test.stopTest();
+
+        System.assertEquals(20, [
+            SELECT ClientPreApprovedHoursNumber__c FROM WorkItem__c WHERE Id = :wi.Id
+        ].ClientPreApprovedHoursNumber__c, 'approve raised the cap 10 + 10 = 20');
+        System.assertEquals(2, [
+            SELECT COUNT() FROM WorkLog__c WHERE WorkItemLookup__c = :wi.Id
+        ], 'the same 5h insert passes once the raised cap covers it');
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // FLAG MODE (the default)
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description With enforcement OFF (the default), an over-cap insert
+     *              SAVES, and the item's newest Accepted request is moved to
+     *              Budget Hold while the approver/developer notification is
+     *              enqueued — flag, don't block.
+     */
+    @IsTest
+    static void testOverCapFlagModeInsertsAndFlipsBudgetHold() {
+        configureSettings(false, UserInfo.getUserId());
+        WorkItem__c wi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'ClientPreApprovedHoursNumber__c' => CAP,
+            'DeveloperLookup__c' => UserInfo.getUserId()
+        });
+        WorkRequest__c accepted = TestDataFactory.createWorkRequest(wi.Id, new Map<String, Object>{
+            'StatusPk__c' => DeliveryWorkCapEnforcementService.REQUEST_ACCEPTED,
+            'QuotedHoursNumber__c' => CAP
+        });
+
+        Test.startTest();
+        TestDataFactory.createWorkLog(wi.Id, 12, null, null); // 12 of 10 — over
+        Test.stopTest();
+
+        System.assertEquals(1, [
+            SELECT COUNT() FROM WorkLog__c WHERE WorkItemLookup__c = :wi.Id
+        ], 'flag mode lets the over-cap log save');
+        System.assertEquals(
+            DeliveryWorkCapEnforcementService.REQUEST_BUDGET_HOLD,
+            [SELECT StatusPk__c FROM WorkRequest__c WHERE Id = :accepted.Id].StatusPk__c,
+            'the Accepted request is parked at Budget Hold for re-entry via requestIncrease');
+    }
+
+    /**
+     * @description An edit that does not touch hours or the parent item on an
+     *              ALREADY over-cap log is never blocked, even after hard
+     *              enforcement is switched on — only changes that can move a
+     *              total are evaluated.
+     */
+    @IsTest
+    static void testNonHoursUpdateOnOverCapItemNotBlocked() {
+        configureSettings(false, null); // flag mode lets the over-cap row in
+        WorkItem__c wi = cappedItem();
+        WorkLog__c log = TestDataFactory.createWorkLog(wi.Id, 12, null, null);
+        configureSettings(true, null); // now hard-block is on
+
+        Test.startTest();
+        log.WorkDescriptionTxt__c = 'clarified the work narrative';
+        update log;
+        Test.stopTest();
+
+        System.assertEquals('clarified the work narrative', [
+            SELECT WorkDescriptionTxt__c FROM WorkLog__c WHERE Id = :log.Id
+        ].WorkDescriptionTxt__c, 'a non-hours edit on an over-cap item still saves');
+    }
+}

--- a/force-app/main/default/classes/DeliveryWorkCapEnforcementServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryWorkCapEnforcementServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryWorkLogTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryWorkLogTriggerHandler.cls
@@ -17,6 +17,10 @@ public with sharing class DeliveryWorkLogTriggerHandler {
      * @param newLogs List of WorkLog__c records being inserted.
      */
     public static void onBeforeInsert(List<WorkLog__c> newLogs) {
+        // Client-approved-cap gate (PR5): addError must happen in the BEFORE
+        // context, so this runs ahead of the settings-dependent defaults below.
+        DeliveryWorkCapEnforcementService.checkInserts(newLogs);
+
         DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
         if (settings == null) {
             return;
@@ -100,6 +104,18 @@ public with sharing class DeliveryWorkLogTriggerHandler {
     }
 
     /**
+     * @description Cap-enforcement gate for updates (PR5): re-evaluates rows
+     *              whose hours or parent item changed against the client-
+     *              approved cap. Runs before update so over-cap rows can be
+     *              blocked with addError when enforcement is on.
+     * @param newLogs List of WorkLog__c records being updated.
+     * @param oldMap Map of pre-update WorkLog__c records keyed by Id.
+     */
+    public static void onBeforeUpdate(List<WorkLog__c> newLogs, Map<Id, WorkLog__c> oldMap) {
+        DeliveryWorkCapEnforcementService.checkUpdates(newLogs, oldMap);
+    }
+
+    /**
      * @description Processes newly inserted WorkLog records and creates outbound sync items
      *              for those tied to client-linked work items. When approval is required,
      *              only logs with StatusPk__c = 'Approved' (or null for backward compat)
@@ -107,6 +123,10 @@ public with sharing class DeliveryWorkLogTriggerHandler {
      * @param newLogs List of newly inserted WorkLog__c records.
      */
     public static void onAfterInsert(List<WorkLog__c> newLogs) {
+        // Drain flag-mode cap side effects now that the rows are committed.
+        // The service honors runAfterLogic internally AND clears its buffer
+        // either way, so it must run ahead of the guard below.
+        DeliveryWorkCapEnforcementService.processPendingFlags();
         if (!DeliveryTriggerControl.runAfterLogic) {
             return;
         }
@@ -125,6 +145,8 @@ public with sharing class DeliveryWorkLogTriggerHandler {
      * @param oldMap Map of old WorkLog__c records keyed by Id.
      */
     public static void onAfterUpdate(List<WorkLog__c> newLogs, Map<Id, WorkLog__c> oldMap) {
+        // Drain flag-mode cap side effects (see onAfterInsert).
+        DeliveryWorkCapEnforcementService.processPendingFlags();
         if (!DeliveryTriggerControl.runAfterLogic) {
             return;
         }

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnforceApprovalCapDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnforceApprovalCapDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnforceApprovalCapDateTime__c</fullName>
+    <description>When populated, work logs that would push a work item's total logged hours past its client-approved cap (ClientPreApprovedHoursNumber__c) are hard-blocked at save. When null (default), over-cap logging is allowed but flagged: the item's newest Accepted work request moves to Budget Hold and the approver/developer are notified. Provides an audit trail of when hard enforcement was enabled.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set this to hard-block logging beyond the client-approved hours cap. Leave blank for flag mode (default): over-cap logs save, but the item's Accepted request moves to Budget Hold and the approver is notified.</inlineHelpText>
+    <label>Enforce Approval Cap Since</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
@@ -229,6 +229,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryWorkCapEnforcementService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryWorkItemController</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
@@ -229,6 +229,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryWorkCapEnforcementService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryWorkItemController</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/force-app/main/default/triggers/DeliveryWorkLogTrigger.trigger
+++ b/force-app/main/default/triggers/DeliveryWorkLogTrigger.trigger
@@ -2,9 +2,12 @@
  * @description Trigger for WorkLog__c. Delegates all logic to DeliveryWorkLogTriggerHandler.
  * @author Cloud Nimbus LLC
  */
-trigger DeliveryWorkLogTrigger on WorkLog__c (before insert, after insert, after update) { // NOPMD
+trigger DeliveryWorkLogTrigger on WorkLog__c (before insert, before update, after insert, after update) { // NOPMD
     if (Trigger.isBefore && Trigger.isInsert) {
         DeliveryWorkLogTriggerHandler.onBeforeInsert(Trigger.new);
+    }
+    if (Trigger.isBefore && Trigger.isUpdate) {
+        DeliveryWorkLogTriggerHandler.onBeforeUpdate(Trigger.new, Trigger.oldMap);
     }
     if (Trigger.isAfter && Trigger.isInsert) {
         DeliveryWorkLogTriggerHandler.onAfterInsert(Trigger.new);


### PR DESCRIPTION
## What

Final PR of the work-approval queue (spec §9 billing close-out). Logging beyond `WorkItem__c.ClientPreApprovedHoursNumber__c` (the canonical cap stamped by the shipped approval flow) is now **blocked or flagged** at WorkLog time, and a budget increase re-enters the queue **for the delta only** via the existing `DeliveryWorkApprovalService.requestIncrease → approve` path (not rebuilt here — exercised end-to-end in the tests).

## Enforce vs flag — the duality

Gated by a new org setting, `DeliveryHubSettings__c.EnforceApprovalCapDateTime__c` (DateTime-not-Boolean toggle, per house pattern):

| Posture | Setting | Behavior |
|---|---|---|
| **Flag mode** — *the default* | `null` | The over-cap log **saves**. After the DML commits, the item's newest **Accepted** `WorkRequest__c` moves to `StatusPk__c='Budget Hold'` and one `DeliveryNotificationQueueable` bell goes to the org-default approver (`ApproverUserIdTxt__c`) + the item's `DeveloperLookup__c`. Flag mode **never throws** — every side effect is WARN-logged on failure. |
| **Enforce mode** | populated | The offending row gets `addError` in the before context: *"Logged hours would exceed the client-approved cap of Nh (currently Mh logged). Request a budget increase to continue."* The row never commits. |

**Off by default on purpose**: subscriber orgs upgrade with zero behavior change — nobody's time entry starts bouncing on install day. An org opts into hard blocking by stamping the setting, and the stamp doubles as the audit trail of *when* enforcement began.

## How

- **`DeliveryWorkCapEnforcementService`** (new, 33 chars): bulkified evaluation — collects parent items, loads caps (null/0 cap = uncapped, never evaluated), sums logged hours **live from `WorkLog__c`** (`TotalLoggedHoursSum__c` is a rollup and stale mid-transaction; in-flight update rows excluded by id, their new hours re-enter as the delta), then walks the batch with a running per-item total so several rows in one batch can't collectively sneak past the cap. All SOQL `WITH SYSTEM_MODE`; skips `DeliveryTriggerControl.inboundSyncContext` (relayed logs were evaluated at origin).
- **Trigger split**: `DeliveryWorkLogTrigger` gains `before update`; handler delegates `checkInserts`/`checkUpdates` in before contexts (where `addError` works) and `processPendingFlags()` in after contexts (where the flag-mode side effects can act on committed rows). The after drain honors `runAfterLogic` and clears its buffer either way.
- Update path only re-evaluates rows whose hours or parent item changed — a description edit on an already-over-cap log is never blocked.
- Approver resolver is a private copy of the shipped services' `ApproverUserIdTxt__c` parser — `DeliveryWorkApprovalService` / `DeliveryNotificationService` are owned by a parallel change and untouched here.
- Permsets: `classAccesses` for the new service in `DeliveryHubApp` + `DeliveryHubAdmin_App` (alphabetical). No fieldPermissions for the settings field — custom settings fields don't take them.

## Tests (`DeliveryWorkCapEnforcementServiceTest`, 8)

1. Under-cap insert passes untouched (enforcement ON)
2. Over-cap insert blocked when enforcement ON (DmlException, row never commits)
3. Over-cap update (raising hours) blocked when enforcement ON
4. Over-cap insert in flag mode saves **and** flips the Accepted request to Budget Hold
5. Uncapped item (null cap) never enforced
6. Bulk mixed batch: only the offending row errors (running total within one batch)
7. **Acceptance loop**: blocked insert passes after the real `requestIncrease` + `approve` raise the cap 10 → 20
8. Non-hours edit on an over-cap log is not blocked after enforcement turns on

PMD (CI engine) clean on the new classes except `AvoidDebugStatements` on WARN-logging in catch blocks — same posture as the shipped `DeliveryWorkApprovalService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)