### PR TITLE
chore: audit quick fixes — strip debug console.log + token-first sObjectType resolution

### DIFF
--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -1239,12 +1239,45 @@ public without sharing class DeliverySyncItemIngestor {
         return processInboundItem(objectType, payload);
     }
 
+    // Typed tokens for the object types this ingestor actually handles
+    // (WorkItem__c / WorkItemComment__c / WorkLog__c sync payloads plus
+    // ContentVersion file transport). Typed tokens resolve correctly in the
+    // delivery__ packaging/namespaced context, where bare-name
+    // Schema.getGlobalDescribe() lookups silently miss (keys are
+    // namespace-prefixed). Keys are namespace-stripped + lowercased so both
+    // the bare ('WorkItem__c') and prefixed ('delivery__WorkItem__c') forms
+    // remote payloads send resolve through the token path.
+    private static final Map<String, Schema.SObjectType> KNOWN_DH_TYPES =
+        new Map<String, Schema.SObjectType>{
+            'workitem__c' => WorkItem__c.SObjectType,
+            'workitemcomment__c' => WorkItemComment__c.SObjectType,
+            'worklog__c' => WorkLog__c.SObjectType,
+            'contentversion' => ContentVersion.SObjectType
+        };
+
+    /**
+     * @description Resolves an SObject type from a payload-supplied API name.
+     * Token-first: the KNOWN_DH_TYPES map of compile-time typed tokens is
+     * consulted before any dynamic describe, because getGlobalDescribe-based
+     * resolution of DH objects breaks in the delivery__ packaging context
+     * (feature-test scratch orgs are non-namespaced and miss it). The
+     * getGlobalDescribe dual lookup (bare name, then delivery__-prefixed)
+     * survives ONLY as the fallback for genuinely-unknown / non-DH names —
+     * processInboundItem's objectType is a dynamic string from remote-org
+     * sync payloads, so arbitrary names must still resolve.
+     * @param apiName The object API name from the sync payload (bare or namespace-prefixed).
+     * @return The resolved SObjectType token, or null when the name is blank or unknown.
+     */
+    @TestVisible
     private static Schema.SObjectType findSObjectType(String apiName) {
         if (String.isBlank(apiName)) { return null; }
+        Schema.SObjectType known = KNOWN_DH_TYPES.get(stripNamespace(apiName).toLowerCase());
+        if (known != null) { return known; }
+
         Map<String, Schema.SObjectType> gd = Schema.getGlobalDescribe();
         if (gd.containsKey(apiName)) { return gd.get(apiName); }
         if (gd.containsKey('delivery__' + apiName)) { return gd.get('delivery__' + apiName); }
-        
+
         String target = stripNamespace(apiName).toLowerCase();
         for (String key : gd.keySet()) {
             if (stripNamespace(key).toLowerCase() == target) {

--- a/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
@@ -1318,4 +1318,37 @@ private class DeliverySyncItemIngestorTest {
                 'When ledger-matched local record was deleted, must insert fresh');
         }
     }
+
+    /**
+     * @description Asserts findSObjectType resolves known DH objects through
+     *              the typed-token map (token path) — identity-equal to the
+     *              compile-time SObjectType token — for both the bare and
+     *              namespace-prefixed name forms remote payloads send, and
+     *              that unknown names still return null via the
+     *              getGlobalDescribe fallback.
+     */
+    @IsTest
+    static void testFindSObjectTypeResolvesViaTokenPath() {
+        System.assertEquals(WorkItem__c.SObjectType,
+            DeliverySyncItemIngestor.findSObjectType('WorkItem__c'),
+            'Bare WorkItem__c must resolve to the typed token');
+        System.assertEquals(WorkItem__c.SObjectType,
+            DeliverySyncItemIngestor.findSObjectType('delivery__WorkItem__c'),
+            'Namespace-prefixed WorkItem__c must resolve to the same typed token');
+        System.assertEquals(WorkItemComment__c.SObjectType,
+            DeliverySyncItemIngestor.findSObjectType('WorkItemComment__c'),
+            'WorkItemComment__c must resolve to the typed token');
+        System.assertEquals(WorkLog__c.SObjectType,
+            DeliverySyncItemIngestor.findSObjectType('WorkLog__c'),
+            'WorkLog__c must resolve to the typed token');
+        System.assertEquals(ContentVersion.SObjectType,
+            DeliverySyncItemIngestor.findSObjectType('ContentVersion'),
+            'ContentVersion must resolve to the typed token');
+        System.assertEquals(null,
+            DeliverySyncItemIngestor.findSObjectType('NoSuchObject__c'),
+            'Unknown object names must return null from the describe fallback');
+        System.assertEquals(null,
+            DeliverySyncItemIngestor.findSObjectType(''),
+            'Blank input must return null');
+    }
 }

--- a/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
+++ b/force-app/main/default/lwc/deliveryProFormaTimeline/deliveryProFormaTimeline.js
@@ -325,8 +325,6 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
 
     _openContextMenu(task, x, y) {
         const id = (task && task.id) || task;
-        // eslint-disable-next-line no-console
-        console.log('[DH ctx-open]', id, { x, y });
         const full = (this._tasks || []).find(t => t.id === id) || task || {};
         this._menuTaskId = id;
         this._menuTaskPriorityGroup = full.priorityGroup || null;
@@ -993,10 +991,6 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             mountConfig.onItemReorderError = (taskId, error) => this._handleItemReorderError(taskId, error);
             mountConfig.onItemEdit = async (taskId, changes) => {
                 const id = this._normalizeTaskId(taskId);
-                let changesLog = {};
-                try { changesLog = JSON.parse(JSON.stringify(changes || {})); } catch (e) { changesLog = { _unserializable: true }; }
-                // eslint-disable-next-line no-console
-                console.log('[DH onItemEdit inline]', { resolvedId: id, changes: changesLog });
                 if (!id) { throw new Error('[DH] onItemEdit missing taskId'); }
                 const keys = Object.keys(changes || {});
                 if (keys.length === 0) {
@@ -1116,8 +1110,6 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
                 recordUrlTemplate: mountConfig.recordUrlTemplate,
                 mountedAt: new Date().toISOString(),
             };
-            // eslint-disable-next-line no-console
-            console.log('[DH mount]', JSON.stringify(mountSnapshot));
             // Triple-publish so the probe has multiple reading paths that
             // don't all depend on the same LWS/Locker proxy behaving. Each
             // publish target gets its own try/catch — in LWS strict mode on
@@ -1221,8 +1213,6 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
     }
 
     async _handlePatch(patch) {
-        // eslint-disable-next-line no-console
-        console.log('[DH onPatch]', JSON.stringify(patch || {}));
         const { id, sortOrder, priorityGroup, parentId, startDate, endDate } = patch;
         const ops = [];
 
@@ -1267,8 +1257,6 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
      */
     async _handleItemEdit(arg1, changes) {
         const taskId = this._normalizeTaskId(arg1);
-        // eslint-disable-next-line no-console
-        console.log('[DH onItemEdit]', { arg1Type: typeof arg1, resolvedTaskId: taskId, changes });
         if (!taskId) { throw new Error('[DH] onItemEdit missing taskId'); }
         const { startDate, endDate } = changes || {};
         if (startDate === undefined && endDate === undefined) {
@@ -1298,69 +1286,9 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
      * MF-Prod traced to this handler ignoring newPriorityGroup — sort updated
      * on both but lane only changed visually; on refresh items snapped back.
      */
-    /**
-     * Print a flat table of every task grouped by priority bucket so a
-     * drag + console scroll shows exactly where each task is before and
-     * after the save. Use NG's current view (mount handle) if available,
-     * else fall back to this._tasks (last refetch).
-     */
-    /** Refetch fresh data from Apex, push into NG via setTasks, then dump. */
-    async _refetchAfterPatchAndDump(label) {
-        try {
-            const data = await getProFormaTimelineData({ showCompleted: false });
-            this._tasks = data || [];
-            if (this._mountHandle && typeof this._mountHandle.setTasks === 'function') {
-                this._mountHandle.setTasks(this._mapTasksForNg(this._tasks));
-            }
-            this._dumpPositions(label);
-        } catch (error) {
-            // eslint-disable-next-line no-console
-            console.warn('[DH refetch] failed:', error);
-        }
-    }
-
-    _dumpPositions(label) {
-        let tasks = null;
-        try {
-            if (this._mountHandle && typeof this._mountHandle.getTasks === 'function') {
-                tasks = this._mountHandle.getTasks();
-            }
-        } catch (e) { /* fall through */ }
-        if (!tasks) tasks = this._tasks || [];
-        const rows = tasks.map(t => ({
-            bucket: t.priorityGroup || '(none)',
-            sortOrder: t.sortOrder,
-            name: (t.name || t.title || '').slice(0, 50),
-            id: t.id,
-        }));
-        rows.sort((a, b) => {
-            if (a.bucket !== b.bucket) return String(a.bucket).localeCompare(String(b.bucket));
-            return Number(a.sortOrder) - Number(b.sortOrder);
-        });
-        // Plain text lines so DevTools "Copy all messages" captures them.
-        // console.table prints nicely but is empty in pasted logs.
-        const lines = rows.map(r =>
-            `  ${String(r.bucket).padEnd(14)} ${String(r.sortOrder).padEnd(10)} ${r.id}  ${r.name}`
-        );
-        // eslint-disable-next-line no-console
-        console.log('[DH positions] ' + label + ' (' + rows.length + ' tasks)\n' + lines.join('\n'));
-    }
-
     async _handleItemReorder(arg1, payload) {
         const taskId = this._normalizeTaskId(arg1);
-        this._dumpPositions('BEFORE onItemReorder ' + taskId);
-        // Expanded payload logging — plain stringify so Glen can copy from
-        // console without needing to expand collapsed objects. Fields
-        // enumerated so we can spot if NG sends date info via reorder
-        // (misclassified canvas horizontal drag).
         const p = payload || {};
-        // Stringify full payload so deparent flags + any NG-side metadata is
-        // visible. Earlier log omitted fields like `deparent: true` which NG
-        // emits for bucket-header drops; handler couldn't branch on them.
-        let fullPayloadJson = '';
-        try { fullPayloadJson = JSON.stringify(p); } catch (e) { fullPayloadJson = '[unserializable]'; }
-        // eslint-disable-next-line no-console
-        console.log('[DH onItemReorder]', 'taskId=', taskId, 'payload=', fullPayloadJson);
         if (!taskId) { throw new Error('[DH] onItemReorder missing taskId'); }
         const { newIndex, newParentId, newPriorityGroup, startDate, endDate, position, beforeTaskId, afterTaskId } = p;
         // If NG smuggled date info through the reorder callback (happens when
@@ -1463,8 +1391,6 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
      */
     _handleItemClick(arg1) {
         const taskId = this._normalizeTaskId(arg1);
-        // eslint-disable-next-line no-console
-        console.log('[DH onItemClick]', { arg1Type: typeof arg1, resolvedTaskId: taskId });
         if (!taskId) {
             return;
         }
@@ -1763,15 +1689,8 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
 
     async _refetchAfterPatch() {
         try {
-            // eslint-disable-next-line no-console
-            console.log('[DH refetch] starting — mountHandle type=', typeof this._mountHandle, 'keys=', this._mountHandle ? Object.keys(this._mountHandle) : 'no handle');
             const data = await getProFormaTimelineData({ showCompleted: false });
             this._tasks = data || [];
-            // eslint-disable-next-line no-console
-            console.log('[DH refetch] fetched', this._tasks.length, 'tasks. Sample sortOrder values:', this._tasks.slice(0, 5).map(t => ({ id: t.id, so: t.sortOrder })));
-            const setTasksType = this._mountHandle ? typeof this._mountHandle.setTasks : 'no handle';
-            // eslint-disable-next-line no-console
-            console.log('[DH refetch] handle.setTasks typeof=', setTasksType);
             const mapped = this._mapTasksForNg(this._tasks);
             // Re-filter deps against the refreshed task set so arrows whose
             // endpoints just dropped out of view (completed, date-cleared)
@@ -1780,12 +1699,8 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             const deps = this._mapDependenciesForNg(this._dependencies || []);
             this._dependencies = deps;
             if (this._mountHandle && typeof this._mountHandle.setData === 'function') {
-                // eslint-disable-next-line no-console
-                console.log('[DH refetch] calling setData with', mapped.length, 'tasks,', deps.length, 'deps');
                 this._mountHandle.setData(mapped, deps);
             } else if (this._mountHandle && typeof this._mountHandle.setTasks === 'function') {
-                // eslint-disable-next-line no-console
-                console.log('[DH refetch] setData unavailable — calling setTasks only with', mapped.length, 'tasks');
                 this._mountHandle.setTasks(mapped);
             } else {
                 // eslint-disable-next-line no-console
@@ -1922,8 +1837,8 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
         const bridge = {
             version: VERSION,
             help: function () {
-                // eslint-disable-next-line no-console
-                console.log(HELP_TEXT);
+                // Returned (not console.log'd) — DevTools echoes the return
+                // value of an interactive call, so help() still reads fine.
                 return HELP_TEXT;
             },
             whoami: function () {
@@ -1976,23 +1891,19 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
             },
             submit: function (_note) {
                 const msg = 'submit() is a no-op in DH: each patch is already persisted. Reload to refetch.';
-                // eslint-disable-next-line no-console
-                console.log('[cn-edit]', msg);
                 return Promise.resolve({ ok: true, msg: msg });
             },
             reset: function () {
                 const msg = 'reset() is a no-op in DH: there are no local overrides. Reload the page to refetch.';
-                // eslint-disable-next-line no-console
-                console.log('[cn-edit]', msg);
                 return msg;
             }
         };
 
         this._cnEditBridge = bridge;
         // Triple-publish: LWS strict mode (MF-Prod, verified 2026-04-19)
-        // sandboxes `window.*` writes so they're invisible to DevTools. The
-        // console.log prints (shared channel) but `window.__cnEdit = bridge`
-        // lands in a distorted window the user can't reach. Fallbacks:
+        // sandboxes `window.*` writes so they're invisible to DevTools —
+        // `window.__cnEdit = bridge` lands in a distorted window the user
+        // can't reach. Fallbacks:
         //   1. window.__cnEdit       — works on non-LWS orgs (scratch, older prod)
         //   2. document.body.__cnEdit — DOM-property attach; survives LWS because
         //                               document.body is a real Element reference
@@ -2012,18 +1923,6 @@ export default class DeliveryProFormaTimeline extends NavigationMixin(LightningE
                 composed: true,
             }));
         } catch (e) { /* dispatchEvent unavailable */ }
-        try {
-            // eslint-disable-next-line no-console
-            console.log(
-                '%c[cn-edit v' + VERSION + ' DH]%c editable timeline ready. Try %cdocument.body.__cnEdit.help()%c (LWS) or %cwindow.__cnEdit.help()%c (scratch).',
-                'color:#a21caf;font-weight:bold',
-                'color:inherit',
-                'color:#a21caf;font-family:monospace',
-                'color:inherit',
-                'color:#a21caf;font-family:monospace',
-                'color:inherit'
-            );
-        } catch (e) { /* console unavailable */ }
     }
 
     _uninstallCnEditBridge() {


### PR DESCRIPTION
Two fixes from the 6/10 best-practices audit, each verified against current main before changing anything.

## Fix 1 — strip debug `console.log` from `deliveryProFormaTimeline`

**Verified:** all 16 `console.log` statements the audit flagged still exist on main (lines 329, 999, 1120, 1225, 1271, 1346, 1363, 1467, 1767, 1771, 1774, 1784, 1788, 1926, 1980, 1986 + the cn-edit ready banner at 2017). No `console.debug` in the file.

**Changed:**
- Removed all 16 `console.log` calls + their `// eslint-disable-next-line no-console` pragmas.
- Removed now-dead support code that existed only to feed logs: the `changesLog` / `fullPayloadJson` JSON-stringify scaffolding, `_dumpPositions()` (its only output was the log), and `_refetchAfterPatchAndDump()` (never called anywhere; its only distinct purpose was the dump).
- Removed the cn-edit "ready" banner `console.log`; updated the adjacent LWS triple-publish comment that referenced it. The `__cnEdit` bridge verbs (`help`/`submit`/`reset`) already return their message strings, and DevTools echoes interactive-call return values, so the bridge UX survives.
- **Kept every `console.error`/`console.warn`** in genuine error paths (LWS error-surface idiom) — 25 of them, untouched.

## Fix 2 — `DeliverySyncItemIngestor.findSObjectType` token-first resolution

**Verified:** the `Schema.getGlobalDescribe()` lookup still exists on main (line 1244). Call-site audit: line 52 passes a **dynamic** payload-driven `objectType` (remote orgs send object names as strings — including `ContentVersion` file-transport payloads), lines 221/681 pass static `'WorkItem__c'`. So the fallback is **not** dead and must survive.

**Changed:**
- Added `KNOWN_DH_TYPES`, a static map of compile-time typed tokens for the objects this ingestor actually handles (enumerated from its objectType branches): `WorkItem__c`, `WorkItemComment__c`, `WorkLog__c`, `ContentVersion`. Keys are namespace-stripped + lowercased so both bare and `delivery__`-prefixed payload forms hit the token path.
- `findSObjectType` consults the token map FIRST; the `getGlobalDescribe()` dual lookup (bare, then `delivery__`-prefixed, then namespace-stripped scan) remains only as the fallback for genuinely-unknown / non-DH names. Comment + ApexDoc explain the ordering and why the fallback survives.
- Made the method `@TestVisible` (was private, untested) and added `testFindSObjectTypeResolvesViaTokenPath` asserting identity-equality to the typed tokens (bare + prefixed forms), null for unknown names, null for blank. No behavior change for non-DH objects; all existing ingestor tests unchanged.

## Tests
- `npm run test:lwc`: 13/14 suites pass, 103/106 tests — the only failures are the 3 known pre-existing `deliveryFeatureCockpit` failures (untouched by this PR, fail identically on main).
- Babel-parsed the edited LWC (decorators) — clean.
- Apex compile + `DeliverySyncItemIngestorTest` run via CI feature-test (no scratch-org auth in this env; connected orgs are subscriber orgs running the packaged `delivery__` code, so local source tests aren't possible there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)