### PR TITLE
feat: approval polish — approved-vs-total pitch stat, backup approver, global service

### DIFF
--- a/force-app/main/default/classes/DeliveryApprovalSummaryController.cls
+++ b/force-app/main/default/classes/DeliveryApprovalSummaryController.cls
@@ -5,9 +5,12 @@
  *               LWC (PR3 of the work-approval queue): three agenda numbers —
  *               hours approved this month, requests pending approval, and
  *               approved work in flight — plus the report ids for tile
- *               click-through. Kept separate from DeliveryWorkApprovalService
- *               (the decision engine) so the card can evolve without touching
- *               the service under review.
+ *               click-through, plus the approved-vs-total pitch pair
+ *               (totalActiveEstimatedHours / totalApprovedHours) so the card
+ *               can surface how little of the active estimated portfolio is
+ *               client-approved — the approval-queue pitch stat. Kept separate
+ *               from DeliveryWorkApprovalService (the decision engine) so the
+ *               card can evolve without touching the service under review.
  *
  *               SOQL is WITH SYSTEM_MODE per CLAUDE.md (WITH USER_MODE breaks
  *               in namespaced package test context). Report ids are resolved
@@ -46,7 +49,19 @@ public with sharing class DeliveryApprovalSummaryController {
     };
 
     /**
-     * @description The three agenda tiles plus report click-through ids.
+     * WorkItem__c stages excluded from the active portfolio scope. Mirrors
+     * DeliveryHoursAnalyticsController's portfolio filter (the board's
+     * canonical "Active" definition) so the pitch denominator matches the
+     * numbers the forecast and gantt board already show.
+     */
+    @TestVisible
+    private static final Set<String> TERMINAL_STAGES = new Set<String>{
+        'Done', 'Cancelled', 'Closed', 'Rejected'
+    };
+
+    /**
+     * @description The three agenda tiles, the approved-vs-total pitch pair,
+     *              plus report click-through ids.
      */
     public class ApprovalSummaryDTO {
         @AuraEnabled public Decimal hoursApprovedThisMonth;
@@ -54,6 +69,10 @@ public with sharing class DeliveryApprovalSummaryController {
         @AuraEnabled public Decimal pendingQuotedHours;
         @AuraEnabled public Integer inProgressCount;
         @AuraEnabled public Decimal inProgressApprovedHours;
+        /** Sum of EstimatedHoursNumber__c across the active portfolio scope. */
+        @AuraEnabled public Decimal totalActiveEstimatedHours;
+        /** Sum of ClientPreApprovedHoursNumber__c across the same scope. */
+        @AuraEnabled public Decimal totalApprovedHours;
         @AuraEnabled public Map<String, String> reportIdsByDeveloperName;
     }
 
@@ -62,8 +81,9 @@ public with sharing class DeliveryApprovalSummaryController {
      *              hours on requests Accepted this calendar month, (2) count +
      *              quoted-hours sum of Offer-Sent requests awaiting a
      *              decision, (3) count + approved-cap sum of in-flight
-     *              WorkItems carrying a client-approved budget — plus the
-     *              report ids backing each tile's click-through.
+     *              WorkItems carrying a client-approved budget, (4) the
+     *              approved-vs-total pitch pair over the active portfolio —
+     *              plus the report ids backing each tile's click-through.
      * @return One ApprovalSummaryDTO; numbers default to 0 when empty.
      */
     @AuraEnabled(cacheable=true)
@@ -73,6 +93,7 @@ public with sharing class DeliveryApprovalSummaryController {
             dto.hoursApprovedThisMonth = sumApprovedThisMonth();
             fillPendingAggregates(dto);
             fillInProgressAggregates(dto);
+            fillApprovedShareAggregates(dto);
             dto.reportIdsByDeveloperName = resolveReportIds();
         } catch (Exception e) {
             System.debug(LoggingLevel.WARN,
@@ -134,6 +155,34 @@ public with sharing class DeliveryApprovalSummaryController {
         Decimal approved = (Decimal) row.get('approved');
         dto.inProgressCount = cnt == null ? 0 : cnt;
         dto.inProgressApprovedHours = approved == null ? 0 : approved;
+    }
+
+    /**
+     * @description The approval-queue pitch pair in ONE aggregate: total
+     *              estimated hours across the active portfolio vs how much of
+     *              it carries a client-approved cap. "Active" borrows the
+     *              board's canonical scope (DeliveryHoursAnalyticsController's
+     *              portfolio filter): activated, not archived, not a template,
+     *              and not in a terminal stage. SUM ignores null caps, so the
+     *              approved figure is exactly the sum of positive
+     *              ClientPreApprovedHoursNumber__c values in that scope.
+     * @param dto DTO to fill (totalActiveEstimatedHours / totalApprovedHours).
+     */
+    private static void fillApprovedShareAggregates(ApprovalSummaryDTO dto) {
+        AggregateResult row = [
+            SELECT SUM(EstimatedHoursNumber__c) est,
+                   SUM(ClientPreApprovedHoursNumber__c) approved
+            FROM WorkItem__c
+            WHERE ActivatedDateTime__c != NULL
+              AND ArchivedDateTime__c = NULL
+              AND TemplateMarkedDateTime__c = NULL
+              AND StageNamePk__c NOT IN :TERMINAL_STAGES
+            WITH SYSTEM_MODE
+        ];
+        Decimal est = (Decimal) row.get('est');
+        Decimal approved = (Decimal) row.get('approved');
+        dto.totalActiveEstimatedHours = est == null ? 0 : est;
+        dto.totalApprovedHours = approved == null ? 0 : approved;
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryApprovalSummaryControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryApprovalSummaryControllerTest.cls
@@ -5,7 +5,9 @@
  *               approved-this-month sum (Accepted + DecisionDateTime this
  *               month only), the pending count/quoted-hours pair (Offer Sent
  *               only), the in-flight aggregate (cap &gt; 0 AND stage inside the
- *               dev → deploying band), and the empty-org zero defaults.
+ *               dev → deploying band), the approved-vs-total pitch pair
+ *               (active portfolio scope only — activated, non-archived,
+ *               non-template, non-terminal), and the empty-org zero defaults.
  *               Report-id resolution is asserted shape-only — the agenda
  *               reports may not be deployed in a bare scratch context, which
  *               is the documented missing-report tolerance.
@@ -130,6 +132,55 @@ private class DeliveryApprovalSummaryControllerTest {
     }
 
     /**
+     * @description The pitch pair sums estimates and caps over the ACTIVE
+     *              portfolio scope only: terminal-stage, non-activated,
+     *              template, and archived items are all excluded from both
+     *              the denominator and the approved numerator.
+     */
+    @IsTest
+    static void testApprovedShareSumsActiveScopeOnly() {
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'In Development',
+            'EstimatedHoursNumber__c' => 100,
+            'ClientPreApprovedHoursNumber__c' => 10
+        });
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'Backlog',
+            'EstimatedHoursNumber__c' => 50
+        }); // active, estimated, not yet approved — denominator only
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'Done',
+            'EstimatedHoursNumber__c' => 40,
+            'ClientPreApprovedHoursNumber__c' => 40
+        }); // terminal stage — excluded from both sums
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'Backlog',
+            'EstimatedHoursNumber__c' => 30,
+            'ActivatedDateTime__c' => null
+        }); // not activated — excluded
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'Backlog',
+            'EstimatedHoursNumber__c' => 20,
+            'TemplateMarkedDateTime__c' => Datetime.now()
+        }); // template — excluded
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'Backlog',
+            'EstimatedHoursNumber__c' => 25,
+            'ArchivedDateTime__c' => Datetime.now()
+        }); // archived — excluded
+
+        Test.startTest();
+        DeliveryApprovalSummaryController.ApprovalSummaryDTO dto =
+            DeliveryApprovalSummaryController.getApprovalSummary();
+        Test.stopTest();
+
+        System.assertEquals(150, dto.totalActiveEstimatedHours,
+            '100 + 50 estimated hours in the active scope — excluded items do not count');
+        System.assertEquals(10, dto.totalApprovedHours,
+            'only the active item\'s cap counts toward the approved numerator');
+    }
+
+    /**
      * @description Empty org returns zero defaults (never null numbers) and a
      *              non-null report-id map. Report rows may or may not exist in
      *              the test org — shape-only assertion, mirroring
@@ -147,6 +198,8 @@ private class DeliveryApprovalSummaryControllerTest {
         System.assertEquals(0, dto.pendingQuotedHours, 'zero default, not null');
         System.assertEquals(0, dto.inProgressCount, 'zero default, not null');
         System.assertEquals(0, dto.inProgressApprovedHours, 'zero default, not null');
+        System.assertEquals(0, dto.totalActiveEstimatedHours, 'zero default, not null');
+        System.assertEquals(0, dto.totalApprovedHours, 'zero default, not null');
         System.assertNotEquals(null, dto.reportIdsByDeveloperName,
             'report-id map is always present (possibly empty)');
     }

--- a/force-app/main/default/classes/DeliveryWorkApprovalService.cls
+++ b/force-app/main/default/classes/DeliveryWorkApprovalService.cls
@@ -52,7 +52,23 @@
  *                    The WorkItem keeps its current stage — only the delta
  *                    awaits a decision, not the already-approved work.
  *               getPendingForApprover(userId)
- *                 -> the queue feed for the approval LWC (PR2).
+ *                 -> the queue feed for the approval LWC (PR2). When the
+ *                    given user is the configured primary OR backup approver,
+ *                    requests assigned to EITHER of them are included.
+ *
+ *               Backup approver: DeliveryHubSettings__c.ApproverBackupUserIdTxt__c
+ *               names an optional second user who may decide pending requests
+ *               (assertCallerMayDecide allows primary or backup). The backup
+ *               is never auto-assigned and gets no submit pings — the primary
+ *               (resolveDefaultApproverId) stays the assignment/notification
+ *               target.
+ *
+ *               GLOBAL on purpose: subscriber orgs install Delivery Hub under
+ *               the delivery__ namespace, where public Apex is invisible to
+ *               subscriber-side anonymous Apex. The class and its service
+ *               methods (and the DTOs they return) are global so admin
+ *               scripting / future MCP automation in subscriber orgs can
+ *               drive the approval lifecycle directly.
  *
  *               WorkRequest__c lifecycle values used here are the verified
  *               picklist values: Draft / Offer Sent / Accepted / In Progress /
@@ -62,8 +78,8 @@
  *               suppression style.
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.CognitiveComplexity')
-public with sharing class DeliveryWorkApprovalService {
+@SuppressWarnings('PMD.ApexCRUDViolation,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.CognitiveComplexity,PMD.AvoidGlobalModifier')
+global with sharing class DeliveryWorkApprovalService {
 
     /** WorkRequest__c lifecycle values (verified picklist values). */
     public static final String REQUEST_DRAFT = 'Draft';
@@ -89,8 +105,10 @@ public with sharing class DeliveryWorkApprovalService {
     /**
      * @description One render-ready pending-approval row for the queue LWC
      *              (PR2): the Offer-Sent request joined with its work item.
+     *              Global because it is the return type of the global
+     *              getPendingForApprover (subscriber-side automation).
      */
-    public class PendingApprovalDTO {
+    global class PendingApprovalDTO {
         @AuraEnabled public Id requestId;
         @AuraEnabled public Id workItemId;
         @AuraEnabled public String workItemName;
@@ -105,9 +123,10 @@ public with sharing class DeliveryWorkApprovalService {
     /**
      * @description Per-item result of submitForApproval — which request the
      *              item landed on and whether the discretionary short-circuit
-     *              auto-approved it.
+     *              auto-approved it. Global because it is the return type of
+     *              the global submitForApproval (subscriber-side automation).
      */
-    public class SubmitResultDTO {
+    global class SubmitResultDTO {
         @AuraEnabled public Id workItemId;
         @AuraEnabled public Id workRequestId;
         @AuraEnabled public Boolean autoApproved;
@@ -124,7 +143,7 @@ public with sharing class DeliveryWorkApprovalService {
      * @param workItemIds The WorkItem__c ids to submit.
      * @return One SubmitResultDTO per submitted item.
      */
-    public static List<SubmitResultDTO> submitForApproval(Set<Id> workItemIds) {
+    global static List<SubmitResultDTO> submitForApproval(Set<Id> workItemIds) {
         return submitForApproval(workItemIds, null);
     }
 
@@ -138,7 +157,7 @@ public with sharing class DeliveryWorkApprovalService {
      *        items absent from the map fall back to EstimatedHoursNumber__c.
      * @return One SubmitResultDTO per submitted item.
      */
-    public static List<SubmitResultDTO> submitForApproval(
+    global static List<SubmitResultDTO> submitForApproval(
         Set<Id> workItemIds, Map<Id, Decimal> quotedHoursByItem
     ) {
         if (workItemIds == null || workItemIds.isEmpty()) {
@@ -353,7 +372,7 @@ public with sharing class DeliveryWorkApprovalService {
      * @param note Optional decision note from the approver.
      */
     @AuraEnabled
-    public static void approve(Id workRequestId, Decimal approvedHours, String note) {
+    global static void approve(Id workRequestId, Decimal approvedHours, String note) {
         WorkRequest__c req = loadPendingRequestOrThrow(workRequestId);
         assertCallerMayDecide(req);
         Decimal granted = approvedHours == null ? req.QuotedHoursNumber__c : approvedHours;
@@ -400,7 +419,7 @@ public with sharing class DeliveryWorkApprovalService {
      * @param reason Why the client declined (stored on the request).
      */
     @AuraEnabled
-    public static void decline(Id workRequestId, String reason) {
+    global static void decline(Id workRequestId, String reason) {
         WorkRequest__c req = loadPendingRequestOrThrow(workRequestId);
         assertCallerMayDecide(req);
         Decimal currentCap = req.WorkItemId__r.ClientPreApprovedHoursNumber__c;
@@ -443,7 +462,7 @@ public with sharing class DeliveryWorkApprovalService {
      * @return The new WorkRequest__c id.
      */
     @AuraEnabled
-    public static Id requestIncrease(Id workItemId, Decimal extraHours, String reason) {
+    global static Id requestIncrease(Id workItemId, Decimal extraHours, String reason) {
         if (workItemId == null) {
             throw new AuraHandledException('workItemId is required.');
         }
@@ -478,13 +497,18 @@ public with sharing class DeliveryWorkApprovalService {
      *              their work item for one-screen render. Includes requests
      *              assigned to the given user AND unassigned requests (no
      *              default approver configured) so the queue never silently
-     *              hides work — approver assignment is settings-optional in PR1.
+     *              hides work — approver assignment is settings-optional in
+     *              PR1. When the given user is the configured primary OR
+     *              backup approver, requests assigned to EITHER of them are
+     *              included — the backup sees (and may work) the primary's
+     *              queue and vice versa.
      * @param userId Approver to fetch for; null = the running user.
      * @return Oldest-first list of PendingApprovalDTO (LIMIT 200).
      */
     @AuraEnabled(cacheable=true)
-    public static List<PendingApprovalDTO> getPendingForApprover(Id userId) {
+    global static List<PendingApprovalDTO> getPendingForApprover(Id userId) {
         Id approverId = userId == null ? UserInfo.getUserId() : userId;
+        Set<Id> approverIds = resolveQueueApproverIds(approverId);
         List<PendingApprovalDTO> out = new List<PendingApprovalDTO>();
         try {
             for (WorkRequest__c req : [
@@ -494,7 +518,7 @@ public with sharing class DeliveryWorkApprovalService {
                        WorkItemId__r.BriefDescriptionTxt__c
                 FROM WorkRequest__c
                 WHERE StatusPk__c = :REQUEST_OFFER_SENT
-                  AND (ApproverUserLookup__c = :approverId
+                  AND (ApproverUserLookup__c IN :approverIds
                        OR ApproverUserLookup__c = NULL)
                 WITH SYSTEM_MODE
                 ORDER BY CreatedDate ASC
@@ -568,19 +592,76 @@ public with sharing class DeliveryWorkApprovalService {
     /**
      * @description Caller guard, mirroring the FeatureToggle rails' caller-
      *              is-approver gate but relaxed for unassigned requests: when
-     *              an approver IS assigned, only that user may decide (the
-     *              @AuraEnabled surface is reachable outside the LWC);
+     *              an approver IS assigned, only that user — or the configured
+     *              BACKUP approver (ApproverBackupUserIdTxt__c) — may decide
+     *              (the @AuraEnabled surface is reachable outside the LWC);
      *              unassigned requests may be decided by any authorised
      *              caller, who is then stamped as the approver — PR1 leaves
      *              approver assignment settings-optional.
      * @param req The loaded pending request.
      */
     private static void assertCallerMayDecide(WorkRequest__c req) {
-        if (req.ApproverUserLookup__c != null
-            && req.ApproverUserLookup__c != UserInfo.getUserId()) {
-            throw new AuraHandledException(
-                'You are not the assigned approver for this request.');
+        if (req.ApproverUserLookup__c == null) {
+            return;
         }
+        Id caller = UserInfo.getUserId();
+        if (req.ApproverUserLookup__c == caller) {
+            return;
+        }
+        Id backupId = resolveBackupApproverId(DeliveryHubSettings__c.getOrgDefaults());
+        if (backupId != null && backupId == caller) {
+            return;
+        }
+        throw new AuraHandledException(
+            'You are not the assigned approver for this request.');
+    }
+
+    /**
+     * @description Resolves the optional BACKUP approver from
+     *              DeliveryHubSettings__c.ApproverBackupUserIdTxt__c — same
+     *              Text(18) parse-and-tolerate idiom as
+     *              resolveDefaultApproverId. The backup may decide pending
+     *              requests but is never auto-assigned and gets no submit
+     *              pings (the primary stays the assignment/ping target).
+     * @param settings Org-default settings (null-safe).
+     * @return The backup approver's user id, or null when unset/invalid.
+     */
+    private static Id resolveBackupApproverId(DeliveryHubSettings__c settings) {
+        if (settings == null || String.isBlank(settings.ApproverBackupUserIdTxt__c)) {
+            return null;
+        }
+        try {
+            return Id.valueOf(settings.ApproverBackupUserIdTxt__c.trim());
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryWorkApprovalService.resolveBackupApproverId] bad id in settings: '
+                + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * @description Builds the assignee set the queue feed matches against:
+     *              just the requested approver — widened to {primary, backup}
+     *              when the requested approver IS the configured primary or
+     *              backup, so either of them sees the whole shared queue.
+     * @param approverId The user the queue is being fetched for.
+     * @return Non-empty set of assignee ids to match ApproverUserLookup__c.
+     */
+    private static Set<Id> resolveQueueApproverIds(Id approverId) {
+        Set<Id> approverIds = new Set<Id>{ approverId };
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        Id primaryId = resolveDefaultApproverId(settings);
+        Id backupId = resolveBackupApproverId(settings);
+        if (approverId == primaryId || approverId == backupId) {
+            if (primaryId != null) {
+                approverIds.add(primaryId);
+            }
+            if (backupId != null) {
+                approverIds.add(backupId);
+            }
+        }
+        return approverIds;
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryWorkApprovalServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkApprovalServiceTest.cls
@@ -25,11 +25,49 @@ private class DeliveryWorkApprovalServiceTest {
      * @param approverId Default approver User ID (null = unassigned requests).
      */
     private static void configureSettings(Decimal threshold, Decimal monthlyCap, Id approverId) {
+        configureSettings(threshold, monthlyCap, approverId, null);
+    }
+
+    /**
+     * @description Writes the discretionary-gate org-default settings
+     *              including the optional BACKUP approver.
+     * @param threshold Per-request Auto ceiling (null/0 disables Auto).
+     * @param monthlyCap Monthly Auto budget (null = uncapped).
+     * @param approverId Default approver User ID (null = unassigned requests).
+     * @param backupId Backup approver User ID (null = no backup).
+     */
+    private static void configureSettings(
+        Decimal threshold, Decimal monthlyCap, Id approverId, Id backupId
+    ) {
         DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
         settings.DiscretionaryThresholdHoursNumber__c = threshold;
         settings.DiscretionaryMonthlyCapHoursNumber__c = monthlyCap;
         settings.ApproverUserIdTxt__c = approverId == null ? null : String.valueOf(approverId);
+        settings.ApproverBackupUserIdTxt__c = backupId == null ? null : String.valueOf(backupId);
         upsert settings;
+    }
+
+    /**
+     * @description Inserts a second Standard User for caller-guard tests.
+     *              runAs isolates the setup-object DML from sObject DML in the
+     *              calling test (MIXED_DML_OPERATION guard).
+     * @return The inserted user.
+     */
+    private static User createOtherUser() {
+        Profile p = [SELECT Id FROM Profile WHERE Name = 'Standard User' LIMIT 1];
+        String stamp = String.valueOf(Datetime.now().getTime())
+            + String.valueOf(Math.abs(Crypto.getRandomInteger())).left(6);
+        User other = new User(
+            Alias = 'wapprv', Email = 'wapprv' + stamp + '@example.com',
+            EmailEncodingKey = 'UTF-8', LastName = 'Approver',
+            LanguageLocaleKey = 'en_US', LocaleSidKey = 'en_US',
+            ProfileId = p.Id, TimeZoneSidKey = 'America/New_York',
+            Username = 'wapprv' + stamp + '@example.com.dhtest'
+        );
+        System.runAs(new User(Id = UserInfo.getUserId())) {
+            insert other;
+        }
+        return other;
     }
 
     /**
@@ -404,6 +442,110 @@ private class DeliveryWorkApprovalServiceTest {
         }
         Test.stopTest();
         System.assert(threw, 'a caller other than the assigned approver must be rejected');
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // BACKUP APPROVER (ApproverBackupUserIdTxt__c)
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description The configured BACKUP approver may decide a request
+     *              assigned to the primary: the approve lands and the
+     *              assignment stays with the primary (stampDecision only
+     *              stamps previously-unassigned requests).
+     */
+    @IsTest
+    static void testBackupApproverMayDecide() {
+        User primary = createOtherUser();
+        // Primary = the other user; backup = the running user.
+        configureSettings(null, null, primary.Id, UserInfo.getUserId());
+        WorkItem__c wi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 10
+        });
+        List<DeliveryWorkApprovalService.SubmitResultDTO> results =
+            DeliveryWorkApprovalService.submitForApproval(new Set<Id>{ wi.Id });
+
+        Test.startTest();
+        DeliveryWorkApprovalService.approve(results[0].workRequestId, 10, 'backup signing off');
+        Test.stopTest();
+
+        WorkRequest__c req = [
+            SELECT StatusPk__c, ApproverUserLookup__c, PreApprovedHoursNumber__c
+            FROM WorkRequest__c WHERE Id = :results[0].workRequestId
+        ];
+        System.assertEquals('Accepted', req.StatusPk__c,
+            'the backup approver\'s decision lands');
+        System.assertEquals(primary.Id, req.ApproverUserLookup__c,
+            'the assignment stays with the primary — the backup decides, not reassigns');
+        System.assertEquals(10, req.PreApprovedHoursNumber__c, 'granted hours stamped');
+
+        WorkItem__c after = [
+            SELECT ClientPreApprovedHoursNumber__c, StageNamePk__c
+            FROM WorkItem__c WHERE Id = :wi.Id
+        ];
+        System.assertEquals(10, after.ClientPreApprovedHoursNumber__c,
+            'canonical cap lands exactly as a primary approve would');
+        System.assertEquals('Ready for Development', after.StageNamePk__c,
+            'approved item is dev-ready');
+    }
+
+    /**
+     * @description A caller who is NEITHER the assigned approver NOR the
+     *              configured backup is still rejected — the backup clause
+     *              must not open the decision surface to everyone.
+     */
+    @IsTest
+    static void testStrangerRejectedEvenWithBackupConfigured() {
+        User other = createOtherUser();
+        // Primary AND backup both point at the other user; the running user
+        // is a stranger to the approval chain.
+        configureSettings(null, null, other.Id, other.Id);
+        WorkItem__c wi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 10
+        });
+        List<DeliveryWorkApprovalService.SubmitResultDTO> results =
+            DeliveryWorkApprovalService.submitForApproval(new Set<Id>{ wi.Id });
+
+        Boolean threw = false;
+        Test.startTest();
+        try {
+            DeliveryWorkApprovalService.decline(results[0].workRequestId, 'nope');
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        Test.stopTest();
+        System.assert(threw,
+            'a stranger must be rejected even when a backup approver is configured');
+        WorkRequest__c req = [
+            SELECT StatusPk__c FROM WorkRequest__c WHERE Id = :results[0].workRequestId
+        ];
+        System.assertEquals('Offer Sent', req.StatusPk__c,
+            'the request stays pending after the rejected attempt');
+    }
+
+    /**
+     * @description The backup approver's queue feed includes requests
+     *              assigned to the PRIMARY approver — primary and backup
+     *              share one queue.
+     */
+    @IsTest
+    static void testGetPendingForBackupIncludesPrimaryQueue() {
+        User primary = createOtherUser();
+        configureSettings(null, null, primary.Id, UserInfo.getUserId());
+        WorkItem__c wi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 20
+        });
+        DeliveryWorkApprovalService.submitForApproval(new Set<Id>{ wi.Id });
+
+        Test.startTest();
+        List<DeliveryWorkApprovalService.PendingApprovalDTO> queue =
+            DeliveryWorkApprovalService.getPendingForApprover(null); // running user = backup
+        Test.stopTest();
+
+        System.assertEquals(1, queue.size(),
+            'the backup sees the request assigned to the primary');
+        System.assertEquals(primary.Id, queue[0].approverUserId,
+            'the row is still assigned to the primary');
     }
 
     // ────────────────────────────────────────────────────────────────────

--- a/force-app/main/default/lwc/deliveryApprovalSummaryCard/__tests__/deliveryApprovalSummaryCard.test.js
+++ b/force-app/main/default/lwc/deliveryApprovalSummaryCard/__tests__/deliveryApprovalSummaryCard.test.js
@@ -3,6 +3,8 @@
  * @license      BSL 1.1 — See LICENSE.md
  * @description  Jest coverage for deliveryApprovalSummaryCard: the three
  *               agenda tiles from the wire (numbers + hour details), the
+ *               approved-vs-total pitch strip ("Nh of Mh approved (P%)")
+ *               including the zero-denominator guard (no Infinity/NaN), the
  *               report click-through wiring (tile carries the resolved report
  *               id; missing report disables the affordance), and the error
  *               state.
@@ -22,6 +24,8 @@ function sampleSummary(overrides = {}) {
         pendingQuotedHours: 16,
         inProgressCount: 5,
         inProgressApprovedHours: 120,
+        totalActiveEstimatedHours: 3155,
+        totalApprovedHours: 10,
         reportIdsByDeveloperName: {
             Hours_Approved_This_Period: REPORT_ID_APPROVED,
             Pending_Approval: REPORT_ID_PENDING
@@ -65,6 +69,45 @@ describe("c-delivery-approval-summary-card", () => {
         expect(text).toContain("16.0h quoted awaiting decision");
         expect(text).toContain("5"); // in-progress count
         expect(text).toContain("120h approved in flight");
+    });
+
+    it("surfaces the approved-vs-total pitch strip with the zero-guarded percentage", async () => {
+        const element = createComponent();
+        getApprovalSummary.emit(sampleSummary());
+        await flushPromises();
+
+        const pitch = element.shadowRoot.querySelector(".agenda-pitch");
+        expect(pitch).not.toBeNull();
+        expect(pitch.textContent).toContain("10.0h of 3155h approved (0.3%)");
+    });
+
+    it("renders 0% (never Infinity/NaN) when the active estimated denominator is zero", async () => {
+        const element = createComponent();
+        getApprovalSummary.emit(
+            sampleSummary({ totalActiveEstimatedHours: 0, totalApprovedHours: 0 })
+        );
+        await flushPromises();
+
+        const pitch = element.shadowRoot.querySelector(".agenda-pitch");
+        expect(pitch.textContent).toContain("0.00h of 0.00h approved (0.0%)");
+        expect(pitch.textContent).not.toContain("Infinity");
+        expect(pitch.textContent).not.toContain("NaN");
+    });
+
+    it("zero-guards the pitch when the summary omits the pitch fields entirely", async () => {
+        const element = createComponent();
+        getApprovalSummary.emit(
+            sampleSummary({
+                totalActiveEstimatedHours: undefined,
+                totalApprovedHours: undefined
+            })
+        );
+        await flushPromises();
+
+        const pitch = element.shadowRoot.querySelector(".agenda-pitch");
+        expect(pitch.textContent).toContain("0.00h of 0.00h approved (0.0%)");
+        expect(pitch.textContent).not.toContain("Infinity");
+        expect(pitch.textContent).not.toContain("NaN");
     });
 
     it("carries the resolved report id on click-through tiles and disables tiles without a report", async () => {

--- a/force-app/main/default/lwc/deliveryApprovalSummaryCard/deliveryApprovalSummaryCard.css
+++ b/force-app/main/default/lwc/deliveryApprovalSummaryCard/deliveryApprovalSummaryCard.css
@@ -69,6 +69,27 @@
     color: #991b1b;
 }
 
+.agenda-pitch {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    padding: 0.875rem 1.5rem 0;
+    flex-wrap: wrap;
+}
+
+.pitch-label {
+    font-size: 0.6875rem;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.pitch-stat {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: #111827;
+}
+
 .agenda-tiles {
     display: flex;
     gap: 1rem;

--- a/force-app/main/default/lwc/deliveryApprovalSummaryCard/deliveryApprovalSummaryCard.html
+++ b/force-app/main/default/lwc/deliveryApprovalSummaryCard/deliveryApprovalSummaryCard.html
@@ -28,6 +28,10 @@
         </template>
 
         <template lwc:if={hasData}>
+            <div class="agenda-pitch">
+                <span class="pitch-label">Client approved</span>
+                <span class="pitch-stat">{approvedShareStat}</span>
+            </div>
             <div class="agenda-tiles">
                 <template for:each={tiles} for:item="tile">
                     <button key={tile.key}

--- a/force-app/main/default/lwc/deliveryApprovalSummaryCard/deliveryApprovalSummaryCard.js
+++ b/force-app/main/default/lwc/deliveryApprovalSummaryCard/deliveryApprovalSummaryCard.js
@@ -4,12 +4,15 @@
  * @description  Approval agenda summary card (PR3 of the work-approval
  *               queue): three click-through tiles — Hours Approved (this
  *               month), Pending Approval, and Approved & In Progress — fed by
- *               DeliveryApprovalSummaryController.getApprovalSummary. Each
- *               tile navigates to its backing report via NavigationMixin
- *               using the report record id the controller resolved by
- *               DeveloperName (namespace-safe: no hardcoded org ids). Tiles
- *               whose report is missing in the org render without the
- *               click-through affordance.
+ *               DeliveryApprovalSummaryController.getApprovalSummary, plus
+ *               the approved-vs-total pitch strip ("Nh of Mh approved (P%)")
+ *               over the active portfolio — THE approval-queue pitch stat.
+ *               The percentage is zero-guarded (a 0h denominator renders 0%,
+ *               never Infinity/NaN). Each tile navigates to its backing
+ *               report via NavigationMixin using the report record id the
+ *               controller resolved by DeveloperName (namespace-safe: no
+ *               hardcoded org ids). Tiles whose report is missing in the org
+ *               render without the click-through affordance.
  * @author       Cloud Nimbus LLC
  */
 import { LightningElement, wire } from "lwc";
@@ -49,6 +52,19 @@ export default class DeliveryApprovalSummaryCard extends NavigationMixin(Lightni
 
     get hasData() {
         return !this.isLoading && !this.errorMessage && Boolean(this.summary);
+    }
+
+    // ── Pitch strip (computed — templates can't do ternaries) ────
+
+    get approvedShareStat() {
+        if (!this.summary) {
+            return "";
+        }
+        const total = this._toFiniteNumber(this.summary.totalActiveEstimatedHours);
+        const approved = this._toFiniteNumber(this.summary.totalApprovedHours);
+        // Zero-guard the ratio: a 0h denominator reads 0%, never Infinity.
+        const pct = total > 0 ? (approved / total) * 100 : 0;
+        return `${this._formatHours(approved)}h of ${this._formatHours(total)}h approved (${this._formatPercent(pct)}%)`;
     }
 
     // ── Tiles (computed — templates can't do ternaries) ──────────
@@ -123,5 +139,21 @@ export default class DeliveryApprovalSummaryCard extends NavigationMixin(Lightni
             return num.toFixed(1);
         }
         return num.toFixed(2);
+    }
+
+    _formatPercent(value) {
+        const num = Number(value);
+        if (!Number.isFinite(num)) {
+            return "0";
+        }
+        if (Math.abs(num) >= 10) {
+            return num.toFixed(0);
+        }
+        return num.toFixed(1);
+    }
+
+    _toFiniteNumber(value) {
+        const num = Number(value);
+        return Number.isFinite(num) ? num : 0;
     }
 }

--- a/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
+++ b/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
@@ -265,12 +265,12 @@ const INFO_REGISTRY = {
     },
     deliveryApprovalSummaryCard: {
         dataSource:
-            'Wires DeliveryApprovalSummaryController.getApprovalSummary — three aggregate SOQL queries: (1) SUM of PreApprovedHoursNumber__c on WorkRequest__c rows Accepted this calendar month, (2) COUNT + quoted-hours SUM of Offer-Sent requests, (3) COUNT + approved-cap SUM of WorkItem__c rows with ClientPreApprovedHoursNumber__c > 0 in the dev-through-deploying stage band. Tile click-throughs navigate to the Delivery Hub Approvals reports, resolved by DeveloperName at runtime.',
+            'Wires DeliveryApprovalSummaryController.getApprovalSummary — four aggregate SOQL queries: (1) SUM of PreApprovedHoursNumber__c on WorkRequest__c rows Accepted this calendar month, (2) COUNT + quoted-hours SUM of Offer-Sent requests, (3) COUNT + approved-cap SUM of WorkItem__c rows with ClientPreApprovedHoursNumber__c > 0 in the dev-through-deploying stage band, (4) the approved-vs-total pitch pair — SUM of EstimatedHoursNumber__c vs SUM of ClientPreApprovedHoursNumber__c over the active portfolio scope (activated, non-archived, non-template, non-terminal). Tile click-throughs navigate to the Delivery Hub Approvals reports, resolved by DeveloperName at runtime.',
         description:
-            'The approval agenda at a glance: hours approved this month, requests pending approval, and approved work in flight. Each tile opens its backing report (Hours Approved / Pending Approval / Approved & In Progress) for the line-item detail behind the number.',
+            'The approval agenda at a glance: how much of the active estimated portfolio is client-approved (the pitch strip), hours approved this month, requests pending approval, and approved work in flight. Each tile opens its backing report (Hours Approved / Pending Approval / Approved & In Progress) for the line-item detail behind the number.',
         friendlyName: 'Approval Agenda',
         keyFields:
-            'WorkRequest__c.StatusPk__c, WorkRequest__c.PreApprovedHoursNumber__c, WorkRequest__c.QuotedHoursNumber__c, WorkRequest__c.DecisionDateTime__c, WorkItem__c.ClientPreApprovedHoursNumber__c, WorkItem__c.StageNamePk__c'
+            'WorkRequest__c.StatusPk__c, WorkRequest__c.PreApprovedHoursNumber__c, WorkRequest__c.QuotedHoursNumber__c, WorkRequest__c.DecisionDateTime__c, WorkItem__c.ClientPreApprovedHoursNumber__c, WorkItem__c.EstimatedHoursNumber__c, WorkItem__c.ActivatedDateTime__c, WorkItem__c.StageNamePk__c'
     },
     deliveryWatcherSetup: {
         dataSource:

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/ApproverBackupUserIdTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/ApproverBackupUserIdTxt__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ApproverBackupUserIdTxt__c</fullName>
+    <description>Salesforce User ID of the BACKUP client-side approver for work-approval queue rows. When set, this user may decide pending requests exactly like the primary (assertCallerMayDecide allows either), and getPendingForApprover surfaces rows assigned to either approver when the caller is either. The backup is never auto-assigned to new requests and receives no submit pings — the primary ApproverUserIdTxt__c remains the assignment/notification target. Custom Settings only support primitive types, so this is a Text(18) User ID rather than a lookup — same pattern as ApproverUserIdTxt__c. Blank (default) = no backup approver.</description>
+    <inlineHelpText>18-character Salesforce User ID of the backup approver. Blank = no backup; only the primary approver decides assigned requests.</inlineHelpText>
+    <label>Approver Backup User ID</label>
+    <length>18</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## Summary

Three approval-queue polish items, per the Cowork directive to surface the approval-queue pitch on the agenda card.

### 1. Approved-vs-total pitch stat (the agenda card)
- `DeliveryApprovalSummaryController.getApprovalSummary` adds `totalActiveEstimatedHours` + `totalApprovedHours` in **one** aggregate over the board-canonical active scope (`ActivatedDateTime__c != NULL AND ArchivedDateTime__c = NULL AND TemplateMarkedDateTime__c = NULL AND StageNamePk__c NOT IN (Done/Cancelled/Closed/Rejected)` — mirrors `DeliveryHoursAnalyticsController`'s portfolio filter), `WITH SYSTEM_MODE`.
- `deliveryApprovalSummaryCard` renders a pitch strip above the tiles: `Nh of Mh approved (P%)` (e.g. `10.0h of 3155h approved (0.3%)` on live MF data). Percentage is zero-guarded — a 0h denominator renders `0.0%`, never Infinity/NaN (this repo has history here).
- `deliveryInfoPopover` registry entry updated to describe the fourth aggregate + pitch strip.

### 2. Backup approver
- New `DeliveryHubSettings__c.ApproverBackupUserIdTxt__c` (Text 18, description mirrors the `ApproverUserIdTxt__c` idiom).
- `assertCallerMayDecide` also allows the configured backup; `getPendingForApprover` shares the queue between primary and backup (the OR-unassigned clause is unchanged).
- `resolveDefaultApproverId` untouched — the primary remains the assignment + submit-ping target; the backup is never auto-assigned.

### 3. Global-ize `DeliveryWorkApprovalService`
- Class + service methods (`submitForApproval` both overloads, `approve`, `decline`, `requestIncrease`, `getPendingForApprover`) are now `global` so subscriber-org anonymous Apex (admin scripting / future MCP routines) can call them under the `delivery__` namespace. Rationale documented in the class ApexDoc.
- `PendingApprovalDTO` / `SubmitResultDTO` become `global` (CLAUDE.md rule: inner return/param types of global methods must be global); their `@AuraEnabled` members stay, matching the `SignalResultDTO` precedent.
- `@SuppressWarnings('PMD.AvoidGlobalModifier')` added, mirroring `DeliveryNotificationService` and the repo-wide posture.
- Constants stay `public`.

### No permset changes
`DeliveryHubAdmin_App` / `DeliveryHubApp` already carry `classAccesses` for both classes; custom-settings fields need no `fieldPermissions`. Verified before touching — nothing to change.

## Tests
- **Apex** (+4): backup may decide (cap/stage land exactly as a primary approve; assignment stays with the primary), stranger still rejected with a backup configured, backup's queue includes primary-assigned rows, pitch aggregate counts the active scope only (terminal/non-activated/template/archived all excluded); empty-org zero defaults extended to the new DTO fields.
- **Jest** (+3, suite 6/6 green locally): pitch strip renders `10.0h of 3155h approved (0.3%)`; zero-denominator renders `(0.0%)` with no Infinity/NaN; missing pitch fields zero-guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
