### PR TITLE
feat: item 8 — ETA write-back on apply + approved-green cohort (+ divergence alerts)

### DIFF
--- a/force-app/main/default/classes/DeliveryForecastAlertService.cls
+++ b/force-app/main/default/classes/DeliveryForecastAlertService.cls
@@ -4,9 +4,16 @@
  * @description Daily forecast-alert sweep. Walks active root WorkItems
  *              (ParentWorkItemLookup__c = NULL), runs the velocity-based
  *              forecast for each, and dispatches bell + email + Slack alerts
- *              to the WI owner when projectedFinalHours exceeds the configured
- *              threshold (default 110% of EstimatedHoursNumber). Cooldown +
- *              delta-detection guard prevents re-alert spam.
+ *              to the WI owner when any divergence condition holds:
+ *              (1) projectedFinalHours exceeds the configured threshold
+ *                  (default 110% of EstimatedHoursNumber);
+ *              (2) item 8 — the velocity-projected completion date falls past
+ *                  the committed CalculatedETADate__c (the ETA stamped when a
+ *                  schedule apply is committed via commitGanttPatches);
+ *              (3) item 8 — projectedFinalHours exceeds the client-approved
+ *                  cap (ClientPreApprovedHoursNumber__c > 0).
+ *              Cooldown + delta-detection guard (LastForecastAlert* fields)
+ *              prevents re-alert spam across all three conditions.
  *
  *              Mirrors DeliveryOverdueReminderService shape — gated by an org
  *              setting DateTime opt-in (EnableForecastAlertsDateTime__c) +
@@ -78,6 +85,7 @@ global with sharing class DeliveryForecastAlertService {
             SELECT Id, Name, BriefDescriptionTxt__c, OwnerId, DeveloperLookup__c,
                    EstimatedHoursNumber__c, TotalLoggedHoursSum__c,
                    StageNamePk__c, ActivatedDateTime__c,
+                   CalculatedETADate__c, ClientPreApprovedHoursNumber__c,
                    LastForecastAlertDateTime__c, LastForecastAlertProjectedHoursNumber__c
             FROM WorkItem__c
             WHERE ParentWorkItemLookup__c = NULL
@@ -116,9 +124,11 @@ global with sharing class DeliveryForecastAlertService {
     }
 
     /**
-     * @description Evaluates a single WI. Returns AlertCandidate when it should
-     *              alert, null when it shouldn't (under threshold, in cooldown,
-     *              or no projection available).
+     * @description Evaluates a single WI. Returns AlertCandidate when any
+     *              divergence condition fires (scope-overrun threshold,
+     *              committed-ETA blow, or approved-cap blow), null when it
+     *              shouldn't alert (no divergence, in cooldown, or no
+     *              projection available).
      */
     private static AlertCandidate evaluate(WorkItem__c wi, Decimal thresholdRatio) {
         DeliveryForecastService.ProjectForecast f;
@@ -135,7 +145,34 @@ global with sharing class DeliveryForecastAlertService {
             return null;
         }
         Decimal ratio = f.projectedFinalHours / f.totalEstimatedHours;
-        if (ratio < thresholdRatio) {
+        Decimal overrunPercent = (ratio * 100 - 100).setScale(1, System.RoundingMode.HALF_UP);
+        Decimal overrunHours = (f.projectedFinalHours - f.totalEstimatedHours).setScale(2, System.RoundingMode.HALF_UP);
+
+        List<String> reasons = new List<String>();
+        // (1) Scope-overrun threshold — the original condition, unchanged.
+        if (ratio >= thresholdRatio) {
+            reasons.add('Projected ' + overrunPercent + '% over scope ('
+                + overrunHours + 'h overrun) at current velocity');
+        }
+        // (2) Item 8 — committed-ETA blow: logged pace implies finishing past the
+        // ETA stamped on schedule apply (commitGanttPatches end-date write-back).
+        if (wi.CalculatedETADate__c != null && f.projectedCompletionDate != null
+                && f.projectedCompletionDate > wi.CalculatedETADate__c) {
+            Integer daysLate = wi.CalculatedETADate__c.daysBetween(f.projectedCompletionDate);
+            reasons.add('Current pace projects completion ' + daysLate
+                + ' day(s) past the committed ETA (' + String.valueOf(wi.CalculatedETADate__c) + ')');
+        }
+        // (3) Item 8 — approved-cap blow: projected final hours exceed the
+        // client-approved cap (the canonical approval-queue number).
+        if (wi.ClientPreApprovedHoursNumber__c != null && wi.ClientPreApprovedHoursNumber__c > 0
+                && f.projectedFinalHours > wi.ClientPreApprovedHoursNumber__c) {
+            Decimal capOver = (f.projectedFinalHours - wi.ClientPreApprovedHoursNumber__c)
+                .setScale(2, System.RoundingMode.HALF_UP);
+            reasons.add('Projected final ' + f.projectedFinalHours
+                + 'h exceeds the client-approved cap of ' + wi.ClientPreApprovedHoursNumber__c
+                + 'h (+' + capOver + 'h)');
+        }
+        if (reasons.isEmpty()) {
             return null;
         }
         if (inCooldown(wi, f)) {
@@ -144,8 +181,9 @@ global with sharing class DeliveryForecastAlertService {
         AlertCandidate ac = new AlertCandidate();
         ac.workItem = wi;
         ac.forecast = f;
-        ac.overrunPercent = (ratio * 100 - 100).setScale(1, System.RoundingMode.HALF_UP);
-        ac.overrunHours = (f.projectedFinalHours - f.totalEstimatedHours).setScale(2, System.RoundingMode.HALF_UP);
+        ac.overrunPercent = overrunPercent;
+        ac.overrunHours = overrunHours;
+        ac.reasons = reasons;
         return ac;
     }
 
@@ -197,9 +235,9 @@ global with sharing class DeliveryForecastAlertService {
                 ? wi.BriefDescriptionTxt__c : wi.Name;
             String recordUrl = orgUrl + '/lightning/r/WorkItem__c/' + wi.Id + '/view';
 
+            String reasonSummary = String.join(ac.reasons, ' · ');
             String bellTitle = 'Forecast risk: ' + wi.Name;
-            String bellBody = 'Projected ' + ac.overrunPercent + '% over scope ('
-                + ac.overrunHours + 'h overrun) at current velocity. Tap to review.';
+            String bellBody = reasonSummary + '. Tap to review.';
 
             for (Id recipientId : routeRecipients(wi)) {
                 if (!userMap.containsKey(recipientId)) {
@@ -216,8 +254,7 @@ global with sharing class DeliveryForecastAlertService {
                     }
                 }
             }
-            slackMessages.put(wi.Name, title + ' · projected ' + ac.overrunPercent
-                + '% over scope (+' + ac.overrunHours + 'h) · ' + recordUrl);
+            slackMessages.put(wi.Name, title + ' · ' + reasonSummary + ' · ' + recordUrl);
         }
 
         if (!emails.isEmpty() && emailGloballyEnabled()) {
@@ -272,8 +309,9 @@ global with sharing class DeliveryForecastAlertService {
             String recordUrl, String title) {
         Messaging.SingleEmailMessage email = new Messaging.SingleEmailMessage();
         email.setToAddresses(new List<String>{ toAddress });
-        email.setSubject('Delivery Hub Forecast Risk: ' + wi.Name
-            + ' projected ' + ac.overrunPercent + '% over scope');
+        // Lead with the first (highest-priority) divergence reason so ETA-only or
+        // cap-only alerts don't claim a scope overrun that didn't fire.
+        email.setSubject('Delivery Hub Forecast Risk: ' + wi.Name + ' — ' + ac.reasons[0]);
         email.setHtmlBody(buildForecastHtml(wi.Name, title, ac, recordUrl));
         email.setSaveAsActivity(false);
         return email;
@@ -284,8 +322,9 @@ global with sharing class DeliveryForecastAlertService {
         return '<div style="font-family: Arial, sans-serif; max-width: 600px;">'
             + '<h2 style="color: #b91c1c; margin: 0 0 16px;">Forecast Risk: ' + escape(wiName) + '</h2>'
             + '<p style="font-size: 14px; color: #374151;">'
-            + '<strong>' + escape(title) + '</strong> is trending past scope at current velocity.</p>'
+            + '<strong>' + escape(title) + '</strong> is diverging from plan at current velocity.</p>'
             + '<table style="border-collapse: collapse; width: 100%; font-size: 13px; margin: 12px 0;">'
+            + row('Why', String.join(ac.reasons, ' · '))
             + row('Estimated hours', String.valueOf(ac.forecast.totalEstimatedHours))
             + row('Logged hours', String.valueOf(ac.forecast.totalLoggedHours))
             + row('Projected final', String.valueOf(ac.forecast.projectedFinalHours)
@@ -374,5 +413,7 @@ global with sharing class DeliveryForecastAlertService {
         DeliveryForecastService.ProjectForecast forecast;
         Decimal overrunPercent;
         Decimal overrunHours;
+        /** Human-readable divergence reasons (scope / ETA / approved-cap) — never empty. */
+        List<String> reasons = new List<String>();
     }
 }

--- a/force-app/main/default/classes/DeliveryForecastAlertServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryForecastAlertServiceTest.cls
@@ -196,6 +196,101 @@ private class DeliveryForecastAlertServiceTest {
         System.assertEquals(0, fired, 'Terminal-stage WIs excluded from sweep');
     }
 
+    // ── Item 8 — divergence alerts (committed-ETA blow / approved-cap blow) ──
+
+    @IsTest
+    static void testEtaDivergenceFiresUnderHoursThreshold() {
+        // 100h estimate, 40h logged at 10h/wk → projected final = 100h = exactly
+        // 100% of scope (UNDER the 110% threshold — the legacy condition is
+        // silent). But remaining 60h at 10h/wk ≈ 6 more weeks, far past the
+        // committed ETA of next week → the ETA-divergence condition must fire.
+        WorkItem__c wi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'ETA diverge',
+            'EstimatedHoursNumber__c' => 100,
+            'EstimatedStartDevDate__c' => Date.today().addDays(-21),
+            'EstimatedEndDevDate__c' => Date.today().addDays(60),
+            'CalculatedETADate__c' => Date.today().addDays(7),
+            'StageNamePk__c' => 'In Development'
+        });
+        insert new List<WorkLog__c>{
+            buildLog(wi.Id, 10, Date.today().addDays(-21)),
+            buildLog(wi.Id, 10, Date.today().addDays(-14)),
+            buildLog(wi.Id, 10, Date.today().addDays(-7)),
+            buildLog(wi.Id, 10, Date.today())
+        };
+        enableFeature(110);
+
+        Test.startTest();
+        Integer fired = DeliveryForecastAlertService.runSweep();
+        Test.stopTest();
+
+        System.assertEquals(1, fired,
+            'Pace blowing the committed CalculatedETADate must fire even under the hours threshold');
+        WorkItem__c after = [SELECT LastForecastAlertDateTime__c FROM WorkItem__c WHERE Id = :wi.Id];
+        System.assertNotEquals(null, after.LastForecastAlertDateTime__c,
+            'Cooldown stamp lands for ETA-divergence alerts too');
+    }
+
+    @IsTest
+    static void testApprovedCapDivergenceFiresUnderHoursThreshold() {
+        // 50h estimate, 40h logged → projected final = 50h = 100% of scope (under
+        // the 110% threshold). But the client approved only 45h → projected 50h
+        // blows the approved cap → the cap-divergence condition must fire.
+        // (Logged 40h stays UNDER the cap so DeliveryWorkCapEnforcementService's
+        // flag path stays out of the picture.)
+        WorkItem__c wi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'Cap diverge',
+            'EstimatedHoursNumber__c' => 50,
+            'ClientPreApprovedHoursNumber__c' => 45,
+            'EstimatedStartDevDate__c' => Date.today().addDays(-21),
+            'EstimatedEndDevDate__c' => Date.today().addDays(28),
+            'StageNamePk__c' => 'In Development'
+        });
+        insert new List<WorkLog__c>{
+            buildLog(wi.Id, 10, Date.today().addDays(-21)),
+            buildLog(wi.Id, 10, Date.today().addDays(-14)),
+            buildLog(wi.Id, 10, Date.today().addDays(-7)),
+            buildLog(wi.Id, 10, Date.today())
+        };
+        enableFeature(110);
+
+        Test.startTest();
+        Integer fired = DeliveryForecastAlertService.runSweep();
+        Test.stopTest();
+
+        System.assertEquals(1, fired,
+            'Projected final blowing the client-approved cap must fire even under the hours threshold');
+    }
+
+    @IsTest
+    static void testNoDivergenceStaysSilentWithEtaAndCapHeadroom() {
+        // Same at-budget shape as testUnderThresholdSilent, but WITH an ETA and a
+        // cap that both have headroom — none of the three conditions fire.
+        WorkItem__c wi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'Healthy item',
+            'EstimatedHoursNumber__c' => 50,
+            'ClientPreApprovedHoursNumber__c' => 60,
+            'EstimatedStartDevDate__c' => Date.today().addDays(-21),
+            'EstimatedEndDevDate__c' => Date.today().addDays(28),
+            'CalculatedETADate__c' => Date.today().addDays(60),
+            'StageNamePk__c' => 'In Development'
+        });
+        insert new List<WorkLog__c>{
+            buildLog(wi.Id, 10, Date.today().addDays(-21)),
+            buildLog(wi.Id, 10, Date.today().addDays(-14)),
+            buildLog(wi.Id, 10, Date.today().addDays(-7)),
+            buildLog(wi.Id, 10, Date.today())
+        };
+        enableFeature(110);
+
+        Test.startTest();
+        Integer fired = DeliveryForecastAlertService.runSweep();
+        Test.stopTest();
+
+        System.assertEquals(0, fired,
+            'On-pace item with ETA + cap headroom must not fire any divergence condition');
+    }
+
     @IsTest
     static void testQueueableDelegates() {
         seedOverBudgetWi();

--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -1500,6 +1500,16 @@ public with sharing class DeliveryGanttController {
      *              outer savepoint can roll back cleanly — the public method
      *              wraps in its own try/catch + AuraHandledException, which
      *              would short-circuit our atomicity guarantee.
+     *
+     *              ETA write-back (item 8, NG dispatch-dh-0611-gate2): a patch
+     *              that lands here is COMMITTED (the operator reviewed the
+     *              pendingBuffer and clicked Submit — previews never reach
+     *              this method). Auto-schedule batches (`onAutoSchedule
+     *              {changes}` → _handleAutoSchedule) and manual drag-edits
+     *              both drain through this path, so any committed end-date
+     *              move also stamps WorkItem__c.CalculatedETADate__c in the
+     *              SAME update statement (same transaction, no extra
+     *              round-trip). Start-only moves do not touch the ETA.
      * @param patch The pending-buffer entry of kind="edit".
      */
     private static void applyEditPatch(Map<String, Object> patch) {
@@ -1522,7 +1532,10 @@ public with sharing class DeliveryGanttController {
         }
         Object ed = changes.get('endDate');
         if (ed != null && String.isNotBlank(String.valueOf(ed))) {
-            item.EstimatedEndDevDate__c = Date.valueOf(String.valueOf(ed));
+            Date committedEnd = Date.valueOf(String.valueOf(ed));
+            item.EstimatedEndDevDate__c = committedEnd;
+            // Committed end-date move → the leveled/applied end IS the new ETA.
+            item.CalculatedETADate__c = committedEnd;
         }
         update item; //NOPMD - with sharing class handles CRUD
     }

--- a/force-app/main/default/classes/DeliveryGanttControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryGanttControllerTest.cls
@@ -427,6 +427,104 @@ private class DeliveryGanttControllerTest {
         }
     }
 
+    // ── commitGanttPatches — ETA write-back on committed apply (item 8) ──
+
+    @IsTest
+    static void testCommitGanttPatchesEndDateMoveStampsCalculatedEta() {
+        System.runAs(testUser) {
+            WorkItem__c item = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Build login page' LIMIT 1];
+            Date newStart = Date.today().addDays(3);
+            Date newEnd = Date.today().addDays(42);
+            String patchesJson = JSON.serialize(new List<Object>{
+                new Map<String, Object>{
+                    'taskId' => item.Id,
+                    'kind' => 'edit',
+                    'changes' => new Map<String, Object>{
+                        'startDate' => String.valueOf(newStart),
+                        'endDate' => String.valueOf(newEnd)
+                    }
+                }
+            });
+
+            Test.startTest();
+            Map<String, Object> result = DeliveryGanttController.commitGanttPatches(patchesJson, 'auto-schedule apply');
+            Test.stopTest();
+
+            System.assertEquals(true, result.get('ok'), 'Commit should succeed');
+            System.assertEquals(1, result.get('committed'), 'One patch committed');
+            WorkItem__c updated = [SELECT EstimatedStartDevDate__c, EstimatedEndDevDate__c, CalculatedETADate__c
+                                   FROM WorkItem__c WHERE Id = :item.Id];
+            System.assertEquals(newStart, updated.EstimatedStartDevDate__c, 'Start date committed');
+            System.assertEquals(newEnd, updated.EstimatedEndDevDate__c, 'End date committed');
+            System.assertEquals(newEnd, updated.CalculatedETADate__c,
+                'Committed end-date move stamps CalculatedETADate__c in the same transaction');
+        }
+    }
+
+    @IsTest
+    static void testCommitGanttPatchesStartOnlyMoveLeavesEtaUntouched() {
+        System.runAs(testUser) {
+            // 'Fix export bug' carries no engineered end and no prior ETA — a
+            // start-only move must NOT invent one.
+            WorkItem__c item = [SELECT Id, CalculatedETADate__c FROM WorkItem__c
+                                WHERE BriefDescriptionTxt__c = 'Fix export bug' LIMIT 1];
+            System.assertEquals(null, item.CalculatedETADate__c, 'Precondition: no ETA yet');
+            String patchesJson = JSON.serialize(new List<Object>{
+                new Map<String, Object>{
+                    'taskId' => item.Id,
+                    'kind' => 'edit',
+                    'changes' => new Map<String, Object>{
+                        'startDate' => String.valueOf(Date.today().addDays(5))
+                    }
+                }
+            });
+
+            Test.startTest();
+            DeliveryGanttController.commitGanttPatches(patchesJson, null);
+            Test.stopTest();
+
+            WorkItem__c updated = [SELECT CalculatedETADate__c FROM WorkItem__c WHERE Id = :item.Id];
+            System.assertEquals(null, updated.CalculatedETADate__c,
+                'A start-only committed move must not stamp CalculatedETADate__c');
+        }
+    }
+
+    @IsTest
+    static void testCommitGanttPatchesAutoScheduleBatchStampsEachMovedItem() {
+        System.runAs(testUser) {
+            // The onAutoSchedule({changes}) batch shape after the operator
+            // Submits: multiple edit patches in one commit — each item with an
+            // end-date move gets its OWN committed end as its ETA.
+            WorkItem__c a = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Build login page' LIMIT 1];
+            WorkItem__c b = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Fix export bug' LIMIT 1];
+            Date endA = Date.today().addDays(21);
+            Date endB = Date.today().addDays(35);
+            String patchesJson = JSON.serialize(new List<Object>{
+                new Map<String, Object>{
+                    'taskId' => a.Id,
+                    'kind' => 'edit',
+                    'changes' => new Map<String, Object>{ 'endDate' => String.valueOf(endA) }
+                },
+                new Map<String, Object>{
+                    'taskId' => b.Id,
+                    'kind' => 'edit',
+                    'changes' => new Map<String, Object>{ 'endDate' => String.valueOf(endB) }
+                }
+            });
+
+            Test.startTest();
+            Map<String, Object> result = DeliveryGanttController.commitGanttPatches(patchesJson, 'leveled batch');
+            Test.stopTest();
+
+            System.assertEquals(2, result.get('committed'), 'Both auto-schedule patches committed');
+            Map<Id, WorkItem__c> updated = new Map<Id, WorkItem__c>([
+                SELECT Id, CalculatedETADate__c FROM WorkItem__c WHERE Id IN (:a.Id, :b.Id)
+            ]);
+            System.assertEquals(endA, updated.get(a.Id).CalculatedETADate__c, 'Item A ETA = its leveled end');
+            System.assertEquals(endB, updated.get(b.Id).CalculatedETADate__c, 'Item B ETA = its leveled end');
+        }
+    }
+
     // ── getGanttDependencies ─────────────────────────────────────────
 
     @IsTest

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
@@ -61,7 +61,8 @@ global with sharing class DeliveryHoursAnalyticsController {
         Date startDate;
         Date endDate;
         /** 0.268 — the stacked-forecast commitment tier (PacingSegment.id) this item
-         *  belongs to, derived once from PriorityGroupPk__c via tierForGroup(). Drives
+         *  belongs to, derived once via tierForItem() (approval truth first —
+         *  ClientPreApprovedHoursNumber__c > 0 → greenlit — else lane-derived). Drives
          *  both the per-bucket `segments` sums and each drill-down item's `tier`. */
         String tier;
     }
@@ -342,29 +343,41 @@ global with sharing class DeliveryHoursAnalyticsController {
 
     /**
      * @description Maps a WorkItem `PriorityGroupPk__c` lane onto the NG stacked-forecast
-     *              commitment tier (PacingSegment.id). Mirrors NG's PACING_LANE_TO_SEGMENT
-     *              (packages/app/src/renderers/pacing.ts) 1:1 so DH's AUTHORITATIVE per-tier
-     *              split reconciles with NG's task-derived PREVIEW split — same lane, same
-     *              tier, no drift. DH's lane values (top-priority/active/follow-on/proposed/
-     *              deferred — see DeliveryGanttController) ARE NG's keys, so no translation.
+     *              commitment tier (PacingSegment.id) for items that are NOT client-approved.
+     *              Item 8 (approved-green cohort): membership in the 'greenlit' (Committed)
+     *              tier is APPROVAL TRUTH, not lane truth — an item is greenlit iff
+     *              `ClientPreApprovedHoursNumber__c > 0` (the canonical client-approved cap
+     *              stamped by DeliveryWorkApprovalService), regardless of lane (see
+     *              tierForItem). Unapproved items land in their lane-derived tier here, so
+     *              the formerly-greenlit lanes (top-priority/active — work that is moving
+     *              but not literally approved) now read 'predicted'. Segment IDS/COLORS are
+     *              an NG contract (SEGMENT_DEFS) and are unchanged — only membership moved.
+     *              This makes DH's AUTHORITATIVE split intentionally STRICTER than NG's
+     *              task-derived PREVIEW (PACING_LANE_TO_SEGMENT in
+     *              packages/app/src/renderers/pacing.ts, which has no approval signal);
+     *              authoritative wins whenever DH feeds segments.
      *              Fallbacks preserve the "no work silently vanishes" invariant: every
      *              forecasted item lands in a tier, so the per-bucket segments always sum to
      *              the bucket forecast (NG renders bar = actual + Σ segments and ignores
-     *              `forecast` once segments are present). Blank/unknown → 'greenlit' (matches
-     *              NG); 'deferred' (on-hold) → 'ready' (the speculative/dotted upside tier)
+     *              `forecast` once segments are present). Blank/unknown unapproved →
+     *              'predicted' (never 'greenlit' — greenlit is approval-only);
+     *              'deferred' (on-hold) → 'ready' (the speculative/dotted upside tier)
      *              rather than NG's exclude, because DH's schedule spread already counts
      *              on-hold remaining and dropping its tier would shrink the bar.
      */
     private static final Map<String, String> PRIORITY_GROUP_TO_TIER = new Map<String, String>{
-        'top-priority' => 'greenlit',
-        'active'       => 'greenlit',
+        'top-priority' => 'predicted',
+        'active'       => 'predicted',
         'follow-on'    => 'predicted',
         'proposed'     => 'ready',
         'deferred'     => 'ready'
     };
 
-    /** @description Fallback tier for blank/unknown lanes (no-vanish — see above). */
-    private static final String DEFAULT_TIER = 'greenlit';
+    /** @description The approval-only Committed tier id (NG PacingSegment.id contract). */
+    private static final String GREENLIT_TIER = 'greenlit';
+
+    /** @description Fallback tier for blank/unknown lanes on UNAPPROVED items (no-vanish — see above). */
+    private static final String DEFAULT_TIER = 'predicted';
 
     /**
      * @description The DH-declared stacked-forecast tier definitions, in stack order, in
@@ -385,7 +398,25 @@ global with sharing class DeliveryHoursAnalyticsController {
     private static final List<String> TIER_ORDER = new List<String>{ 'greenlit', 'predicted', 'ready', 'recurring' };
 
     /**
-     * @description Resolves a WorkItem lane to its forecast tier (see PRIORITY_GROUP_TO_TIER).
+     * @description Resolves a WorkItem's forecast tier. Approval truth first: any item the
+     *              client has pre-approved hours for (`ClientPreApprovedHoursNumber__c > 0`)
+     *              is 'greenlit' regardless of lane; everything else falls back to its
+     *              lane-derived tier (see PRIORITY_GROUP_TO_TIER — never 'greenlit').
+     * @param approvedHours The WorkItem `ClientPreApprovedHoursNumber__c` value (nullable).
+     * @param lane The WorkItem `PriorityGroupPk__c` value (may be blank).
+     * @return A PacingSegment.id — never null.
+     */
+    private static String tierForItem(Decimal approvedHours, String lane) {
+        if (approvedHours != null && approvedHours > 0) {
+            return GREENLIT_TIER;
+        }
+        return tierForGroup(lane);
+    }
+
+    /**
+     * @description Resolves a WorkItem lane to its UNAPPROVED forecast tier (see
+     *              PRIORITY_GROUP_TO_TIER). Callers wanting the full approval-aware
+     *              resolution use tierForItem.
      * @param lane The WorkItem `PriorityGroupPk__c` value (may be blank).
      * @return A PacingSegment.id — never null (blank/unknown fall back to DEFAULT_TIER).
      */
@@ -910,6 +941,7 @@ global with sharing class DeliveryHoursAnalyticsController {
         List<WorkItem__c> items = [
             SELECT Id, Name, BriefDescriptionTxt__c, StageNamePk__c, DeveloperLookup__r.Name,
                    EstimatedHoursNumber__c, PriorityGroupPk__c, ParentWorkItemLookup__c,
+                   ClientPreApprovedHoursNumber__c,
                    EstimatedStartDevDate__c, EstimatedEndDevDate__c
             FROM WorkItem__c
             WHERE Id IN :portfolioIds
@@ -968,7 +1000,9 @@ global with sharing class DeliveryHoursAnalyticsController {
             sched.logged = logged;
             sched.startDate = wi.EstimatedStartDevDate__c;
             sched.endDate = wi.EstimatedEndDevDate__c;
-            sched.tier = tierForGroup(wi.PriorityGroupPk__c);
+            // Item 8 — greenlit = literally approved (ClientPreApprovedHoursNumber__c > 0),
+            // regardless of lane; unapproved items keep their lane-derived tier.
+            sched.tier = tierForItem(wi.ClientPreApprovedHoursNumber__c, wi.PriorityGroupPk__c);
             portfolioItemSchedules.add(sched);
             Date s = wi.EstimatedStartDevDate__c;
             if (s != null && (dto.earliestStart == null || s < dto.earliestStart)) {

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
@@ -993,8 +993,10 @@ private class DeliveryHoursAnalyticsControllerTest {
 
     // ────────────────────────────────────────────────────────────────────
     // getPacing — cohort/commitment-tier split (the stacked hockey-stick).
-    // PriorityGroupPk__c → segment id: active/top-priority→greenlit,
-    // follow-on→predicted, proposed/deferred→ready. Per-bucket `segments`
+    // Item 8: greenlit (Committed) = APPROVAL TRUTH — an item is greenlit
+    // iff ClientPreApprovedHoursNumber__c > 0, regardless of lane.
+    // Unapproved items map by lane: top-priority/active/follow-on→predicted,
+    // proposed/deferred→ready; blank/unknown→predicted. Per-bucket `segments`
     // sum to forecast; items carry `tier`; top-level segments[] advertises
     // only tiers that carry hours.
     // ────────────────────────────────────────────────────────────────────
@@ -1011,6 +1013,20 @@ private class DeliveryHoursAnalyticsControllerTest {
         });
     }
 
+    /** @description Same as insertTieredWi but client-approved (the greenlit membership signal). */
+    @SuppressWarnings('PMD.ExcessiveParameterList')
+    private static WorkItem__c insertApprovedWi(String briefDesc, Decimal estimate, Date startDate, Date endDate, String priorityGroup, Decimal approvedHours) {
+        return TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => briefDesc,
+            'EstimatedHoursNumber__c' => estimate,
+            'EstimatedStartDevDate__c' => startDate,
+            'EstimatedEndDevDate__c' => endDate,
+            'PriorityGroupPk__c' => priorityGroup,
+            'ClientPreApprovedHoursNumber__c' => approvedHours,
+            'ActivatedDateTime__c' => System.now()
+        });
+    }
+
     /** @description Pulls the top-level segments[] defs out of a getPacing payload. */
     private static List<Object> segmentDefsOf(String pacingJson) {
         Map<String, Object> data = (Map<String, Object>) JSON.deserializeUntyped(pacingJson);
@@ -1020,12 +1036,13 @@ private class DeliveryHoursAnalyticsControllerTest {
     @IsTest
     static void testCohortSplitTiersBucketsAndItems() {
         // Three active roots over the SAME future window → their forecast buckets carry
-        // all three commitment tiers, mapped from PriorityGroupPk__c.
+        // all three commitment tiers. Greenlit = client-approved (item 8); the other
+        // two map from PriorityGroupPk__c.
         Date nextMonthStart = Date.today().toStartOfMonth().addMonths(1);
         Date spanEnd = nextMonthStart.addMonths(3).addDays(-1);
-        insertTieredWi('CommittedWI', 90, nextMonthStart, spanEnd, 'active');     // → greenlit
-        insertTieredWi('PredictedWI', 60, nextMonthStart, spanEnd, 'follow-on');  // → predicted
-        insertTieredWi('ProposedWI',  30, nextMonthStart, spanEnd, 'proposed');   // → ready
+        insertApprovedWi('CommittedWI', 90, nextMonthStart, spanEnd, 'active', 90); // approved → greenlit
+        insertTieredWi('PredictedWI', 60, nextMonthStart, spanEnd, 'follow-on');    // → predicted
+        insertTieredWi('ProposedWI',  30, nextMonthStart, spanEnd, 'proposed');     // → ready
 
         Test.startTest();
         String pacingJson = DeliveryHoursAnalyticsController.getPacing('Month', 6, 4);
@@ -1069,7 +1086,7 @@ private class DeliveryHoursAnalyticsControllerTest {
                 String name = (String) item.get('name');
                 String tier = (String) item.get('tier');
                 if (name == 'CommittedWI') {
-                    System.assertEquals('greenlit', tier, 'active lane → greenlit');
+                    System.assertEquals('greenlit', tier, 'client-approved item → greenlit');
                 } else if (name == 'PredictedWI') {
                     System.assertEquals('predicted', tier, 'follow-on lane → predicted');
                 } else if (name == 'ProposedWI') {
@@ -1082,9 +1099,11 @@ private class DeliveryHoursAnalyticsControllerTest {
     }
 
     @IsTest
-    static void testBlankLaneFallsBackToGreenlitNoVanish() {
-        // A future-dated item with NO priority lane must still land in a tier (greenlit),
+    static void testBlankLaneFallsBackToPredictedNoVanish() {
+        // A future-dated UNAPPROVED item with NO priority lane must still land in a tier,
         // so its forecast hours never vanish from the stack (Σ segments == forecast).
+        // Item 8: the no-vanish fallback is 'predicted' — never 'greenlit', because
+        // greenlit membership is approval truth only.
         Date nextMonthStart = Date.today().toStartOfMonth().addMonths(1);
         Date spanEnd = nextMonthStart.addMonths(2).addDays(-1);
         insertTieredWi('NoLaneWI', 50, nextMonthStart, spanEnd, null);
@@ -1097,17 +1116,58 @@ private class DeliveryHoursAnalyticsControllerTest {
         for (Object o : segmentDefsOf(pacingJson)) {
             ids.add((String) ((Map<String, Object>) o).get('id'));
         }
-        System.assertEquals(new List<String>{ 'greenlit' }, ids,
-            'blank lane folds into the single greenlit tier (no-vanish fallback)');
+        System.assertEquals(new List<String>{ 'predicted' }, ids,
+            'blank lane on an unapproved item folds into the single predicted tier (no-vanish fallback)');
         for (Object o : bucketsOf(pacingJson)) {
             Map<String, Object> b = (Map<String, Object>) o;
             Decimal forecast = (Decimal) b.get('forecast');
             if (forecast != null && forecast > 0) {
                 Map<String, Object> segs = (Map<String, Object>) b.get('segments');
-                System.assertEquals(forecast, (Decimal) segs.get('greenlit'),
-                    'all forecast hours land in greenlit when no lane is set');
+                System.assertEquals(forecast, (Decimal) segs.get('predicted'),
+                    'all forecast hours land in predicted when no lane is set and nothing is approved');
             }
         }
+    }
+
+    @IsTest
+    static void testGreenlitMembershipIsApprovalTruthNotLane() {
+        // Item 8 acceptance pair: an APPROVED item lands greenlit even from the
+        // lowliest lane ('proposed'), and an UNAPPROVED top-priority item does NOT
+        // land greenlit (it keeps its lane-derived tier, 'predicted').
+        Date nextMonthStart = Date.today().toStartOfMonth().addMonths(1);
+        Date spanEnd = nextMonthStart.addMonths(2).addDays(-1);
+        insertApprovedWi('ApprovedProposedWI', 40, nextMonthStart, spanEnd, 'proposed', 40);
+        insertTieredWi('UnapprovedTopWI', 80, nextMonthStart, spanEnd, 'top-priority');
+
+        Test.startTest();
+        String pacingJson = DeliveryHoursAnalyticsController.getPacing('Month', 6, 4);
+        Test.stopTest();
+
+        Boolean sawApproved = false;
+        Boolean sawUnapproved = false;
+        for (Object o : bucketsOf(pacingJson)) {
+            Map<String, Object> b = (Map<String, Object>) o;
+            List<Object> items = (List<Object>) b.get('items');
+            if (items == null) {
+                continue;
+            }
+            for (Object io : items) {
+                Map<String, Object> item = (Map<String, Object>) io;
+                String name = (String) item.get('name');
+                String tier = (String) item.get('tier');
+                if (name == 'ApprovedProposedWI') {
+                    System.assertEquals('greenlit', tier,
+                        'Approved item is greenlit regardless of its (proposed) lane');
+                    sawApproved = true;
+                } else if (name == 'UnapprovedTopWI') {
+                    System.assertEquals('predicted', tier,
+                        'Unapproved top-priority item must NOT be greenlit');
+                    sawUnapproved = true;
+                }
+            }
+        }
+        System.assert(sawApproved && sawUnapproved,
+            'Both items appear in the forecast drill-down');
     }
 
     @IsTest


### PR DESCRIPTION
## Item 8 of the-machine-0610 — three sub-items

### (a) ETA write-back on schedule apply — `DeliveryGanttController.applyEditPatch`
Per NG's contract (`nimbus-gantt/docs/dispatch-dh-0611-gate2.md`): leveled dates flow through DH's existing apply paths — `onAutoSchedule({changes})` → `_handleAutoSchedule` stages PATCHes into the NG audit `pendingBuffer`; operator Submit drains it via `onAuditSubmit` → `commitGanttPatches`. A patch reaching `applyEditPatch` is by definition **committed** (previews never get there), so any edit patch carrying an `endDate` now also stamps `WorkItem__c.CalculatedETADate__c` **in the same `update` statement** (same Apex transaction, no extra round-trip). Start-only moves do not touch the ETA.

Scope note: this covers the default (audit-pass ON) posture, which is the path both auto-schedule batches and manual drag-edits commit through. Bypass mode (`BypassAuditPassDateTime__c` set → immediate-DML `updateWorkItemDates`) is deliberately unchanged — outside the dispatch's "committed batch" contract and a behavior expansion for legacy single-drag surfaces.

### (b) Green cohort = literally approved — `DeliveryHoursAnalyticsController`
`PRIORITY_GROUP_TO_TIER` no longer hands out `greenlit`: membership in the Committed tier is approval truth — an item is greenlit **iff `ClientPreApprovedHoursNumber__c > 0`** (the canonical client-approved cap stamped by the shipped approval queue), regardless of lane (new `tierForItem`, one extra field in the existing rollup SOQL). Unapproved items keep lane-derived tiers; the formerly-greenlit lanes (`top-priority`/`active`) and the blank-lane no-vanish fallback re-point to `predicted` (never `greenlit`). **Segment ids/colors/order (`SEGMENT_DEFS` — the NG PacingSegment contract) are unchanged; only membership moved.** The no-vanish invariant (Σ segments == bucket forecast) is preserved.

### (c) Divergence alerts — implemented (not deferred)
`DeliveryForecastAlertService` already IS the plan-vs-actual drift sweep (velocity-projected final hours vs estimate, with `LastForecastAlertDateTime__c` / `LastForecastAlertProjectedHoursNumber__c` cooldown + bell/email/Slack dispatch + per-user `Forecast_Risk` preferences). Extension was clean and minimal: `evaluate()` now fires on any of three reasons —
1. scope overrun ≥ threshold (existing, unchanged);
2. **committed-ETA blow** — `projectedCompletionDate > CalculatedETADate__c` (the ETA stamped by (a));
3. **approved-cap blow** — `projectedFinalHours > ClientPreApprovedHoursNumber__c` when the cap > 0.

Reasons are carried on the candidate and rendered in the bell body, email subject/Why-row, and Slack line. Dedupe reuses the existing `LastForecastAlert*` cooldown for all three conditions. The bell stays on the existing `DeliveryEscalationNotifService.sendBellNotification` path rather than per-candidate `DeliveryNotificationQueueable` enqueues: the sweep already runs inside `DeliveryForecastAlertQueueable`, and a queueable may enqueue only ONE child job — per-candidate enqueues would blow the chain limit, and the existing path already enforces per-user bell opt-in. `DeliveryNotificationService` untouched.

## Verification done
- `CalculatedETADate__c`, `LastForecastAlertDateTime__c`, `LastForecastAlertProjectedHoursNumber__c`, `ClientPreApprovedHoursNumber__c` all verified to exist under `force-app/main/default/objects/WorkItem__c/fields/` (no field creation needed); `CalculatedETADate__c` + `ClientPreApprovedHoursNumber__c` already in both App/Admin permsets.
- `DeliveryWorkItemTriggerHandler` only SYNCS `CalculatedETADate__c` (cross-org field list) — it never recomputes it, so the stamp survives the trigger.
- `DeliveryWorkCapEnforcementService` flag/enforce posture checked — the divergence-cap test keeps logged hours under the cap so the enforcement trigger stays inert.
- `greenlit` literal swept repo-wide: only the analytics controller/test + an unrelated LWC comment + the vendored NG bundle reference it — no other membership consumers.
- New/changed SOQL is `WITH SYSTEM_MODE`; ApexDoc on touched members; no new metadata.

## Tests (9 new, 3 updated)
- `DeliveryGanttControllerTest` (+3): end-date commit stamps ETA; start-only commit leaves ETA null; two-item auto-schedule batch stamps each item's own leveled end.
- `DeliveryHoursAnalyticsControllerTest` (+1 new, 2 updated): new `testGreenlitMembershipIsApprovalTruthNotLane` (approved item in the `proposed` lane → greenlit; unapproved `top-priority` → NOT greenlit); `testCohortSplitTiersBucketsAndItems` updated (Committed row now approval-driven); `testBlankLaneFallsBackToGreenlitNoVanish` → `...PredictedNoVanish`.
- `DeliveryForecastAlertServiceTest` (+3): ETA blow fires under the 110% threshold; cap blow fires under the threshold; healthy item with ETA + cap headroom stays silent.

No local org auth in this environment — relying on the PR feature-test + PMD checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
