### PR TITLE
feat: bulk-approve selected — approval queue (spec §6a)

### DIFF
--- a/force-app/main/default/classes/DeliveryWorkApprovalService.cls
+++ b/force-app/main/default/classes/DeliveryWorkApprovalService.cls
@@ -39,6 +39,14 @@
  *                    approved delta when the request is a budget increase,
  *                    never overwritten — and the stage moves to
  *                    'Ready for Development'.
+ *               approveMany(workRequestIds, note)
+ *                 -> bulk "Approve selected" for the queue LWC (spec §6a).
+ *                    Loops the single approve() per id so every id gets the
+ *                    EXACT same semantics (caller guard, raise-for-increase
+ *                    delta math, null hours -> quoted fallback). Partial-
+ *                    failure policy: process every id, collect failures, and
+ *                    return both lists in BulkApproveResultDTO — one bad row
+ *                    never blocks the rest of the batch.
  *               decline(workRequestId, reason)
  *                 -> request StatusPk__c='Inactive' with StandDownReasonTxt__c;
  *                    the WorkItem parks (ClientIntentionPk__c='On Hold') ONLY
@@ -131,6 +139,18 @@ global with sharing class DeliveryWorkApprovalService {
         @AuraEnabled public Id workRequestId;
         @AuraEnabled public Boolean autoApproved;
         @AuraEnabled public Decimal quotedHours;
+    }
+
+    /**
+     * @description Result of a bulk approve (approveMany): which requests
+     *              landed and one human-readable entry per failure. Global
+     *              because it is the return type of the global approveMany
+     *              (subscriber-side automation) — CLAUDE.md: inner classes
+     *              used as global return types must be global.
+     */
+    global class BulkApproveResultDTO {
+        @AuraEnabled public List<Id> approvedIds = new List<Id>();
+        @AuraEnabled public List<String> failures = new List<String>();
     }
 
     // ────────────────────────────────────────────────────────────────────
@@ -403,6 +423,47 @@ global with sharing class DeliveryWorkApprovalService {
         writeAuditRow(req.WorkItemId__c, isIncrease ? 'Approve_Increase' : 'Approve', req.Id, note);
         // Fire-and-forget dev ping — null-safe, never throws back here.
         DeliveryNotificationService.notifyWorkApprovalDecided(req.Id, true);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // BULK APPROVE (queue LWC "Approve selected" — spec §6a)
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Bulk approve at quoted hours for the queue LWC's
+     *              "Approve selected" action. Each id delegates to the single
+     *              approve() so it gets the EXACT same semantics: per-item
+     *              caller guard, raise-for-increase delta math, and the null
+     *              approvedHours -> QuotedHoursNumber__c fallback. Partial-
+     *              failure policy: every id is processed; failures are
+     *              collected per id and returned alongside the approved ids
+     *              instead of aborting the batch (@AuraEnabled cannot both
+     *              return and throw). DML stays per-item by design — the
+     *              queue feed is capped at 200 rows (MAX_QUEUE_ROWS), so the
+     *              loop is well inside limits at queue scale.
+     * @param workRequestIds The WorkRequest__c ids to approve at their
+     *        quoted hours (each approve passes null approvedHours).
+     * @param note Optional decision note applied to every approved request.
+     * @return BulkApproveResultDTO carrying the successfully approved ids
+     *         plus one "<requestId>: <reason>" entry per failed id.
+     */
+    @AuraEnabled
+    global static BulkApproveResultDTO approveMany(List<Id> workRequestIds, String note) {
+        if (workRequestIds == null || workRequestIds.isEmpty()) {
+            throw new AuraHandledException('workRequestIds is required.');
+        }
+        BulkApproveResultDTO result = new BulkApproveResultDTO();
+        for (Id requestId : workRequestIds) {
+            try {
+                approve(requestId, null, note);
+                result.approvedIds.add(requestId);
+            } catch (Exception e) {
+                // AuraHandledException.getMessage() comes back generic inside
+                // the managed package — the id prefix is the actionable part.
+                result.failures.add(requestId + ': ' + e.getMessage());
+            }
+        }
+        return result;
     }
 
     // ────────────────────────────────────────────────────────────────────

--- a/force-app/main/default/classes/DeliveryWorkApprovalServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkApprovalServiceTest.cls
@@ -2,7 +2,8 @@
  * @name         Delivery Hub
  * @license      BSL 1.1 — See LICENSE.md
  * @description  Tests for the PR1 work-approval queue service:
- *               submit / approve / decline / requestIncrease / queue feed,
+ *               submit / approve / approveMany (bulk, partial-failure
+ *               collection) / decline / requestIncrease / queue feed,
  *               plus the discretionary Auto short-circuit (under-threshold
  *               auto-approves; an exhausted monthly cap does not), the
  *               canonical cap landing on ClientPreApprovedHoursNumber__c, and
@@ -549,6 +550,166 @@ private class DeliveryWorkApprovalServiceTest {
     }
 
     // ────────────────────────────────────────────────────────────────────
+    // BULK APPROVE (approveMany — spec §6a "Approve selected")
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description approveMany approves 2 of 2 pending requests at their
+     *              quoted hours (null approvedHours -> quoted fallback per
+     *              item): both Accepted, both items dev-ready with the
+     *              canonical cap = each item's own quote, no failures.
+     */
+    @IsTest
+    static void testApproveManyApprovesAll() {
+        configureSettings(null, null, UserInfo.getUserId());
+        WorkItem__c first = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 12
+        });
+        WorkItem__c second = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 8
+        });
+        List<DeliveryWorkApprovalService.SubmitResultDTO> submitted =
+            DeliveryWorkApprovalService.submitForApproval(
+                new Set<Id>{ first.Id, second.Id });
+        List<Id> requestIds = new List<Id>();
+        for (DeliveryWorkApprovalService.SubmitResultDTO dto : submitted) {
+            requestIds.add(dto.workRequestId);
+        }
+
+        Test.startTest();
+        DeliveryWorkApprovalService.BulkApproveResultDTO result =
+            DeliveryWorkApprovalService.approveMany(requestIds, 'bulk sign-off');
+        Test.stopTest();
+
+        System.assertEquals(2, result.approvedIds.size(), 'both requests approved');
+        System.assertEquals(0, result.failures.size(), 'no failures in a clean batch');
+
+        Integer acceptedCount = [
+            SELECT COUNT() FROM WorkRequest__c
+            WHERE Id IN :requestIds AND StatusPk__c = 'Accepted'
+        ];
+        System.assertEquals(2, acceptedCount, 'both requests landed Accepted');
+
+        Map<Id, WorkItem__c> afterById = new Map<Id, WorkItem__c>([
+            SELECT ClientPreApprovedHoursNumber__c, StageNamePk__c
+            FROM WorkItem__c WHERE Id IN (:first.Id, :second.Id)
+        ]);
+        System.assertEquals(12, afterById.get(first.Id).ClientPreApprovedHoursNumber__c,
+            'first item capped at its own quote — null hours fall back per item');
+        System.assertEquals(8, afterById.get(second.Id).ClientPreApprovedHoursNumber__c,
+            'second item capped at its own quote');
+        System.assertEquals('Ready for Development', afterById.get(first.Id).StageNamePk__c,
+            'first item dev-ready');
+        System.assertEquals('Ready for Development', afterById.get(second.Id).StageNamePk__c,
+            'second item dev-ready');
+    }
+
+    /**
+     * @description Mixed batch: one id is already decided (declined before
+     *              the bulk call) — that id lands in failures while the
+     *              still-pending id approves. One bad row never blocks the
+     *              rest. The failure entry carries the failing id (the id
+     *              prefix is OUR formatting — the AuraHandledException text
+     *              itself is never asserted).
+     */
+    @IsTest
+    static void testApproveManyMixedBatchCollectsFailure() {
+        configureSettings(null, null, null);
+        WorkItem__c decidedWi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 10
+        });
+        WorkItem__c pendingWi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 6
+        });
+        List<DeliveryWorkApprovalService.SubmitResultDTO> submitted =
+            DeliveryWorkApprovalService.submitForApproval(
+                new Set<Id>{ decidedWi.Id, pendingWi.Id });
+        Id decidedRequestId;
+        Id pendingRequestId;
+        for (DeliveryWorkApprovalService.SubmitResultDTO dto : submitted) {
+            if (dto.workItemId == decidedWi.Id) {
+                decidedRequestId = dto.workRequestId;
+            } else {
+                pendingRequestId = dto.workRequestId;
+            }
+        }
+        // Pre-decide one request so the bulk call hits a non-pending row.
+        DeliveryWorkApprovalService.decline(decidedRequestId, 'already handled');
+
+        Test.startTest();
+        DeliveryWorkApprovalService.BulkApproveResultDTO result =
+            DeliveryWorkApprovalService.approveMany(
+                new List<Id>{ decidedRequestId, pendingRequestId }, null);
+        Test.stopTest();
+
+        System.assertEquals(1, result.approvedIds.size(),
+            'only the still-pending request approves');
+        System.assertEquals(pendingRequestId, result.approvedIds[0],
+            'the pending id is the approved one');
+        System.assertEquals(1, result.failures.size(),
+            'the already-decided id lands in failures');
+        System.assert(result.failures[0].contains(String.valueOf(decidedRequestId)),
+            'the failure entry names the failing request id');
+
+        WorkRequest__c decided = [
+            SELECT StatusPk__c FROM WorkRequest__c WHERE Id = :decidedRequestId
+        ];
+        System.assertEquals('Inactive', decided.StatusPk__c,
+            'the declined request stays declined — bulk approve never resurrects it');
+        WorkRequest__c approved = [
+            SELECT StatusPk__c FROM WorkRequest__c WHERE Id = :pendingRequestId
+        ];
+        System.assertEquals('Accepted', approved.StatusPk__c,
+            'the pending request approved despite the sibling failure');
+    }
+
+    /**
+     * @description The caller guard runs PER ITEM inside the bulk loop: a
+     *              request assigned to another approver fails (and stays
+     *              pending) while an unassigned request in the same batch
+     *              approves for the running user.
+     */
+    @IsTest
+    static void testApproveManyRespectsCallerGuardPerItem() {
+        User other = createOtherUser();
+        // First item submits while the OTHER user is the configured approver.
+        configureSettings(null, null, other.Id);
+        WorkItem__c guardedWi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 10
+        });
+        Id guardedRequestId = DeliveryWorkApprovalService.submitForApproval(
+            new Set<Id>{ guardedWi.Id })[0].workRequestId;
+        // Second item submits unassigned — any authorised caller may decide.
+        configureSettings(null, null, null);
+        WorkItem__c openWi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 5
+        });
+        Id openRequestId = DeliveryWorkApprovalService.submitForApproval(
+            new Set<Id>{ openWi.Id })[0].workRequestId;
+
+        Test.startTest();
+        DeliveryWorkApprovalService.BulkApproveResultDTO result =
+            DeliveryWorkApprovalService.approveMany(
+                new List<Id>{ guardedRequestId, openRequestId }, null);
+        Test.stopTest();
+
+        System.assertEquals(1, result.approvedIds.size(),
+            'only the unassigned request approves for the non-approver caller');
+        System.assertEquals(openRequestId, result.approvedIds[0],
+            'the unassigned id is the approved one');
+        System.assertEquals(1, result.failures.size(),
+            'the guarded id is rejected per item');
+        System.assert(result.failures[0].contains(String.valueOf(guardedRequestId)),
+            'the failure entry names the guarded request id');
+
+        WorkRequest__c guarded = [
+            SELECT StatusPk__c FROM WorkRequest__c WHERE Id = :guardedRequestId
+        ];
+        System.assertEquals('Offer Sent', guarded.StatusPk__c,
+            'the guarded request stays pending for its assigned approver');
+    }
+
+    // ────────────────────────────────────────────────────────────────────
     // DECLINE
     // ────────────────────────────────────────────────────────────────────
 
@@ -840,6 +1001,22 @@ private class DeliveryWorkApprovalServiceTest {
             threw = true;
         }
         System.assert(threw, 'approve on a Draft (not awaiting decision) should throw');
+
+        threw = false;
+        try {
+            DeliveryWorkApprovalService.approveMany(new List<Id>(), null);
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        System.assert(threw, 'empty workRequestIds should throw');
+
+        threw = false;
+        try {
+            DeliveryWorkApprovalService.approveMany(null, null);
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        System.assert(threw, 'null workRequestIds should throw');
     }
 
     /**

--- a/force-app/main/default/lwc/deliveryApprovalQueue/__tests__/deliveryApprovalQueue.test.js
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/__tests__/deliveryApprovalQueue.test.js
@@ -4,14 +4,16 @@
  * @description  Jest coverage for deliveryApprovalQueue: wire-driven rows
  *               (label fallback, increase badge, headline totals), the
  *               imperative approve flow (apex call + success toast + wire
- *               refresh), the inline decline flow, and the caught-up empty
- *               state.
+ *               refresh), the bulk "Approve selected" flow (selection
+ *               toggles, approveMany call shape, outcome toasts), the inline
+ *               decline flow, and the caught-up empty state.
  * @author       Cloud Nimbus LLC
  */
 import { createElement } from "lwc";
 import DeliveryApprovalQueue from "c/deliveryApprovalQueue";
 import getPendingForApprover from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.getPendingForApprover";
 import approve from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.approve";
+import approveMany from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.approveMany";
 import decline from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.decline";
 
 const REQUEST_ONE = "a0G000000000001AAA";
@@ -60,6 +62,17 @@ function findButtonByLabel(element, label) {
     return Array.from(element.shadowRoot.querySelectorAll("lightning-button")).find(
         (b) => b.label === label
     );
+}
+
+function findInputByLabel(element, label) {
+    return Array.from(element.shadowRoot.querySelectorAll("lightning-input")).find(
+        (i) => i.label === label
+    );
+}
+
+function setCheckbox(input, checked) {
+    input.checked = checked;
+    input.dispatchEvent(new CustomEvent("change"));
 }
 
 describe("c-delivery-approval-queue", () => {
@@ -113,6 +126,98 @@ describe("c-delivery-approval-queue", () => {
         expect(toastHandler).toHaveBeenCalled();
         const toastDetail = toastHandler.mock.calls[0][0].detail;
         expect(toastDetail.variant).toBe("success");
+    });
+
+    it("selection toggles drive the bulk button label and disabled state", async () => {
+        const element = createComponent();
+        getPendingForApprover.emit(samplePending());
+        await flushPromises();
+
+        let bulkButton = findButtonByLabel(element, "Approve selected (0)");
+        expect(bulkButton).toBeTruthy();
+        expect(bulkButton.disabled).toBe(true);
+
+        // Tick the first row checkbox -> (1), enabled.
+        const rowCheckbox = findInputByLabel(element, "Select request");
+        setCheckbox(rowCheckbox, true);
+        await flushPromises();
+
+        bulkButton = findButtonByLabel(element, "Approve selected (1)");
+        expect(bulkButton).toBeTruthy();
+        expect(bulkButton.disabled).toBe(false);
+
+        // Select all -> (2).
+        setCheckbox(findInputByLabel(element, "Select all"), true);
+        await flushPromises();
+        expect(findButtonByLabel(element, "Approve selected (2)")).toBeTruthy();
+
+        // Clear via select-all -> back to (0), disabled.
+        setCheckbox(findInputByLabel(element, "Select all"), false);
+        await flushPromises();
+        bulkButton = findButtonByLabel(element, "Approve selected (0)");
+        expect(bulkButton).toBeTruthy();
+        expect(bulkButton.disabled).toBe(true);
+    });
+
+    it("bulk approve calls apex with the selected ids and toasts the success count", async () => {
+        approveMany.mockResolvedValue({
+            approvedIds: [REQUEST_ONE, REQUEST_TWO],
+            failures: []
+        });
+        const element = createComponent();
+        const toastHandler = jest.fn();
+        element.addEventListener("lightning__showtoast", toastHandler);
+
+        getPendingForApprover.emit(samplePending());
+        await flushPromises();
+
+        setCheckbox(findInputByLabel(element, "Select all"), true);
+        await flushPromises();
+
+        findButtonByLabel(element, "Approve selected (2)").dispatchEvent(
+            new CustomEvent("click")
+        );
+        await flushPromises();
+        await flushPromises();
+
+        expect(approveMany).toHaveBeenCalledWith({
+            workRequestIds: [REQUEST_ONE, REQUEST_TWO],
+            note: null
+        });
+        expect(toastHandler).toHaveBeenCalled();
+        const toastDetail = toastHandler.mock.calls[0][0].detail;
+        expect(toastDetail.variant).toBe("success");
+        expect(toastDetail.message).toContain("2 requests approved");
+    });
+
+    it("bulk approve toasts a warning summarizing partial failures", async () => {
+        approveMany.mockResolvedValue({
+            approvedIds: [REQUEST_ONE],
+            failures: [`${REQUEST_TWO}: not awaiting a decision`]
+        });
+        const element = createComponent();
+        const toastHandler = jest.fn();
+        element.addEventListener("lightning__showtoast", toastHandler);
+
+        getPendingForApprover.emit(samplePending());
+        await flushPromises();
+
+        setCheckbox(findInputByLabel(element, "Select all"), true);
+        await flushPromises();
+
+        findButtonByLabel(element, "Approve selected (2)").dispatchEvent(
+            new CustomEvent("click")
+        );
+        await flushPromises();
+        await flushPromises();
+
+        expect(approveMany).toHaveBeenCalledWith({
+            workRequestIds: [REQUEST_ONE, REQUEST_TWO],
+            note: null
+        });
+        const toastDetail = toastHandler.mock.calls[0][0].detail;
+        expect(toastDetail.variant).toBe("warning");
+        expect(toastDetail.message).toContain("1 approved, 1 failed");
     });
 
     it("decline requires a reason then calls apex", async () => {

--- a/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.css
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.css
@@ -97,6 +97,21 @@
     color: #111827;
 }
 
+.queue-bulk-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.5rem 1.5rem;
+    border-bottom: 1px solid #f3f4f6;
+    background: #f9fafb;
+    flex-wrap: wrap;
+}
+
+.queue-row-select {
+    flex: 0 0 auto;
+}
+
 .queue-list {
     list-style: none;
     margin: 0;

--- a/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.html
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.html
@@ -46,10 +46,35 @@
                 </div>
             </div>
 
+            <div class="queue-bulk-bar">
+                <lightning-input
+                    type="checkbox"
+                    label="Select all"
+                    checked={isAllSelected}
+                    onchange={handleSelectAll}
+                    class="queue-select-all">
+                </lightning-input>
+                <lightning-button
+                    variant="brand"
+                    label={bulkApproveLabel}
+                    disabled={isBulkApproveDisabled}
+                    onclick={handleBulkApprove}>
+                </lightning-button>
+            </div>
+
             <ul class="queue-list">
                 <template for:each={rows} for:item="row">
                     <li key={row.key} class="queue-row">
                         <div class="queue-row-main">
+                            <lightning-input
+                                type="checkbox"
+                                label="Select request"
+                                variant="label-hidden"
+                                data-request-id={row.key}
+                                checked={row.isSelected}
+                                onchange={handleRowSelect}
+                                class="queue-row-select">
+                            </lightning-input>
                             <div class="queue-row-info">
                                 <button class="queue-item-link"
                                         data-work-item-id={row.workItemId}

--- a/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.js
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.js
@@ -5,7 +5,10 @@
  *               work-approval queue). Wires
  *               DeliveryWorkApprovalService.getPendingForApprover and renders
  *               each Offer-Sent WorkRequest__c with inline Approve /
- *               Approve-with-change / Decline actions. After any decision the
+ *               Approve-with-change / Decline actions, plus row checkboxes +
+ *               select-all feeding a bulk "Approve selected (N)" action
+ *               (approveMany — spec §6a) that toasts the approved/failed
+ *               counts from BulkApproveResultDTO. After any decision the
  *               wire is refreshed and a toast confirms the outcome using OUR
  *               labels (AuraHandledException messages come back generic inside
  *               the managed package). Clicking the item name navigates to the
@@ -20,6 +23,7 @@ import { ShowToastEvent } from "lightning/platformShowToastEvent";
 import WORK_ITEM_OBJECT from "@salesforce/schema/WorkItem__c";
 import getPendingForApprover from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.getPendingForApprover";
 import approveApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.approve";
+import approveManyApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.approveMany";
 import declineApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.decline";
 
 const MS_PER_DAY = 86400000;
@@ -31,6 +35,9 @@ export default class DeliveryApprovalQueue extends NavigationMixin(LightningElem
     errorMessage = "";
     isLoading = true;
     isSaving = false;
+
+    // Bulk selection: request ids ticked for "Approve selected".
+    selectedIds = [];
 
     // One inline panel open at a time: the row + which panel.
     activeRequestId = null;
@@ -68,6 +75,7 @@ export default class DeliveryApprovalQueue extends NavigationMixin(LightningElem
                 hasIncrease: dto.requestedIncrease > 0,
                 increaseBadge: `increase +${this._formatHours(dto.requestedIncrease)}h`,
                 ageDisplay: this._ageDisplay(dto.submittedAt),
+                isSelected: this.selectedIds.includes(dto.requestId),
                 isChangeOpen: isActive && this.activeMode === MODE_CHANGE,
                 isDeclineOpen: isActive && this.activeMode === MODE_DECLINE
             };
@@ -86,6 +94,24 @@ export default class DeliveryApprovalQueue extends NavigationMixin(LightningElem
 
     get hasError() {
         return !this.isLoading && this.errorMessage.length > 0;
+    }
+
+    // ── Bulk selection (templates can't do ternaries — getters) ──
+
+    get selectedCount() {
+        return this._selectedPendingIds().length;
+    }
+
+    get bulkApproveLabel() {
+        return `Approve selected (${this.selectedCount})`;
+    }
+
+    get isBulkApproveDisabled() {
+        return this.isSaving || this.selectedCount === 0;
+    }
+
+    get isAllSelected() {
+        return this.pendingRaw.length > 0 && this.selectedCount === this.pendingRaw.length;
     }
 
     // ── Headline numbers ─────────────────────────────────────────
@@ -117,6 +143,50 @@ export default class DeliveryApprovalQueue extends NavigationMixin(LightningElem
                 actionName: "view"
             }
         });
+    }
+
+    // ── Bulk selection actions ───────────────────────────────────
+
+    handleRowSelect(event) {
+        const requestId = event.target.dataset.requestId;
+        if (!requestId) {
+            return;
+        }
+        const next = this.selectedIds.filter((id) => id !== requestId);
+        if (event.target.checked) {
+            next.push(requestId);
+        }
+        this.selectedIds = next;
+    }
+
+    handleSelectAll(event) {
+        this.selectedIds = event.target.checked
+            ? this.pendingRaw.map((dto) => dto.requestId)
+            : [];
+    }
+
+    handleBulkApprove() {
+        const ids = this._selectedPendingIds();
+        if (ids.length === 0 || this.isSaving) {
+            return;
+        }
+        this.isSaving = true;
+        approveManyApex({ workRequestIds: ids, note: null })
+            .then((result) => {
+                this.isSaving = false;
+                this.selectedIds = [];
+                this._closeInline();
+                this._toastBulkOutcome(result);
+                return refreshApex(this.wiredResult);
+            })
+            .catch((err) => {
+                this.isSaving = false;
+                this._toast(
+                    "Bulk approve failed",
+                    this._errorText(err, "The selected requests could not be approved."),
+                    "error"
+                );
+            });
     }
 
     // ── Decision actions ─────────────────────────────────────────
@@ -193,6 +263,38 @@ export default class DeliveryApprovalQueue extends NavigationMixin(LightningElem
     }
 
     // ── Internals ────────────────────────────────────────────────
+
+    // Selected ids still present in the pending feed — stale selections
+    // (rows decided elsewhere then refreshed away) never reach apex.
+    _selectedPendingIds() {
+        const pending = new Set(this.pendingRaw.map((dto) => dto.requestId));
+        return this.selectedIds.filter((id) => pending.has(id));
+    }
+
+    _toastBulkOutcome(result) {
+        const approved = result && result.approvedIds ? result.approvedIds.length : 0;
+        const failed = result && result.failures ? result.failures.length : 0;
+        if (failed === 0) {
+            const noun = approved === 1 ? "request" : "requests";
+            this._toast(
+                "Approved",
+                `${approved} ${noun} approved at the quoted hours.`,
+                "success"
+            );
+        } else if (approved === 0) {
+            this._toast(
+                "Bulk approve failed",
+                `0 approved, ${failed} failed.`,
+                "error"
+            );
+        } else {
+            this._toast(
+                "Partially approved",
+                `${approved} approved, ${failed} failed.`,
+                "warning"
+            );
+        }
+    }
 
     _openInline(requestId, mode) {
         if (!requestId) {

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.approveMany.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.approveMany.js
@@ -1,0 +1,4 @@
+/**
+ * Mock for DeliveryWorkApprovalService.approveMany (imperative bulk approve).
+ */
+module.exports = { default: jest.fn() };


### PR DESCRIPTION
## What

Spec section 6a required "Bulk-approve selected" in the approval queue; PR2 shipped per-row actions only. This closes the gap.

### Apex — `DeliveryWorkApprovalService`
- New `@AuraEnabled global static BulkApproveResultDTO approveMany(List<Id> workRequestIds, String note)` — loops the EXISTING single `approve()` per id (no duplicated logic), so every id gets the exact single-approve semantics: per-item caller guard (primary/backup/unassigned), raise-for-increase delta math, and the null-approvedHours -> `QuotedHoursNumber__c` fallback.
- Partial-failure policy: every id is processed; failures are collected per id and returned alongside the approved ids (`@AuraEnabled` cannot both return and throw). New `global class BulkApproveResultDTO { List<Id> approvedIds; List<String> failures; }` (global inner class per CLAUDE.md).
- DML stays per-item — the queue feed is capped at 200 rows (`MAX_QUEUE_ROWS`), well inside limits at queue scale.

### LWC — `deliveryApprovalQueue`
- Row checkboxes + a select-all checkbox, and an "Approve selected (N)" bulk button (disabled at 0 or while saving) in a new bulk bar under the summary tiles.
- Bulk click calls `approveMany` imperatively, toasts the outcome (success / warning "X approved, Y failed" / error), clears the selection, and `refreshApex`es the wire. Stale selections (rows refreshed away) are filtered out before the apex call.
- Per-row Approve / Approve w/ change / Decline unchanged. No template ternaries — getters; `%%%NAMESPACE_DOT%%%` only in the apex import path.

No permset / flexipage changes needed — `classAccesses` for the service already exist, and the component placement is unchanged.

## Tests
- **Apex (+3 tests, +2 validation asserts):** `approveMany` approves 2 of 2 (per-item quoted fallback, caps, stages); mixed batch where an already-decided id lands in `failures` while the pending sibling approves; caller guard respected per item (guarded row stays Offer Sent, unassigned row approves); empty/null input throws.
- **Jest (+3 tests, suite now 8/8 green):** selection toggles drive the bulk button label/disabled state; bulk call invoked with the selected ids + success toast counts; partial-failure warning toast. New imperative mock for `approveMany` following the existing harness idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
