### PR TITLE
docs: DH-MCP server design + 0.272–0.276 docs refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ It is open source under the [BSL 1.1 license](LICENSE.md) and ships as an unlock
 
 ## Install
 
-**Current release**: [`release/0.273.0.2`](https://github.com/Nimba-Solutions/Delivery-Hub/releases) (production-promoted 2026-06-11). Carries the work-approval queue (estimate → approve → cap rails, pending-approval queue on Home, approval reports + agenda card, Deployed-to-Prod ship loop), forecast/board scope parity, and NimbusGantt 0.204.0 (pace-aware auto-schedule, unified click-through, search + axis fixes) with a de-cluttered default Pacing view. See [GitHub Releases](https://github.com/Nimba-Solutions/Delivery-Hub/releases) for the full version history.
+**Current release**: [`release/0.276.0.2`](https://github.com/Nimba-Solutions/Delivery-Hub/releases) (production-promoted 2026-06-12). Completes the work-approval queue arc on top of 0.273's foundation (estimate → approve rails, pending-approval queue on Home, approval reports + agenda card, Deployed-to-Prod ship loop, NimbusGantt 0.204.0, de-cluttered Pacing view). 0.274 → 0.276 add: **approval pings** (submit notifies the approver, decisions notify the dev), **WorkLog cap enforcement** (over-cap logs flag by default, hard-block via `EnforceApprovalCapDateTime__c`), NimbusGantt **0.204.1** (empty-state fix), **approved-green forecast cohort** (greenlit tier = client-approved hours, not lane), **ETA write-back** on gantt apply (`CalculatedETADate__c`) + pace-divergence alerts, and the **approved-vs-total pitch stat** + backup approver + `global` `DeliveryWorkApprovalService`. See [GitHub Releases](https://github.com/Nimba-Solutions/Delivery-Hub/releases) for the full version history.
 
 | Environment | Link |
 |---|---|
-| **Production** | [![Install in Production](https://img.shields.io/badge/Install-Production-0070d2?logo=salesforce&style=for-the-badge)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000Vxi9IAC) |
-| **Sandbox** | [![Install in Sandbox](https://img.shields.io/badge/Install-Sandbox-3e8b3e?logo=salesforce&style=for-the-badge)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000Vxi9IAC) |
+| **Production** | [![Install in Production](https://img.shields.io/badge/Install-Production-0070d2?logo=salesforce&style=for-the-badge)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000VyeDIAS) |
+| **Sandbox** | [![Install in Sandbox](https://img.shields.io/badge/Install-Sandbox-3e8b3e?logo=salesforce&style=for-the-badge)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000VyeDIAS) |
 
 **Quickstart (≈5 minutes):**
 
@@ -89,7 +89,7 @@ Delivery Hub is organized into 8 layers. Layers 1–3 are the original delivery 
 
 | Layer | Name | Purpose |
 |---|---|---|
-| **1** | Core domain | `WorkItem__c`, `WorkRequest__c`, `WorkLog__c`, `WorkItemComment__c`, `WorkItemDependency__c` |
+| **1** | Core domain | `WorkItem__c`, `WorkRequest__c`, `WorkLog__c`, `WorkItemComment__c`, `WorkItemDependency__c` — plus the **work-approval queue** (0.272–0.276): the client estimate decision lives ON `WorkRequest__c` (no child approval object), with a discretionary auto-approve gate, an approved-hours cap enforced at WorkLog time, and a pending-approval queue on Home |
 | **2** | Sync & integration | `SyncItem__c`, `NetworkEntity__c`, Slack inbound/outbound, inbound email, IntegrationProvider webhooks |
 | **3** | Observability | `ActivityLog__c` (hash-chained), `WatcherDigest__c`, daily Watcher digest (Signals 1-3) |
 | **4** | Feature Catalog | `Feature__c` + `FeatureDefinition__mdt` + `FeatureDependency__c` + `deliveryFeatureCockpit` LWC |
@@ -97,6 +97,8 @@ Delivery Hub is organized into 8 layers. Layers 1–3 are the original delivery 
 | **6** | Dev-loop mirror | `ScratchOrgInstance__c` + `DevLoopGuide__mdt` + REST `POST/PATCH /scratch-orgs` |
 | **7** | Dataset templates | `DatasetTemplate__c` + `DatasetTemplateAssignment__c` + `load_feature_data` CCI task |
 | **8** | Approval framework | `FeatureToggleRequest__c` + `FeatureToggleApproval__c` + multi-step cascading approvals + in-app notifications |
+
+> **Two approval systems, on purpose.** Layer 8 approves *feature toggles* (request/approval pair, multi-step `StepNumber` chain). The Layer-1 **work-approval queue** approves *client work estimates* (decision stamped directly on `WorkRequest__c` — a request is decided at most once, budget increases are NEW requests, so per-step child rows would be speculative machinery). They are deliberately separate shapes today; unifying them under one approval framework is a someday-refactor, not a bug. See [docs/ARCHITECTURE.md § Work-Approval Queue](docs/ARCHITECTURE.md#work-approval-queue).
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the deep object/class/trigger reference, [docs/COCKPIT.md](docs/COCKPIT.md) for the per-layer cockpit detail, and [docs/SETUP.md](docs/SETUP.md) for the install/smoke-test runbook.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -625,6 +625,77 @@ See [DOCUMENT_ACTIONING_FEATURE.md](DOCUMENT_ACTIONING_FEATURE.md) for the full 
 
 ---
 
+## Work-Approval Queue
+
+Shipped across 0.272 → 0.276 (PRs #891–#893, #899–#900, #904). Client-facing estimate approval for `WorkItem__c` work: the vendor submits an estimate, the client (approver) accepts or declines, and the accepted hours become a hard budget cap enforced when hours are logged.
+
+**Design decision — the decision lives ON `WorkRequest__c`, no child approval object.** A request is decided at most once in its lifecycle (Offer Sent → Accepted/Inactive; budget increases are NEW requests), so per-step child rows would be speculative machinery. This mirrors the shipped `DeliveryDocApprovalService` pattern (decision state on the record + immutable per-event history in `ActivityLog__c` via the SHA-256 hash-chain trigger), and is deliberately distinct from Layer 8's FeatureToggle request/approval pair, whose multi-step `StepNumber` machinery this flow does not need. If a tiered chain ever becomes real, a child object can be ADDED then — objects shipped in the package cannot be removed.
+
+### Objects touched
+
+| Object | Fields | Role |
+|--------|--------|------|
+| **WorkRequest__c** | `StatusPk__c` (lifecycle: Draft / Offer Sent / Accepted / In Progress / Completed / Budget Hold / Inactive), `QuotedHoursNumber__c`, `PreApprovedHoursNumber__c`, `RequestedBudgetIncreaseNumber__c`, `ApproverUserLookup__c`, `DecisionDateTime__c`, `DecisionNoteTxt__c`, `StandDownReasonTxt__c`, `AutoApprovedDateTime__c` | Carries the quote and the final decision state |
+| **WorkItem__c** | `ClientPreApprovedHoursNumber__c` (THE canonical client-approved cap), `StageNamePk__c` (moved by the lifecycle), `ClientIntentionPk__c` (`On Hold` on decline of a never-approved item) | Receives the cap; stage reflects approval state |
+| **DeliveryHubSettings__c** | `ApproverUserIdTxt__c` (default approver, Text 18), `ApproverBackupUserIdTxt__c` (optional backup approver — may decide, never auto-assigned, gets no submit pings), `DiscretionaryThresholdHoursNumber__c` (per-request auto-approve ceiling), `DiscretionaryMonthlyCapHoursNumber__c` (monthly auto-approve budget), `EnforceApprovalCapDateTime__c` (flag-vs-block cap mode toggle) | Approver routing + discretionary gate + cap posture |
+| **ActivityLog__c** | `ActionTypePk__c = 'Work_Approval'` rows (Auto_Approve / Approve / Approve_Increase / Decline / Request_Increase) | Immutable per-event decision history on the SHA-256 hash chain |
+
+### Classes
+
+| Class | Responsibility |
+|-------|---------------|
+| **DeliveryWorkApprovalService** (`global`) | The decision engine: `submitForApproval(workItemIds[, quotedHoursByItem])`, `approve(workRequestId, approvedHours, note)`, `decline(workRequestId, reason)`, `requestIncrease(workItemId, extraHours, reason)`, `getPendingForApprover(userId)`. Global (with global DTOs `PendingApprovalDTO` / `SubmitResultDTO`) so subscriber-org anonymous Apex and future MCP automation can drive the lifecycle under the `delivery__` namespace. Caller guard: `assertCallerMayDecide` allows the assigned approver OR the configured backup; unassigned requests may be decided by any authorised caller, who is then stamped as approver. |
+| **DeliveryApprovalSummaryController** | Read-only aggregate feed for the `deliveryApprovalSummaryCard` LWC: hours approved this month, pending count/hours, approved-in-flight, the approved-vs-total pitch pair (`totalActiveEstimatedHours` / `totalApprovedHours` over the board-canonical active scope), and report ids for tile click-through (`Hours_Approved_This_Period`, `Pending_Approval`, `Approved_In_Progress`, `Deployed_To_Prod_Awaiting_Verification`). |
+| **DeliveryWorkCapEnforcementService** | Enforces `ClientPreApprovedHoursNumber__c` at `WorkLog__c` time from the WorkLog trigger (before-context `checkInserts`/`checkUpdates` + after-context `processPendingFlags`). Sums logged totals LIVE from `WorkLog__c` (rollups are stale mid-transaction); running per-item total so several rows in one batch can't collectively sneak past the cap; inbound-sync DML is exempt. |
+| **DeliveryNotificationService** (additions) | `notifyWorkApprovalSubmitted(workRequestIds)` — summarized bell ping to the assigned approver on submit; `notifyWorkApprovalDecided(workRequestId, approved)` — pings the item's developer on approve/decline. Both fire-and-forget, null-safe, never throw back into the calling transaction. |
+| **deliveryApprovalQueue** (LWC) | The pending-approval queue on DH Home — renders `getPendingForApprover` with inline approve/decline. |
+| **deliveryApprovalSummaryCard** (LWC) | Agenda card: three tiles + the `Nh of Mh approved (P%)` pitch strip (zero-guarded denominator). |
+
+### Lifecycle
+
+```
+                       submitForApproval(workItemIds)
+                                  │
+              quoted ≤ DiscretionaryThresholdHoursNumber__c
+              AND month's auto-sum < DiscretionaryMonthlyCapHoursNumber__c?
+                     │                            │
+                    yes                           no
+                     │                            │
+        WorkRequest: Accepted          WorkRequest: 'Offer Sent'
+        (AutoApprovedDateTime__c)      (ApproverUserLookup__c assigned,
+        WI cap stamped,                 approver pinged)
+        WI → Ready for Development     WI → Ready for Final Approval
+                                                  │
+                                   ┌──────────────┴──────────────┐
+                              approve(...)                  decline(...)
+                                   │                              │
+                        WorkRequest: Accepted          WorkRequest: Inactive
+                        WI ClientPreApprovedHours      (StandDownReasonTxt__c)
+                        SET — or RAISED by delta       WI → On Hold ONLY if
+                        on a budget increase,          nothing was previously
+                        never overwritten              approved (declining an
+                        WI → Ready for Development     increase leaves the item
+                                   │                   and original cap intact)
+                                   ▼
+                   hours logged against the cap (WorkLog__c)
+                                   │
+                  over cap? ── requestIncrease(workItemId, extraHours)
+                                   → NEW WorkRequest__c ('Offer Sent',
+                                     RequestedBudgetIncreaseNumber__c;
+                                     increases NEVER auto-approve)
+```
+
+### Cap enforcement: flag vs block
+
+Gated by `DeliveryHubSettings__c.EnforceApprovalCapDateTime__c` (DateTime-not-Boolean toggle pattern):
+
+- **FLAG MODE (default — setting null):** an over-cap WorkLog still **saves**, but the item's newest Accepted `WorkRequest__c` moves to `StatusPk__c = 'Budget Hold'` and one bell notification goes to the org-default approver plus the item's assigned developer. Flag mode never throws — every side effect is WARN-logged on failure.
+- **ENFORCE MODE (setting populated):** the offending row gets `addError()` in the BEFORE context, so the over-cap log never commits. The unblock path is `requestIncrease(...)` → `approve(...)`, which raises the cap by the approved delta only.
+
+Items with a null/zero cap are uncapped and never evaluated.
+
+---
+
 ## Enterprise Services
 
 17 service classes ship with the package for organizations that need formal governance, compliance controls, and audit-grade integrity. Every one is opt-in via a `*DateTime__c` toggle on `DeliveryHubSettings__c` or a per-entity configuration field — installing the package doesn't change behavior until you turn something on.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the Delivery Hub package are documented here. Versions ma
 
 ---
 
+## [0.272 — 0.276] — 2026-06-11 → 2026-06-12 (work-approval queue arc)
+
+The work-approval queue shipped end-to-end across five production promotions in ~36 hours (release tags map to merges via the beta timestamps; PR descriptions on GitHub stay authoritative):
+
+- **0.272.0.1 (6/11 morning)** — Work-approval queue PR1–PR3: schema + `DeliveryWorkApprovalService` decision engine (#891 — decision lives ON `WorkRequest__c`, discretionary auto-approve gate, budget-increase requests), `deliveryApprovalQueue` pending-approval LWC on DH Home (#892), approval reports + `deliveryApprovalSummaryCard` agenda card + Deploy-to-Prod ship report & ping (#893). Plus #894 (scope-test alignment with 0.269 leaf-only counting — unblocked the beta).
+- **0.273.0.2 (6/11 afternoon, PROMOTED + pinned)** — NimbusGantt 0.204.0 two-bundle adoption (#895 — pace-aware auto-schedule, unified click-through, search + axis fixes), six untracked working docs committed (#896), de-cluttered default Pacing view (#897 — measure/mode/breakout pill groups suppressed).
+- **0.274.0.3 (6/11 evening)** — Approval pings (#899 — submit notifies the approver, decisions notify the dev; `DeliveryNotificationService.notifyWorkApprovalSubmitted`/`notifyWorkApprovalDecided`), **WorkLog cap enforcement** (#900 — `DeliveryWorkCapEnforcementService`: over-cap logs flag by default → newest Accepted request to `Budget Hold` + bell pings; hard-block via `EnforceApprovalCapDateTime__c`), NG 0.204.1 app bundle (#901 — empty-state for zero-result view filters).
+- **0.275.0.2 (6/11 night)** — `deliveryCartBuilder` placed on AdminHome + subscriber org-sync deploy bundle (#902), audit quick fixes (#903 — debug `console.log` stripped from timeline, token-first sObjectType resolution).
+- **0.276.0.2 (6/12, PROMOTED — `04tQr000000VyeDIAS`)** — Approval polish (#904 — approved-vs-total **pitch stat** on the agenda card (`totalActiveEstimatedHours`/`totalApprovedHours`, zero-guarded), backup approver via `ApproverBackupUserIdTxt__c`, `DeliveryWorkApprovalService` + DTOs made **global** for subscriber-org scripting / future MCP automation). Item 8 (#905 — **ETA write-back**: `commitGanttPatches` stamps `CalculatedETADate__c` on committed endDate moves; **approved-green cohort**: greenlit forecast tier membership = `ClientPreApprovedHoursNumber__c > 0`, not priority lane; divergence alerts when logged pace implies blowing the committed ETA or the approved cap).
+
+Per-PR detail intentionally not back-filled — PR descriptions on GitHub stay authoritative. (0.251 — 0.271, the forecast-credibility arc, is documented in the GitHub release tags.)
+
+---
+
 ## [0.240 — 0.250] — 2026-05-15 → 2026-05-26 (per-PR detail not back-filled)
 
 The strategic plan (`wild-roaming-rocket.md`) Phase 0 closed at 0.240 and the 50h DH Cockpit plan ran end-to-end across 0.243 → 0.245. Phase 2 Watcher v1 landed at 0.246. The "subscriber-ready first impression" cheap-wins bundle landed at 0.247. The audit-driven UX-gap fan-out closed across 0.248 → 0.250. Major themes that shipped in this stretch:

--- a/docs/plans/dh-mcp-server-design-2026-06-12.md
+++ b/docs/plans/dh-mcp-server-design-2026-06-12.md
@@ -1,0 +1,201 @@
+# DH-MCP Server — Design Doc (2026-06-12)
+
+> Glen, 6/11 call with Mahi: *"we should be building Delivery Hub into the endpoints
+> that it needs to access so that it can access its own thing through its own MCP
+> server and make the appropriate updates without having to do the Salesforce CLI."*
+
+This is a design doc only — no server code ships with this PR. It grounds the MCP
+server in the REST surfaces that **already exist** in the package, names the gaps,
+and proposes a crawl/walk/run rollout with PR-sized build chunks.
+
+---
+
+## 1. Architecture (one page)
+
+### What exists today
+
+Delivery Hub already ships three key-authenticated REST surfaces (all under
+`/services/apexrest/delivery/`):
+
+| Surface | Class | Base path | Auth | Scoping |
+|---|---|---|---|---|
+| **Public API** | `DeliveryPublicApiService` | `/deliveryhub/v1/api/*` | `X-Api-Key` (NetworkEntity) | Entity-scoped (most routes) |
+| **Task API** | `DeliveryTaskAPI` | `/deliveryhub/v1/tasks/*` | `X-Api-Key` | **Tenant-less** — any active entity key sees all WorkItems |
+| **Sync API** | `DeliveryHubSyncService` | `/deliveryhub/v1/sync/*` | `X-Api-Key` + optional HMAC | Org-to-org sync only — **not** an MCP target |
+
+And, as of 0.276 (PR #904), the work-approval lifecycle is a **`global` Apex
+service**: `DeliveryWorkApprovalService` — `submitForApproval(×2)`, `approve`,
+`decline`, `requestIncrease`, `getPendingForApprover`, with global DTOs
+(`PendingApprovalDTO`, `SubmitResultDTO`). The class comment says it explicitly:
+global *"so admin scripting / future MCP automation in subscriber orgs can drive
+the approval lifecycle directly."* The Apex half of the MCP story is done; the
+missing half is thin REST routes in front of it (§4).
+
+### Proposed shape
+
+A small **TypeScript MCP server over stdio** (`@modelcontextprotocol/sdk`), run
+locally by Claude Code / Claude Desktop, that wraps the REST endpoints as typed
+tools. No Salesforce CLI in the request path.
+
+```
+┌─────────────────────┐   stdio (MCP)   ┌──────────────────────────┐   HTTPS
+│ Claude Code /        │ ◄─────────────► │ dh-mcp server (TS, Node) │ ─────────►
+│ Claude Desktop       │                 │  - tool registry          │
+│ (.mcp.json entry)    │                 │  - REST client            │  Salesforce org
+└─────────────────────┘                 │  - auth from env          │  /services/apexrest/delivery/
+                                        │  - {success,error} →      │    deliveryhub/v1/api/*
+                                        │    MCP result / isError   │    deliveryhub/v1/tasks/*
+                                        └──────────────────────────┘
+        env: DH_INSTANCE_URL, DH_API_KEY, SF_ACCESS_TOKEN (or OAuth refresh)
+```
+
+- **Transport**: stdio. One server per org connection; org/instance URL from env.
+- **Namespace-aware**: base path is `/services/apexrest/delivery/...` on
+  namespaced installs, `/services/apexrest/...` on scratch orgs — same
+  configurable-prefix pattern the delivery-hub-companion `lib/api-client.js`
+  already proved out.
+- **Error mapping**: every DH endpoint returns the `{success, data}` /
+  `{success: false, error}` envelope. The server maps `success:false` and non-2xx
+  to MCP tool errors (`isError: true`) with the DH error string passed through —
+  no string-parsing heuristics needed.
+- **Rate-limit awareness**: Public API returns HTTP 429 + `Retry-After: 3600`
+  when `PublicApiRateLimitNumber__c` is breached (default 100/hr when enabled).
+  The server surfaces 429 as a retryable error rather than hammering.
+
+### Auth model
+
+Two credentials are involved, and they answer different questions:
+
+1. **`X-Api-Key`** (NetworkEntity key, from `DH_API_KEY` env) — *which tenant
+   slice* the call is scoped to. Never hardcoded; never written to disk by the
+   server.
+2. **Salesforce access token** (`Authorization: Bearer`) — *which user* the
+   Apex transaction runs as. `/services/apexrest` on a My Domain host requires a
+   session; only the Site-guest path avoids it.
+
+**Per-user vs integration-user trade-off.** An integration user (one stored
+refresh token, shared by everyone) is operationally simpler but breaks exactly
+the things the approval queue was built on: `approve()`/`decline()` enforce
+caller-is-approver via `UserInfo.getUserId()` (`assertCallerMayDecide`), audit
+rows (`ActivityLog__c`, SHA-256 hash-chained) stamp the running user, and
+unassigned requests stamp the decider as the approver. With an integration user
+every decision would attribute to the bot. **Recommendation: per-user OAuth**
+(Connected App, PKCE or JWT per user; v0 can bootstrap from `sf org display`'s
+access token the way the companion extension does). This matches Glen's stated
+preference from the Jose MCP rollout — *"it layers through their user
+permissions"* — the MCP server should inherit the human's authority, not mint
+its own.
+
+### Where does the server live? (delivery-hub-companion inspected)
+
+`C:\Projects\delivery-hub-companion` is a **Manifest V3 Chrome extension** —
+vanilla JS, popup/background/content scripts, and an explicit repo rule: *"Keep
+it zero-dependency — no npm, no build step, no bundler."* An MCP server is the
+opposite animal: a Node stdio process with npm deps (`@modelcontextprotocol/sdk`,
+`zod`) and a TypeScript build. **Verdict: not a viable home.** What IS reusable
+from it: `lib/api-client.js`'s namespace-aware REST patterns and its
+access-token-from-`sf org display` bootstrap. **Recommendation:** a new
+standalone repo `delivery-hub-mcp` (mirrors the nimbus-gantt pattern — a
+standalone TS library consumed alongside the Salesforce repo), keeping the DH
+repo's CumulusCI packaging tree free of Node tooling.
+
+---
+
+## 2. Proposed v1 tool list (one page)
+
+Names use a `dh_` prefix. "Exists" = the REST endpoint ships in 0.276 today.
+
+### Crawl — read-only (Phase 1)
+
+| Tool | Wraps | Exists? |
+|---|---|---|
+| `dh_get_dashboard` | `GET /api/dashboard` | ✅ |
+| `dh_list_work_items` | `GET /api/work-items?status=` | ✅ |
+| `dh_get_work_item` | `GET /api/work-items/{id}` (detail + comments + stages) | ✅ |
+| `dh_get_activity_feed` | `GET /api/activity-feed?filterType=&pageOffset=` | ✅ |
+| `dh_list_work_logs` | `GET /api/work-logs?workItemId=` | ✅ |
+| `dh_get_pending_worklog_approvals` | `GET /api/pending-approvals` | ✅ |
+| `dh_list_documents` | `GET /api/documents` (invoices/statements, read-only) | ✅ |
+| `dh_get_board_summary` | `GET /api/board-summary` (AI summary; null-safe) | ✅ |
+| `dh_get_pending_work_approvals` | work-approval queue feed (`getPendingForApprover`) | ❌ gap G1 |
+| `dh_get_billing_preview` | unbilled approved hours × rate hierarchy for a period | ❌ gap G2 |
+
+### Walk — low-risk writes (Phase 2)
+
+| Tool | Wraps | Exists? |
+|---|---|---|
+| `dh_create_work_item` | `POST /api/work-items` (`title`/`description`/`priority`/`type`) | ✅ |
+| `dh_add_comment` | `POST /api/work-items/{id}/comments` | ✅ |
+| `dh_log_hours` | `POST /api/log-hours` (lands as Draft → human approval pipeline) | ✅ |
+| `dh_update_work_item` | `PATCH /tasks/{id}` (stage + priority only today) | ⚠️ gap G3 |
+
+### Run — decision verbs (Phase 3, after gap G1 ships + per-user OAuth)
+
+| Tool | Wraps | Exists? |
+|---|---|---|
+| `dh_submit_for_approval` | `DeliveryWorkApprovalService.submitForApproval` | ❌ gap G1 |
+| `dh_approve_work_request` | `DeliveryWorkApprovalService.approve` | ❌ gap G1 |
+| `dh_decline_work_request` | `DeliveryWorkApprovalService.decline` | ❌ gap G1 |
+| `dh_request_budget_increase` | `DeliveryWorkApprovalService.requestIncrease` | ❌ gap G1 |
+| `dh_approve_worklogs` / `dh_reject_worklogs` | `POST /api/approve-worklogs` / `/api/reject-worklogs` | ✅ |
+
+Tool descriptions will be prescriptive about *when* to call each tool (decision
+verbs say "only when the user explicitly asks to decide"), and the three Phase-3
+decision tools should be annotated non-read-only so hosts prompt for
+confirmation.
+
+---
+
+## 3. Rollout: crawl / walk / run
+
+Mirrors the MF org-MCP rollout decision — **read-only toolset first**, writes
+only after the read layer has been used in anger.
+
+1. **Crawl (read-only)** — ship the 8 existing-endpoint read tools. Zero new
+   Apex. Risk ≈ zero; immediately useful for "what's on the board / what's
+   pending / what got logged" questions without `sf` CLI.
+2. **Walk (additive writes)** — create/comment/log-hours. All three are already
+   guarded server-side (blank-create guard, entity-scope 403s, Draft worklog
+   status), and none can destroy data.
+3. **Run (decisions)** — approval verbs, only after (a) the new REST routes
+   (G1) ship and (b) per-user OAuth is in place so `assertCallerMayDecide` and
+   the audit chain attribute the human, not a bot.
+
+---
+
+## 4. Gap list — new Apex REST work needed
+
+Verified against `DeliveryPublicApiService` routing (0.276): the Public API has
+worklog approve/reject and **feature-toggle** approval verbs (Layer 8), but **no
+work-approval (WorkRequest decision) routes at all**.
+
+| # | Gap | What's needed | Notes |
+|---|---|---|---|
+| **G1** | Work-approval verbs not exposed via REST | New routes wrapping the now-global `DeliveryWorkApprovalService`: `POST /api/work-approvals/submit` (workItemIds + optional quoted hours), `POST /api/work-requests/{id}/approve` (`approvedHours`, `note`), `POST /api/work-requests/{id}/decline` (`reason`), `POST /api/work-items/{id}/request-increase` (`extraHours`, `reason`), `GET /api/work-approvals/pending` | The service is decision-complete (discretionary auto-approve, increase-delta math, backup approver, pings, audit rows). Routes are thin adapters + tests. Follow the PR #842 pattern: add as a NEW router tier to dodge the PMD complexity cap. |
+| **G2** | No billing-preview endpoint | `GET /api/billing-preview?entityId=&periodStart=&periodEnd=` — dry-run of `DeliveryDocGenerationService`'s snapshot math (hours × 3-tier rate hierarchy, prior balance) **without inserting** a `DeliveryDocument__c` | The billing-preview PR was **not merged** as of 0.276 — checked the merge log through #905. Until it ships, the MCP tool is blocked (nearest read-only approximations: `/api/documents` + `/api/work-logs`). |
+| **G3** | Work-item update is stage+priority only | Task API `PATCH /tasks/{id}` accepts `{stage, priority}` and is tenant-less (any active entity key). Either extend the Public API with an entity-scoped `PATCH /api/work-items/{id}` (estimate, developer, dates) or accept the narrow Task API surface for v1 | v1 can ship with the narrow surface; flag the tenant-less auth in the tool description. |
+| **G4** | Per-user attribution | Connected App + per-user OAuth flow for the MCP server (PKCE; v0 bootstrap from `sf org display` token is acceptable for Glen-only use) | Without it, decisions/audit stamp the integration user — conflicts with the "layers through their user permissions" model. |
+| **G5** | Idempotency on POSTs | `POST /api/work-items` and `POST /api/log-hours` create duplicates on retry (same known gap as `/scratch-orgs`) | Acceptable for v1 (agent retries are rare); v2 adds an `Idempotency-Key` header. |
+| **G6** | Rate-limit headroom | Agent traffic vs `PublicApiRateLimitNumber__c` (100/hr default when enabled) | Operational knob, not code — document in the server README. |
+
+## 5. Build estimate (PR-sized chunks)
+
+**DH repo (Apex):**
+
+| PR | Scope | Est. |
+|---|---|---|
+| DH-1 | G1: work-approval REST routes + tests (new router tier) | 4–6 h |
+| DH-2 | G2: `GET /api/billing-preview` dry-run + tests | ~4 h |
+| DH-3 (optional) | G3: entity-scoped `PATCH /api/work-items/{id}` | ~3 h |
+
+**delivery-hub-mcp repo (TypeScript):**
+
+| PR | Scope | Est. |
+|---|---|---|
+| MCP-1 | Scaffold: stdio server, env auth, namespace-aware REST client, error mapping + the 8 crawl read tools | ~4 h |
+| MCP-2 | Walk write tools (create / comment / log-hours / narrow update) | ~2 h |
+| MCP-3 | Run tools wired to DH-1 + billing preview wired to DH-2 | ~3 h |
+| MCP-4 | `.mcp.json` example, README, smoke harness against a scratch org | ~2 h |
+
+Total ≈ 20–24 h across 6–7 PRs. Crawl is shippable after MCP-1 alone (no Apex
+changes required).


### PR DESCRIPTION
## Part 1 — DH-MCP server design doc

New `docs/plans/dh-mcp-server-design-2026-06-12.md` — design only, no server code. Grounds Glen's 6/11 vision ("access its own thing through its own MCP server… without having to do the Salesforce CLI") in what exists today:

- **Architecture**: TypeScript stdio MCP server wrapping the key-authenticated REST surfaces (Public API `/deliveryhub/v1/api/*`, Task API `/deliveryhub/v1/tasks/*`) + the now-`global` `DeliveryWorkApprovalService`. Namespace-aware base path, `{success,error}` envelope → MCP error mapping, 429/rate-limit awareness.
- **Auth**: `X-Api-Key` (tenant slice) + Salesforce Bearer (running user). Recommends **per-user OAuth** over an integration user — `assertCallerMayDecide`, audit-chain attribution, and approver stamping all key off `UserInfo.getUserId()`, matching Glen's "layers through their user permissions" preference from the Jose MCP rollout.
- **v1 tool list** in crawl/walk/run phases (read-only first, mirroring the MF org-MCP rollout decision).
- **Companion repo verdict**: `delivery-hub-companion` is a zero-dependency Chrome MV3 extension — not a viable home for a Node stdio server; recommend a standalone `delivery-hub-mcp` repo (its `lib/api-client.js` namespace/auth patterns are reusable).
- **REST gap list** (G1–G6) + PR-sized build estimate (~20–24 h across 6–7 PRs; crawl phase needs zero new Apex).

## Part 2 — docs refresh (0.272 → 0.276)

- **README**: install pin 0.273.0.2 → **0.276.0.2 / `04tQr000000VyeDIAS`** (both badge links + Current-release line: approval pings, WorkLog cap enforcement flag/block, NG 0.204.1, approved-green cohort, ETA write-back + divergence alerts, pitch stat + backup approver + global service). 8-layer cockpit table: work-approval queue noted under Layer 1, with the deliberate two-approval-systems distinction vs Layer 8 (FeatureToggle) and the unify-later note.
- **docs/ARCHITECTURE.md**: new **Work-Approval Queue** section — objects/fields (WorkRequest decision fields, `ClientPreApprovedHoursNumber__c`, settings incl. `EnforceApprovalCapDateTime__c` + `ApproverBackupUserIdTxt__c`), classes (`DeliveryWorkApprovalService` (global), `DeliveryApprovalSummaryController`, `DeliveryWorkCapEnforcementService`, `DeliveryNotificationService` additions, 2 LWCs), ASCII lifecycle diagram, flag-vs-block cap modes.
- **docs/CHANGELOG.md**: `[0.272 — 0.276]` entry mapping PRs #891–#905 to the five promotions (verified against GitHub release timestamps).

**Note**: billing preview — no merged PR found through #905, so it is intentionally absent from the README release line and tracked as gap G2 in the design doc.

Every class/field/endpoint name verified against merged code on main (no guesses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)