### PR TITLE
feat: billing preview — Approved vs Logged vs Billable monthly view (spec §9)

### DIFF
--- a/force-app/main/default/classes/DeliveryBillingPreviewController.cls
+++ b/force-app/main/default/classes/DeliveryBillingPreviewController.cls
@@ -1,0 +1,322 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Read-only monthly billing close-out feed for the
+ *               deliveryBillingPreview LWC (approval-queue spec §9 — the
+ *               "Approved vs Logged vs Billable" view): for every WorkItem
+ *               carrying a client-approved cap (ClientPreApprovedHoursNumber__c
+ *               &gt; 0), shows what was logged in the selected calendar month,
+ *               how much of it is billable under the cap, and the over-cap
+ *               excess that is NOT billable until a budget increase is
+ *               approved. The total billable figure is the invoice preview
+ *               that should ≈ the actual invoice — no-invoice-surprises,
+ *               made visible.
+ *
+ *               v1 billable formula (kept deliberately simple):
+ *                 headroom = MAX(0, approvedCap − loggedBeforeThisMonth)
+ *                 billable = MIN(monthLogged, headroom)
+ *                 overCap  = monthLogged − billable
+ *               where loggedBeforeThisMonth is the item's LIFETIME logged
+ *               hours prior to the selected month (a proxy for cap headroom
+ *               already consumed — v1 assumes all prior logged hours drew
+ *               against the cap; there is no per-invoice billed-to-date
+ *               ledger yet).
+ *
+ *               Dollars: mirrors DeliveryHoursAnalyticsController's
+ *               resolveBlendedRate — a single blended hourly rate is surfaced
+ *               only when EXACTLY ONE active NetworkEntity__c carries a
+ *               DefaultHourlyRateCurrency__c; zero or many distinct rates is
+ *               ambiguous → hours-only display.
+ *
+ *               SOQL is WITH SYSTEM_MODE per CLAUDE.md (WITH USER_MODE breaks
+ *               in namespaced package test context). Kept separate from
+ *               DeliveryApprovalSummaryController (the agenda card feed) so
+ *               the close-out view can evolve independently.
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation')
+public with sharing class DeliveryBillingPreviewController {
+
+    /** @description Hard cap on capped WorkItems scanned for the preview. */
+    private static final Integer MAX_CAPPED_ITEMS = 1000;
+
+    /** @description Hard cap on the per-item WorkLog aggregate rows consumed. */
+    private static final Integer MAX_AGGREGATE_ROWS = 5000;
+
+    /** @description Three-letter month names for the headline label. */
+    private static final List<String> MONTH_NAMES = new List<String>{
+        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+    };
+
+    /** @description One per-item Approved vs Logged vs Billable row. */
+    public class BillingRowDTO {
+        @AuraEnabled public Id workItemId;
+        /** Brief description, else the WorkItem auto-number Name (mirrors the forecast drill-down fallback). */
+        @AuraEnabled public String label;
+        /** The client-approved cap (ClientPreApprovedHoursNumber__c). */
+        @AuraEnabled public Decimal approvedCap;
+        /** Lifetime hours logged BEFORE the selected month (v1 headroom proxy). */
+        @AuraEnabled public Decimal loggedBefore;
+        /** Hours logged inside the selected calendar month. */
+        @AuraEnabled public Decimal monthLogged;
+        /** MIN(monthLogged, MAX(0, approvedCap − loggedBefore)). */
+        @AuraEnabled public Decimal billable;
+        /** monthLogged − billable: the non-billable over-cap excess this month. */
+        @AuraEnabled public Decimal overCap;
+        /** True when any of this month's hours exceed the remaining cap headroom. */
+        @AuraEnabled public Boolean isOverCap;
+    }
+
+    /** @description The month's billing close-out: per-item rows + totals + optional dollars. */
+    public class BillingPreviewDTO {
+        @AuraEnabled public Integer year;
+        @AuraEnabled public Integer month;
+        /** Display label for the selected month, e.g. "Jun 2026". */
+        @AuraEnabled public String monthLabel;
+        /** Single blended hourly rate, or null when zero/many rates exist (hours-only). */
+        @AuraEnabled public Decimal blendedRate;
+        /** Count of WorkItems carrying a cap, whether or not they logged this month. */
+        @AuraEnabled public Integer cappedItemCount;
+        /** Sum of approvedCap across the rows shown (items that logged this month). */
+        @AuraEnabled public Decimal totalApprovedCap;
+        /** Sum of monthLogged across the rows shown. */
+        @AuraEnabled public Decimal totalMonthLogged;
+        /** Sum of billable across the rows shown — the invoice preview headline. */
+        @AuraEnabled public Decimal totalBillable;
+        /** Sum of overCap across the rows shown — hours parked pending an increase. */
+        @AuraEnabled public Decimal totalOverCap;
+        /** totalBillable × blendedRate, or null when no unambiguous rate resolves. */
+        @AuraEnabled public Decimal totalBillableAmount;
+        /** Per-item rows (only items that logged hours in the selected month), monthLogged desc. */
+        @AuraEnabled public List<BillingRowDTO> rows;
+    }
+
+    /**
+     * @description Builds the monthly Approved vs Logged vs Billable close-out:
+     *              one row per capped WorkItem that logged hours in the selected
+     *              calendar month, with the v1 billable split (see class doc),
+     *              plus totals and the optional blended-rate dollar figure.
+     * @param year Calendar year of the month to preview. Null defaults to the
+     *             current year (both params null = current month).
+     * @param month Calendar month 1–12. Null defaults to the current month.
+     * @return BillingPreviewDTO; numbers default to 0 and rows to empty — never null.
+     */
+    @AuraEnabled(cacheable=true)
+    public static BillingPreviewDTO getBillingPreview(Integer year, Integer month) {
+        try {
+            Date today = Date.today();
+            Integer effectiveYear = (year == null) ? today.year() : year;
+            Integer effectiveMonth = (month == null) ? today.month() : month;
+            if (effectiveMonth < 1 || effectiveMonth > 12) {
+                throw new AuraHandledException('month must be between 1 and 12.');
+            }
+            if (effectiveYear < 1900 || effectiveYear > 2200) {
+                throw new AuraHandledException('year is out of range.');
+            }
+
+            Date monthStart = Date.newInstance(effectiveYear, effectiveMonth, 1);
+            Date monthEnd = monthStart.addMonths(1).addDays(-1);
+
+            BillingPreviewDTO dto = new BillingPreviewDTO();
+            dto.year = effectiveYear;
+            dto.month = effectiveMonth;
+            dto.monthLabel = MONTH_NAMES[effectiveMonth - 1] + ' ' + effectiveYear;
+            dto.rows = new List<BillingRowDTO>();
+            dto.totalApprovedCap = 0;
+            dto.totalMonthLogged = 0;
+            dto.totalBillable = 0;
+            dto.totalOverCap = 0;
+
+            List<WorkItem__c> cappedItems = queryCappedItems();
+            dto.cappedItemCount = cappedItems.size();
+
+            if (!cappedItems.isEmpty()) {
+                Set<Id> itemIds = new Map<Id, WorkItem__c>(cappedItems).keySet();
+                Map<Id, Decimal> monthLoggedByItem =
+                    sumLoggedByItem(itemIds, monthStart, monthEnd);
+                Map<Id, Decimal> beforeLoggedByItem =
+                    sumLoggedByItem(itemIds, null, monthStart.addDays(-1));
+                buildRows(dto, cappedItems, monthLoggedByItem, beforeLoggedByItem);
+            }
+
+            sortRowsByMonthLoggedDesc(dto.rows);
+
+            dto.blendedRate = resolveBlendedRate();
+            if (dto.blendedRate != null) {
+                dto.totalBillableAmount = (dto.totalBillable * dto.blendedRate)
+                    .setScale(2, System.RoundingMode.HALF_UP);
+            }
+            return dto;
+        } catch (AuraHandledException ahe) {
+            throw ahe;
+        } catch (Exception e) {
+            AuraHandledException ahe = new AuraHandledException(e.getMessage());
+            ahe.setMessage(e.getMessage());
+            throw ahe;
+        }
+    }
+
+    /**
+     * @description All WorkItems carrying a positive client-approved cap — the
+     *              billing universe. Deliberately NOT filtered by stage or
+     *              activation: a capped item that logged hours this month
+     *              belongs on the invoice preview regardless of board state.
+     * @return Capped WorkItems (id + label fields + cap), LIMIT-guarded.
+     */
+    private static List<WorkItem__c> queryCappedItems() {
+        return [
+            SELECT Id, Name, BriefDescriptionTxt__c, ClientPreApprovedHoursNumber__c
+            FROM WorkItem__c
+            WHERE ClientPreApprovedHoursNumber__c > 0
+            WITH SYSTEM_MODE
+            LIMIT :MAX_CAPPED_ITEMS
+        ];
+    }
+
+    /**
+     * @description One grouped WorkLog aggregate: per-item SUM(HoursLoggedNumber__c)
+     *              over an optional WorkDateDate__c window. Passing a null
+     *              windowStart makes the window open-ended on the left (lifetime
+     *              logged up to windowEnd — the loggedBefore aggregate).
+     * @param itemIds The capped WorkItem ids.
+     * @param windowStart Inclusive lower bound, or null for open-ended.
+     * @param windowEnd Inclusive upper bound.
+     * @return Map of WorkItem id → summed hours (items with no logs absent).
+     */
+    private static Map<Id, Decimal> sumLoggedByItem(Set<Id> itemIds, Date windowStart, Date windowEnd) {
+        List<AggregateResult> results;
+        if (windowStart == null) {
+            results = [
+                SELECT WorkItemLookup__c wid, SUM(HoursLoggedNumber__c) total
+                FROM WorkLog__c
+                WHERE WorkItemLookup__c IN :itemIds
+                  AND WorkDateDate__c <= :windowEnd
+                WITH SYSTEM_MODE
+                GROUP BY WorkItemLookup__c
+                LIMIT :MAX_AGGREGATE_ROWS
+            ];
+        } else {
+            results = [
+                SELECT WorkItemLookup__c wid, SUM(HoursLoggedNumber__c) total
+                FROM WorkLog__c
+                WHERE WorkItemLookup__c IN :itemIds
+                  AND WorkDateDate__c >= :windowStart
+                  AND WorkDateDate__c <= :windowEnd
+                WITH SYSTEM_MODE
+                GROUP BY WorkItemLookup__c
+                LIMIT :MAX_AGGREGATE_ROWS
+            ];
+        }
+        Map<Id, Decimal> byItem = new Map<Id, Decimal>();
+        for (AggregateResult ar : results) {
+            Object widObj = ar.get('wid');
+            Object totalObj = ar.get('total');
+            if (widObj != null && totalObj != null) {
+                byItem.put((Id) widObj, (Decimal) totalObj);
+            }
+        }
+        return byItem;
+    }
+
+    /**
+     * @description Applies the v1 billable formula per capped item and appends a
+     *              row for every item that logged hours in the selected month,
+     *              accumulating the DTO totals as it goes. Items with no
+     *              month activity are skipped (they contribute nothing to the
+     *              invoice) but still count in cappedItemCount.
+     * @param dto The DTO being filled (rows + totals).
+     * @param cappedItems The capped-WorkItem universe.
+     * @param monthLoggedByItem Per-item hours logged inside the month.
+     * @param beforeLoggedByItem Per-item lifetime hours logged before the month.
+     */
+    private static void buildRows(
+        BillingPreviewDTO dto,
+        List<WorkItem__c> cappedItems,
+        Map<Id, Decimal> monthLoggedByItem,
+        Map<Id, Decimal> beforeLoggedByItem
+    ) {
+        for (WorkItem__c wi : cappedItems) {
+            Decimal monthLogged = monthLoggedByItem.containsKey(wi.Id)
+                ? monthLoggedByItem.get(wi.Id) : 0;
+            if (monthLogged <= 0) {
+                continue;
+            }
+            Decimal cap = wi.ClientPreApprovedHoursNumber__c;
+            Decimal loggedBefore = beforeLoggedByItem.containsKey(wi.Id)
+                ? beforeLoggedByItem.get(wi.Id) : 0;
+            Decimal headroom = cap - loggedBefore;
+            if (headroom < 0) {
+                headroom = 0;
+            }
+            Decimal billable = (monthLogged < headroom) ? monthLogged : headroom;
+
+            BillingRowDTO row = new BillingRowDTO();
+            row.workItemId = wi.Id;
+            // Brief description, else the auto-number Name — mirrors the forecast
+            // drill-down name fallback so the invoice preview never shows raw ids.
+            row.label = String.isNotBlank(wi.BriefDescriptionTxt__c)
+                ? wi.BriefDescriptionTxt__c : wi.Name;
+            row.approvedCap = cap;
+            row.loggedBefore = loggedBefore.setScale(2, System.RoundingMode.HALF_UP);
+            row.monthLogged = monthLogged.setScale(2, System.RoundingMode.HALF_UP);
+            row.billable = billable.setScale(2, System.RoundingMode.HALF_UP);
+            row.overCap = (monthLogged - billable).setScale(2, System.RoundingMode.HALF_UP);
+            row.isOverCap = row.overCap > 0;
+            dto.rows.add(row);
+
+            dto.totalApprovedCap += cap;
+            dto.totalMonthLogged += row.monthLogged;
+            dto.totalBillable += row.billable;
+            dto.totalOverCap += row.overCap;
+        }
+        dto.totalApprovedCap = dto.totalApprovedCap.setScale(2, System.RoundingMode.HALF_UP);
+        dto.totalMonthLogged = dto.totalMonthLogged.setScale(2, System.RoundingMode.HALF_UP);
+        dto.totalBillable = dto.totalBillable.setScale(2, System.RoundingMode.HALF_UP);
+        dto.totalOverCap = dto.totalOverCap.setScale(2, System.RoundingMode.HALF_UP);
+    }
+
+    /**
+     * @description In-place sort of the rows by monthLogged desc so the biggest
+     *              line items lead the invoice preview (same simple selection
+     *              swap the forecast drill-down uses — row counts are small).
+     * @param rows The rows to sort.
+     */
+    private static void sortRowsByMonthLoggedDesc(List<BillingRowDTO> rows) {
+        for (Integer i = 0; i < rows.size(); i++) {
+            for (Integer j = i + 1; j < rows.size(); j++) {
+                if (rows[j].monthLogged > rows[i].monthLogged) {
+                    BillingRowDTO tmp = rows[i];
+                    rows[i] = rows[j];
+                    rows[j] = tmp;
+                }
+            }
+        }
+    }
+
+    /**
+     * @description Reads a single blended hourly rate when EXACTLY ONE active
+     *              NetworkEntity carries a DefaultHourlyRateCurrency__c, so the
+     *              LWC can render the ≈ $ figure. Returns null when zero or
+     *              many distinct rates exist (ambiguous — hours-only display).
+     *              Mirrors DeliveryHoursAnalyticsController.resolveBlendedRate
+     *              (private there) so the billing preview and the pacing card
+     *              can never disagree on the rate.
+     * @return The single blended rate, or null when ambiguous.
+     */
+    private static Decimal resolveBlendedRate() {
+        List<NetworkEntity__c> rated = [
+            SELECT DefaultHourlyRateCurrency__c
+            FROM NetworkEntity__c
+            WHERE DefaultHourlyRateCurrency__c != NULL
+              AND DefaultHourlyRateCurrency__c > 0
+              AND StatusPk__c = 'Active'
+            WITH SYSTEM_MODE
+            LIMIT 2
+        ];
+        if (rated.size() == 1) {
+            return rated[0].DefaultHourlyRateCurrency__c;
+        }
+        return null;
+    }
+}

--- a/force-app/main/default/classes/DeliveryBillingPreviewController.cls
+++ b/force-app/main/default/classes/DeliveryBillingPreviewController.cls
@@ -105,49 +105,7 @@ public with sharing class DeliveryBillingPreviewController {
     @AuraEnabled(cacheable=true)
     public static BillingPreviewDTO getBillingPreview(Integer year, Integer month) {
         try {
-            Date today = Date.today();
-            Integer effectiveYear = (year == null) ? today.year() : year;
-            Integer effectiveMonth = (month == null) ? today.month() : month;
-            if (effectiveMonth < 1 || effectiveMonth > 12) {
-                throw new AuraHandledException('month must be between 1 and 12.');
-            }
-            if (effectiveYear < 1900 || effectiveYear > 2200) {
-                throw new AuraHandledException('year is out of range.');
-            }
-
-            Date monthStart = Date.newInstance(effectiveYear, effectiveMonth, 1);
-            Date monthEnd = monthStart.addMonths(1).addDays(-1);
-
-            BillingPreviewDTO dto = new BillingPreviewDTO();
-            dto.year = effectiveYear;
-            dto.month = effectiveMonth;
-            dto.monthLabel = MONTH_NAMES[effectiveMonth - 1] + ' ' + effectiveYear;
-            dto.rows = new List<BillingRowDTO>();
-            dto.totalApprovedCap = 0;
-            dto.totalMonthLogged = 0;
-            dto.totalBillable = 0;
-            dto.totalOverCap = 0;
-
-            List<WorkItem__c> cappedItems = queryCappedItems();
-            dto.cappedItemCount = cappedItems.size();
-
-            if (!cappedItems.isEmpty()) {
-                Set<Id> itemIds = new Map<Id, WorkItem__c>(cappedItems).keySet();
-                Map<Id, Decimal> monthLoggedByItem =
-                    sumLoggedByItem(itemIds, monthStart, monthEnd);
-                Map<Id, Decimal> beforeLoggedByItem =
-                    sumLoggedByItem(itemIds, null, monthStart.addDays(-1));
-                buildRows(dto, cappedItems, monthLoggedByItem, beforeLoggedByItem);
-            }
-
-            sortRowsByMonthLoggedDesc(dto.rows);
-
-            dto.blendedRate = resolveBlendedRate();
-            if (dto.blendedRate != null) {
-                dto.totalBillableAmount = (dto.totalBillable * dto.blendedRate)
-                    .setScale(2, System.RoundingMode.HALF_UP);
-            }
-            return dto;
+            return buildPreview(resolveMonthStart(year, month));
         } catch (AuraHandledException ahe) {
             throw ahe;
         } catch (Exception e) {
@@ -155,6 +113,71 @@ public with sharing class DeliveryBillingPreviewController {
             ahe.setMessage(e.getMessage());
             throw ahe;
         }
+    }
+
+    /**
+     * @description Resolves and validates the requested month: null params
+     *              default to the current calendar month; an out-of-range
+     *              month or year is rejected.
+     * @param year Calendar year, or null for the current year.
+     * @param month Calendar month 1–12, or null for the current month.
+     * @return The first day of the resolved calendar month.
+     */
+    private static Date resolveMonthStart(Integer year, Integer month) {
+        Date today = Date.today();
+        Integer effectiveYear = (year == null) ? today.year() : year;
+        Integer effectiveMonth = (month == null) ? today.month() : month;
+        if (effectiveMonth < 1 || effectiveMonth > 12) {
+            throw new AuraHandledException('month must be between 1 and 12.');
+        }
+        if (effectiveYear < 1900 || effectiveYear > 2200) {
+            throw new AuraHandledException('year is out of range.');
+        }
+        return Date.newInstance(effectiveYear, effectiveMonth, 1);
+    }
+
+    /**
+     * @description Assembles the close-out for the resolved month: queries the
+     *              capped-item universe, runs the two windowed WorkLog
+     *              aggregates, applies the v1 billable split per item, sorts
+     *              the rows, and prices the billable total when a single
+     *              blended rate resolves.
+     * @param monthStart First day of the (already validated) calendar month.
+     * @return The fully populated BillingPreviewDTO.
+     */
+    private static BillingPreviewDTO buildPreview(Date monthStart) {
+        Date monthEnd = monthStart.addMonths(1).addDays(-1);
+
+        BillingPreviewDTO dto = new BillingPreviewDTO();
+        dto.year = monthStart.year();
+        dto.month = monthStart.month();
+        dto.monthLabel = MONTH_NAMES[dto.month - 1] + ' ' + dto.year;
+        dto.rows = new List<BillingRowDTO>();
+        dto.totalApprovedCap = 0;
+        dto.totalMonthLogged = 0;
+        dto.totalBillable = 0;
+        dto.totalOverCap = 0;
+
+        List<WorkItem__c> cappedItems = queryCappedItems();
+        dto.cappedItemCount = cappedItems.size();
+
+        if (!cappedItems.isEmpty()) {
+            Set<Id> itemIds = new Map<Id, WorkItem__c>(cappedItems).keySet();
+            Map<Id, Decimal> monthLoggedByItem =
+                sumLoggedByItem(itemIds, monthStart, monthEnd);
+            Map<Id, Decimal> beforeLoggedByItem =
+                sumLoggedByItem(itemIds, null, monthStart.addDays(-1));
+            buildRows(dto, cappedItems, monthLoggedByItem, beforeLoggedByItem);
+        }
+
+        sortRowsByMonthLoggedDesc(dto.rows);
+
+        dto.blendedRate = resolveBlendedRate();
+        if (dto.blendedRate != null) {
+            dto.totalBillableAmount = (dto.totalBillable * dto.blendedRate)
+                .setScale(2, System.RoundingMode.HALF_UP);
+        }
+        return dto;
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryBillingPreviewController.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryBillingPreviewController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryBillingPreviewControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryBillingPreviewControllerTest.cls
@@ -21,12 +21,18 @@
 @IsTest
 private class DeliveryBillingPreviewControllerTest {
 
-    /** @description Start of the current calendar month — the test anchor. */
+    /**
+     * @description Start of the current calendar month — the test anchor.
+     * @return First day of the current month.
+     */
     private static Date monthStart() {
         return Date.today().toStartOfMonth();
     }
 
-    /** @description A date safely inside the PRIOR calendar month. */
+    /**
+     * @description A date safely inside the PRIOR calendar month.
+     * @return The last day of the previous month.
+     */
     private static Date priorMonthDate() {
         return monthStart().addDays(-1);
     }
@@ -42,7 +48,10 @@ private class DeliveryBillingPreviewControllerTest {
         });
     }
 
-    /** @description Runs getBillingPreview for the current calendar month. */
+    /**
+     * @description Runs getBillingPreview for the current calendar month.
+     * @return The controller's BillingPreviewDTO for the current month.
+     */
     private static DeliveryBillingPreviewController.BillingPreviewDTO runCurrentMonth() {
         Date anchor = monthStart();
         return DeliveryBillingPreviewController.getBillingPreview(anchor.year(), anchor.month());

--- a/force-app/main/default/classes/DeliveryBillingPreviewControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryBillingPreviewControllerTest.cls
@@ -1,0 +1,244 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for the monthly billing close-out feed (approval-queue
+ *               spec §9 — Approved vs Logged vs Billable): the v1 billable
+ *               formula billable = MIN(monthLogged, MAX(0, cap −
+ *               loggedBefore)) including partial headroom and fully-exhausted
+ *               caps, month-window scoping (prior-month logs reduce headroom,
+ *               other-month logs never count as month activity), exclusion of
+ *               uncapped items and zero-activity rows, totals accumulation,
+ *               the blended-rate dollar figure (single active rated entity →
+ *               dollars; ambiguous → hours-only), null-param defaulting to
+ *               the current month, invalid-month rejection, and empty-org
+ *               zero defaults. All month math is anchored on Date.today()
+ *               (see feedback_anchor_rolling_window_tests_on_today.md).
+ *               Exception assertions are type-only — never on message
+ *               (AuraHandledException.getMessage() is generic in a managed
+ *               package per CLAUDE.md).
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryBillingPreviewControllerTest {
+
+    /** @description Start of the current calendar month — the test anchor. */
+    private static Date monthStart() {
+        return Date.today().toStartOfMonth();
+    }
+
+    /** @description A date safely inside the PRIOR calendar month. */
+    private static Date priorMonthDate() {
+        return monthStart().addDays(-1);
+    }
+
+    /**
+     * @description Seeds a WorkItem__c with an optional client-approved cap.
+     * @param cap ClientPreApprovedHoursNumber__c value (null = uncapped).
+     * @return The inserted item.
+     */
+    private static WorkItem__c seedItem(Decimal cap) {
+        return TestDataFactory.createWorkItem(new Map<String, Object>{
+            'ClientPreApprovedHoursNumber__c' => cap
+        });
+    }
+
+    /** @description Runs getBillingPreview for the current calendar month. */
+    private static DeliveryBillingPreviewController.BillingPreviewDTO runCurrentMonth() {
+        Date anchor = monthStart();
+        return DeliveryBillingPreviewController.getBillingPreview(anchor.year(), anchor.month());
+    }
+
+    /**
+     * @description Prior-month consumption shrinks the cap headroom: cap 10,
+     *              4h logged last month, 8h logged this month → only 6h of
+     *              this month's work is billable, 2h is over-cap excess.
+     */
+    @IsTest
+    static void testBillableCappedAtRemainingHeadroom() {
+        WorkItem__c wi = seedItem(10);
+        TestDataFactory.createWorkLog(wi.Id, 4, priorMonthDate(), null);
+        TestDataFactory.createWorkLog(wi.Id, 8, Date.today(), null);
+
+        Test.startTest();
+        DeliveryBillingPreviewController.BillingPreviewDTO dto = runCurrentMonth();
+        Test.stopTest();
+
+        System.assertEquals(1, dto.rows.size(), 'one capped item logged this month');
+        DeliveryBillingPreviewController.BillingRowDTO row = dto.rows[0];
+        System.assertEquals(10, row.approvedCap, 'cap carried through');
+        System.assertEquals(4, row.loggedBefore, 'prior-month hours consumed headroom');
+        System.assertEquals(8, row.monthLogged, 'this month\'s logged hours');
+        System.assertEquals(6, row.billable, 'MIN(8, MAX(0, 10-4)) = 6 billable');
+        System.assertEquals(2, row.overCap, '8 logged - 6 billable = 2 over-cap');
+        System.assertEquals(true, row.isOverCap, 'row flagged over-cap');
+    }
+
+    /**
+     * @description Under-cap work is fully billable with zero over-cap.
+     */
+    @IsTest
+    static void testFullyBillableWhenUnderCap() {
+        WorkItem__c wi = seedItem(20);
+        TestDataFactory.createWorkLog(wi.Id, 5, Date.today(), null);
+
+        Test.startTest();
+        DeliveryBillingPreviewController.BillingPreviewDTO dto = runCurrentMonth();
+        Test.stopTest();
+
+        System.assertEquals(1, dto.rows.size(), 'one row');
+        DeliveryBillingPreviewController.BillingRowDTO row = dto.rows[0];
+        System.assertEquals(5, row.billable, 'all 5h fit under the 20h cap');
+        System.assertEquals(0, row.overCap, 'no excess');
+        System.assertEquals(false, row.isOverCap, 'not flagged');
+    }
+
+    /**
+     * @description A cap already exhausted before the month starts makes ALL
+     *              of this month's hours non-billable (headroom clamps at 0 —
+     *              never negative).
+     */
+    @IsTest
+    static void testExhaustedCapMakesMonthNonBillable() {
+        WorkItem__c wi = seedItem(5);
+        TestDataFactory.createWorkLog(wi.Id, 6, priorMonthDate(), null);
+        TestDataFactory.createWorkLog(wi.Id, 3, Date.today(), null);
+
+        Test.startTest();
+        DeliveryBillingPreviewController.BillingPreviewDTO dto = runCurrentMonth();
+        Test.stopTest();
+
+        DeliveryBillingPreviewController.BillingRowDTO row = dto.rows[0];
+        System.assertEquals(0, row.billable, 'headroom MAX(0, 5-6) = 0 → nothing billable');
+        System.assertEquals(3, row.overCap, 'all 3h parked as over-cap');
+        System.assertEquals(true, row.isOverCap, 'row flagged over-cap');
+    }
+
+    /**
+     * @description Uncapped items never appear (even with month activity), and
+     *              capped items with logs only OUTSIDE the month produce no row
+     *              — but still count in cappedItemCount.
+     */
+    @IsTest
+    static void testScopeExcludesUncappedAndZeroActivityItems() {
+        WorkItem__c uncapped = seedItem(null);
+        TestDataFactory.createWorkLog(uncapped.Id, 7, Date.today(), null);
+        WorkItem__c quietCapped = seedItem(15);
+        TestDataFactory.createWorkLog(quietCapped.Id, 2, priorMonthDate(), null);
+        WorkItem__c active = seedItem(10);
+        TestDataFactory.createWorkLog(active.Id, 1, Date.today(), null);
+
+        Test.startTest();
+        DeliveryBillingPreviewController.BillingPreviewDTO dto = runCurrentMonth();
+        Test.stopTest();
+
+        System.assertEquals(2, dto.cappedItemCount, 'both capped items counted in the universe');
+        System.assertEquals(1, dto.rows.size(), 'only the capped item with month activity gets a row');
+        System.assertEquals(active.Id, dto.rows[0].workItemId, 'the active capped item is the row');
+    }
+
+    /**
+     * @description Totals sum across rows, and rows order by monthLogged desc.
+     */
+    @IsTest
+    static void testTotalsAggregateAndRowsSortByMonthLoggedDesc() {
+        WorkItem__c small = seedItem(10);
+        TestDataFactory.createWorkLog(small.Id, 2, Date.today(), null);
+        WorkItem__c big = seedItem(4);
+        TestDataFactory.createWorkLog(big.Id, 6, Date.today(), null); // 4 billable + 2 over
+
+        Test.startTest();
+        DeliveryBillingPreviewController.BillingPreviewDTO dto = runCurrentMonth();
+        Test.stopTest();
+
+        System.assertEquals(2, dto.rows.size(), 'two rows');
+        System.assertEquals(big.Id, dto.rows[0].workItemId, 'biggest month-logged row leads');
+        System.assertEquals(14, dto.totalApprovedCap, '10 + 4 caps across rows');
+        System.assertEquals(8, dto.totalMonthLogged, '2 + 6 logged this month');
+        System.assertEquals(6, dto.totalBillable, '2 + MIN(6, 4) billable');
+        System.assertEquals(2, dto.totalOverCap, 'the over-cap excess');
+    }
+
+    /**
+     * @description Exactly one active rated NetworkEntity resolves the blended
+     *              rate and prices the billable total; the dollar figure is
+     *              totalBillable × rate.
+     */
+    @IsTest
+    static void testSingleRatedEntityResolvesDollars() {
+        TestDataFactory.createNetworkEntity(new Map<String, Object>{
+            'DefaultHourlyRateCurrency__c' => 90
+        });
+        WorkItem__c wi = seedItem(10);
+        TestDataFactory.createWorkLog(wi.Id, 4, Date.today(), null);
+
+        Test.startTest();
+        DeliveryBillingPreviewController.BillingPreviewDTO dto = runCurrentMonth();
+        Test.stopTest();
+
+        System.assertEquals(90, dto.blendedRate, 'the single active rate resolves');
+        System.assertEquals(360, dto.totalBillableAmount, '4 billable hours × $90');
+    }
+
+    /**
+     * @description Two distinct rated entities are ambiguous: no blended rate,
+     *              no dollar figure — hours-only display.
+     */
+    @IsTest
+    static void testAmbiguousRatesYieldHoursOnly() {
+        TestDataFactory.createNetworkEntity(new Map<String, Object>{
+            'DefaultHourlyRateCurrency__c' => 90
+        });
+        TestDataFactory.createNetworkEntity(new Map<String, Object>{
+            'DefaultHourlyRateCurrency__c' => 120
+        });
+        WorkItem__c wi = seedItem(10);
+        TestDataFactory.createWorkLog(wi.Id, 4, Date.today(), null);
+
+        Test.startTest();
+        DeliveryBillingPreviewController.BillingPreviewDTO dto = runCurrentMonth();
+        Test.stopTest();
+
+        System.assertEquals(null, dto.blendedRate, 'many rates → ambiguous → null');
+        System.assertEquals(null, dto.totalBillableAmount, 'no dollar figure without a rate');
+    }
+
+    /**
+     * @description Null params default to the current calendar month, and an
+     *              empty org returns zero totals + an empty row list (never
+     *              nulls).
+     */
+    @IsTest
+    static void testNullParamsDefaultToCurrentMonthWithZeroDefaults() {
+        Test.startTest();
+        DeliveryBillingPreviewController.BillingPreviewDTO dto =
+            DeliveryBillingPreviewController.getBillingPreview(null, null);
+        Test.stopTest();
+
+        System.assertEquals(Date.today().year(), dto.year, 'defaults to the current year');
+        System.assertEquals(Date.today().month(), dto.month, 'defaults to the current month');
+        System.assertEquals(0, dto.rows.size(), 'empty org → no rows');
+        System.assertEquals(0, dto.cappedItemCount, 'zero default, not null');
+        System.assertEquals(0, dto.totalApprovedCap, 'zero default, not null');
+        System.assertEquals(0, dto.totalMonthLogged, 'zero default, not null');
+        System.assertEquals(0, dto.totalBillable, 'zero default, not null');
+        System.assertEquals(0, dto.totalOverCap, 'zero default, not null');
+        System.assertNotEquals(null, dto.monthLabel, 'month label always present');
+    }
+
+    /**
+     * @description An out-of-range month is rejected. Type-only assertion —
+     *              the exception message is generic in a managed package.
+     */
+    @IsTest
+    static void testInvalidMonthThrows() {
+        Boolean threw = false;
+        Test.startTest();
+        try {
+            DeliveryBillingPreviewController.getBillingPreview(2026, 13);
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        Test.stopTest();
+        System.assertEquals(true, threw, 'month 13 rejected with AuraHandledException');
+    }
+}

--- a/force-app/main/default/classes/DeliveryBillingPreviewControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryBillingPreviewControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/flexipages/DeliveryHubAdminHome.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryHubAdminHome.flexipage-meta.xml
@@ -37,6 +37,12 @@
         </itemInstances>
         <itemInstances>
             <componentInstance>
+                <componentName>deliveryBillingPreview</componentName>
+                <identifier>c_deliveryBillingPreview</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
                 <componentName>deliveryCartCheckout</componentName>
                 <identifier>c_deliveryCartCheckout</identifier>
             </componentInstance>

--- a/force-app/main/default/lwc/deliveryBillingPreview/__tests__/deliveryBillingPreview.test.js
+++ b/force-app/main/default/lwc/deliveryBillingPreview/__tests__/deliveryBillingPreview.test.js
@@ -1,0 +1,179 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryBillingPreview: the totals header
+ *               (billable headline + the ≈ $ figure only when a blended rate
+ *               resolves), the per-item Approved vs Logged vs Billable table
+ *               with over-cap rows flagged (row class + badge), the month
+ *               selector defaulting to the current month with 12 trailing
+ *               options, the empty state, and the error state.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from "lwc";
+import DeliveryBillingPreview from "c/deliveryBillingPreview";
+import getBillingPreview from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryBillingPreviewController.getBillingPreview";
+
+const WI_OK = "a00000000000001AAA";
+const WI_OVER = "a00000000000002AAA";
+
+function samplePreview(overrides = {}) {
+    return {
+        year: 2026,
+        month: 6,
+        monthLabel: "Jun 2026",
+        blendedRate: 90,
+        cappedItemCount: 2,
+        totalApprovedCap: 30,
+        totalMonthLogged: 14,
+        totalBillable: 11,
+        totalOverCap: 3,
+        totalBillableAmount: 990,
+        rows: [
+            {
+                workItemId: WI_OVER,
+                label: "Over-cap rock",
+                approvedCap: 10,
+                loggedBefore: 4,
+                monthLogged: 9,
+                billable: 6,
+                overCap: 3,
+                isOverCap: true
+            },
+            {
+                workItemId: WI_OK,
+                label: "Healthy item",
+                approvedCap: 20,
+                loggedBefore: 0,
+                monthLogged: 5,
+                billable: 5,
+                overCap: 0,
+                isOverCap: false
+            }
+        ],
+        ...overrides
+    };
+}
+
+function createComponent() {
+    const element = createElement("c-delivery-billing-preview", {
+        is: DeliveryBillingPreview
+    });
+    document.body.appendChild(element);
+    return element;
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("c-delivery-billing-preview", () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it("renders the billable headline with the dollar figure when a rate resolves", async () => {
+        const element = createComponent();
+        getBillingPreview.emit(samplePreview());
+        await flushPromises();
+
+        const billableTile = element.shadowRoot.querySelector(".summary-tile--billable");
+        expect(billableTile).not.toBeNull();
+        expect(billableTile.textContent).toContain("Billable this month");
+        expect(billableTile.textContent).toContain("11.0h");
+        expect(billableTile.textContent).toContain("$990");
+    });
+
+    it("omits the dollar figure when no blended rate resolves (hours-only)", async () => {
+        const element = createComponent();
+        getBillingPreview.emit(
+            samplePreview({ blendedRate: null, totalBillableAmount: null })
+        );
+        await flushPromises();
+
+        const billableTile = element.shadowRoot.querySelector(".summary-tile--billable");
+        expect(billableTile.textContent).toContain("11.0h");
+        expect(billableTile.textContent).not.toContain("$");
+        expect(billableTile.querySelector(".summary-money")).toBeNull();
+    });
+
+    it("renders one table row per item with the approved/logged/billable/over-cap split", async () => {
+        const element = createComponent();
+        getBillingPreview.emit(samplePreview());
+        await flushPromises();
+
+        const rows = element.shadowRoot.querySelectorAll("tbody tr");
+        expect(rows.length).toBe(2);
+
+        const overRow = rows[0];
+        expect(overRow.textContent).toContain("Over-cap rock");
+        expect(overRow.textContent).toContain("10.0h"); // approved cap
+        expect(overRow.textContent).toContain("9.00h"); // month logged
+        expect(overRow.textContent).toContain("6.00h"); // billable
+        expect(overRow.textContent).toContain("3.00h"); // over cap
+    });
+
+    it("flags over-cap rows with the row class and badge; healthy rows stay unflagged", async () => {
+        const element = createComponent();
+        getBillingPreview.emit(samplePreview());
+        await flushPromises();
+
+        const rows = element.shadowRoot.querySelectorAll("tbody tr");
+        expect(rows[0].classList.contains("preview-row--over")).toBe(true);
+        expect(rows[0].querySelector(".over-badge")).not.toBeNull();
+        expect(rows[1].classList.contains("preview-row--over")).toBe(false);
+        expect(rows[1].querySelector(".over-badge")).toBeNull();
+    });
+
+    it("carries the work item id on the row link for record navigation", async () => {
+        const element = createComponent();
+        getBillingPreview.emit(samplePreview());
+        await flushPromises();
+
+        const links = element.shadowRoot.querySelectorAll(".row-link");
+        expect(links[0].dataset.workItemId).toBe(WI_OVER);
+        expect(links[1].dataset.workItemId).toBe(WI_OK);
+    });
+
+    it("defaults the month selector to the current month with 12 trailing options", async () => {
+        const element = createComponent();
+        getBillingPreview.emit(samplePreview());
+        await flushPromises();
+
+        const combobox = element.shadowRoot.querySelector("lightning-combobox");
+        const now = new Date();
+        expect(combobox.value).toBe(`${now.getFullYear()}-${now.getMonth() + 1}`);
+        expect(combobox.options.length).toBe(12);
+        expect(combobox.options[0].value).toBe(combobox.value);
+    });
+
+    it("shows the empty state when the month has no billable activity", async () => {
+        const element = createComponent();
+        getBillingPreview.emit(
+            samplePreview({
+                rows: [],
+                totalApprovedCap: 0,
+                totalMonthLogged: 0,
+                totalBillable: 0,
+                totalOverCap: 0,
+                totalBillableAmount: 0
+            })
+        );
+        await flushPromises();
+
+        expect(element.shadowRoot.querySelector(".billing-empty")).not.toBeNull();
+        expect(element.shadowRoot.querySelector(".billing-table")).toBeNull();
+        expect(element.shadowRoot.textContent).toContain("Jun 2026");
+    });
+
+    it("shows an error when the wire errors", async () => {
+        const element = createComponent();
+        getBillingPreview.error();
+        await flushPromises();
+
+        expect(element.shadowRoot.querySelector(".billing-error")).not.toBeNull();
+        expect(element.shadowRoot.querySelector(".billing-table")).toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/deliveryBillingPreview/deliveryBillingPreview.css
+++ b/force-app/main/default/lwc/deliveryBillingPreview/deliveryBillingPreview.css
@@ -1,0 +1,222 @@
+:host {
+    display: block;
+}
+
+.billing-card {
+    background: #ffffff;
+    border-radius: 0.75rem;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    font-size: 0.8125rem;
+}
+
+.billing-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.125rem 1.5rem;
+    border-bottom: 1px solid #e5e7eb;
+    background: linear-gradient(135deg, #eff6ff 0%, #f5f3ff 100%);
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.billing-header-left {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.billing-header-icon {
+    color: #7c3aed;
+}
+
+.billing-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0 0 0.15rem 0;
+}
+
+.billing-subtitle {
+    font-size: 0.75rem;
+    color: #6b7280;
+    margin: 0;
+}
+
+.billing-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.billing-select {
+    min-width: 8rem;
+}
+
+.billing-loading {
+    padding: 2rem;
+    display: flex;
+    justify-content: center;
+}
+
+.billing-error {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 1rem 1.5rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    background: #fef2f2;
+    border: 1px solid #fca5a5;
+    color: #991b1b;
+}
+
+.billing-summary-row {
+    display: flex;
+    gap: 1rem;
+    padding: 1rem 1.5rem 0.25rem;
+    flex-wrap: wrap;
+}
+
+.summary-tile {
+    flex: 1 1 10rem;
+    min-width: 9rem;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    padding: 0.875rem 1rem;
+}
+
+.summary-tile--billable {
+    background: #ecfdf5;
+    border-color: #a7f3d0;
+}
+
+.summary-label {
+    font-size: 0.6875rem;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.25rem;
+}
+
+.summary-value {
+    font-size: 1.375rem;
+    font-weight: 600;
+    color: #111827;
+}
+
+.summary-value--over {
+    color: #b45309;
+}
+
+.summary-money {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: #047857;
+    margin-top: 0.15rem;
+}
+
+.summary-note {
+    font-size: 0.6875rem;
+    color: #b45309;
+    margin-top: 0.15rem;
+}
+
+.billing-table-wrap {
+    padding: 0.75rem 1.5rem 1.25rem;
+    overflow-x: auto;
+}
+
+.billing-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.billing-table th {
+    font-size: 0.6875rem;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+    text-align: left;
+    padding: 0.5rem 0.625rem;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.billing-table td {
+    padding: 0.5rem 0.625rem;
+    border-bottom: 1px solid #f3f4f6;
+    color: #1f2937;
+}
+
+.billing-table .col-num {
+    text-align: right;
+    white-space: nowrap;
+}
+
+.preview-row--over td {
+    background: #fffbeb;
+}
+
+.row-link {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    color: #4338ca;
+    font-weight: 600;
+    cursor: pointer;
+    text-align: left;
+}
+
+.row-link:hover {
+    text-decoration: underline;
+}
+
+.over-badge {
+    display: inline-block;
+    margin-left: 0.5rem;
+    padding: 0.1rem 0.45rem;
+    border-radius: 9999px;
+    background: #fef3c7;
+    border: 1px solid #fcd34d;
+    color: #92400e;
+    font-size: 0.625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.cell-billable {
+    font-weight: 600;
+    color: #047857;
+}
+
+.cell-over {
+    color: #b45309;
+}
+
+.billing-empty {
+    padding: 2rem 1.5rem;
+    text-align: center;
+    color: #6b7280;
+}
+
+.billing-empty-icon {
+    margin-bottom: 0.5rem;
+}
+
+.billing-empty p {
+    margin: 0.15rem 0;
+    font-weight: 600;
+    color: #374151;
+}
+
+.billing-empty .billing-empty-sub {
+    font-weight: 400;
+    font-size: 0.75rem;
+    color: #6b7280;
+}

--- a/force-app/main/default/lwc/deliveryBillingPreview/deliveryBillingPreview.html
+++ b/force-app/main/default/lwc/deliveryBillingPreview/deliveryBillingPreview.html
@@ -1,0 +1,109 @@
+<template>
+    <div class="billing-card">
+
+        <div class="billing-header">
+            <div class="billing-header-left">
+                <lightning-icon icon-name="standard:invoice" alternative-text="Billing preview" size="small" class="billing-header-icon"></lightning-icon>
+                <div>
+                    <h2 class="billing-title">Billing Preview</h2>
+                    <p class="billing-subtitle">Approved vs logged vs billable &mdash; the invoice preview for the selected month</p>
+                </div>
+            </div>
+            <div class="billing-controls">
+                <c-delivery-info-popover component-name="deliveryBillingPreview"></c-delivery-info-popover>
+                <lightning-combobox
+                    name="billingMonth"
+                    label="Month"
+                    variant="label-hidden"
+                    value={monthValue}
+                    options={monthOptions}
+                    onchange={handleMonthChange}
+                    class="billing-select">
+                </lightning-combobox>
+            </div>
+        </div>
+
+        <template lwc:if={isLoading}>
+            <div class="billing-loading">
+                <lightning-spinner alternative-text="Loading billing preview..." size="small"></lightning-spinner>
+            </div>
+        </template>
+
+        <template lwc:if={hasError}>
+            <div class="billing-error">
+                <lightning-icon icon-name="utility:error" size="x-small"></lightning-icon>
+                <span>{errorMessage}</span>
+            </div>
+        </template>
+
+        <template lwc:if={hasData}>
+            <div class="billing-summary-row">
+                <div class="summary-tile summary-tile--billable">
+                    <div class="summary-label">Billable this month</div>
+                    <div class="summary-value">{billableHeadline}</div>
+                    <template lwc:if={hasRate}>
+                        <div class="summary-money">{billableDollarDisplay}</div>
+                    </template>
+                </div>
+                <div class="summary-tile">
+                    <div class="summary-label">Logged this month</div>
+                    <div class="summary-value">{loggedDisplay}</div>
+                </div>
+                <div class="summary-tile">
+                    <div class="summary-label">Approved caps</div>
+                    <div class="summary-value">{approvedCapDisplay}</div>
+                </div>
+                <div class="summary-tile">
+                    <div class="summary-label">Over cap (not billable)</div>
+                    <div class="summary-value summary-value--over">{overCapDisplay}</div>
+                    <template lwc:if={hasOverCapTotal}>
+                        <div class="summary-note">Needs an approved increase</div>
+                    </template>
+                </div>
+            </div>
+
+            <div class="billing-table-wrap">
+                <table class="billing-table">
+                    <thead>
+                        <tr>
+                            <th class="col-label">Work item</th>
+                            <th class="col-num">Approved cap</th>
+                            <th class="col-num">Logged before</th>
+                            <th class="col-num">Logged ({monthLabel})</th>
+                            <th class="col-num">Billable</th>
+                            <th class="col-num">Over cap</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <template for:each={rows} for:item="row">
+                            <tr key={row.key} class={row.rowClass}>
+                                <td class="col-label">
+                                    <button class="row-link"
+                                            data-work-item-id={row.workItemId}
+                                            onclick={handleItemClick}>{row.label}</button>
+                                    <template lwc:if={row.isOverCap}>
+                                        <span class="over-badge">Over cap</span>
+                                    </template>
+                                </td>
+                                <td class="col-num">{row.approvedCap}</td>
+                                <td class="col-num">{row.loggedBefore}</td>
+                                <td class="col-num">{row.monthLogged}</td>
+                                <td class="col-num cell-billable">{row.billable}</td>
+                                <td class="col-num cell-over">{row.overCap}</td>
+                            </tr>
+                        </template>
+                    </tbody>
+                </table>
+            </div>
+        </template>
+
+        <template lwc:if={isEmpty}>
+            <div class="billing-empty">
+                <lightning-icon icon-name="standard:invoice" size="medium" class="billing-empty-icon"></lightning-icon>
+                <p>Nothing to invoice yet</p>
+                <p class="billing-empty-sub">{emptyStateDetail}</p>
+            </div>
+        </template>
+
+    </div>
+</template>

--- a/force-app/main/default/lwc/deliveryBillingPreview/deliveryBillingPreview.js
+++ b/force-app/main/default/lwc/deliveryBillingPreview/deliveryBillingPreview.js
@@ -1,0 +1,233 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Monthly billing close-out card (approval-queue spec §9 — the
+ *               "Approved vs Logged vs Billable" view): a month selector
+ *               (defaults to the current month), a totals header whose
+ *               headline ("Billable this month: Nh ≈ $X" when a single
+ *               blended rate resolves) is the invoice preview that should ≈
+ *               the actual invoice, and a per-item table where rows whose
+ *               month hours exceed the remaining approved-cap headroom are
+ *               visually flagged — the over-cap excess is non-billable until
+ *               a budget increase is approved. Fed by
+ *               DeliveryBillingPreviewController.getBillingPreview. Item
+ *               labels click through to the WorkItem record via
+ *               NavigationMixin (objectApiName from @salesforce/schema —
+ *               namespace-safe). All display strings are computed in getters
+ *               (templates can't do ternaries at API 62).
+ * @author       Cloud Nimbus LLC
+ */
+import { LightningElement, wire } from "lwc";
+import { NavigationMixin } from "lightning/navigation";
+import WORK_ITEM_OBJECT from "@salesforce/schema/WorkItem__c";
+import getBillingPreview from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryBillingPreviewController.getBillingPreview";
+
+const MONTH_NAMES = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+];
+const MONTH_OPTION_COUNT = 12;
+
+export default class DeliveryBillingPreview extends NavigationMixin(LightningElement) {
+    preview;
+    errorMessage = "";
+    isLoading = true;
+
+    year;
+    month;
+
+    connectedCallback() {
+        const now = new Date();
+        this.year = now.getFullYear();
+        this.month = now.getMonth() + 1;
+    }
+
+    @wire(getBillingPreview, { year: "$year", month: "$month" })
+    wiredPreview({ data, error }) {
+        if (data) {
+            this.preview = data;
+            this.errorMessage = "";
+            this.isLoading = false;
+        } else if (error) {
+            this.errorMessage =
+                error.body && error.body.message
+                    ? error.body.message
+                    : "Unable to load the billing preview.";
+            this.preview = null;
+            this.isLoading = false;
+        }
+    }
+
+    // ── Month selector ───────────────────────────────────────────
+
+    get monthValue() {
+        return `${this.year}-${this.month}`;
+    }
+
+    get monthOptions() {
+        const options = [];
+        const now = new Date();
+        let y = now.getFullYear();
+        let m = now.getMonth() + 1;
+        for (let i = 0; i < MONTH_OPTION_COUNT; i++) {
+            options.push({
+                label: `${MONTH_NAMES[m - 1]} ${y}`,
+                value: `${y}-${m}`
+            });
+            m -= 1;
+            if (m === 0) {
+                m = 12;
+                y -= 1;
+            }
+        }
+        return options;
+    }
+
+    handleMonthChange(event) {
+        const [y, m] = event.detail.value.split("-");
+        this.year = parseInt(y, 10);
+        this.month = parseInt(m, 10);
+        this.isLoading = true;
+    }
+
+    // ── State flags ──────────────────────────────────────────────
+
+    get hasError() {
+        return !this.isLoading && this.errorMessage.length > 0;
+    }
+
+    get hasData() {
+        return (
+            !this.isLoading &&
+            !this.errorMessage &&
+            Boolean(this.preview) &&
+            this.rows.length > 0
+        );
+    }
+
+    get isEmpty() {
+        return (
+            !this.isLoading &&
+            !this.errorMessage &&
+            Boolean(this.preview) &&
+            this.rows.length === 0
+        );
+    }
+
+    get hasRate() {
+        return Boolean(
+            this.preview &&
+                this.preview.totalBillableAmount !== null &&
+                this.preview.totalBillableAmount !== undefined
+        );
+    }
+
+    // ── Totals header (computed — no template ternaries) ─────────
+
+    get monthLabel() {
+        return this.preview && this.preview.monthLabel ? this.preview.monthLabel : "";
+    }
+
+    get billableHeadline() {
+        if (!this.preview) {
+            return "";
+        }
+        return `${this._formatHours(this.preview.totalBillable)}h`;
+    }
+
+    get billableDollarDisplay() {
+        if (!this.hasRate) {
+            return "";
+        }
+        return `≈ ${this._formatMoney(this.preview.totalBillableAmount)}`;
+    }
+
+    get loggedDisplay() {
+        return this.preview ? `${this._formatHours(this.preview.totalMonthLogged)}h` : "";
+    }
+
+    get approvedCapDisplay() {
+        return this.preview ? `${this._formatHours(this.preview.totalApprovedCap)}h` : "";
+    }
+
+    get overCapDisplay() {
+        return this.preview ? `${this._formatHours(this.preview.totalOverCap)}h` : "";
+    }
+
+    get hasOverCapTotal() {
+        return Boolean(this.preview) && Number(this.preview.totalOverCap) > 0;
+    }
+
+    get emptyStateDetail() {
+        return `No hours were logged on client-approved work in ${this.monthLabel}.`;
+    }
+
+    // ── Table rows (computed — no template ternaries) ────────────
+
+    get rows() {
+        if (!this.preview || !this.preview.rows) {
+            return [];
+        }
+        return this.preview.rows.map((row) => {
+            const isOverCap = Boolean(row.isOverCap);
+            return {
+                key: row.workItemId,
+                workItemId: row.workItemId,
+                label: row.label,
+                approvedCap: `${this._formatHours(row.approvedCap)}h`,
+                loggedBefore: `${this._formatHours(row.loggedBefore)}h`,
+                monthLogged: `${this._formatHours(row.monthLogged)}h`,
+                billable: `${this._formatHours(row.billable)}h`,
+                overCap: `${this._formatHours(row.overCap)}h`,
+                isOverCap,
+                rowClass: isOverCap
+                    ? "preview-row preview-row--over"
+                    : "preview-row"
+            };
+        });
+    }
+
+    // ── Navigation ───────────────────────────────────────────────
+
+    handleItemClick(event) {
+        const workItemId = event.currentTarget.dataset.workItemId;
+        if (!workItemId) {
+            return;
+        }
+        this[NavigationMixin.Navigate]({
+            type: "standard__recordPage",
+            attributes: {
+                recordId: workItemId,
+                objectApiName: WORK_ITEM_OBJECT.objectApiName,
+                actionName: "view"
+            }
+        });
+    }
+
+    // ── Formatting ───────────────────────────────────────────────
+
+    _formatHours(value) {
+        const num = Number(value);
+        if (!Number.isFinite(num)) {
+            return "0";
+        }
+        if (Math.abs(num) >= 100) {
+            return num.toFixed(0);
+        }
+        if (Math.abs(num) >= 10) {
+            return num.toFixed(1);
+        }
+        return num.toFixed(2);
+    }
+
+    _formatMoney(value) {
+        const num = Number(value);
+        if (!Number.isFinite(num)) {
+            return "$0";
+        }
+        return `$${num.toLocaleString("en-US", {
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 0
+        })}`;
+    }
+}

--- a/force-app/main/default/lwc/deliveryBillingPreview/deliveryBillingPreview.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryBillingPreview/deliveryBillingPreview.js-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__HomePage</target>
+        <target>lightning__AppPage</target>
+    </targets>
+    <masterLabel>Delivery Billing Preview</masterLabel>
+    <description>Monthly Approved vs Logged vs Billable close-out — the invoice preview for the selected month, with over-cap (non-billable) excess flagged per work item.</description>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
+++ b/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
@@ -272,6 +272,15 @@ const INFO_REGISTRY = {
         keyFields:
             'WorkRequest__c.StatusPk__c, WorkRequest__c.PreApprovedHoursNumber__c, WorkRequest__c.QuotedHoursNumber__c, WorkRequest__c.DecisionDateTime__c, WorkItem__c.ClientPreApprovedHoursNumber__c, WorkItem__c.EstimatedHoursNumber__c, WorkItem__c.ActivatedDateTime__c, WorkItem__c.StageNamePk__c'
     },
+    deliveryBillingPreview: {
+        dataSource:
+            'Wires DeliveryBillingPreviewController.getBillingPreview for the selected calendar month: one query for every WorkItem__c carrying a client-approved cap (ClientPreApprovedHoursNumber__c > 0), plus two grouped WorkLog__c aggregates — SUM(HoursLoggedNumber__c) inside the month and SUM before the month. Per item: billable = MIN(month logged, MAX(0, cap − logged before)); the excess is over-cap and non-billable until an increase is approved. Dollars appear only when exactly one active NetworkEntity__c carries a DefaultHourlyRateCurrency__c (the same blended-rate resolution the pacing card uses).',
+        description:
+            'The monthly billing close-out — Approved vs Logged vs Billable per work item. The billable total is the invoice preview that should match the actual invoice: hours under each item\'s approved cap bill, hours over the remaining cap headroom are flagged and held non-billable until a budget increase is approved. No invoice surprises.',
+        friendlyName: 'Billing Preview',
+        keyFields:
+            'WorkItem__c.ClientPreApprovedHoursNumber__c, WorkItem__c.BriefDescriptionTxt__c, WorkLog__c.HoursLoggedNumber__c, WorkLog__c.WorkDateDate__c, NetworkEntity__c.DefaultHourlyRateCurrency__c'
+    },
     deliveryWatcherSetup: {
         dataSource:
             'Calls DeliveryWatcherSetupController.getSettings to load the Watcher digest configuration from DeliveryHubSettings__c, and saveSettings to persist it. Flipping the master toggle stamps EnableWatcherDigestDateTime__c; the recipient list is validated against active Users and stored in WatcherDigestRecipientUserIdsTxt__c; an optional Slack webhook override updates the org-wide webhook used by escalations and forecasts.',

--- a/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
@@ -29,6 +29,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryBillingPreviewController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryBurndownController</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
@@ -29,6 +29,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryBillingPreviewController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryBurndownController</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryBillingPreviewController.getBillingPreview.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryBillingPreviewController.getBillingPreview.js
@@ -1,0 +1,8 @@
+/**
+ * Wire adapter mock for DeliveryBillingPreviewController.getBillingPreview.
+ * Used by the c-delivery-billing-preview jest tests.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+
+const getBillingPreview = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getBillingPreview };

--- a/unpackaged/post/testSuites/DH.testSuite-meta.xml
+++ b/unpackaged/post/testSuites/DH.testSuite-meta.xml
@@ -131,5 +131,6 @@
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryOnboardingHistoryControllerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryNotificationServiceTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryApprovalSummaryControllerTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryBillingPreviewControllerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryShipVerificationTest</testClassName>
 </ApexTestSuite>


### PR DESCRIPTION
﻿## What

The billing close-out view — **spec §9 of the approval-queue spec, the last unbuilt piece**: a monthly **Approved vs Logged vs Billable** view = the invoice preview that should ≈ the actual invoice. Danny's no-invoice-surprises loop, made visible.

## The billable formula (v1)

Per WorkItem carrying a client-approved cap (`ClientPreApprovedHoursNumber__c > 0`), for the selected calendar month (window on `WorkLog__c.WorkDateDate__c` — verified in metadata):

```
loggedBefore = SUM(WorkLog hours) with WorkDateDate__c < month start   (lifetime)
monthLogged  = SUM(WorkLog hours) inside the calendar month
headroom     = MAX(0, approvedCap − loggedBefore)
billable     = MIN(monthLogged, headroom)
overCap      = monthLogged − billable        <- non-billable until an increase is approved
```

### v1 simplifications (deliberate)
- **`loggedBefore` is a proxy for cap headroom already consumed.** There is no per-invoice billed-to-date ledger yet, so v1 assumes all prior logged hours drew against the cap. When a real billed-to-date ledger exists, swap `loggedBefore` for it — the formula shape stays.
- **The billing universe is every capped item**, not the board-active scope: a capped item that logged hours this month belongs on the invoice preview regardless of stage/activation.
- **Rows only for items with month activity** (zero-activity capped items contribute nothing to the invoice; they still count in `cappedItemCount`).
- **Dollars** mirror `DeliveryHoursAnalyticsController.resolveBlendedRate` exactly: a single blended rate only when EXACTLY ONE active `NetworkEntity__c` carries `DefaultHourlyRateCurrency__c`; zero/many → hours-only. The billing preview and the pacing card can never disagree on the rate.

## Pieces

- **`DeliveryBillingPreviewController`** (32 chars, `with sharing`, `WITH SYSTEM_MODE`, `@AuraEnabled(cacheable=true)`): 1 capped-item query + 2 grouped WorkLog aggregates (month / before), all LIMIT-guarded; rows sorted monthLogged desc; totals + optional `totalBillableAmount`.
- **`deliveryBillingPreview` LWC** (API 62, HomePage+AppPage): month selector defaulting to the current month (12 trailing options), totals header (Billable this month: Nh ≈ $X when the rate resolves), per-item table with over-cap rows tinted + badged, item labels click through to the WorkItem record (`@salesforce/schema` objectApiName — namespace-safe), empty + error states. No template ternaries; matches the deliveryApprovalSummaryCard visual idiom.
- **Placement**: `DeliveryHubAdminHome` FlexiPage, right after the Approval Agenda card. Deliberately NOT on `DeliveryHubHome` — admin/billing surface only.
- **Permsets**: `classAccesses` for the controller in both `DeliveryHubAdmin_App` and `DeliveryHubApp` (alphabetical, after DeliveryApprovalSummaryController).
- **Extras**: DH test-suite entry, info-popover registry entry, apex wire jest mock.

## Tests

- **Apex (9)**: headroom-capped billable, fully billable under cap, exhausted cap → all non-billable, uncapped/zero-activity exclusion, totals + sort, single-rate dollars, ambiguous-rate hours-only, null-params → current month + empty-org zero defaults, invalid month rejection (type-only assert). All month math anchored on `Date.today()`.
- **Jest (8)**: headline + $ figure, hours-only when no rate, row split, over-cap flagging, record-nav dataset, month selector default + options, empty state, error state. All green locally.

Note: the 3 pre-existing `deliveryFeatureCockpit` jest failures on main are unrelated (verified identical with this branch's changes stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
