### PR TITLE
feat: item 9 — estimate proposals on the record (propose → queue shows reasoning → approve-with-change)

### DIFF
--- a/force-app/main/default/classes/DeliveryWorkApprovalService.cls
+++ b/force-app/main/default/classes/DeliveryWorkApprovalService.cls
@@ -16,6 +16,17 @@
  *               tiered chain ever becomes real, a child object can be ADDED
  *               then — objects shipped in the package cannot be removed.
  *
+ *               proposeEstimate(workItemId, proposedHours, reasoning)
+ *                 -> the vendor-side estimate PROPOSAL (item 9 — the haggle
+ *                    on the record): stamps the proposed hours into the
+ *                    WorkItem's EstimatedHoursNumber__c AND the newest Draft
+ *                    request's QuotedHoursNumber__c (minting a Draft when
+ *                    absent — same reuse semantics as submitForApproval's
+ *                    ensureRequest), writes the reasoning as a
+ *                    WorkItemComment__c prefixed PROPOSAL_NOTE_PREFIX so the
+ *                    queue can surface it, and audit-logs the event. The
+ *                    request stays Draft — proposal != submission; the
+ *                    Offer-Sent step remains submitForApproval's job.
  *               submitForApproval(workItemIds)
  *                 -> ensures ONE WorkRequest__c per WorkItem (reusing the
  *                    newest Draft request when present), stamps
@@ -106,6 +117,20 @@ global with sharing class DeliveryWorkApprovalService {
     private static final Integer MAX_QUEUE_ROWS = 200;
     private static final Integer MAX_CAP_ROWS = 5000;
 
+    /**
+     * Marker prefix on proposeEstimate's reasoning comment. The queue feed
+     * matches on it to surface the latest proposal note per item — keep it
+     * stable; changing it orphans existing proposal comments.
+     */
+    public static final String PROPOSAL_NOTE_PREFIX = '📐 Estimate proposal: ';
+
+    /**
+     * Newest-first comment-scan window for the queue's proposal-note join.
+     * BodyTxt__c is a rich-text (Html) field — NOT filterable in SOQL — so
+     * the prefix match happens in Apex over this bounded window.
+     */
+    private static final Integer MAX_PROPOSAL_SCAN_ROWS = 2000;
+
     // ────────────────────────────────────────────────────────────────────
     // DTOs
     // ────────────────────────────────────────────────────────────────────
@@ -126,6 +151,12 @@ global with sharing class DeliveryWorkApprovalService {
         @AuraEnabled public String requestStatus;
         @AuraEnabled public DateTime submittedAt;
         @AuraEnabled public Id approverUserId;
+        /**
+         * Body of the newest PROPOSAL_NOTE_PREFIX-marked WorkItemComment__c
+         * on the work item ("why this estimate"); null when no proposal
+         * comment exists.
+         */
+        @AuraEnabled public String latestProposalNote;
     }
 
     /**
@@ -151,6 +182,72 @@ global with sharing class DeliveryWorkApprovalService {
     global class BulkApproveResultDTO {
         @AuraEnabled public List<Id> approvedIds = new List<Id>();
         @AuraEnabled public List<String> failures = new List<String>();
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // PROPOSE ESTIMATE (item 9 — the haggle on the record)
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Lands a proposed estimate ON the record so the negotiation
+     *              happens in-system, not in Slack: stamps the proposed hours
+     *              into the WorkItem's EstimatedHoursNumber__c AND the newest
+     *              Draft WorkRequest__c's QuotedHoursNumber__c (minting a
+     *              Draft when none exists — the same reuse semantics as
+     *              submitForApproval's ensureRequest), and writes the
+     *              reasoning as a WorkItemComment__c prefixed
+     *              PROPOSAL_NOTE_PREFIX so the approval queue can surface
+     *              "why this estimate" next to the row. The request stays
+     *              Draft on purpose — proposal != submission; moving it to
+     *              Offer Sent remains submitForApproval's job. The approver
+     *              counters via approve(id, hours, note) or questions in the
+     *              item's comments.
+     * @param workItemId The WorkItem__c the estimate is proposed for.
+     * @param proposedHours The proposed estimate in hours (must be > 0).
+     * @param reasoning Why this estimate — written to the proposal comment
+     *        and audit-logged (required).
+     * @return The Draft WorkRequest__c id carrying the proposed quote.
+     */
+    @AuraEnabled
+    global static Id proposeEstimate(Id workItemId, Decimal proposedHours, String reasoning) {
+        if (workItemId == null) {
+            throw new AuraHandledException('workItemId is required.');
+        }
+        if (proposedHours == null || proposedHours <= 0) {
+            throw new AuraHandledException('proposedHours must be greater than zero.');
+        }
+        if (String.isBlank(reasoning)) {
+            throw new AuraHandledException('reasoning is required.');
+        }
+        List<WorkItem__c> items = loadWorkItemsForSubmit(new Set<Id>{ workItemId });
+        if (items.isEmpty()) {
+            throw new AuraHandledException('No matching work item found.');
+        }
+        WorkItem__c wi = items[0];
+        WorkRequest__c req = ensureRequest(wi);
+        if (req.Id == null) {
+            req.StatusPk__c = REQUEST_DRAFT;
+        }
+        req.QuotedHoursNumber__c = proposedHours;
+        WorkItemComment__c note = new WorkItemComment__c(
+            WorkItemId__c = wi.Id,
+            BodyTxt__c = PROPOSAL_NOTE_PREFIX + String.valueOf(proposedHours)
+                + 'h — ' + reasoning,
+            SourcePk__c = 'Salesforce',
+            AuthorTxt__c = UserInfo.getName()
+        );
+        try {
+            upsert req;
+            update new WorkItem__c(Id = wi.Id, EstimatedHoursNumber__c = proposedHours);
+            insert note;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryWorkApprovalService.proposeEstimate] DML failed: '
+                + e.getMessage());
+            throw new AuraHandledException('Unable to record the estimate proposal.');
+        }
+        writeAuditRow(wi.Id, 'Propose_Estimate', req.Id, reasoning);
+        return req.Id;
     }
 
     // ────────────────────────────────────────────────────────────────────
@@ -587,6 +684,7 @@ global with sharing class DeliveryWorkApprovalService {
             ]) {
                 out.add(toPendingDto(req));
             }
+            applyLatestProposalNotes(out);
         } catch (Exception e) {
             System.debug(LoggingLevel.WARN,
                 '[DeliveryWorkApprovalService.getPendingForApprover] failed: '
@@ -594,6 +692,48 @@ global with sharing class DeliveryWorkApprovalService {
             throw new AuraHandledException('Unable to load the approval queue.');
         }
         return out;
+    }
+
+    /**
+     * @description Backfills latestProposalNote on the page of queue rows:
+     *              ONE bulkified WorkItemComment__c query across the page's
+     *              work items, newest-first, keeping the first
+     *              PROPOSAL_NOTE_PREFIX-marked body per item. BodyTxt__c is a
+     *              rich-text (Html) field — not filterable in SOQL — so the
+     *              prefix match runs in Apex over a bounded scan window
+     *              (MAX_PROPOSAL_SCAN_ROWS); on an extremely chatty page a
+     *              proposal older than the window is simply not surfaced.
+     * @param rows The page of pending rows to decorate (mutated in place).
+     */
+    private static void applyLatestProposalNotes(List<PendingApprovalDTO> rows) {
+        Set<Id> workItemIds = new Set<Id>();
+        for (PendingApprovalDTO dto : rows) {
+            if (dto.workItemId != null) {
+                workItemIds.add(dto.workItemId);
+            }
+        }
+        if (workItemIds.isEmpty()) {
+            return;
+        }
+        Map<Id, String> noteByItem = new Map<Id, String>();
+        for (WorkItemComment__c c : [
+            SELECT WorkItemId__c, BodyTxt__c
+            FROM WorkItemComment__c
+            WHERE WorkItemId__c IN :workItemIds
+            WITH SYSTEM_MODE
+            ORDER BY CreatedDate DESC, Id DESC
+            LIMIT :MAX_PROPOSAL_SCAN_ROWS
+        ]) {
+            if (noteByItem.containsKey(c.WorkItemId__c)) {
+                continue;
+            }
+            if (c.BodyTxt__c != null && c.BodyTxt__c.startsWith(PROPOSAL_NOTE_PREFIX)) {
+                noteByItem.put(c.WorkItemId__c, c.BodyTxt__c);
+            }
+        }
+        for (PendingApprovalDTO dto : rows) {
+            dto.latestProposalNote = noteByItem.get(dto.workItemId);
+        }
     }
 
     private static PendingApprovalDTO toPendingDto(WorkRequest__c req) {
@@ -757,8 +897,8 @@ global with sharing class DeliveryWorkApprovalService {
      *              immutable per-event decision history (the request itself
      *              carries only its final decision state).
      * @param workItemId WorkItem__c the decision concerns.
-     * @param action Lifecycle verb (Auto_Approve / Approve / Approve_Increase
-     *        / Decline / Request_Increase).
+     * @param action Lifecycle verb (Propose_Estimate / Auto_Approve / Approve
+     *        / Approve_Increase / Decline / Request_Increase).
      * @param requestId The WorkRequest__c id (carried in ContextData).
      * @param note Optional decision note carried in ContextData.
      */

--- a/force-app/main/default/classes/DeliveryWorkApprovalServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkApprovalServiceTest.cls
@@ -3,7 +3,9 @@
  * @license      BSL 1.1 — See LICENSE.md
  * @description  Tests for the PR1 work-approval queue service:
  *               submit / approve / approveMany (bulk, partial-failure
- *               collection) / decline / requestIncrease / queue feed,
+ *               collection) / decline / requestIncrease / proposeEstimate
+ *               (item 9 — proposal stamps both sides, stays Draft, prefixed
+ *               reasoning comment + audit row, queue note join) / queue feed,
  *               plus the discretionary Auto short-circuit (under-threshold
  *               auto-approves; an exhausted monthly cap does not), the
  *               canonical cap landing on ClientPreApprovedHoursNumber__c, and
@@ -897,6 +899,175 @@ private class DeliveryWorkApprovalServiceTest {
     }
 
     // ────────────────────────────────────────────────────────────────────
+    // PROPOSE ESTIMATE (item 9 — the haggle on the record)
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description proposeEstimate stamps the proposed hours on BOTH sides
+     *              (WorkItem estimate + the existing Draft request's quote),
+     *              keeps the request Draft (proposal != submission), writes
+     *              the prefixed reasoning comment, and audit-logs a
+     *              Propose_Estimate row.
+     */
+    @IsTest
+    static void testProposeEstimateStampsItemDraftCommentAndAudit() {
+        configureSettings(null, null, null);
+        WorkItem__c wi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 20
+        });
+        WorkRequest__c draft = TestDataFactory.createWorkRequest(wi.Id, new Map<String, Object>{
+            'StatusPk__c' => DeliveryWorkApprovalService.REQUEST_DRAFT
+        });
+
+        Test.startTest();
+        Id requestId = DeliveryWorkApprovalService.proposeEstimate(
+            wi.Id, 12.5, 'Similar to the last two reporting tickets');
+        Test.stopTest();
+
+        System.assertEquals(draft.Id, requestId,
+            'the existing Draft request carries the proposal — not a duplicate');
+        Integer requestCount = [
+            SELECT COUNT() FROM WorkRequest__c WHERE WorkItemId__c = :wi.Id
+        ];
+        System.assertEquals(1, requestCount, 'no duplicate request minted');
+
+        WorkItem__c afterItem = [
+            SELECT EstimatedHoursNumber__c FROM WorkItem__c WHERE Id = :wi.Id
+        ];
+        System.assertEquals(12.5, afterItem.EstimatedHoursNumber__c,
+            'proposed hours land on the WorkItem estimate');
+
+        WorkRequest__c afterReq = [
+            SELECT StatusPk__c, QuotedHoursNumber__c FROM WorkRequest__c WHERE Id = :draft.Id
+        ];
+        System.assertEquals(12.5, afterReq.QuotedHoursNumber__c,
+            'proposed hours land on the Draft quote');
+        System.assertEquals('Draft', afterReq.StatusPk__c,
+            'proposal must NOT move the request to Offer Sent — submit stays separate');
+
+        // BodyTxt__c is Html (not SOQL-filterable) — match the prefix in Apex.
+        String proposalBody;
+        for (WorkItemComment__c c : [
+            SELECT BodyTxt__c FROM WorkItemComment__c WHERE WorkItemId__c = :wi.Id
+        ]) {
+            if (c.BodyTxt__c != null
+                && c.BodyTxt__c.startsWith(DeliveryWorkApprovalService.PROPOSAL_NOTE_PREFIX)) {
+                proposalBody = c.BodyTxt__c;
+            }
+        }
+        System.assertNotEquals(null, proposalBody,
+            'the reasoning lands as a prefixed WorkItemComment__c');
+        System.assert(proposalBody.contains('12.5h'),
+            'the comment names the proposed hours');
+        System.assert(proposalBody.contains('Similar to the last two reporting tickets'),
+            'the comment carries the reasoning');
+
+        Boolean auditFound = false;
+        for (ActivityLog__c row : [
+            SELECT ContextDataTxt__c FROM ActivityLog__c
+            WHERE ActionTypePk__c = 'Work_Approval'
+              AND RecordIdTxt__c = :String.valueOf(wi.Id)
+        ]) {
+            if (row.ContextDataTxt__c != null
+                && row.ContextDataTxt__c.contains('Propose_Estimate')) {
+                auditFound = true;
+            }
+        }
+        System.assert(auditFound, 'one Propose_Estimate audit row is written');
+    }
+
+    /**
+     * @description With no Draft request on the item, proposeEstimate mints
+     *              one (Draft, quoted at the proposal) — mirroring
+     *              submitForApproval's ensureRequest reuse semantics.
+     */
+    @IsTest
+    static void testProposeEstimateCreatesDraftWhenAbsent() {
+        configureSettings(null, null, null);
+        WorkItem__c wi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 20
+        });
+
+        Test.startTest();
+        Id requestId = DeliveryWorkApprovalService.proposeEstimate(
+            wi.Id, 6, 'Fresh sizing for a brand-new item');
+        Test.stopTest();
+
+        System.assertNotEquals(null, requestId, 'a request is minted for the proposal');
+        WorkRequest__c req = [
+            SELECT StatusPk__c, QuotedHoursNumber__c, WorkItemId__c
+            FROM WorkRequest__c WHERE Id = :requestId
+        ];
+        System.assertEquals(wi.Id, req.WorkItemId__c, 'parented to the work item');
+        System.assertEquals('Draft', req.StatusPk__c,
+            'the minted request parks at Draft — proposal != submission');
+        System.assertEquals(6, req.QuotedHoursNumber__c, 'proposed quote stamped');
+
+        WorkItem__c afterItem = [
+            SELECT EstimatedHoursNumber__c FROM WorkItem__c WHERE Id = :wi.Id
+        ];
+        System.assertEquals(6, afterItem.EstimatedHoursNumber__c,
+            'proposed hours land on the WorkItem estimate');
+        Integer requestCount = [
+            SELECT COUNT() FROM WorkRequest__c WHERE WorkItemId__c = :wi.Id
+        ];
+        System.assertEquals(1, requestCount, 'exactly one request minted');
+    }
+
+    /**
+     * @description proposeEstimate validation: null item, null/zero hours,
+     *              blank reasoning, and a well-formed but non-existent item id
+     *              all throw.
+     */
+    @IsTest
+    static void testProposeEstimateValidationErrors() {
+        WorkItem__c wi = TestDataFactory.createWorkItem(null);
+
+        Boolean threw = false;
+        try {
+            DeliveryWorkApprovalService.proposeEstimate(null, 5, 'why');
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        System.assert(threw, 'null workItemId should throw');
+
+        threw = false;
+        try {
+            DeliveryWorkApprovalService.proposeEstimate(wi.Id, null, 'why');
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        System.assert(threw, 'null proposedHours should throw');
+
+        threw = false;
+        try {
+            DeliveryWorkApprovalService.proposeEstimate(wi.Id, 0, 'why');
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        System.assert(threw, 'zero proposedHours should throw');
+
+        threw = false;
+        try {
+            DeliveryWorkApprovalService.proposeEstimate(wi.Id, 5, '   ');
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        System.assert(threw, 'blank reasoning should throw');
+
+        Id missingId = Id.valueOf(
+            WorkItem__c.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED)
+                .getKeyPrefix() + '000000000000');
+        threw = false;
+        try {
+            DeliveryWorkApprovalService.proposeEstimate(missingId, 5, 'why');
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        System.assert(threw, 'a non-existent work item should throw');
+    }
+
+    // ────────────────────────────────────────────────────────────────────
     // QUEUE FEED
     // ────────────────────────────────────────────────────────────────────
 
@@ -953,6 +1124,64 @@ private class DeliveryWorkApprovalServiceTest {
 
         System.assertEquals(1, queue.size(), 'unassigned pending request is visible');
         System.assertEquals(null, queue[0].approverUserId, 'request is unassigned');
+    }
+
+    /**
+     * @description The queue feed carries the NEWEST prefixed proposal note
+     *              per work item (older proposals and plain non-proposal
+     *              comments never mask it) and leaves latestProposalNote null
+     *              on rows whose item has no proposal comment.
+     */
+    @IsTest
+    static void testGetPendingCarriesLatestProposalNote() {
+        configureSettings(null, null, null);
+        WorkItem__c proposedWi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 20
+        });
+        WorkItem__c plainWi = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 15
+        });
+        DeliveryWorkApprovalService.proposeEstimate(
+            proposedWi.Id, 10, 'first pass sizing');
+        DeliveryWorkApprovalService.proposeEstimate(
+            proposedWi.Id, 12, 'second pass after reviewing the schema');
+        // A newer NON-proposal comment must not mask the proposal note.
+        TestDataFactory.createWorkItemComment(
+            proposedWi.Id, 'Quick question about scope', null);
+        DeliveryWorkApprovalService.submitForApproval(
+            new Set<Id>{ proposedWi.Id, plainWi.Id });
+
+        Test.startTest();
+        List<DeliveryWorkApprovalService.PendingApprovalDTO> queue =
+            DeliveryWorkApprovalService.getPendingForApprover(null);
+        Test.stopTest();
+
+        System.assertEquals(2, queue.size(), 'both submitted items pend');
+        DeliveryWorkApprovalService.PendingApprovalDTO proposedDto;
+        DeliveryWorkApprovalService.PendingApprovalDTO plainDto;
+        for (DeliveryWorkApprovalService.PendingApprovalDTO dto : queue) {
+            if (dto.workItemId == proposedWi.Id) {
+                proposedDto = dto;
+            } else if (dto.workItemId == plainWi.Id) {
+                plainDto = dto;
+            }
+        }
+        System.assertNotEquals(null, proposedDto, 'proposed item row present');
+        System.assertNotEquals(null, plainDto, 'plain item row present');
+        System.assertNotEquals(null, proposedDto.latestProposalNote,
+            'the proposal note rides the queue row');
+        System.assert(
+            proposedDto.latestProposalNote.startsWith(
+                DeliveryWorkApprovalService.PROPOSAL_NOTE_PREFIX),
+            'the carried note is the prefixed proposal comment');
+        System.assert(
+            proposedDto.latestProposalNote.contains('second pass after reviewing the schema'),
+            'the NEWEST proposal wins');
+        System.assert(
+            !proposedDto.latestProposalNote.contains('first pass sizing'),
+            'the older proposal is not the one carried');
+        System.assertEquals(null, plainDto.latestProposalNote,
+            'no proposal comment = null note on the row');
     }
 
     // ────────────────────────────────────────────────────────────────────

--- a/force-app/main/default/lwc/deliveryApprovalQueue/__tests__/deliveryApprovalQueue.test.js
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/__tests__/deliveryApprovalQueue.test.js
@@ -30,7 +30,9 @@ function samplePending() {
             requestedIncrease: null,
             requestStatus: "Offer Sent",
             submittedAt: new Date().toISOString(),
-            approverUserId: "005000000000001AAA"
+            approverUserId: "005000000000001AAA",
+            latestProposalNote:
+                "📐 Estimate proposal: 12h — Mirrors the last two reporting tickets"
         },
         {
             requestId: REQUEST_TWO,
@@ -41,7 +43,8 @@ function samplePending() {
             requestedIncrease: 4,
             requestStatus: "Offer Sent",
             submittedAt: new Date(Date.now() - 3 * 86400000).toISOString(),
-            approverUserId: null
+            approverUserId: null,
+            latestProposalNote: null
         }
     ];
 }
@@ -245,6 +248,46 @@ describe("c-delivery-approval-queue", () => {
             workRequestId: REQUEST_ONE,
             reason: "Budget exhausted for this quarter"
         });
+    });
+
+    it("shows the why-this-estimate toggle only on rows carrying a proposal note", async () => {
+        const element = createComponent();
+        getPendingForApprover.emit(samplePending());
+        await flushPromises();
+
+        const toggles = element.shadowRoot.querySelectorAll(".queue-proposal-toggle");
+        expect(toggles.length).toBe(1); // only REQUEST_ONE carries a note
+        expect(toggles[0].textContent).toBe("Why this estimate");
+        // Collapsed by default — no note body rendered yet.
+        expect(element.shadowRoot.querySelector(".queue-proposal-note")).toBeNull();
+    });
+
+    it("expands and collapses the proposal note on toggle clicks", async () => {
+        const element = createComponent();
+        getPendingForApprover.emit(samplePending());
+        await flushPromises();
+
+        const toggle = element.shadowRoot.querySelector(".queue-proposal-toggle");
+        toggle.dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+
+        const note = element.shadowRoot.querySelector(".queue-proposal-note");
+        expect(note).not.toBeNull();
+        expect(note.textContent).toContain(
+            "📐 Estimate proposal: 12h — Mirrors the last two reporting tickets"
+        );
+        expect(
+            element.shadowRoot.querySelector(".queue-proposal-toggle").textContent
+        ).toBe("Hide why this estimate");
+
+        element.shadowRoot
+            .querySelector(".queue-proposal-toggle")
+            .dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+        expect(element.shadowRoot.querySelector(".queue-proposal-note")).toBeNull();
+        expect(
+            element.shadowRoot.querySelector(".queue-proposal-toggle").textContent
+        ).toBe("Why this estimate");
     });
 
     it("shows the caught-up empty state when nothing is pending", async () => {

--- a/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.css
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.css
@@ -194,6 +194,39 @@
     flex-wrap: wrap;
 }
 
+.queue-proposal {
+    margin-top: 0.4rem;
+}
+
+.queue-proposal-toggle {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: #7c3aed;
+    text-align: left;
+}
+
+.queue-proposal-toggle:hover {
+    text-decoration: underline;
+    color: #5b21b6;
+}
+
+.queue-proposal-note {
+    margin-top: 0.4rem;
+    padding: 0.6rem 0.9rem;
+    border-radius: 0.5rem;
+    background: #f5f3ff;
+    border: 1px solid #ddd6fe;
+    color: #4c1d95;
+    font-size: 0.75rem;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
 .queue-inline {
     display: flex;
     align-items: flex-end;

--- a/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.html
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.html
@@ -112,6 +112,17 @@
                             </div>
                         </div>
 
+                        <template lwc:if={row.hasProposalNote}>
+                            <div class="queue-proposal">
+                                <button class="queue-proposal-toggle"
+                                        data-request-id={row.key}
+                                        onclick={handleToggleProposalNote}>{row.proposalToggleLabel}</button>
+                                <template lwc:if={row.isProposalOpen}>
+                                    <div class="queue-proposal-note">{row.proposalNote}</div>
+                                </template>
+                            </div>
+                        </template>
+
                         <template lwc:if={row.isChangeOpen}>
                             <div class="queue-inline">
                                 <lightning-input

--- a/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.js
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.js
@@ -13,7 +13,10 @@
  *               labels (AuraHandledException messages come back generic inside
  *               the managed package). Clicking the item name navigates to the
  *               WorkItem__c record via NavigationMixin + @salesforce/schema so
- *               the object API name stays namespace-safe.
+ *               the object API name stays namespace-safe. Rows carrying a
+ *               latestProposalNote (proposeEstimate's reasoning comment)
+ *               expose an expandable "Why this estimate" line under the row
+ *               (item 9 — the estimate haggle on the record).
  * @author       Cloud Nimbus LLC
  */
 import { LightningElement, wire } from "lwc";
@@ -46,6 +49,9 @@ export default class DeliveryApprovalQueue extends NavigationMixin(LightningElem
     draftNote = "";
     draftReason = "";
 
+    // Rows whose "why this estimate" proposal note is expanded.
+    expandedNoteIds = [];
+
     wiredResult;
 
     @wire(getPendingForApprover, { userId: null })
@@ -67,6 +73,8 @@ export default class DeliveryApprovalQueue extends NavigationMixin(LightningElem
     get rows() {
         return this.pendingRaw.map((dto) => {
             const isActive = dto.requestId === this.activeRequestId;
+            const hasProposalNote = Boolean(dto.latestProposalNote);
+            const isProposalOpen = hasProposalNote && this.expandedNoteIds.includes(dto.requestId);
             return {
                 key: dto.requestId,
                 workItemId: dto.workItemId,
@@ -77,7 +85,13 @@ export default class DeliveryApprovalQueue extends NavigationMixin(LightningElem
                 ageDisplay: this._ageDisplay(dto.submittedAt),
                 isSelected: this.selectedIds.includes(dto.requestId),
                 isChangeOpen: isActive && this.activeMode === MODE_CHANGE,
-                isDeclineOpen: isActive && this.activeMode === MODE_DECLINE
+                isDeclineOpen: isActive && this.activeMode === MODE_DECLINE,
+                hasProposalNote,
+                isProposalOpen,
+                proposalNote: dto.latestProposalNote || "",
+                proposalToggleLabel: isProposalOpen
+                    ? "Hide why this estimate"
+                    : "Why this estimate"
             };
         });
     }
@@ -260,6 +274,20 @@ export default class DeliveryApprovalQueue extends NavigationMixin(LightningElem
         if (this.wiredResult) {
             refreshApex(this.wiredResult);
         }
+    }
+
+    // ── Proposal note ("why this estimate") ──────────────────────
+
+    handleToggleProposalNote(event) {
+        const requestId = event.currentTarget.dataset.requestId;
+        if (!requestId) {
+            return;
+        }
+        const next = this.expandedNoteIds.filter((id) => id !== requestId);
+        if (next.length === this.expandedNoteIds.length) {
+            next.push(requestId);
+        }
+        this.expandedNoteIds = next;
     }
 
     // ── Internals ────────────────────────────────────────────────

--- a/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
+++ b/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
@@ -258,7 +258,7 @@ const INFO_REGISTRY = {
         dataSource:
             'Wires DeliveryWorkApprovalService.getPendingForApprover — every WorkRequest__c at StatusPk__c=Offer Sent assigned to the running user (plus unassigned requests), oldest first. Approve / Approve-with-change / Decline call the service imperatively; approve stamps the decision on the request and lands ClientPreApprovedHoursNumber__c on the WorkItem (a budget INCREASE raises the existing cap by the approved delta), decline stands the request down and parks the item only when nothing was previously approved.',
         description:
-            'The approver\'s pending-work queue. Each Offer-Sent work request shows the item, quoted hours, any requested budget increase, and time in queue — with one-click Approve, an Approve-with-change inline hours/note form, and an inline-reason Decline. Item names click through to the Work Item record.',
+            'The approver\'s pending-work queue. Each Offer-Sent work request shows the item, quoted hours, any requested budget increase, and time in queue — with one-click Approve, an Approve-with-change inline hours/note form, and an inline-reason Decline. Rows with a proposed estimate expose an expandable "Why this estimate" line carrying the proposer\'s reasoning comment, so the estimate negotiation stays on the record. Item names click through to the Work Item record.',
         friendlyName: 'Pending Work Approvals',
         keyFields:
             'WorkRequest__c.StatusPk__c, WorkRequest__c.QuotedHoursNumber__c, WorkRequest__c.RequestedBudgetIncreaseNumber__c, WorkRequest__c.ApproverUserLookup__c, WorkRequest__c.DecisionDateTime__c, WorkItem__c.ClientPreApprovedHoursNumber__c, WorkItem__c.StageNamePk__c'


### PR DESCRIPTION
## What

The PROPOSAL half of in-system estimate negotiation (machine-plan item 9). Approve-with-change (`approve(id, hours, note)`) already shipped — this adds the other side of the haggle, so the whole exchange lives on the record instead of Slack.

### Service (`DeliveryWorkApprovalService`)
- **`proposeEstimate(workItemId, proposedHours, reasoning)`** — `@AuraEnabled global static Id`. Validates inputs (null item / non-positive hours / blank reasoning / missing item all throw), then:
  - stamps `proposedHours` into **`EstimatedHoursNumber__c`** on the WorkItem AND **`QuotedHoursNumber__c`** on its newest **Draft** `WorkRequest__c` — minting a Draft when absent, mirroring `ensureRequest`'s reuse semantics. The request **stays Draft**: proposal ≠ submission; Offer Sent remains `submitForApproval`'s job.
  - writes the reasoning as a `WorkItemComment__c` (`WorkItemId__c` + `BodyTxt__c`, `SourcePk__c='Salesforce'`, `AuthorTxt__c=UserInfo.getName()`) prefixed `📐 Estimate proposal: Nh — ` (prefix exposed as `PROPOSAL_NOTE_PREFIX`).
  - one `ActivityLog__c` audit row via the existing `writeAuditRow` idiom (action `Propose_Estimate`).
  - Null-safe, `WITH SYSTEM_MODE`, ApexDoc'd, same DML-suppression style as the rest of the class.

### Queue surfacing
- `PendingApprovalDTO.latestProposalNote` — backfilled in `getPendingForApprover` by **one** additional bulkified `WorkItemComment__c` query across the page's work items, newest-first, keeping the first prefix-matched body per item. `BodyTxt__c` is an Html field (NOT SOQL-filterable), so the prefix match runs in Apex over a bounded scan window (`MAX_PROPOSAL_SCAN_ROWS=2000`); newer non-proposal comments never mask the note.
- `deliveryApprovalQueue` renders rows carrying a note with an expandable **"Why this estimate"** line under the row — getter-precomputed flags/labels (no template ternaries), matching the existing row idiom. Info-popover copy updated.

## Tests
- **4 new Apex tests** (31 → 35 in `DeliveryWorkApprovalServiceTest`): proposal stamps WI estimate + Draft quote + prefixed comment + `Propose_Estimate` audit row and keeps the request Draft; absent-Draft mints exactly one Draft; validation errors across the surface; queue DTO carries the NEWEST proposal note (older proposals and newer plain comments don't mask it) and stays null on rows without one.
- **2 new jest tests** (8 → 10, all green locally): toggle renders only on rows with a note + collapsed by default; expand/collapse round-trip with body text and label flip.

## Notes
- `WorkItemComment__c` field names verified in force-app metadata: body = `BodyTxt__c` (Html 130,768), parent = `WorkItemId__c` (Master-Detail to `WorkItem__c`), plus `AuthorTxt__c` / `SourcePk__c`.
- No changes to `deliveryProFormaTimeline` / `DeliveryGanttController` / `docs/` (sibling agents own those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)