### PR TITLE
fix(approvals): ASCII proposal marker + Html-tolerant match (unblocks beta)

### DIFF
--- a/force-app/main/default/classes/DeliveryWorkApprovalService.cls
+++ b/force-app/main/default/classes/DeliveryWorkApprovalService.cls
@@ -122,7 +122,7 @@ global with sharing class DeliveryWorkApprovalService {
      * matches on it to surface the latest proposal note per item — keep it
      * stable; changing it orphans existing proposal comments.
      */
-    public static final String PROPOSAL_NOTE_PREFIX = '📐 Estimate proposal: ';
+    public static final String PROPOSAL_NOTE_PREFIX = 'Estimate proposal: ';
 
     /**
      * Newest-first comment-scan window for the queue's proposal-note join.
@@ -232,7 +232,7 @@ global with sharing class DeliveryWorkApprovalService {
         WorkItemComment__c note = new WorkItemComment__c(
             WorkItemId__c = wi.Id,
             BodyTxt__c = PROPOSAL_NOTE_PREFIX + String.valueOf(proposedHours)
-                + 'h — ' + reasoning,
+                + 'h - ' + reasoning,
             SourcePk__c = 'Salesforce',
             AuthorTxt__c = UserInfo.getName()
         );
@@ -727,8 +727,14 @@ global with sharing class DeliveryWorkApprovalService {
             if (noteByItem.containsKey(c.WorkItemId__c)) {
                 continue;
             }
-            if (c.BodyTxt__c != null && c.BodyTxt__c.startsWith(PROPOSAL_NOTE_PREFIX)) {
-                noteByItem.put(c.WorkItemId__c, c.BodyTxt__c);
+            // BodyTxt__c is rich text (Html): packaging orgs can wrap content in
+            // markup and entity-encode on save, so normalize to plain text
+            // before the marker match — and carry plain text to the LWC.
+            String plain = c.BodyTxt__c == null
+                ? ''
+                : c.BodyTxt__c.stripHtmlTags().unescapeHtml4().trim();
+            if (plain.startsWith(PROPOSAL_NOTE_PREFIX)) {
+                noteByItem.put(c.WorkItemId__c, plain);
             }
         }
         for (PendingApprovalDTO dto : rows) {

--- a/force-app/main/default/classes/DeliveryWorkApprovalServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkApprovalServiceTest.cls
@@ -950,9 +950,13 @@ private class DeliveryWorkApprovalServiceTest {
         for (WorkItemComment__c c : [
             SELECT BodyTxt__c FROM WorkItemComment__c WHERE WorkItemId__c = :wi.Id
         ]) {
-            if (c.BodyTxt__c != null
-                && c.BodyTxt__c.startsWith(DeliveryWorkApprovalService.PROPOSAL_NOTE_PREFIX)) {
-                proposalBody = c.BodyTxt__c;
+            // Normalize the Html round-trip the same way the service's queue
+            // join does — packaging orgs can wrap/entity-encode rich text.
+            String plain = c.BodyTxt__c == null
+                ? ''
+                : c.BodyTxt__c.stripHtmlTags().unescapeHtml4().trim();
+            if (plain.startsWith(DeliveryWorkApprovalService.PROPOSAL_NOTE_PREFIX)) {
+                proposalBody = plain;
             }
         }
         System.assertNotEquals(null, proposalBody,


### PR DESCRIPTION
The item-9 proposal comment used an emoji-prefixed marker stored in
WorkItemComment__c.BodyTxt__c (rich text / Html) and prefix-matched the
raw read-back. The packaging org's Html round-trip wraps/entity-encodes
content, so both proposal tests failed there (null match) while the
namespaced feature-test scratch passed — the known upload-beta-stricter
class. Beta for 0.278 was blocked on it (safety stop held the promote).

- PROPOSAL_NOTE_PREFIX -> ASCII ('Estimate proposal: '); stored body
  uses an ASCII hyphen too
- queue join + test matching normalize via stripHtmlTags().
  unescapeHtml4().trim() before the prefix match; the DTO now carries
  plain text (better for the LWC line as well)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
