### PR TITLE
fix: reconcile Home active-item counts (label scopes) + wire tiles to native reports

### DIFF
--- a/force-app/main/default/classes/DeliveryDashboardCardController.cls
+++ b/force-app/main/default/classes/DeliveryDashboardCardController.cls
@@ -37,11 +37,20 @@ global with sharing class DeliveryDashboardCardController {
     global static Object getCardData(String dataSource, String filterJson) {
         switch on dataSource {
             when 'activeWorkItems' {
+                // Canonical "active" definition, shared with System Pulse
+                // (DeliveryHubDashboardController.getBudgetMetrics.activeRequests):
+                // activated + non-archived + non-template + NON-TERMINAL stage.
+                // Pre-fix this count was missing the terminal-stage exclusion, so
+                // Done/Cancelled items still counted as "Active" and the Exec
+                // Dashboard disagreed with System Pulse (155 vs 110 on live data).
+                Set<String> terminalStages =
+                    DeliveryWorkflowConfigService.getTerminalStageValues('Software_Delivery');
                 return [
                     SELECT COUNT() FROM WorkItem__c
                     WHERE ActivatedDateTime__c != NULL
                     AND ArchivedDateTime__c = NULL
                     AND TemplateMarkedDateTime__c = NULL
+                    AND StageNamePk__c NOT IN :terminalStages
                     WITH SYSTEM_MODE
                 ];
             }
@@ -56,11 +65,19 @@ global with sharing class DeliveryDashboardCardController {
                 ];
             }
             when 'hoursThisMonth' {
+                // Hours WORKED this month, keyed on WorkDateDate__c (when the work
+                // actually happened) with a CreatedDate fallback for legacy rows
+                // where the work date was never captured — the exact semantics of
+                // System Pulse's "Hours Performed This Month" and the Monthly_Hours
+                // report. Pre-fix this card summed by CreatedDate (entry time),
+                // which silently diverged from both whenever entries were backdated.
                 Date monthStart = Date.today().toStartOfMonth();
+                DateTime monthStartDt = DateTime.newInstance(monthStart, Time.newInstance(0, 0, 0, 0));
                 AggregateResult[] results = [
                     SELECT SUM(HoursLoggedNumber__c) total
                     FROM WorkLog__c
-                    WHERE CreatedDate >= :monthStart
+                    WHERE (WorkDateDate__c >= :monthStart)
+                       OR (WorkDateDate__c = NULL AND CreatedDate >= :monthStartDt)
                     WITH SYSTEM_MODE
                 ];
                 return results.isEmpty() || results[0].get('total') == null ? 0 : results[0].get('total');

--- a/force-app/main/default/classes/DeliveryDashboardCardControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryDashboardCardControllerTest.cls
@@ -179,11 +179,90 @@ private class DeliveryDashboardCardControllerTest {
             DeliveryWorkItemTriggerHandler.triggerDisabled = false;
         }
 
+        // Terminal-stage item — activated but Done, must NOT count as "Active".
+        // Regression guard for the canonical-filter fix: pre-fix this row counted
+        // and the Exec Dashboard disagreed with System Pulse.
+        insert new WorkItem__c(
+            BriefDescriptionTxt__c = 'Done item',
+            StageNamePk__c         = 'Done',
+            ActivatedDateTime__c   = Datetime.now()
+        );
+
+        // Archived item — activated and non-terminal but archived, must NOT count.
+        insert new WorkItem__c(
+            BriefDescriptionTxt__c = 'Archived item',
+            StageNamePk__c         = 'In Development',
+            ActivatedDateTime__c   = Datetime.now(),
+            ArchivedDateTime__c    = Datetime.now()
+        );
+
         Test.startTest();
         Object result = DeliveryDashboardCardController.getCardData('activeWorkItems', null);
         Test.stopTest();
 
-        System.assertEquals(2, (Integer) result, 'Should count only items with ActivatedDateTime__c set');
+        System.assertEquals(2, (Integer) result,
+            'Should count only activated, non-archived, non-template items in non-terminal stages '
+            + '(the canonical active definition shared with System Pulse)');
+    }
+
+    /**
+     * @description Regression guard for the hoursThisMonth work-date fix: the card
+     *              must sum by WorkDateDate__c (when the work happened) with a
+     *              CreatedDate fallback only for rows where the work date is null —
+     *              matching System Pulse and the Monthly_Hours report. A log entered
+     *              today but WORKED last month must not count toward this month.
+     */
+    @IsTest
+    static void testHoursThisMonthKeysOnWorkDateNotEntryDate() {
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c = 'WorkDate semantics test',
+            StageNamePk__c         = 'In Development',
+            ActivatedDateTime__c   = Datetime.now()
+        );
+        insert wi;
+        WorkRequest__c wr = new WorkRequest__c(
+            WorkItemId__c         = wi.Id,
+            QuotedHoursNumber__c  = 10,
+            HourlyRateCurrency__c = 100,
+            StatusPk__c           = 'Accepted'
+        );
+        insert wr;
+
+        // Worked THIS month → counts (2h)
+        insert new WorkLog__c(
+            RequestId__c          = wr.Id,
+            WorkItemLookup__c     = wi.Id,
+            HoursLoggedNumber__c  = 2,
+            WorkDateDate__c       = Date.today().toStartOfMonth(),
+            WorkDescriptionTxt__c = 'worked this month'
+        );
+        // Entered now but worked LAST month → must NOT count
+        insert new WorkLog__c(
+            RequestId__c          = wr.Id,
+            WorkItemLookup__c     = wi.Id,
+            HoursLoggedNumber__c  = 40,
+            WorkDateDate__c       = Date.today().toStartOfMonth().addDays(-1),
+            WorkDescriptionTxt__c = 'backdated to last month'
+        );
+        // No work date at all → CreatedDate fallback counts it (0.5h)
+        WorkLog__c undated = new WorkLog__c(
+            RequestId__c          = wr.Id,
+            WorkItemLookup__c     = wi.Id,
+            HoursLoggedNumber__c  = 0.5,
+            WorkDateDate__c       = Date.today(),
+            WorkDescriptionTxt__c = 'undated legacy row'
+        );
+        insert undated;
+        undated.WorkDateDate__c = null;
+        update undated;
+
+        Test.startTest();
+        Object result = DeliveryDashboardCardController.getCardData('hoursThisMonth', null);
+        Test.stopTest();
+
+        System.assertEquals(2.5, (Decimal) result,
+            'Should sum the this-month work date (2h) + the undated fallback row (0.5h) '
+            + 'and exclude the entry logged now but worked last month');
     }
 
     @IsTest

--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -152,7 +152,13 @@ public with sharing class DeliveryGanttController {
                 query += 'AND (ActivatedDateTime__c != null '
                     + 'OR LastModifiedDate >= LAST_N_DAYS:' + DEFAULT_STALE_CUTOFF_DAYS + ') ';
             } else {
-                query += 'AND ActivatedDateTime__c != null ';
+                // Default view: canonical active scope — activated AND not archived.
+                // Pre-fix the archived filter was missing, so archived items still
+                // rendered on the timeline and its count disagreed with every other
+                // "active items" surface on Home. (showCompleted=true deliberately
+                // keeps archived/inactive items, bounded by the freshness window.)
+                query += 'AND ActivatedDateTime__c != null '
+                    + 'AND ArchivedDateTime__c = null ';
             }
 
             query += 'WITH SYSTEM_MODE '
@@ -1093,7 +1099,10 @@ public with sharing class DeliveryGanttController {
                 query += 'AND (ActivatedDateTime__c != null '
                     + 'OR LastModifiedDate >= LAST_N_DAYS:' + DEFAULT_STALE_CUTOFF_DAYS + ') ';
             } else {
-                query += 'AND ActivatedDateTime__c != null ';
+                // Default view: canonical active scope — activated AND not archived
+                // (mirrors getGanttData; pre-fix archived items still rendered).
+                query += 'AND ActivatedDateTime__c != null '
+                    + 'AND ArchivedDateTime__c = null ';
             }
 
             // SortOrderNumber__c is the primary sort — drag-to-reorder writes it,

--- a/force-app/main/default/classes/DeliveryGanttControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryGanttControllerTest.cls
@@ -219,6 +219,38 @@ private class DeliveryGanttControllerTest {
         }
     }
 
+    /**
+     * @description Regression guard for the archived-filter fix: the default
+     *              (showCompleted=false) timeline scope is the canonical active
+     *              definition — activated AND not archived. Pre-fix archived items
+     *              still rendered, so the timeline count disagreed with every other
+     *              "active items" surface on Home.
+     */
+    @IsTest
+    static void testGetGanttDataExcludesArchivedByDefault() {
+        System.runAs(testUser) {
+            insert new WorkItem__c(
+                BriefDescriptionTxt__c   = 'Archived item',
+                StageNamePk__c           = 'In Development',
+                ActivatedDateTime__c     = Datetime.now(),
+                ArchivedDateTime__c      = Datetime.now(),
+                EstimatedStartDevDate__c = Date.today(),
+                EstimatedEndDevDate__c   = Date.today().addDays(5)
+            );
+
+            Test.startTest();
+            List<DeliveryGanttController.GanttTask> tasks = DeliveryGanttController.getGanttData(false);
+            Test.stopTest();
+
+            System.assertEquals(3, tasks.size(),
+                'Archived items must be excluded from the default timeline view even when activated.');
+            for (DeliveryGanttController.GanttTask t : tasks) {
+                System.assertNotEquals('Archived item', t.description,
+                    'The archived item must not render on the default timeline.');
+            }
+        }
+    }
+
     @IsTest
     static void testGetGanttDataIncludesCompleted() {
         System.runAs(testUser) {
@@ -635,6 +667,35 @@ private class DeliveryGanttControllerTest {
                     'Every row should have a priorityGroup (explicit or derived)');
                 System.assertNotEquals(null, row.startDate, 'startDate should resolve');
                 System.assertNotEquals(null, row.endDate, 'endDate should resolve');
+            }
+        }
+    }
+
+    /**
+     * @description Mirror of testGetGanttDataExcludesArchivedByDefault for the
+     *              Pro Forma Timeline feed — default scope must exclude archived
+     *              items so the timeline reconciles with the other Home surfaces.
+     */
+    @IsTest
+    static void testGetProFormaTimelineDataExcludesArchivedByDefault() {
+        System.runAs(testUser) {
+            insert new WorkItem__c(
+                BriefDescriptionTxt__c   = 'Archived timeline item',
+                StageNamePk__c           = 'In Development',
+                ActivatedDateTime__c     = Datetime.now(),
+                ArchivedDateTime__c      = Datetime.now(),
+                EstimatedStartDevDate__c = Date.today(),
+                EstimatedEndDevDate__c   = Date.today().addDays(5)
+            );
+
+            Test.startTest();
+            List<DeliveryGanttController.ProFormaTimelineRow> rows =
+                DeliveryGanttController.getProFormaTimelineData(false);
+            Test.stopTest();
+
+            for (DeliveryGanttController.ProFormaTimelineRow row : rows) {
+                System.assertNotEquals('Archived timeline item', row.title,
+                    'Archived items must be excluded from the default Pro Forma Timeline view.');
             }
         }
     }

--- a/force-app/main/default/classes/DeliveryHubDashboardController.cls
+++ b/force-app/main/default/classes/DeliveryHubDashboardController.cls
@@ -496,7 +496,12 @@ global with sharing class DeliveryHubDashboardController {
         }
         metrics.put('completed', completed);
 
-        // Items modified (stage changed) in range — exclude templates and archived.
+        // Items modified (stage changed) in range — surfaced as the "In Progress"
+        // tile. Requires the full canonical active-item filter set (activated +
+        // non-template + non-archived + non-terminal) so this count reconciles
+        // with System Pulse's activeRequests and the What's-In-Flight phase
+        // tiles. Pre-fix the ActivatedDateTime__c check was missing, so
+        // unactivated backlog items modified in the window inflated the number.
         Integer moved;
         if (endDt != null) {
             moved = [
@@ -505,6 +510,7 @@ global with sharing class DeliveryHubDashboardController {
                 WHERE LastModifiedDate >= :startDt
                 AND LastModifiedDate < :endDt
                 AND StageNamePk__c NOT IN :terminalStages
+                AND ActivatedDateTime__c != null
                 AND TemplateMarkedDateTime__c = null
                 AND ArchivedDateTime__c = null
             ];
@@ -514,6 +520,7 @@ global with sharing class DeliveryHubDashboardController {
                 FROM WorkItem__c
                 WHERE LastModifiedDate >= :startDt
                 AND StageNamePk__c NOT IN :terminalStages
+                AND ActivatedDateTime__c != null
                 AND TemplateMarkedDateTime__c = null
                 AND ArchivedDateTime__c = null
             ];

--- a/force-app/main/default/classes/DeliveryHubDashboardControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHubDashboardControllerTest.cls
@@ -259,6 +259,46 @@ private class DeliveryHubDashboardControllerTest {
         }
     }
 
+    /**
+     * @description Regression guard for the "In Progress" (moved) metric fix:
+     *              the count must use the full canonical active-item filter —
+     *              including ActivatedDateTime__c != null — so unactivated
+     *              backlog items modified in the window do not inflate the
+     *              This-Week tile relative to System Pulse's active count.
+     */
+    @IsTest
+    static void testThisWeekMovedExcludesUnactivatedItems() {
+        System.runAs(testUser) {
+            // Active item modified now — should count
+            insert new WorkItem__c(
+                BriefDescriptionTxt__c = 'Active moved item',
+                StageNamePk__c = 'In Development',
+                ActivatedDateTime__c = Datetime.now()
+            );
+
+            // Unactivated backlog item modified now — should NOT count.
+            // Bypass the auto-stamp trigger so it lands genuinely unactivated.
+            DeliveryWorkItemTriggerHandler.triggerDisabled = true;
+            try {
+                insert new WorkItem__c(
+                    BriefDescriptionTxt__c = 'Backlog unactivated moved',
+                    StageNamePk__c = 'Backlog'
+                );
+            } finally {
+                DeliveryWorkItemTriggerHandler.triggerDisabled = false;
+            }
+
+            Test.startTest();
+            Map<String, Object> result = DeliveryHubDashboardController.getClientDashboard('thisWeek', 'Software_Delivery');
+            Test.stopTest();
+
+            Map<String, Object> thisWeek = (Map<String, Object>) result.get('thisWeek');
+            System.assertEquals(1, (Integer) thisWeek.get('moved'),
+                'moved should count only ACTIVATED, non-archived, non-template, non-terminal items '
+                + 'modified in the window — the unactivated backlog item must be excluded');
+        }
+    }
+
     @IsTest
     static void testGetClientDashboard() {
         System.runAs(testUser) {

--- a/force-app/main/default/customMetadata/DashboardCard.Active_Work_Items.md-meta.xml
+++ b/force-app/main/default/customMetadata/DashboardCard.Active_Work_Items.md-meta.xml
@@ -3,7 +3,7 @@
     <label>Active Work Items</label>
     <protected>false</protected>
     <values><field>TitleTxt__c</field><value xsi:type="xsd:string">Active Work Items</value></values>
-    <values><field>DescriptionTxt__c</field><value xsi:type="xsd:string">Total active, non-archived work items</value></values>
+    <values><field>DescriptionTxt__c</field><value xsi:type="xsd:string">Activated, non-archived, non-terminal items — matches System Pulse</value></values>
     <values><field>CardTypePk__c</field><value xsi:type="xsd:string">Metric</value></values>
     <values><field>IconNameTxt__c</field><value xsi:type="xsd:string">utility:task</value></values>
     <values><field>DataSourceTxt__c</field><value xsi:type="xsd:string">activeWorkItems</value></values>
@@ -15,4 +15,6 @@
     <values><field>CardSizeTxt__c</field><value xsi:type="xsd:string">small</value></values>
     <values><field>ThresholdWarningNumber__c</field><value xsi:type="xsd:double">50</value></values>
     <values><field>ThresholdCriticalNumber__c</field><value xsi:type="xsd:double">100</value></values>
+    <values><field>ClickThroughUrlTxt__c</field><value xsi:type="xsd:string">report:In_Flight_Work_Items</value></values>
+    <values><field>InfoPopoverTxt__c</field><value xsi:type="xsd:string">Counts WorkItems that are activated (ActivatedDateTime set), not archived, not recurring templates, and in a non-terminal workflow stage — the same canonical "active" definition System Pulse uses, so the two headline numbers always agree. Click the card to open the In-Flight Work Items report (note: the report additionally narrows to items modified this month).</value></values>
 </CustomMetadata>

--- a/force-app/main/default/customMetadata/DashboardCard.Blocked_Items.md-meta.xml
+++ b/force-app/main/default/customMetadata/DashboardCard.Blocked_Items.md-meta.xml
@@ -15,4 +15,6 @@
     <values><field>CardSizeTxt__c</field><value xsi:type="xsd:string">small</value></values>
     <values><field>ThresholdWarningNumber__c</field><value xsi:type="xsd:double">3</value></values>
     <values><field>ThresholdCriticalNumber__c</field><value xsi:type="xsd:double">5</value></values>
+    <values><field>ClickThroughUrlTxt__c</field><value xsi:type="xsd:string">report:Blocked_Work_Items</value></values>
+    <values><field>InfoPopoverTxt__c</field><value xsi:type="xsd:string">Counts activated, non-archived, non-template WorkItems whose stage name contains "Blocked" — current state, not time-bounded. Click the card to open the Blocked Work Items report for the line-item detail.</value></values>
 </CustomMetadata>

--- a/force-app/main/default/customMetadata/DashboardCard.Completed_This_Week.md-meta.xml
+++ b/force-app/main/default/customMetadata/DashboardCard.Completed_This_Week.md-meta.xml
@@ -15,4 +15,6 @@
     <values><field>CardSizeTxt__c</field><value xsi:type="xsd:string">small</value></values>
     <values><field>ThresholdWarningNumber__c</field><value xsi:nil="true"/></values>
     <values><field>ThresholdCriticalNumber__c</field><value xsi:nil="true"/></values>
+    <values><field>ClickThroughUrlTxt__c</field><value xsi:type="xsd:string">report:Recently_Completed</value></values>
+    <values><field>InfoPopoverTxt__c</field><value xsi:type="xsd:string">Counts non-template WorkItems whose stage is Done and that were last modified this week. Click the card to open the Recently Completed report (note: the report uses a this-MONTH window, so it can show more rows than this week's count).</value></values>
 </CustomMetadata>

--- a/force-app/main/default/customMetadata/DashboardCard.Items_By_Stage.md-meta.xml
+++ b/force-app/main/default/customMetadata/DashboardCard.Items_By_Stage.md-meta.xml
@@ -3,7 +3,7 @@
     <label>Items By Stage</label>
     <protected>false</protected>
     <values><field>TitleTxt__c</field><value xsi:type="xsd:string">Items by Stage</value></values>
-    <values><field>DescriptionTxt__c</field><value xsi:type="xsd:string">Active work items grouped by workflow stage</value></values>
+    <values><field>DescriptionTxt__c</field><value xsi:type="xsd:string">All activated, non-archived items by stage — includes completed (top 10 stages)</value></values>
     <values><field>CardTypePk__c</field><value xsi:type="xsd:string">BarChart</value></values>
     <values><field>IconNameTxt__c</field><value xsi:type="xsd:string">utility:kanban</value></values>
     <values><field>DataSourceTxt__c</field><value xsi:type="xsd:string">workItemsByPhase</value></values>
@@ -15,4 +15,6 @@
     <values><field>CardSizeTxt__c</field><value xsi:type="xsd:string">medium</value></values>
     <values><field>ThresholdWarningNumber__c</field><value xsi:nil="true"/></values>
     <values><field>ThresholdCriticalNumber__c</field><value xsi:nil="true"/></values>
+    <values><field>ClickThroughUrlTxt__c</field><value xsi:type="xsd:string">report:Work_Item_Pipeline</value></values>
+    <values><field>InfoPopoverTxt__c</field><value xsi:type="xsd:string">Stage breakdown of every activated, non-archived, non-template WorkItem — DELIBERATELY including terminal stages (Done, etc.) so you can see the full pipeline shape, capped at the 10 largest stages. This is why its total exceeds the Active Work Items metric, which excludes completed items. Click the card to open the Work Item Pipeline by Stage report for the uncapped, line-item view.</value></values>
 </CustomMetadata>

--- a/force-app/main/default/lwc/deliveryBudgetSummary/deliveryBudgetSummary.html
+++ b/force-app/main/default/lwc/deliveryBudgetSummary/deliveryBudgetSummary.html
@@ -20,11 +20,12 @@
                         <div class="slds-media__figure">
                             <lightning-icon icon-name="standard:case" size="medium"></lightning-icon>
                         </div>
-                        <div class="slds-media__body" style="cursor: pointer;" onclick={handleActiveItemsClick}>
+                        <div class="slds-media__body" style="cursor: pointer;" onclick={handleActiveItemsClick} title="Activated, non-archived items in non-terminal stages — excludes completed and templates">
                             <div class="slds-text-heading_large slds-var-m-bottom_xx-small">
                                 <strong>{metrics.activeRequests}</strong>
                             </div>
                             <div class="slds-text-title_caps slds-text-color_weak">Active Work Items</div>
+                            <div class="slds-text-body_small slds-text-color_weak">excludes completed &amp; archived</div>
                         </div>
                     </div>
                 </div>

--- a/force-app/main/default/lwc/deliveryClientDashboard/deliveryClientDashboard.html
+++ b/force-app/main/default/lwc/deliveryClientDashboard/deliveryClientDashboard.html
@@ -135,13 +135,13 @@
                     <template lwc:if={isLoaded}>
                         <div class="slds-grid slds-wrap slds-gutters_x-small slds-p-horizontal_medium slds-p-bottom_medium">
                             <div class="slds-col slds-size_1-of-4 slds-text-align_center">
-                                <button class="tw-metric tw-metric--clickable" onclick={handleCompletedClick} title="View recently completed work items">
+                                <button class="tw-metric tw-metric--clickable" onclick={handleCompletedClick} title="Items reaching a terminal stage in the selected period — click to open the Recently Completed report">
                                     <div class="tw-metric-value tw-metric--success dh-metric">{thisWeek.completed}</div>
                                     <div class="tw-metric-label dh-metric-label">Completed</div>
                                 </button>
                             </div>
                             <div class="slds-col slds-size_1-of-4 slds-text-align_center">
-                                <button class="tw-metric tw-metric--clickable" onclick={handleInProgressClick} title="View in-flight work items">
+                                <button class="tw-metric tw-metric--clickable" onclick={handleInProgressClick} title="Active items (activated, not archived, not completed) updated in the selected period — click to open the In-Flight Work Items report">
                                     <div class="tw-metric-value tw-metric--info dh-metric">{thisWeek.moved}</div>
                                     <div class="tw-metric-label dh-metric-label">In Progress</div>
                                 </button>
@@ -153,7 +153,7 @@
                                 </button>
                             </div>
                             <div class="slds-col slds-size_1-of-4 slds-text-align_center">
-                                <button class="tw-metric tw-metric--clickable" onclick={handleBlockedClick} title="View blocked work items">
+                                <button class="tw-metric tw-metric--clickable" onclick={handleBlockedClick} title="Items currently blocked by a dependency — current state, not limited to the selected period">
                                     <div class="tw-metric-value tw-metric--warning dh-metric">{thisWeek.blocked}</div>
                                     <div class="tw-metric-label dh-metric-label">Blocked</div>
                                 </button>

--- a/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
+++ b/force-app/main/default/lwc/deliveryInfoPopover/deliveryInfoPopover.js
@@ -49,16 +49,16 @@ const INFO_REGISTRY = {
     },
     deliveryBudgetSummary: {
         dataSource:
-            'Calls getBudgetMetrics which counts active WorkItems (IsActive = true), sums WorkLog hours for current and previous months, and tallies Sync_Item__c records by status to compute connection health percentage.',
+            'Calls getBudgetMetrics. "Active Work Items" uses the canonical active definition — ActivatedDateTime set, not archived, not a recurring template, and in a non-terminal workflow stage (excludes Done/Cancelled) — the same scope as the Executive Dashboard\'s Active Work Items card and the What\'s In Flight tiles. Hours sum WorkLog entries for the current and previous months (by work date, with an entry-date fallback for undated rows). Connection health tallies Sync_Item__c records by status.',
         description:
-            'Quick health check showing active work item count, hours logged this month vs. last month, and (optionally) sync connection health with success/failure counts.',
+            'Quick health check showing active work item count (excludes completed and archived), hours logged this month vs. last month, and (optionally) sync connection health with success/failure counts.',
         friendlyName: 'System Pulse',
         keyFields:
             'WorkItem__c.ActivatedDateTime__c, WorkLog__c.HoursNumber__c, WorkLog__c.WorkDateDate__c, Sync_Item__c.StatusPk__c'
     },
     deliveryClientDashboard: {
         dataSource:
-            'Queries active Work Items where the current user\'s persona requires action (e.g., client approval stages). Attention items are scored by days-in-stage, priority, and blocked status. Phase counts come from non-terminal workflow stages defined in Custom Metadata. The "This Week" metrics count completions, stage moves, hours logged, and blocked items within the selected time range.',
+            'Queries active Work Items where the current user\'s persona requires action (e.g., client approval stages). Attention items are scored by days-in-stage, priority, and blocked status. Phase counts come from non-terminal workflow stages defined in Custom Metadata, scoped to activated, non-archived, non-template items. The "This Week" metrics: Completed = items reaching a terminal stage in the window; In Progress = ACTIVE items (activated, not archived, not completed) updated in the window; Hours Logged = WorkLog hours by work date in the window; Blocked = current-state dependency-blocked items, not time-bounded.',
         description:
             'Your personal delivery overview. Shows a greeting, items needing your attention ranked by urgency, a phase-by-phase count of active work, a "This Week" snapshot, and recently updated items.',
         friendlyName: 'Client Dashboard',
@@ -220,7 +220,7 @@ const INFO_REGISTRY = {
     },
     deliveryProFormaTimeline: {
         dataSource:
-            'Calls DeliveryGanttController.getProFormaTimelineData to load WorkItem__c records with priority group + estimated hours. Drag-to-reparent, drag-to-reorder, and drag-to-reschedule dispatch write-backs via updateWorkItemDates / updateWorkItemSortOrder / updateWorkItemPriorityGroup / updateWorkItemParent.',
+            'Calls DeliveryGanttController.getProFormaTimelineData to load WorkItem__c records with priority group + estimated hours. Default scope: activated, non-archived, non-template items — completed (Done) items stay visible on the timeline until archived, so this count can exceed the Active Work Items metric. The show-completed toggle additionally pulls in unactivated items modified in the last 90 days. Drag-to-reparent, drag-to-reorder, and drag-to-reschedule dispatch write-backs via updateWorkItemDates / updateWorkItemSortOrder / updateWorkItemPriorityGroup / updateWorkItemParent.',
         description:
             'Pro Forma Timeline — template-driven gantt built on the @nimbus-gantt/app framework (v10). Renders six views (Gantt, List, Treemap, Bubbles, Calendar, Flow) with priority-group buckets (NOW / NEXT / PLANNED / PROPOSED / HOLD), drag-to-reparent, depth shading, and a fullscreen toggle that escapes the Salesforce chrome. Same template ships to cloudnimbusllc.com for cross-platform parity.',
         friendlyName: 'Pro Forma Timeline',


### PR DESCRIPTION
## Cowork items 3 + 4 — Home count reconciliation + report wiring

### Item 3 — why five Home surfaces showed five different "active" numbers

Live MF evidence: System Pulse **110** / This Week **112** / Exec Dashboard **155** / Items-by-Stage **152** / Gantt **157**.

Canonical active definition: `ActivatedDateTime__c != null AND ArchivedDateTime__c = null AND TemplateMarkedDateTime__c = null`, non-terminal stage where intended.

#### Scope table (before → after)

| Surface (live #) | Controller | WHERE before | Verdict | After |
|---|---|---|---|---|
| **System Pulse "Active Work Items" (110)** — `deliveryBudgetSummary` | `DeliveryHubDashboardController.getBudgetMetrics.activeRequests` | canonical + non-terminal (CMT) | ✅ already canonical — the baseline | unchanged; scope subtitle "excludes completed & archived" + tooltip added |
| **This Week → "In Progress" (112)** — `deliveryClientDashboard` | `getClientDashboard` → `thisWeek.moved` | `LastModifiedDate` in window + non-terminal + non-template + non-archived — **missing `ActivatedDateTime != null`** | 🐛 **real bug** — unactivated backlog items modified in the window counted as "In Progress" (112 vs 110) | + `ActivatedDateTime__c != null`; tooltip now states "active items updated in the selected period" |
| **What's In Flight phase tiles** — `deliveryClientDashboard` | `fetchPhaseList` | canonical + non-terminal | ✅ already canonical (fixed in an earlier release) | unchanged |
| **Exec Dashboard "Active Work Items" (155)** — `deliveryExecutiveDashboard` | `DeliveryDashboardCardController.getCardData('activeWorkItems')` | activated + non-archived + non-template — **includes Done/Cancelled** | 🐛 **real bug** — a card titled "Active" counted terminal-stage items (155 vs 110) | + `StageNamePk__c NOT IN :terminalStages` (CMT-driven); description now "matches System Pulse" |
| **Exec Dashboard "Items by Stage" (152)** — same | `getCardData('workItemsByPhase')` | activated + non-archived + non-template, incl. terminal, top 10 stages | 🏷️ **deliberate** — a pipeline-shape breakdown should show the Done pile | query unchanged; description + ⓘ popover now say "includes completed (top 10 stages)" and explain why it exceeds the Active metric |
| **Timeline / Gantt (157)** — `deliveryProFormaTimeline` | `DeliveryGanttController.getGanttData` + `getProFormaTimelineData` (showCompleted=false) | activated + non-template — **missing `ArchivedDateTime__c = null`**; includes terminal | 🐛 **real bug** (archived items rendered — the 157 vs 155 delta) + 🏷️ deliberate (completed items stay visible until archived) | + `ArchivedDateTime__c = null` in the default branch only (`showCompleted=true` deliberately keeps archived/inactive, 90-day bounded); popover documents the scope |
| **Exec Dashboard "Hours This Month"** — same | `getCardData('hoursThisMonth')` | `CreatedDate >= monthStart` (entry date) | 🐛 **real bug** — its own ⓘ popover, System Pulse, and the `Monthly_Hours` report it drills into all key on **work date** | work-date with entry-date fallback for undated rows (exact System Pulse semantics) |

**Deliberate differences kept and labeled** (the scopeLabel lesson): Items-by-Stage includes completed; the timeline shows completed-until-archived; client-dashboard "Blocked" is current-state not week-bounded; "Hours entered vs performed" dual metric stays. Each now carries a subtitle/tooltip/popover stating its scope, so the numbers read as deliberate rather than broken. Expected post-fix: System Pulse = Exec "Active" = ~110; Items-by-Stage ≈ Gantt = active + completed-unarchived; "In Progress" ≤ active.

### Item 4 — Home tiles → native reports

System Pulse and the client-dashboard tiles were **already fully wired** (`getReportIds` by DeveloperName + NavigationMixin — verified against current main; no-op there). The genuinely unwired surface was the Exec Dashboard, which already ships a cross-org-portable CMT mechanism (`ClickThroughUrlTxt__c` = `report:DeveloperName`, resolved by `resolveClickThroughUrl` via SOQL on Report) — so no new Apex helper was needed; this is pure metadata:

| Card | Report wired |
|---|---|
| Active Work Items | `report:In_Flight_Work_Items` |
| Items by Stage | `report:Work_Item_Pipeline` (pipeline by stage) |
| Blocked Items | `report:Blocked_Work_Items` |
| Completed This Week | `report:Recently_Completed` (popover notes the report's this-MONTH window) |

Not wired (no genuinely matching report, per brief): Overdue Items, Items by Priority, Sync Health, Recent Activity, Project Health Pills. `Hours_By_Month_Last_6` → `Hours_By_Project_By_Month` was already wired. **No new reports.**

### Tests
- `testActiveWorkItemsCounts` extended: Done + archived rows must not count (canonical-filter guard)
- `testHoursThisMonthKeysOnWorkDateNotEntryDate`: backdated-to-last-month entry excluded; undated fallback counted
- `testThisWeekMovedExcludesUnactivatedItems`: trigger-bypassed unactivated item excluded from `moved`
- `testGetGanttDataExcludesArchivedByDefault` + `testGetProFormaTimelineDataExcludesArchivedByDefault`
- Jest: `deliveryClientDashboard` 15/15 pass (no new click handlers — exec click-through reuses existing `handleCardClick`)

### Files changed
- `force-app/main/default/classes/DeliveryDashboardCardController.cls` (+Test)
- `force-app/main/default/classes/DeliveryHubDashboardController.cls` (+Test)
- `force-app/main/default/classes/DeliveryGanttController.cls` (+Test)
- `force-app/main/default/customMetadata/DashboardCard.{Active_Work_Items,Items_By_Stage,Blocked_Items,Completed_This_Week}.md-meta.xml`
- `force-app/main/default/lwc/{deliveryBudgetSummary,deliveryClientDashboard}/…html`, `deliveryInfoPopover.js` (scope labels; also fixed the stale "IsActive = true" popover text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
