### PR TITLE
fix(sync): worklog relay minting runs without sharing — guest REST context minted nothing

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,6 +109,8 @@ The sync engine handles bidirectional data replication between connected Salesfo
 | **DeliveryHubPoller** | Schedulable. Polls connected vendor orgs for staged changes on a 15-minute schedule. |
 | **DeliveryHubScheduler** | Scheduled tick. Drains Pending SyncItems via `requeuePendingItems()` every 15 minutes in addition to its existing reconciliation and poller work, so Pending backlog self-heals without admin intervention. |
 
+**Sharing rule:** relay-minting paths MUST be `without sharing` (`DeliverySyncEngine`, `DeliveryWorkLogRelayMinter`) — inbound REST runs as the Site Guest User (forced-Private record access), and `WITH SYSTEM_MODE` bypasses FLS but NOT sharing, so eligibility queries inside a `with sharing` class return empty and silently mint nothing (2026-06 nimba incident: 65 WorkLog rows / 138.5h never relayed to the billing org).
+
 ### Push Flow
 
 ```

--- a/force-app/main/default/classes/DeliveryWorkLogRelayMinter.cls
+++ b/force-app/main/default/classes/DeliveryWorkLogRelayMinter.cls
@@ -1,0 +1,227 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Relay-mint path for WorkLog__c outbound sync, extracted from
+ *              DeliveryWorkLogTriggerHandler (which stays `with sharing`).
+ *              Evaluates Hub-mode (upstream-to-Client) and Push-mode
+ *              (downstream-to-Vendor via WorkRequest bridge) eligibility for a
+ *              set of WorkLogs and inserts the outbound SyncItem__c relays.
+ * @author Cloud Nimbus LLC
+ */
+// without sharing: Required so WorkLog relay minting succeeds regardless of the running
+// user's record access — specifically the Delivery Hub Site Guest User. Inbound worklogs
+// arrive via REST (DeliveryHubSyncService → DeliverySyncItemIngestor → WorkLog trigger)
+// under the guest user, whose record access is forced Private. The eligibility queries on
+// WorkItem__c / WorkRequest__c are WITH SYSTEM_MODE, which bypasses FLS but NOT sharing —
+// inside a `with sharing` class they returned empty for the guest and the mint silently
+// no-opped: no relay, worklogs never synced onward (2026-06 nimba: 65 rows / 138.5h went
+// invisible to the billing org). DeliverySyncEngine is `without sharing` for the same
+// reason, which is why WorkItem relays in the SAME guest transactions DID mint.
+@SuppressWarnings('PMD.ApexCRUDViolation, PMD.CyclomaticComplexity')
+public without sharing class DeliveryWorkLogRelayMinter {
+
+    /**
+     * @description Mints outbound SyncItem__c relays for sync-eligible WorkLogs.
+     *              Hub mode: parent WorkItem linked to a Client/Both NetworkEntity
+     *              with an endpoint. Push mode: parent WorkItem fans out via active
+     *              WorkRequest bridges to Vendor/Both entities with endpoints.
+     *              Inserts the relays in SYSTEM_MODE and enqueues the dispatcher.
+     *              Callers (the WorkLog trigger handler) apply the approval gate
+     *              BEFORE calling — every log passed in is presumed sync-eligible.
+     * @param logs The WorkLog__c records to evaluate and relay outbound.
+     */
+    public static void mintForLogs(List<WorkLog__c> logs) {
+        Set<Id> workItemIds = new Set<Id>();
+        for (WorkLog__c wl : logs) {
+            if (wl.WorkItemLookup__c != null) {
+                workItemIds.add(wl.WorkItemLookup__c);
+            }
+        }
+        if (workItemIds.isEmpty()) {
+            return;
+        }
+
+        // ── Hub mode: upstream to Client ───────────────────────────────
+        // Eligible iff the parent WorkItem's ClientNetworkEntityLookup__c
+        // is Client/Both with a populated endpoint. Without this guard
+        // WorkLogs shipped to orgs that never received the parent WorkItem
+        // (T-0129: 8.5h on dh-prod as orphan inbound, permanently unbillable
+        // until manual hand-firing).
+        Map<Id, WorkItem__c> clientWorkItems = new Map<Id, WorkItem__c>([
+            SELECT Id, ClientNetworkEntityLookup__c
+            FROM WorkItem__c
+            WHERE Id IN :workItemIds
+            AND ClientNetworkEntityLookup__c != null
+            AND ClientNetworkEntityLookup__r.EntityTypePk__c IN ('Client', 'Both')
+            AND ClientNetworkEntityLookup__r.IntegrationEndpointUrlTxt__c != null
+            WITH SYSTEM_MODE
+        ]);
+
+        // ── Push mode: downstream to Vendor via WorkRequest bridge ─────
+        // Mirrors the Push branch in DeliverySyncEngine.captureChanges
+        // (lines 86-104) so WorkLog outbound also fans out via active
+        // WorkRequest connections to Vendor/Both entities. Pre-fix the WL
+        // handler ONLY did Hub mode — orgs whose WI parent had no Client
+        // entry (e.g. MF-Prod, where the only NetworkEntity is Cloud Nimbus
+        // as a Vendor) silently dropped every WorkLog outbound. Empirically:
+        // MF-Prod 9 WLs inserted 2026-05-01 → zero SyncItems → 69.5h had
+        // to be manually mirrored to dh-prod for the April invoice.
+        Map<Id, List<WorkRequest__c>> pushRoutes = new Map<Id, List<WorkRequest__c>>();
+        for (WorkRequest__c req : [
+            SELECT Id, WorkItemId__c, RemoteWorkItemIdTxt__c
+            FROM WorkRequest__c
+            WHERE WorkItemId__c IN :workItemIds
+            AND StatusPk__c != 'Inactive'
+            AND DeliveryEntityLookup__c != null
+            AND DeliveryEntityLookup__r.EntityTypePk__c IN ('Vendor', 'Both')
+            AND DeliveryEntityLookup__r.IntegrationEndpointUrlTxt__c != null
+            WITH SYSTEM_MODE
+        ]) {
+            if (!pushRoutes.containsKey(req.WorkItemId__c)) {
+                pushRoutes.put(req.WorkItemId__c, new List<WorkRequest__c>());
+            }
+            pushRoutes.get(req.WorkItemId__c).add(req);
+        }
+
+        if (clientWorkItems.isEmpty() && pushRoutes.isEmpty()) {
+            return;
+        }
+
+        List<SyncItem__c> syncItems = buildSyncItems(logs, clientWorkItems);
+        syncItems.addAll(buildPushSyncItems(logs, pushRoutes));
+        if (!syncItems.isEmpty()) {
+            Database.insert(syncItems, AccessLevel.SYSTEM_MODE);
+            if (!Test.isRunningTest() && Limits.getQueueableJobs() == 0 && !System.isQueueable() && !System.isFuture()) {
+                System.enqueueJob(new DeliverySyncItemProcessor());
+            }
+        }
+    }
+
+    /**
+     * @description Builds the list of SyncItem__c records for WorkLogs on client-linked work items.
+     * @param logs The WorkLog records to evaluate.
+     * @param clientWorkItems Map of work item Ids that have a client entity linked.
+     * @return List of SyncItem__c records ready for insert.
+     */
+    private static List<SyncItem__c> buildSyncItems(List<WorkLog__c> logs, Map<Id, WorkItem__c> clientWorkItems) {
+        String senderOrgId = UserInfo.getOrganizationId();
+        Map<Id, String> recordToGlobalSource = buildGlobalSourceMap(logs);
+        List<SyncItem__c> items = new List<SyncItem__c>();
+        for (WorkLog__c wl : logs) {
+            if (!clientWorkItems.containsKey(wl.WorkItemLookup__c)) {
+                continue;
+            }
+            // Inherit the ORIGIN GlobalSourceId if this WorkLog arrived via an
+            // inbound relay; otherwise this org is the birthplace and the id
+            // is minted from the local record. Without inheritance the origin
+            // id is re-minted at every MF → Nimba → dh-prod hop, killing the
+            // cross-path dedup on the receiver and duplicating invoice hours.
+            String gsid = recordToGlobalSource.containsKey(wl.Id)
+                ? recordToGlobalSource.get(wl.Id)
+                : (String) wl.Id;
+            Map<String, Object> payload = new Map<String, Object>{
+                'SourceId'               => wl.Id,
+                'SenderOrgId'            => senderOrgId,
+                'GlobalSourceId'         => gsid,
+                'WorkItemLookup__c'          => wl.WorkItemLookup__c,
+                'HoursLoggedNumber__c'   => wl.HoursLoggedNumber__c,
+                'WorkDateDate__c'        => String.valueOf(wl.WorkDateDate__c),
+                'WorkDescriptionTxt__c'  => wl.WorkDescriptionTxt__c
+            };
+            items.add(new SyncItem__c(
+                ObjectTypePk__c         = 'WorkLog__c',
+                LocalRecordIdTxt__c     = wl.Id,
+                WorkItemLookup__c           = wl.WorkItemLookup__c,
+                DirectionPk__c          = 'Outbound',
+                StatusPk__c             = 'Queued',
+                GlobalSourceIdTxt__c    = gsid,
+                PayloadTxt__c           = JSON.serialize(payload)
+            ));
+        }
+        return items;
+    }
+
+    /**
+     * @description Bulk-loads the origin GlobalSourceId for a set of WorkLogs by
+     *              walking their Inbound SyncItem ledger rows. Mirrors the
+     *              inheritance map built in DeliverySyncEngine.captureChanges so
+     *              relayed WorkLogs keep their birthplace id across hops instead
+     *              of re-minting it at every relay. One query, no SOQL-in-loop.
+     * @param logs The WorkLog records about to be emitted outbound.
+     * @return Map of WorkLog Id → inherited origin GlobalSourceId. WorkLogs with
+     *         no inbound ledger row are absent (caller treats absence as birthplace).
+     */
+    private static Map<Id, String> buildGlobalSourceMap(List<WorkLog__c> logs) {
+        Map<Id, String> recordToGlobalSource = new Map<Id, String>();
+        Set<Id> idSet = new Set<Id>();
+        for (WorkLog__c wl : logs) {
+            idSet.add(wl.Id);
+        }
+        if (idSet.isEmpty()) {
+            return recordToGlobalSource;
+        }
+        for (SyncItem__c inbound : [
+            SELECT LocalRecordIdTxt__c, GlobalSourceIdTxt__c
+            FROM SyncItem__c
+            WHERE LocalRecordIdTxt__c IN :idSet
+            AND GlobalSourceIdTxt__c != NULL
+            AND DirectionPk__c = 'Inbound'
+            WITH SYSTEM_MODE
+        ]) {
+            recordToGlobalSource.put((Id) inbound.LocalRecordIdTxt__c, inbound.GlobalSourceIdTxt__c);
+        }
+        return recordToGlobalSource;
+    }
+
+    /**
+     * @description Builds Push-mode outbound SyncItem__c records — one per
+     *              (WorkLog × WorkRequest-route) pair — for every WorkLog
+     *              whose parent WorkItem fans out to a Vendor/Both
+     *              NetworkEntity through an active WorkRequest bridge.
+     *              Mirrors the Hub-mode buildSyncItems shape but populates
+     *              RequestLookup__c + payload.TargetId so the dispatcher
+     *              routes via the WorkRequest's DeliveryEntity endpoint.
+     * @param logs The WorkLog__c records being synced.
+     * @param pushRoutes Map of parent WorkItem Id → list of active
+     *                   WorkRequest connections to Vendor/Both entities.
+     * @return List of Push-mode SyncItem__c records ready for insert.
+     */
+    private static List<SyncItem__c> buildPushSyncItems(List<WorkLog__c> logs, Map<Id, List<WorkRequest__c>> pushRoutes) {
+        String senderOrgId = UserInfo.getOrganizationId();
+        Map<Id, String> recordToGlobalSource = buildGlobalSourceMap(logs);
+        List<SyncItem__c> items = new List<SyncItem__c>();
+        for (WorkLog__c wl : logs) {
+            List<WorkRequest__c> reqs = pushRoutes.get(wl.WorkItemLookup__c);
+            if (reqs == null || reqs.isEmpty()) {
+                continue;
+            }
+            // Inherit origin GlobalSourceId across relay hops (see buildSyncItems).
+            String gsid = recordToGlobalSource.containsKey(wl.Id)
+                ? recordToGlobalSource.get(wl.Id)
+                : (String) wl.Id;
+            for (WorkRequest__c req : reqs) {
+                Map<String, Object> payload = new Map<String, Object>{
+                    'SourceId'               => wl.Id,
+                    'SenderOrgId'            => senderOrgId,
+                    'GlobalSourceId'         => gsid,
+                    'TargetId'               => req.RemoteWorkItemIdTxt__c,
+                    'WorkItemLookup__c'      => wl.WorkItemLookup__c,
+                    'HoursLoggedNumber__c'   => wl.HoursLoggedNumber__c,
+                    'WorkDateDate__c'        => String.valueOf(wl.WorkDateDate__c),
+                    'WorkDescriptionTxt__c'  => wl.WorkDescriptionTxt__c
+                };
+                items.add(new SyncItem__c(
+                    ObjectTypePk__c         = 'WorkLog__c',
+                    LocalRecordIdTxt__c     = wl.Id,
+                    WorkItemLookup__c       = wl.WorkItemLookup__c,
+                    RequestLookup__c        = req.Id,
+                    DirectionPk__c          = 'Outbound',
+                    StatusPk__c             = 'Queued',
+                    GlobalSourceIdTxt__c    = gsid,
+                    PayloadTxt__c           = JSON.serialize(payload)
+                ));
+            }
+        }
+        return items;
+    }
+}

--- a/force-app/main/default/classes/DeliveryWorkLogRelayMinter.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryWorkLogRelayMinter.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryWorkLogRelayMinterTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkLogRelayMinterTest.cls
@@ -1,0 +1,185 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Tests for DeliveryWorkLogRelayMinter. The killer regression here is
+ *              the guest-REST sharing bug (2026-06 nimba): worklogs arriving via
+ *              DeliveryHubSyncService run the WorkLog trigger as the Delivery Hub
+ *              Site Guest User, whose record access is forced Private. The relay
+ *              eligibility queries were WITH SYSTEM_MODE inside a `with sharing`
+ *              handler — FLS bypassed but sharing still enforced — so they returned
+ *              empty and the mint silently no-opped: 65 rows / 138.5h never relayed
+ *              to the billing org. These tests prove relays mint when the insert
+ *              runs under a user with no sharing access to the parent records.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryWorkLogRelayMinterTest {
+
+    @TestSetup
+    static void setup() {
+        NetworkEntity__c client = new NetworkEntity__c(
+            Name = 'Relay Test Client', EntityTypePk__c = 'Client', StatusPk__c = 'Active',
+            IntegrationEndpointUrlTxt__c = 'https://relay-test-client.example.com'
+        );
+        // Vendor deliberately has NO endpoint → Push-mode stays ineligible, so the
+        // guest test below expects exactly one (Hub-mode) relay.
+        NetworkEntity__c vendor = new NetworkEntity__c(
+            Name = 'Relay Test Vendor', EntityTypePk__c = 'Vendor', StatusPk__c = 'Active'
+        );
+        insert new List<NetworkEntity__c>{ client, vendor };
+
+        WorkItem__c linkedWorkItem = new WorkItem__c(
+            BriefDescriptionTxt__c       = 'Relay Client Work Item',
+            StageNamePk__c               = 'In Development',
+            ClientNetworkEntityLookup__c = client.Id
+        );
+        insert linkedWorkItem;
+
+        // Every WorkLog__c is Master-Detail to WorkRequest__c.
+        insert new WorkRequest__c(
+            WorkItemId__c           = linkedWorkItem.Id,
+            DeliveryEntityLookup__c = vendor.Id,
+            QuotedHoursNumber__c    = 20,
+            HourlyRateCurrency__c   = 100,
+            StatusPk__c             = 'Accepted'
+        );
+    }
+
+    /**
+     * @description Resolves a user whose sharing context reproduces the guest REST
+     *              path. Preferred: the real Site Guest User (forced-Private record
+     *              access — the exact context that minted nothing pre-fix; present
+     *              in CI scratch orgs because unpackaged/post deploys the Delivery
+     *              Hub site). Fallback when the org has no active guest user (e.g.
+     *              the upload-beta packaging/validation org, where unpackaged/post
+     *              is not deployed): a fresh minimal Standard User — weaker, since
+     *              WorkItem__c's internal OWD is Public ReadWrite, but it keeps the
+     *              test runnable everywhere while feature-test CI provides the
+     *              true guest-sharing proof.
+     * @return A user to runAs for the restricted-sharing insert.
+     */
+    private static User getRestrictedUser() {
+        List<User> guests = [
+            SELECT Id FROM User
+            WHERE UserType = 'Guest' AND IsActive = true
+            LIMIT 1
+        ];
+        if (!guests.isEmpty()) {
+            return guests[0];
+        }
+        Profile standardProfile = [SELECT Id FROM Profile WHERE Name = 'Standard User' LIMIT 1];
+        String unique = String.valueOf(Crypto.getRandomInteger()).replace('-', '') + Datetime.now().getTime();
+        User restricted = new User(
+            FirstName         = 'Relay',
+            LastName          = 'Restricted',
+            Alias             = 'rlymint',
+            Email             = 'relay.restricted@example.com',
+            Username          = 'relay.restricted.' + unique + '@example.com',
+            ProfileId         = standardProfile.Id,
+            TimeZoneSidKey    = 'America/New_York',
+            LocaleSidKey      = 'en_US',
+            EmailEncodingKey  = 'UTF-8',
+            LanguageLocaleKey = 'en_US'
+        );
+        // Setup-object DML wrapped in runAs to dodge MIXED_DML with the
+        // WorkLog__c DML that follows in the same test transaction.
+        System.runAs(new User(Id = UserInfo.getUserId())) {
+            insert restricted;
+        }
+        return restricted;
+    }
+
+    /**
+     * @description KILLER REGRESSION (guest REST relay mint). A WorkLog inserted
+     *              under a user with no sharing access to WorkItem__c /
+     *              WorkRequest__c must STILL mint its outbound relay. Pre-fix
+     *              (`with sharing` handler owning the eligibility queries) this
+     *              minted zero SyncItems under the Site Guest User; post-fix the
+     *              `without sharing` DeliveryWorkLogRelayMinter mints exactly one
+     *              Hub-mode relay — matching DeliverySyncEngine, which already ran
+     *              `without sharing` and minted WorkItem relays in the same guest
+     *              transactions.
+     */
+    @IsTest
+    static void testRelayMintsUnderGuestSharingContext() {
+        WorkItem__c workItem = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Relay Client Work Item' LIMIT 1];
+        WorkRequest__c request = [SELECT Id FROM WorkRequest__c WHERE WorkItemId__c = :workItem.Id LIMIT 1];
+        User restricted = getRestrictedUser();
+
+        System.runAs(restricted) {
+            Test.startTest();
+            insert new WorkLog__c(
+                RequestId__c          = request.Id,
+                WorkItemLookup__c     = workItem.Id,
+                HoursLoggedNumber__c  = 2.5,
+                WorkDateDate__c       = Date.today(),
+                WorkDescriptionTxt__c = 'Inbound REST worklog (guest context)'
+            );
+            Test.stopTest();
+        }
+
+        // Assert OUTSIDE runAs — the restricted user can't see the SyncItems either.
+        List<SyncItem__c> items = [
+            SELECT ObjectTypePk__c, DirectionPk__c, StatusPk__c, RequestLookup__c
+            FROM SyncItem__c
+            WHERE WorkItemLookup__c = :workItem.Id
+            AND ObjectTypePk__c = 'WorkLog__c'
+        ];
+        System.assertEquals(1, items.size(),
+            'Relay must mint under a guest/restricted sharing context — empty means the '
+            + 'eligibility queries ran with sharing enforced and the worklog will never sync onward');
+        System.assertEquals('Outbound', items[0].DirectionPk__c, 'Relay must be Outbound');
+        System.assertEquals('Queued', items[0].StatusPk__c, 'Relay must be Queued for the dispatcher');
+        System.assertEquals(null, items[0].RequestLookup__c,
+            'Expected the Hub-mode relay (vendor route has no endpoint in this setup)');
+    }
+
+    /**
+     * @description Direct-call sanity check: mintForLogs with an eligible WorkLog
+     *              produces one Hub-mode relay carrying the payload fields the
+     *              receiver ingestor needs.
+     */
+    @IsTest
+    static void testMintForLogsDirectCall() {
+        WorkItem__c workItem = [SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c = 'Relay Client Work Item' LIMIT 1];
+        WorkRequest__c request = [SELECT Id FROM WorkRequest__c WHERE WorkItemId__c = :workItem.Id LIMIT 1];
+
+        DeliveryTriggerControl.disableAfterLogic();
+        WorkLog__c log = new WorkLog__c(
+            RequestId__c          = request.Id,
+            WorkItemLookup__c     = workItem.Id,
+            HoursLoggedNumber__c  = 1.0,
+            WorkDateDate__c       = Date.today(),
+            WorkDescriptionTxt__c = 'Direct mint call'
+        );
+        insert log;
+        DeliveryTriggerControl.enableAfterLogic();
+
+        Test.startTest();
+        DeliveryWorkLogRelayMinter.mintForLogs(new List<WorkLog__c>{ log });
+        Test.stopTest();
+
+        List<SyncItem__c> items = [
+            SELECT GlobalSourceIdTxt__c, PayloadTxt__c, StatusPk__c
+            FROM SyncItem__c
+            WHERE LocalRecordIdTxt__c = :log.Id
+            AND DirectionPk__c = 'Outbound'
+        ];
+        System.assertEquals(1, items.size(), 'Direct mint should produce one outbound relay');
+        System.assertEquals((String) log.Id, items[0].GlobalSourceIdTxt__c,
+            'Birthplace WorkLog mints its own Id as GlobalSourceId');
+        System.assert(items[0].PayloadTxt__c.contains('HoursLoggedNumber__c'),
+            'Payload must carry the hours field');
+    }
+
+    /**
+     * @description mintForLogs must no-op cleanly when no log has a parent WorkItem.
+     */
+    @IsTest
+    static void testMintForLogsNoParentNoOp() {
+        Test.startTest();
+        DeliveryWorkLogRelayMinter.mintForLogs(new List<WorkLog__c>{ new WorkLog__c(HoursLoggedNumber__c = 1.0) });
+        Test.stopTest();
+        System.assertEquals(0, [SELECT COUNT() FROM SyncItem__c], 'No parent WorkItem → no relay');
+    }
+}

--- a/force-app/main/default/classes/DeliveryWorkLogRelayMinterTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkLogRelayMinterTest.cls
@@ -90,15 +90,20 @@ private class DeliveryWorkLogRelayMinterTest {
     }
 
     /**
-     * @description KILLER REGRESSION (guest REST relay mint). A WorkLog inserted
-     *              under a user with no sharing access to WorkItem__c /
-     *              WorkRequest__c must STILL mint its outbound relay. Pre-fix
-     *              (`with sharing` handler owning the eligibility queries) this
-     *              minted zero SyncItems under the Site Guest User; post-fix the
-     *              `without sharing` DeliveryWorkLogRelayMinter mints exactly one
-     *              Hub-mode relay — matching DeliverySyncEngine, which already ran
-     *              `without sharing` and minted WorkItem relays in the same guest
-     *              transactions.
+     * @description KILLER REGRESSION (guest REST relay mint). The mint queries
+     *              executed under a user with no sharing access to WorkItem__c /
+     *              WorkRequest__c must STILL find the parents and mint the relay.
+     *              Pre-fix (`with sharing` handler owning the eligibility queries)
+     *              this minted zero SyncItems under the Site Guest User; post-fix
+     *              the `without sharing` DeliveryWorkLogRelayMinter mints exactly
+     *              one Hub-mode relay — matching DeliverySyncEngine, which already
+     *              ran `without sharing` and minted WorkItem relays in the same
+     *              guest transactions. The WorkLog DML itself runs as admin: the
+     *              restricted user cannot perform the insert in test context (the
+     *              platform rejects the master-detail WorkRequest__c reference
+     *              with INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY before any
+     *              trigger fires) — in production the guest never owns that DML
+     *              either; the without-sharing ingestor does.
      */
     @IsTest
     static void testRelayMintsUnderGuestSharingContext() {
@@ -106,15 +111,20 @@ private class DeliveryWorkLogRelayMinterTest {
         WorkRequest__c request = [SELECT Id FROM WorkRequest__c WHERE WorkItemId__c = :workItem.Id LIMIT 1];
         User restricted = getRestrictedUser();
 
+        DeliveryTriggerControl.disableAfterLogic();
+        WorkLog__c log = new WorkLog__c(
+            RequestId__c          = request.Id,
+            WorkItemLookup__c     = workItem.Id,
+            HoursLoggedNumber__c  = 2.5,
+            WorkDateDate__c       = Date.today(),
+            WorkDescriptionTxt__c = 'Inbound REST worklog (guest context)'
+        );
+        insert log;
+        DeliveryTriggerControl.enableAfterLogic();
+
         System.runAs(restricted) {
             Test.startTest();
-            insert new WorkLog__c(
-                RequestId__c          = request.Id,
-                WorkItemLookup__c     = workItem.Id,
-                HoursLoggedNumber__c  = 2.5,
-                WorkDateDate__c       = Date.today(),
-                WorkDescriptionTxt__c = 'Inbound REST worklog (guest context)'
-            );
+            DeliveryWorkLogRelayMinter.mintForLogs(new List<WorkLog__c>{ log });
             Test.stopTest();
         }
 
@@ -180,6 +190,9 @@ private class DeliveryWorkLogRelayMinterTest {
         Test.startTest();
         DeliveryWorkLogRelayMinter.mintForLogs(new List<WorkLog__c>{ new WorkLog__c(HoursLoggedNumber__c = 1.0) });
         Test.stopTest();
-        System.assertEquals(0, [SELECT COUNT() FROM SyncItem__c], 'No parent WorkItem → no relay');
+        // Scope to WorkLog relays — @TestSetup's WorkItem/NetworkEntity inserts mint
+        // their own (non-WorkLog) SyncItems via DeliverySyncEngine.
+        System.assertEquals(0, [SELECT COUNT() FROM SyncItem__c WHERE ObjectTypePk__c = 'WorkLog__c'],
+            'No parent WorkItem → no relay');
     }
 }

--- a/force-app/main/default/classes/DeliveryWorkLogRelayMinterTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryWorkLogRelayMinterTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryWorkLogTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryWorkLogTriggerHandler.cls
@@ -213,72 +213,18 @@ public with sharing class DeliveryWorkLogTriggerHandler {
 
     // ── Shared sync item creation ──────────────────────────────────────
 
-    @SuppressWarnings('PMD.CyclomaticComplexity')
+    /**
+     * @description Delegates outbound relay minting to DeliveryWorkLogRelayMinter.
+     *              The mint path lives in a dedicated `without sharing` class because
+     *              inbound worklogs arrive via REST under the Site Guest User, whose
+     *              record access is forced Private — inside this `with sharing`
+     *              handler the WITH SYSTEM_MODE eligibility queries (FLS bypass only,
+     *              sharing still enforced) returned empty and no relay was minted
+     *              (2026-06 nimba: 65 rows / 138.5h never reached the billing org).
+     * @param logs Sync-eligible WorkLog__c records (approval gate already applied).
+     */
     private static void createSyncItemsForLogs(List<WorkLog__c> logs) {
-        Set<Id> workItemIds = new Set<Id>();
-        for (WorkLog__c wl : logs) {
-            if (wl.WorkItemLookup__c != null) {
-                workItemIds.add(wl.WorkItemLookup__c);
-            }
-        }
-        if (workItemIds.isEmpty()) {
-            return;
-        }
-
-        // ── Hub mode: upstream to Client ───────────────────────────────
-        // Eligible iff the parent WorkItem's ClientNetworkEntityLookup__c
-        // is Client/Both with a populated endpoint. Without this guard
-        // WorkLogs shipped to orgs that never received the parent WorkItem
-        // (T-0129: 8.5h on dh-prod as orphan inbound, permanently unbillable
-        // until manual hand-firing).
-        Map<Id, WorkItem__c> clientWorkItems = new Map<Id, WorkItem__c>([
-            SELECT Id, ClientNetworkEntityLookup__c
-            FROM WorkItem__c
-            WHERE Id IN :workItemIds
-            AND ClientNetworkEntityLookup__c != null
-            AND ClientNetworkEntityLookup__r.EntityTypePk__c IN ('Client', 'Both')
-            AND ClientNetworkEntityLookup__r.IntegrationEndpointUrlTxt__c != null
-            WITH SYSTEM_MODE
-        ]);
-
-        // ── Push mode: downstream to Vendor via WorkRequest bridge ─────
-        // Mirrors the Push branch in DeliverySyncEngine.captureChanges
-        // (lines 86-104) so WorkLog outbound also fans out via active
-        // WorkRequest connections to Vendor/Both entities. Pre-fix the WL
-        // handler ONLY did Hub mode — orgs whose WI parent had no Client
-        // entry (e.g. MF-Prod, where the only NetworkEntity is Cloud Nimbus
-        // as a Vendor) silently dropped every WorkLog outbound. Empirically:
-        // MF-Prod 9 WLs inserted 2026-05-01 → zero SyncItems → 69.5h had
-        // to be manually mirrored to dh-prod for the April invoice.
-        Map<Id, List<WorkRequest__c>> pushRoutes = new Map<Id, List<WorkRequest__c>>();
-        for (WorkRequest__c req : [
-            SELECT Id, WorkItemId__c, RemoteWorkItemIdTxt__c
-            FROM WorkRequest__c
-            WHERE WorkItemId__c IN :workItemIds
-            AND StatusPk__c != 'Inactive'
-            AND DeliveryEntityLookup__c != null
-            AND DeliveryEntityLookup__r.EntityTypePk__c IN ('Vendor', 'Both')
-            AND DeliveryEntityLookup__r.IntegrationEndpointUrlTxt__c != null
-            WITH SYSTEM_MODE
-        ]) {
-            if (!pushRoutes.containsKey(req.WorkItemId__c)) {
-                pushRoutes.put(req.WorkItemId__c, new List<WorkRequest__c>());
-            }
-            pushRoutes.get(req.WorkItemId__c).add(req);
-        }
-
-        if (clientWorkItems.isEmpty() && pushRoutes.isEmpty()) {
-            return;
-        }
-
-        List<SyncItem__c> syncItems = buildSyncItems(logs, clientWorkItems);
-        syncItems.addAll(buildPushSyncItems(logs, pushRoutes));
-        if (!syncItems.isEmpty()) {
-            Database.insert(syncItems, AccessLevel.SYSTEM_MODE);
-            if (!Test.isRunningTest() && Limits.getQueueableJobs() == 0 && !System.isQueueable() && !System.isFuture()) {
-                System.enqueueJob(new DeliverySyncItemProcessor());
-            }
-        }
+        DeliveryWorkLogRelayMinter.mintForLogs(logs);
     }
 
     // ── Approval gate filter ───────────────────────────────────────────
@@ -315,131 +261,4 @@ public with sharing class DeliveryWorkLogTriggerHandler {
         return settings.RequireWorkLogApprovalDateTime__c != null;
     }
 
-    /**
-     * @description Builds the list of SyncItem__c records for WorkLogs on client-linked work items.
-     * @param logs The WorkLog records to evaluate.
-     * @param clientWorkItems Map of work item Ids that have a client entity linked.
-     * @return List of SyncItem__c records ready for insert.
-     */
-    private static List<SyncItem__c> buildSyncItems(List<WorkLog__c> logs, Map<Id, WorkItem__c> clientWorkItems) {
-        String senderOrgId = UserInfo.getOrganizationId();
-        Map<Id, String> recordToGlobalSource = buildGlobalSourceMap(logs);
-        List<SyncItem__c> items = new List<SyncItem__c>();
-        for (WorkLog__c wl : logs) {
-            if (!clientWorkItems.containsKey(wl.WorkItemLookup__c)) {
-                continue;
-            }
-            // Inherit the ORIGIN GlobalSourceId if this WorkLog arrived via an
-            // inbound relay; otherwise this org is the birthplace and the id
-            // is minted from the local record. Without inheritance the origin
-            // id is re-minted at every MF → Nimba → dh-prod hop, killing the
-            // cross-path dedup on the receiver and duplicating invoice hours.
-            String gsid = recordToGlobalSource.containsKey(wl.Id)
-                ? recordToGlobalSource.get(wl.Id)
-                : (String) wl.Id;
-            Map<String, Object> payload = new Map<String, Object>{
-                'SourceId'               => wl.Id,
-                'SenderOrgId'            => senderOrgId,
-                'GlobalSourceId'         => gsid,
-                'WorkItemLookup__c'          => wl.WorkItemLookup__c,
-                'HoursLoggedNumber__c'   => wl.HoursLoggedNumber__c,
-                'WorkDateDate__c'        => String.valueOf(wl.WorkDateDate__c),
-                'WorkDescriptionTxt__c'  => wl.WorkDescriptionTxt__c
-            };
-            items.add(new SyncItem__c(
-                ObjectTypePk__c         = 'WorkLog__c',
-                LocalRecordIdTxt__c     = wl.Id,
-                WorkItemLookup__c           = wl.WorkItemLookup__c,
-                DirectionPk__c          = 'Outbound',
-                StatusPk__c             = 'Queued',
-                GlobalSourceIdTxt__c    = gsid,
-                PayloadTxt__c           = JSON.serialize(payload)
-            ));
-        }
-        return items;
-    }
-
-    /**
-     * @description Bulk-loads the origin GlobalSourceId for a set of WorkLogs by
-     *              walking their Inbound SyncItem ledger rows. Mirrors the
-     *              inheritance map built in DeliverySyncEngine.captureChanges so
-     *              relayed WorkLogs keep their birthplace id across hops instead
-     *              of re-minting it at every relay. One query, no SOQL-in-loop.
-     * @param logs The WorkLog records about to be emitted outbound.
-     * @return Map of WorkLog Id → inherited origin GlobalSourceId. WorkLogs with
-     *         no inbound ledger row are absent (caller treats absence as birthplace).
-     */
-    private static Map<Id, String> buildGlobalSourceMap(List<WorkLog__c> logs) {
-        Map<Id, String> recordToGlobalSource = new Map<Id, String>();
-        Set<Id> idSet = new Set<Id>();
-        for (WorkLog__c wl : logs) {
-            idSet.add(wl.Id);
-        }
-        if (idSet.isEmpty()) {
-            return recordToGlobalSource;
-        }
-        for (SyncItem__c inbound : [
-            SELECT LocalRecordIdTxt__c, GlobalSourceIdTxt__c
-            FROM SyncItem__c
-            WHERE LocalRecordIdTxt__c IN :idSet
-            AND GlobalSourceIdTxt__c != NULL
-            AND DirectionPk__c = 'Inbound'
-            WITH SYSTEM_MODE
-        ]) {
-            recordToGlobalSource.put((Id) inbound.LocalRecordIdTxt__c, inbound.GlobalSourceIdTxt__c);
-        }
-        return recordToGlobalSource;
-    }
-
-    /**
-     * @description Builds Push-mode outbound SyncItem__c records — one per
-     *              (WorkLog × WorkRequest-route) pair — for every WorkLog
-     *              whose parent WorkItem fans out to a Vendor/Both
-     *              NetworkEntity through an active WorkRequest bridge.
-     *              Mirrors the Hub-mode buildSyncItems shape but populates
-     *              RequestLookup__c + payload.TargetId so the dispatcher
-     *              routes via the WorkRequest's DeliveryEntity endpoint.
-     * @param logs The WorkLog__c records being synced.
-     * @param pushRoutes Map of parent WorkItem Id → list of active
-     *                   WorkRequest connections to Vendor/Both entities.
-     * @return List of Push-mode SyncItem__c records ready for insert.
-     */
-    private static List<SyncItem__c> buildPushSyncItems(List<WorkLog__c> logs, Map<Id, List<WorkRequest__c>> pushRoutes) {
-        String senderOrgId = UserInfo.getOrganizationId();
-        Map<Id, String> recordToGlobalSource = buildGlobalSourceMap(logs);
-        List<SyncItem__c> items = new List<SyncItem__c>();
-        for (WorkLog__c wl : logs) {
-            List<WorkRequest__c> reqs = pushRoutes.get(wl.WorkItemLookup__c);
-            if (reqs == null || reqs.isEmpty()) {
-                continue;
-            }
-            // Inherit origin GlobalSourceId across relay hops (see buildSyncItems).
-            String gsid = recordToGlobalSource.containsKey(wl.Id)
-                ? recordToGlobalSource.get(wl.Id)
-                : (String) wl.Id;
-            for (WorkRequest__c req : reqs) {
-                Map<String, Object> payload = new Map<String, Object>{
-                    'SourceId'               => wl.Id,
-                    'SenderOrgId'            => senderOrgId,
-                    'GlobalSourceId'         => gsid,
-                    'TargetId'               => req.RemoteWorkItemIdTxt__c,
-                    'WorkItemLookup__c'      => wl.WorkItemLookup__c,
-                    'HoursLoggedNumber__c'   => wl.HoursLoggedNumber__c,
-                    'WorkDateDate__c'        => String.valueOf(wl.WorkDateDate__c),
-                    'WorkDescriptionTxt__c'  => wl.WorkDescriptionTxt__c
-                };
-                items.add(new SyncItem__c(
-                    ObjectTypePk__c         = 'WorkLog__c',
-                    LocalRecordIdTxt__c     = wl.Id,
-                    WorkItemLookup__c       = wl.WorkItemLookup__c,
-                    RequestLookup__c        = req.Id,
-                    DirectionPk__c          = 'Outbound',
-                    StatusPk__c             = 'Queued',
-                    GlobalSourceIdTxt__c    = gsid,
-                    PayloadTxt__c           = JSON.serialize(payload)
-                ));
-            }
-        }
-        return items;
-    }
 }

--- a/force-app/main/default/permissionsets/DeliveryHubGuestUser.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubGuestUser.permissionset-meta.xml
@@ -56,6 +56,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryWorkLogRelayMinter</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>WebhookSignatureVerifier</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/unpackaged/post/testSuites/DH.testSuite-meta.xml
+++ b/unpackaged/post/testSuites/DH.testSuite-meta.xml
@@ -33,6 +33,7 @@
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryWorkItemQuotesControllerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryWorkItemTriggerHandlerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryTimeLoggerControllerTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryWorkLogRelayMinterTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryWorkLogTriggerHandlerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryWorkflowConfigServiceTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryEscalationServiceTest</testClassName>


### PR DESCRIPTION
## What

WorkLog relays from guest-site REST transactions (MF -> nimba POSTs) silently never minted: 65 June rows / 138.5h never relayed to the billing org. WorkItem relays in the SAME transactions DID mint.

## Root cause (live-diagnosed on nimba 2026-06)

Inbound worklogs run the WorkLog trigger as the Delivery Hub Site Guest User (record access forced Private). `DeliveryWorkLogTriggerHandler` is `with sharing`, and its relay eligibility queries on `WorkItem__c`/`WorkRequest__c` use `WITH SYSTEM_MODE` — which bypasses FLS but NOT sharing. The queries returned empty for the guest and the mint no-opped with no error. `DeliverySyncEngine` is `without sharing` (the repo's own sync-path precedent), which is why WorkItem relays worked.

## Fix (minimal blast radius)

- Extract the relay-mint path (eligibility queries + `buildSyncItems`/`buildPushSyncItems`/`buildGlobalSourceMap`) into **`DeliveryWorkLogRelayMinter`**, a dedicated `without sharing` class with the incident documented at the declaration.
- Handler keeps `with sharing` for everything else (field defaults, lockout, approval gate, title autofill) and delegates minting.
- `DeliveryHubGuestUser` permset: classAccess for the new class.
- Test class includes a guest-context `runAs` regression.
- `docs/ARCHITECTURE.md`: sync sharing rule documented.

## After merge

Re-run `delivery.DeliveryHubScheduler.reconcileNow()` on nimba was already done manually (65 rows minted); this PR makes the trigger path mint on its own going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)