### PR TITLE
refactor: unify terminal-stage definitions on the WorkflowStage CMT

### DIFF
--- a/force-app/main/default/classes/DeliveryApprovalSummaryController.cls
+++ b/force-app/main/default/classes/DeliveryApprovalSummaryController.cls
@@ -49,9 +49,9 @@ public with sharing class DeliveryApprovalSummaryController {
     };
 
     /**
-     * WorkItem__c stages excluded from the active portfolio scope. CMT-driven
-     * cross-type terminal union so the pitch denominator matches the active
-     * definition every other dashboard/forecast count uses.
+     * @description WorkItem__c stages excluded from the active portfolio scope.
+     * CMT-driven cross-type terminal union so the pitch denominator matches the
+     * active definition every other dashboard/forecast count uses.
      */
     @TestVisible
     private static Set<String> terminalStages {

--- a/force-app/main/default/classes/DeliveryApprovalSummaryController.cls
+++ b/force-app/main/default/classes/DeliveryApprovalSummaryController.cls
@@ -49,15 +49,20 @@ public with sharing class DeliveryApprovalSummaryController {
     };
 
     /**
-     * WorkItem__c stages excluded from the active portfolio scope. Mirrors
-     * DeliveryHoursAnalyticsController's portfolio filter (the board's
-     * canonical "Active" definition) so the pitch denominator matches the
-     * numbers the forecast and gantt board already show.
+     * WorkItem__c stages excluded from the active portfolio scope. CMT-driven
+     * cross-type terminal union so the pitch denominator matches the active
+     * definition every other dashboard/forecast count uses.
      */
     @TestVisible
-    private static final Set<String> TERMINAL_STAGES = new Set<String>{
-        'Done', 'Cancelled', 'Closed', 'Rejected'
-    };
+    private static Set<String> terminalStages {
+        get {
+            if (terminalStages == null) {
+                terminalStages = DeliveryWorkflowConfigService.getAllTerminalStageValues();
+            }
+            return terminalStages;
+        }
+        set;
+    }
 
     /**
      * @description The three agenda tiles, the approved-vs-total pitch pair,
@@ -176,7 +181,7 @@ public with sharing class DeliveryApprovalSummaryController {
             WHERE ActivatedDateTime__c != NULL
               AND ArchivedDateTime__c = NULL
               AND TemplateMarkedDateTime__c = NULL
-              AND StageNamePk__c NOT IN :TERMINAL_STAGES
+              AND StageNamePk__c NOT IN :terminalStages
             WITH SYSTEM_MODE
         ];
         Decimal est = (Decimal) row.get('est');

--- a/force-app/main/default/classes/DeliveryDashboardCardController.cls
+++ b/force-app/main/default/classes/DeliveryDashboardCardController.cls
@@ -8,6 +8,17 @@
 @SuppressWarnings('PMD.ApexDoc, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryDashboardCardController {
 
+    /** @description Terminal stages excluded from active-scope card counts (CMT-driven cross-type union). */
+    private static Set<String> terminalStages {
+        get {
+            if (terminalStages == null) {
+                terminalStages = DeliveryWorkflowConfigService.getAllTerminalStageValues();
+            }
+            return terminalStages;
+        }
+        set;
+    }
+
     @AuraEnabled(cacheable=true)
     global static List<CardConfig> getCardsForPage(String pageKey) {
         String currentProfile = [SELECT Profile.Name FROM User WHERE Id = :UserInfo.getUserId() WITH SYSTEM_MODE].Profile.Name;
@@ -103,7 +114,7 @@ global with sharing class DeliveryDashboardCardController {
                     WHERE EstimatedEndDevDate__c < :Date.today()
                     AND ActivatedDateTime__c != NULL
                     AND ArchivedDateTime__c = NULL
-                    AND StageNamePk__c NOT IN ('Done', 'Cancelled', 'Closed', 'Rejected')
+                    AND StageNamePk__c NOT IN :terminalStages
                     WITH SYSTEM_MODE
                 ];
             }
@@ -270,7 +281,7 @@ global with sharing class DeliveryDashboardCardController {
                     WHERE ActivatedDateTime__c != NULL
                     AND ArchivedDateTime__c = NULL
                     AND TemplateMarkedDateTime__c = NULL
-                    AND StageNamePk__c NOT IN ('Done', 'Cancelled', 'Closed', 'Rejected')
+                    AND StageNamePk__c NOT IN :terminalStages
                     AND EstimatedHoursNumber__c != NULL
                     AND EstimatedHoursNumber__c > 0
                     WITH SYSTEM_MODE

--- a/force-app/main/default/classes/DeliveryForecastAlertService.cls
+++ b/force-app/main/default/classes/DeliveryForecastAlertService.cls
@@ -60,10 +60,16 @@ global with sharing class DeliveryForecastAlertService {
     @TestVisible
     private static final Integer MAX_WORKITEMS_PER_SWEEP = 20;
 
-    /** @description Terminal stages — exclude from sweep. */
-    private static final Set<String> TERMINAL_STAGES = new Set<String>{
-        'Done', 'Cancelled', 'Closed', 'Rejected'
-    };
+    /** @description Terminal stages — exclude from sweep (CMT-driven cross-type union). */
+    private static Set<String> terminalStages {
+        get {
+            if (terminalStages == null) {
+                terminalStages = DeliveryWorkflowConfigService.getAllTerminalStageValues();
+            }
+            return terminalStages;
+        }
+        set;
+    }
 
     /**
      * @description Runs the daily sweep. Called by DeliveryForecastAlertQueueable
@@ -92,7 +98,7 @@ global with sharing class DeliveryForecastAlertService {
               AND ActivatedDateTime__c != NULL
               AND ArchivedDateTime__c = NULL
               AND TemplateMarkedDateTime__c = NULL
-              AND StageNamePk__c NOT IN :TERMINAL_STAGES
+              AND StageNamePk__c NOT IN :terminalStages
               AND EstimatedHoursNumber__c != NULL
               AND EstimatedHoursNumber__c > 0
             WITH SYSTEM_MODE

--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -238,7 +238,7 @@ public with sharing class DeliveryGanttController {
         Boolean hasEngineeredEnd = item.EstimatedEndDevDate__c != null
             || item.ProjectedUATReadyDate__c != null
             || item.CalculatedETADate__c != null;
-        Boolean isTerminal = TERMINAL_STAGES.contains(item.StageNamePk__c);
+        Boolean isTerminal = terminalStages.contains(item.StageNamePk__c);
 
         // Terminal items without engineered dates use LastModifiedDate as a real
         // completion timestamp; otherwise the existing fallback chain handles it.
@@ -377,12 +377,20 @@ public with sharing class DeliveryGanttController {
      * @description Stage values considered terminal for Gantt rendering. Terminal
      *              items receive their LastModifiedDate as the bar end instead of
      *              the synthesized +14-day forward bar that the fallback chain
-     *              would otherwise produce. Hardcoded here (not CMT-driven) so the
-     *              Gantt's terminal definition stays stable across workflow types.
+     *              would otherwise produce. CMT-driven cross-type union plus
+     *              'Deployed to Prod' (ship-loop: workflow-active but no remaining
+     *              schedulable effort) — spans all workflow types because the Gantt
+     *              renders items regardless of type.
      */
-    private static final Set<String> TERMINAL_STAGES = new Set<String>{
-        'Done', 'Deployed to Prod', 'Cancelled', 'Closed', 'Rejected'
-    };
+    private static Set<String> terminalStages {
+        get {
+            if (terminalStages == null) {
+                terminalStages = DeliveryWorkflowConfigService.getAllEffortTerminalStageValues();
+            }
+            return terminalStages;
+        }
+        set;
+    }
 
     /** @description Days back from today that count as "recently done" for the style decorator. */
     private static final Integer RECENTLY_DONE_WINDOW_DAYS = 7;
@@ -409,7 +417,7 @@ public with sharing class DeliveryGanttController {
      * @param item The work item being mapped
      * @param startDt The already-resolved start date for fallback anchoring
      * @param hasEngineeredEnd True when at least one engineered end-date field is set
-     * @param isTerminal True when the item's stage is in TERMINAL_STAGES
+     * @param isTerminal True when the item's stage is in terminalStages
      * @return The end date the Gantt should render
      */
     private static Date chooseEndDate(WorkItem__c item, Date startDt, Boolean hasEngineeredEnd, Boolean isTerminal) {
@@ -1050,7 +1058,7 @@ public with sharing class DeliveryGanttController {
         if (looksPaused) {
             return 'deferred';
         }
-        if (TERMINAL_STAGES.contains(stage)) {
+        if (terminalStages.contains(stage)) {
             return 'follow-on';
         }
         Boolean isActive = ACTIVE_STAGES.contains(stage);
@@ -1287,7 +1295,7 @@ public with sharing class DeliveryGanttController {
         Boolean hasEngineeredEnd = item.EstimatedEndDevDate__c != null
             || item.ProjectedUATReadyDate__c != null
             || item.CalculatedETADate__c != null;
-        Boolean isTerminal = TERMINAL_STAGES.contains(item.StageNamePk__c);
+        Boolean isTerminal = terminalStages.contains(item.StageNamePk__c);
         Date endDt = chooseEndDate(item, startDt, hasEngineeredEnd, isTerminal);
         if (endDt < startDt) {
             endDt = startDt.addDays(1);

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
@@ -336,10 +336,16 @@ global with sharing class DeliveryHoursAnalyticsController {
     /** @description Months in a quarter — period stepping for Quarter granularity. */
     private static final Integer MONTHS_PER_QUARTER = 3;
 
-    /** @description Terminal stages excluded from the active-portfolio scope. */
-    private static final Set<String> TERMINAL_STAGES = new Set<String>{
-        'Done', 'Cancelled', 'Closed', 'Rejected'
-    };
+    /** @description Terminal stages excluded from the active-portfolio scope (CMT-driven cross-type union). */
+    private static Set<String> terminalStages {
+        get {
+            if (terminalStages == null) {
+                terminalStages = DeliveryWorkflowConfigService.getAllTerminalStageValues();
+            }
+            return terminalStages;
+        }
+        set;
+    }
 
     /**
      * @description Maps a WorkItem `PriorityGroupPk__c` lane onto the NG stacked-forecast
@@ -851,7 +857,7 @@ global with sharing class DeliveryHoursAnalyticsController {
               AND ActivatedDateTime__c != NULL
               AND ArchivedDateTime__c = NULL
               AND TemplateMarkedDateTime__c = NULL
-              AND StageNamePk__c NOT IN :TERMINAL_STAGES
+              AND StageNamePk__c NOT IN :terminalStages
             WITH SYSTEM_MODE
             LIMIT :MAX_PORTFOLIO_ROOTS
         ]) {
@@ -976,7 +982,7 @@ global with sharing class DeliveryHoursAnalyticsController {
             // their remaining here and in spreadScheduleBasedForecast via the same stage
             // flag (carried on ItemSchedule.stage).
             Boolean isTerminal = String.isNotBlank(wi.StageNamePk__c)
-                && TERMINAL_STAGES.contains(wi.StageNamePk__c);
+                && terminalStages.contains(wi.StageNamePk__c);
             Decimal estimate = (wi.EstimatedHoursNumber__c == null) ? 0 : wi.EstimatedHoursNumber__c;
             dto.totalEstimatedHours += estimate;
             Decimal logged = loggedByItem.containsKey(wi.Id) ? loggedByItem.get(wi.Id) : 0;
@@ -1308,7 +1314,7 @@ global with sharing class DeliveryHoursAnalyticsController {
         for (ItemSchedule sched : portfolioItemSchedules) {
             // Terminal-stage items contribute 0 remaining — never spread onto a forecast
             // bar and never pushed into the unscheduled bucket (dead work isn't forecast).
-            if (String.isNotBlank(sched.stage) && TERMINAL_STAGES.contains(sched.stage)) {
+            if (String.isNotBlank(sched.stage) && terminalStages.contains(sched.stage)) {
                 continue;
             }
             Decimal itemRemaining = sched.estimate - sched.logged;

--- a/force-app/main/default/classes/DeliveryWorkItemETAService.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemETAService.cls
@@ -12,6 +12,21 @@
 @SuppressWarnings('PMD.AvoidGlobalModifier')
 global with sharing class DeliveryWorkItemETAService {
 
+    /**
+     * @description Stages carrying no remaining schedulable effort (CMT-driven
+     * cross-type terminal union + 'Deployed to Prod'): excluded from the
+     * simulation queue and treated as resolved when evaluating blockers.
+     */
+    private static Set<String> effortTerminalStages {
+        get {
+            if (effortTerminalStages == null) {
+                effortTerminalStages = DeliveryWorkflowConfigService.getAllEffortTerminalStageValues();
+            }
+            return effortTerminalStages;
+        }
+        set;
+    }
+
     // #################################################################################
     // SECTION 1: LWC Integration & DTOs
     // #################################################################################
@@ -66,7 +81,7 @@ global with sharing class DeliveryWorkItemETAService {
                 SELECT BlockedWorkItemLookup__c FROM WorkItemDependency__c
                 WHERE BlockedWorkItemLookup__c IN :processedIds
                 AND BlockingWorkItemLookup__c NOT IN (
-                    SELECT Id FROM WorkItem__c WHERE StageNamePk__c IN ('Done', 'Deployed to Prod', 'Cancelled')
+                    SELECT Id FROM WorkItem__c WHERE StageNamePk__c IN :DeliveryWorkItemETAService.effortTerminalStages
                 )
                 WITH SYSTEM_MODE
             ]) {
@@ -375,7 +390,7 @@ global with sharing class DeliveryWorkItemETAService {
                        DeveloperDaysSizeNumber__c, EstimatedHoursNumber__c,
                        SortOrderNumber__c, DeveloperLookup__c, CreatedDate
                 FROM WorkItem__c
-                WHERE StageNamePk__c NOT IN ('Done', 'Deployed to Prod', 'Cancelled')
+                WHERE StageNamePk__c NOT IN :DeliveryWorkItemETAService.effortTerminalStages
                   AND (
                       (DeveloperDaysSizeNumber__c != null AND DeveloperDaysSizeNumber__c > 0)
                       OR (EstimatedHoursNumber__c != null AND EstimatedHoursNumber__c > 0)
@@ -395,7 +410,7 @@ global with sharing class DeliveryWorkItemETAService {
             return [
                 SELECT Id
                 FROM WorkItem__c
-                WHERE StageNamePk__c NOT IN ('Done', 'Deployed to Prod', 'Cancelled')
+                WHERE StageNamePk__c NOT IN :DeliveryWorkItemETAService.effortTerminalStages
                   AND (DeveloperDaysSizeNumber__c = null OR DeveloperDaysSizeNumber__c <= 0)
                   AND (EstimatedHoursNumber__c = null OR EstimatedHoursNumber__c <= 0)
                   AND (

--- a/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
@@ -384,11 +384,14 @@ public without sharing class DeliveryWorkItemTriggerHandler {
         }
         if (!workItemsToCheck.isEmpty()) {
             // FIX: Swapped USER_MODE for SYSTEM_MODE
+            // Blockers in any effort-terminal stage (CMT cross-type union + 'Deployed
+            // to Prod') count as resolved and no longer hold their dependents.
+            Set<String> resolvedStages = DeliveryWorkflowConfigService.getAllEffortTerminalStageValues();
             List<WorkItemDependency__c> unresolvedBlockers = [
                 SELECT BlockedWorkItemLookup__c, BlockingWorkItemLookup__r.BriefDescriptionTxt__c, BlockingWorkItemLookup__r.StageNamePk__c
                 FROM WorkItemDependency__c
                 WHERE BlockedWorkItemLookup__c IN :workItemsToCheck
-                AND BlockingWorkItemLookup__r.StageNamePk__c NOT IN ('Done', 'Deployed to Prod', 'Cancelled')
+                AND BlockingWorkItemLookup__r.StageNamePk__c NOT IN :resolvedStages
                 WITH SYSTEM_MODE
             ];
             for (WorkItemDependency__c dependency : unresolvedBlockers) {

--- a/force-app/main/default/classes/DeliveryWorkflowConfigService.cls
+++ b/force-app/main/default/classes/DeliveryWorkflowConfigService.cls
@@ -267,6 +267,61 @@ global with sharing class DeliveryWorkflowConfigService {
     }
 
     /**
+     * @description The ship-loop stage: workflow-ACTIVE (the item still awaits ship
+     * verification before moving to Done) but carrying zero remaining delivery effort.
+     * Single authority for this value — do not re-hardcode it in consumers.
+     */
+    public static final String STAGE_DEPLOYED_TO_PROD = 'Deployed to Prod';
+
+    /**
+     * @description Returns the union of terminal stage ApiValues across ALL workflow
+     * types, for org-wide WorkItem__c queries that cannot filter per type (dashboard
+     * counts, portfolio scopes, sweeps). A value is included only when EVERY workflow
+     * type that uses it marks it terminal — e.g. 'Resolved' is excluded because it is
+     * terminal for Operations but an active stage for Support_Triage, and treating it
+     * as terminal would hide active Support_Triage items from org-wide counts.
+     * @return Set of ApiValue strings terminal in every workflow type that defines them
+     *         (defaults to 'Done','Cancelled' if CMT empty).
+     */
+    public static Set<String> getAllTerminalStageValues() {
+        Set<String> terminal = new Set<String>();
+        Set<String> nonTerminal = new Set<String>();
+        for (WorkflowStage__mdt s : [
+            SELECT ApiValueTxt__c, TerminalDateTime__c
+            FROM WorkflowStage__mdt
+            WITH SYSTEM_MODE
+        ]) {
+            if (s.TerminalDateTime__c != null) {
+                terminal.add(s.ApiValueTxt__c);
+            } else {
+                nonTerminal.add(s.ApiValueTxt__c);
+            }
+        }
+        terminal.removeAll(nonTerminal);
+        // Defensive: if CMT is empty (e.g. scratch org first deploy), default to 'Done'
+        if (terminal.isEmpty()) {
+            terminal.add('Done');
+            terminal.add('Cancelled');
+        }
+        return terminal;
+    }
+
+    /**
+     * @description getAllTerminalStageValues() plus 'Deployed to Prod' — the
+     * "no remaining delivery effort" set. 'Deployed to Prod' is deliberately NOT
+     * terminal in WorkflowStage__mdt (the item is still workflow-active while it
+     * awaits ship verification, so dashboards count it as active work), but it must
+     * not consume forecast/scheduling capacity (Gantt, ETA engine), block dependents,
+     * or raise stuck/SLA watcher signals.
+     * @return Cross-type terminal ApiValues plus the Deployed-to-Prod ship-loop stage.
+     */
+    public static Set<String> getAllEffortTerminalStageValues() {
+        Set<String> result = getAllTerminalStageValues();
+        result.add(STAGE_DEPLOYED_TO_PROD);
+        return result;
+    }
+
+    /**
      * @description Returns the set of attention stage ApiValues for a workflow type.
      * Used by DashboardController to build the Needs Attention section.
      * @param workflowTypeName DeveloperName of the WorkflowType__mdt record.

--- a/force-app/main/default/classes/DeliveryWorkflowConfigServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkflowConfigServiceTest.cls
@@ -106,6 +106,45 @@ private class DeliveryWorkflowConfigServiceTest {
         }
     }
 
+    /**
+     * @description Verifies the cross-type terminal union: includes every value
+     * that is terminal in all types defining it, and excludes collision values
+     * (terminal in one type, active in another) plus active stages.
+     */
+    @isTest
+    static void testGetAllTerminalStageValues() {
+        System.runAs(testUser) {
+            Set<String> terminals = DeliveryWorkflowConfigService.getAllTerminalStageValues();
+            System.assert(terminals.contains('Done'), 'Done (Software_Delivery) must be in the union');
+            System.assert(terminals.contains('Cancelled'), 'Cancelled must be in the union');
+            System.assert(terminals.contains('Closed'), 'Closed (Implementation_Project/Support_Triage) must be in the union');
+            System.assert(terminals.contains('Rejected'), 'Rejected (Change_Management) must be in the union');
+            System.assert(terminals.contains('Completed'), 'Completed (Change_Management/Onboarding) must be in the union');
+            System.assert(!terminals.contains('Resolved'),
+                'Resolved is terminal for Operations but ACTIVE for Support_Triage — the union must exclude it '
+                + 'or org-wide counts would hide active Support_Triage items');
+            System.assert(!terminals.contains('In Development'), 'Active stages must never be in the union');
+            System.assert(!terminals.contains('Deployed to Prod'),
+                'Deployed to Prod is workflow-active (awaits ship verification) — only the EFFORT-terminal set adds it');
+        }
+    }
+
+    /**
+     * @description Verifies the effort-terminal set = terminal union + 'Deployed to Prod'.
+     */
+    @isTest
+    static void testGetAllEffortTerminalStageValues() {
+        System.runAs(testUser) {
+            Set<String> effortTerminals = DeliveryWorkflowConfigService.getAllEffortTerminalStageValues();
+            Set<String> terminals = DeliveryWorkflowConfigService.getAllTerminalStageValues();
+            System.assert(effortTerminals.containsAll(terminals), 'Effort-terminal set must contain the full terminal union');
+            System.assert(effortTerminals.contains(DeliveryWorkflowConfigService.STAGE_DEPLOYED_TO_PROD),
+                'Effort-terminal set must add Deployed to Prod');
+            System.assertEquals(terminals.size() + 1, effortTerminals.size(),
+                'Effort-terminal set must be exactly the terminal union plus Deployed to Prod');
+        }
+    }
+
     @isTest
     static void testGetAttentionStageValues() {
         System.runAs(testUser) {

--- a/force-app/main/default/classes/WatcherSLABreachQueryService.cls
+++ b/force-app/main/default/classes/WatcherSLABreachQueryService.cls
@@ -32,10 +32,16 @@ public with sharing class WatcherSLABreachQueryService {
     @TestVisible
     private static final Integer TOP_ENTRY_CAP = 5;
 
-    /** @description Terminal stages excluded from sweep (matches the SLA formula's `Met` carve-out + adds a couple more). */
-    private static final Set<String> EXCLUDED_STAGES = new Set<String>{
-        'Done', 'Cancelled', 'Closed', 'Rejected', 'Deployed to Prod'
-    };
+    /** @description Stages excluded from sweep: CMT-driven cross-type terminal union + 'Deployed to Prod' (shipped items don't breach SLA). */
+    private static Set<String> excludedStages {
+        get {
+            if (excludedStages == null) {
+                excludedStages = DeliveryWorkflowConfigService.getAllEffortTerminalStageValues();
+            }
+            return excludedStages;
+        }
+        set;
+    }
 
     /**
      * @description Run the signal. Single SOQL over WorkItem__c, filtered by
@@ -64,7 +70,7 @@ public with sharing class WatcherSLABreachQueryService {
               AND ActivatedDateTime__c != NULL
               AND ArchivedDateTime__c = NULL
               AND TemplateMarkedDateTime__c = NULL
-              AND StageNamePk__c NOT IN :EXCLUDED_STAGES
+              AND StageNamePk__c NOT IN :excludedStages
             WITH SYSTEM_MODE
             ORDER BY SLAStatusTxt__c ASC, SLATargetDate__c ASC NULLS LAST
             LIMIT :ROW_CAP

--- a/force-app/main/default/classes/WatcherStuckStageQueryService.cls
+++ b/force-app/main/default/classes/WatcherStuckStageQueryService.cls
@@ -52,10 +52,16 @@ public with sharing class WatcherStuckStageQueryService {
     @TestVisible
     private static final Integer FALLBACK_DAYS = 5;
 
-    /** @description Terminal stages excluded from the sweep regardless of rule definitions. */
-    private static final Set<String> EXCLUDED_STAGES = new Set<String>{
-        'Done', 'Cancelled', 'Closed', 'Rejected', 'Deployed to Prod'
-    };
+    /** @description Stages excluded from the sweep regardless of rule definitions: CMT-driven cross-type terminal union + 'Deployed to Prod' (shipped items aren't stuck). */
+    private static Set<String> excludedStages {
+        get {
+            if (excludedStages == null) {
+                excludedStages = DeliveryWorkflowConfigService.getAllEffortTerminalStageValues();
+            }
+            return excludedStages;
+        }
+        set;
+    }
 
     /**
      * @description Test-only cluster override. When set, query() uses this
@@ -99,7 +105,7 @@ public with sharing class WatcherStuckStageQueryService {
         List<WorkflowEscalationRule__mdt> rules = queryActiveRules();
         for (WorkflowEscalationRule__mdt rule : rules) {
             if (String.isBlank(rule.TriggerStageTxt__c)
-                || EXCLUDED_STAGES.contains(rule.TriggerStageTxt__c)) {
+                || excludedStages.contains(rule.TriggerStageTxt__c)) {
                 continue;
             }
             Integer days = (rule.DaysThresholdNumber__c == null)
@@ -160,7 +166,7 @@ public with sharing class WatcherStuckStageQueryService {
                 FROM WorkItem__c
                 WHERE StageEnteredDateTime__c <= :cutoff
                   AND StageNamePk__c = :stageFilter
-                  AND StageNamePk__c NOT IN :EXCLUDED_STAGES
+                  AND StageNamePk__c NOT IN :excludedStages
                   AND SLAPausedDateTime__c = NULL
                   AND ActivatedDateTime__c != NULL
                   AND ArchivedDateTime__c = NULL

--- a/force-app/main/default/classes/WatcherStuckStageQueryServiceTest.cls
+++ b/force-app/main/default/classes/WatcherStuckStageQueryServiceTest.cls
@@ -125,11 +125,11 @@ private class WatcherStuckStageQueryServiceTest {
     /**
      * @description Terminal stages must be discarded during cluster
      *              construction even when a rule somehow names one of them.
-     *              Validates the EXCLUDED_STAGES guard in buildClustersByStage.
+     *              Validates the excludedStages guard in buildClustersByStage.
      */
     @IsTest
     static void testTerminalStageClusterIsDropped() {
-        // 'Done' is in EXCLUDED_STAGES — should be filtered out at cluster build.
+        // 'Done' is in excludedStages — should be filtered out at cluster build.
         WatcherStuckStageQueryService.testClusterOverride = clusterMap(
             'In Development', 5, false
         );


### PR DESCRIPTION
## The drift bug

Nine classes hand-rolled their own terminal-stage sets, and they drifted (#913 fixed the worst instance on the dashboard). The hardcoded sets were stale cross-type unions:

- `'Closed'` / `'Rejected'` belong to OTHER workflow types (Implementation_Project, Change_Management) — they were copied around as if they were Software_Delivery values.
- Those other types' remaining terminal values (`Completed`, `Won't Fix`, `Denied`, `Paid`) were missing everywhere — e.g. a Change_Management item in `Completed` still counted as "active" in every org-wide scope, Gantt bar, and watcher sweep.

## The fix — two canonical accessors on the existing CMT authority

`DeliveryWorkflowConfigService` (which already owns per-type `getTerminalStageValues`) gains:

1. **`getAllTerminalStageValues()`** — union of `TerminalDateTime__c`-marked ApiValues across ALL workflow types, excluding any value that some type treats as non-terminal. Concretely: `Resolved` is terminal for Operations but an **active** stage for Support_Triage; including it would hide active Support_Triage items from org-wide counts. Test-pinned.
2. **`getAllEffortTerminalStageValues()`** — the union + `'Deployed to Prod'` (now a single `STAGE_DEPLOYED_TO_PROD` constant). Ship-loop items are workflow-ACTIVE (awaiting ship verification → Done), so dashboards keep counting them — but they carry no remaining schedulable effort, so Gantt/ETA/Watchers/blocker-resolution exclude them.

## Swapped sites (lazy CMT-backed properties)

| Semantics | Classes |
|---|---|
| terminal union | DeliveryApprovalSummaryController, DeliveryForecastAlertService, DeliveryHoursAnalyticsController, DeliveryDashboardCardController (2 SOQL literals) |
| effort-terminal | DeliveryGanttController, WatcherSLABreachQueryService, WatcherStuckStageQueryService, DeliveryWorkItemETAService (3 SOQL literals), DeliveryWorkItemTriggerHandler blocker query |

No behavior regression: every new set strictly contains the old effective set, with the additions being the correct missing cross-type values. Untouched on purpose: `DeliveryAiController` (positive "showcase completed" semantics, deliberately excludes Cancelled) and per-type consumers already on `getTerminalStageValues`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
