### PR TITLE
feat(approvals): group approval queue by parent epic + Approve-all-in-epic

### DIFF
--- a/force-app/main/default/classes/DeliveryWorkApprovalService.cls
+++ b/force-app/main/default/classes/DeliveryWorkApprovalService.cls
@@ -152,6 +152,13 @@ global with sharing class DeliveryWorkApprovalService {
         @AuraEnabled public DateTime submittedAt;
         @AuraEnabled public Id approverUserId;
         /**
+         * Parent (epic) WorkItem the queued item rolls up to, so the queue LWC
+         * can group requests by epic and offer "Approve all in this epic".
+         * Null when the work item has no parent (an orphan / top-level item).
+         */
+        @AuraEnabled public Id parentWorkItemId;
+        @AuraEnabled public String parentLabel;
+        /**
          * Body of the newest PROPOSAL_NOTE_PREFIX-marked WorkItemComment__c
          * on the work item ("why this estimate"); null when no proposal
          * comment exists.
@@ -673,7 +680,10 @@ global with sharing class DeliveryWorkApprovalService {
                 SELECT Id, StatusPk__c, QuotedHoursNumber__c,
                        RequestedBudgetIncreaseNumber__c, ApproverUserLookup__c,
                        CreatedDate, WorkItemId__c, WorkItemId__r.Name,
-                       WorkItemId__r.BriefDescriptionTxt__c
+                       WorkItemId__r.BriefDescriptionTxt__c,
+                       WorkItemId__r.ParentWorkItemLookup__c,
+                       WorkItemId__r.ParentWorkItemLookup__r.Name,
+                       WorkItemId__r.ParentWorkItemLookup__r.BriefDescriptionTxt__c
                 FROM WorkRequest__c
                 WHERE StatusPk__c = :REQUEST_OFFER_SENT
                   AND (ApproverUserLookup__c IN :approverIds
@@ -757,6 +767,13 @@ global with sharing class DeliveryWorkApprovalService {
             dto.workItemLabel = String.isNotBlank(brief)
                 ? brief
                 : req.WorkItemId__r.Name;
+            dto.parentWorkItemId = req.WorkItemId__r.ParentWorkItemLookup__c;
+            if (req.WorkItemId__r.ParentWorkItemLookup__r != null) {
+                String parentBrief = req.WorkItemId__r.ParentWorkItemLookup__r.BriefDescriptionTxt__c;
+                dto.parentLabel = String.isNotBlank(parentBrief)
+                    ? parentBrief
+                    : req.WorkItemId__r.ParentWorkItemLookup__r.Name;
+            }
         }
         return dto;
     }

--- a/force-app/main/default/classes/DeliveryWorkApprovalServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkApprovalServiceTest.cls
@@ -1109,6 +1109,51 @@ private class DeliveryWorkApprovalServiceTest {
     }
 
     /**
+     * @description The queue feed carries the parent (epic) join so the LWC can
+     *              group requests by epic; an item with a parent surfaces the
+     *              parent id + label, an orphan leaves parentWorkItemId null.
+     */
+    @IsTest
+    static void testGetPendingCarriesParentEpic() {
+        configureSettings(null, null, null);
+        WorkItem__c epic = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'Billing epic',
+            'EstimatedHoursNumber__c' => 0
+        });
+        WorkItem__c child = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 20,
+            'ParentWorkItemLookup__c' => epic.Id
+        });
+        WorkItem__c orphan = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EstimatedHoursNumber__c' => 15
+        });
+        DeliveryWorkApprovalService.submitForApproval(new Set<Id>{ child.Id, orphan.Id });
+
+        Test.startTest();
+        List<DeliveryWorkApprovalService.PendingApprovalDTO> queue =
+            DeliveryWorkApprovalService.getPendingForApprover(null);
+        Test.stopTest();
+
+        DeliveryWorkApprovalService.PendingApprovalDTO childDto;
+        DeliveryWorkApprovalService.PendingApprovalDTO orphanDto;
+        for (DeliveryWorkApprovalService.PendingApprovalDTO dto : queue) {
+            if (dto.workItemId == child.Id) {
+                childDto = dto;
+            } else if (dto.workItemId == orphan.Id) {
+                orphanDto = dto;
+            }
+        }
+        System.assertNotEquals(null, childDto, 'child item pends');
+        System.assertEquals(epic.Id, childDto.parentWorkItemId,
+            'parent epic id surfaced for queue grouping');
+        System.assertEquals('Billing epic', childDto.parentLabel,
+            'parent label surfaced (brief description)');
+        System.assertNotEquals(null, orphanDto, 'orphan item pends');
+        System.assertEquals(null, orphanDto.parentWorkItemId,
+            'orphan has no parent epic');
+    }
+
+    /**
      * @description Unassigned Offer-Sent requests (no default approver
      *              configured) still surface in any approver's queue — the
      *              queue never silently hides work.

--- a/force-app/main/default/lwc/deliveryApprovalQueue/__tests__/deliveryApprovalQueue.test.js
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/__tests__/deliveryApprovalQueue.test.js
@@ -49,6 +49,48 @@ function samplePending() {
     ];
 }
 
+function samplePendingWithEpics() {
+    const base = {
+        requestedIncrease: null,
+        requestStatus: "Offer Sent",
+        submittedAt: new Date().toISOString(),
+        approverUserId: null,
+        latestProposalNote: null
+    };
+    return [
+        {
+            ...base,
+            requestId: "a0G000000000010AAA",
+            workItemId: "a42000000000010AAA",
+            workItemName: "T-2001",
+            workItemLabel: "Stripe webhook",
+            quotedHours: 10,
+            parentWorkItemId: "a42000000000EPCAAA",
+            parentLabel: "Billing epic"
+        },
+        {
+            ...base,
+            requestId: "a0G000000000011AAA",
+            workItemId: "a42000000000011AAA",
+            workItemName: "T-2002",
+            workItemLabel: "Invoice PDF",
+            quotedHours: 6,
+            parentWorkItemId: "a42000000000EPCAAA",
+            parentLabel: "Billing epic"
+        },
+        {
+            ...base,
+            requestId: "a0G000000000012AAA",
+            workItemId: "a42000000000012AAA",
+            workItemName: "T-2003",
+            workItemLabel: "Login redesign",
+            quotedHours: 8,
+            parentWorkItemId: "a42000000000EPCBBB",
+            parentLabel: "UX epic"
+        }
+    ];
+}
+
 function createComponent() {
     const element = createElement("c-delivery-approval-queue", {
         is: DeliveryApprovalQueue
@@ -305,5 +347,41 @@ describe("c-delivery-approval-queue", () => {
         await flushPromises();
 
         expect(element.shadowRoot.querySelector(".queue-error")).not.toBeNull();
+    });
+
+    it("groups the queue into epic sections with per-epic headers", async () => {
+        const element = createComponent();
+        getPendingForApprover.emit(samplePendingWithEpics());
+        await flushPromises();
+
+        const sections = element.shadowRoot.querySelectorAll(".queue-section");
+        expect(sections.length).toBe(2);
+        const names = Array.from(
+            element.shadowRoot.querySelectorAll(".queue-section-name")
+        ).map((n) => n.textContent);
+        expect(names).toContain("Billing epic");
+        expect(names).toContain("UX epic");
+        // every row still renders, just nested under its epic
+        expect(element.shadowRoot.querySelectorAll(".queue-row").length).toBe(3);
+    });
+
+    it("approve-all on an epic section bulk-approves only that epic's requests", async () => {
+        approveMany.mockResolvedValue({
+            approvedIds: ["a0G000000000010AAA", "a0G000000000011AAA"],
+            failures: []
+        });
+        const element = createComponent();
+        getPendingForApprover.emit(samplePendingWithEpics());
+        await flushPromises();
+
+        const billingApproveAll = findButtonByLabel(element, "Approve all (2)");
+        expect(billingApproveAll).toBeTruthy();
+        billingApproveAll.click();
+        await flushPromises();
+
+        expect(approveMany).toHaveBeenCalledWith({
+            workRequestIds: ["a0G000000000010AAA", "a0G000000000011AAA"],
+            note: null
+        });
     });
 });

--- a/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.css
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.css
@@ -269,3 +269,43 @@
     color: #9ca3af;
     margin-top: 0.25rem;
 }
+
+/* ── Epic sections ─────────────────────────────────────────────── */
+.queue-section {
+    border-top: 1px solid #e5e7eb;
+}
+.queue-section:first-of-type {
+    border-top: none;
+}
+.queue-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.5rem 1.5rem;
+    background: #f9fafb;
+    border-bottom: 1px solid #eef2f7;
+}
+.queue-section-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+}
+.queue-section-icon {
+    color: #7c3aed;
+    flex: none;
+}
+.queue-section-name {
+    font-weight: 600;
+    color: #1f2937;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.queue-section-meta {
+    color: #6b7280;
+    font-size: 0.75rem;
+    white-space: nowrap;
+    flex: none;
+}

--- a/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.html
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.html
@@ -62,8 +62,24 @@
                 </lightning-button>
             </div>
 
-            <ul class="queue-list">
-                <template for:each={rows} for:item="row">
+            <template for:each={sections} for:item="section">
+              <div key={section.key} class="queue-section">
+                <div class="queue-section-header">
+                    <div class="queue-section-title">
+                        <lightning-icon icon-name="utility:rows" size="xx-small" class="queue-section-icon"></lightning-icon>
+                        <span class="queue-section-name">{section.title}</span>
+                        <span class="queue-section-meta">{section.countDisplay} &middot; {section.hoursDisplay}</span>
+                    </div>
+                    <lightning-button
+                        variant="brand-outline"
+                        label={section.approveAllLabel}
+                        data-section-key={section.key}
+                        disabled={section.isApproveAllDisabled}
+                        onclick={handleApproveSection}>
+                    </lightning-button>
+                </div>
+                <ul class="queue-list">
+                    <template for:each={section.rows} for:item="row">
                     <li key={row.key} class="queue-row">
                         <div class="queue-row-main">
                             <lightning-input
@@ -184,8 +200,10 @@
                             </div>
                         </template>
                     </li>
-                </template>
-            </ul>
+                    </template>
+                </ul>
+              </div>
+            </template>
         </template>
 
         <template lwc:if={isEmpty}>

--- a/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.js
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.js
@@ -71,29 +71,76 @@ export default class DeliveryApprovalQueue extends NavigationMixin(LightningElem
     // ── Row shaping (templates can't do ternaries — precompute) ──
 
     get rows() {
-        return this.pendingRaw.map((dto) => {
-            const isActive = dto.requestId === this.activeRequestId;
-            const hasProposalNote = Boolean(dto.latestProposalNote);
-            const isProposalOpen = hasProposalNote && this.expandedNoteIds.includes(dto.requestId);
+        return this.pendingRaw.map((dto) => this._shapeRow(dto));
+    }
+
+    // Queue grouped by parent (epic). Each section carries its own rows, a
+    // header summary, and an "Approve all in this epic" action that reuses the
+    // bulk-approve path. Items without a parent collect in an "Ungrouped"
+    // section that always sorts last. Section order otherwise follows first
+    // appearance in the oldest-first feed, so the longest-waiting epic leads.
+    get sections() {
+        const UNGROUPED = "__ungrouped__";
+        const order = [];
+        const byKey = new Map();
+        for (const dto of this.pendingRaw) {
+            const key = dto.parentWorkItemId || UNGROUPED;
+            if (!byKey.has(key)) {
+                order.push(key);
+                byKey.set(key, {
+                    key,
+                    hasParent: Boolean(dto.parentWorkItemId),
+                    parentWorkItemId: dto.parentWorkItemId || null,
+                    title: dto.parentWorkItemId ? dto.parentLabel || "(epic)" : "Ungrouped",
+                    rows: [],
+                    count: 0,
+                    totalHours: 0
+                });
+            }
+            const group = byKey.get(key);
+            group.rows.push(this._shapeRow(dto));
+            group.count += 1;
+            group.totalHours += dto.quotedHours || 0;
+        }
+        const sorted = order.sort((a, b) => {
+            if (a === UNGROUPED) return 1;
+            if (b === UNGROUPED) return -1;
+            return 0;
+        });
+        return sorted.map((key) => {
+            const group = byKey.get(key);
             return {
-                key: dto.requestId,
-                workItemId: dto.workItemId,
-                label: dto.workItemLabel || dto.workItemName || "(unnamed item)",
-                quotedDisplay: `${this._formatHours(dto.quotedHours)}h quoted`,
-                hasIncrease: dto.requestedIncrease > 0,
-                increaseBadge: `increase +${this._formatHours(dto.requestedIncrease)}h`,
-                ageDisplay: this._ageDisplay(dto.submittedAt),
-                isSelected: this.selectedIds.includes(dto.requestId),
-                isChangeOpen: isActive && this.activeMode === MODE_CHANGE,
-                isDeclineOpen: isActive && this.activeMode === MODE_DECLINE,
-                hasProposalNote,
-                isProposalOpen,
-                proposalNote: dto.latestProposalNote || "",
-                proposalToggleLabel: isProposalOpen
-                    ? "Hide why this estimate"
-                    : "Why this estimate"
+                ...group,
+                countDisplay: `${group.count} ${group.count === 1 ? "item" : "items"}`,
+                hoursDisplay: `${this._formatHours(group.totalHours)}h`,
+                approveAllLabel: `Approve all (${group.count})`,
+                isApproveAllDisabled: this.isSaving
             };
         });
+    }
+
+    _shapeRow(dto) {
+        const isActive = dto.requestId === this.activeRequestId;
+        const hasProposalNote = Boolean(dto.latestProposalNote);
+        const isProposalOpen = hasProposalNote && this.expandedNoteIds.includes(dto.requestId);
+        return {
+            key: dto.requestId,
+            workItemId: dto.workItemId,
+            label: dto.workItemLabel || dto.workItemName || "(unnamed item)",
+            quotedDisplay: `${this._formatHours(dto.quotedHours)}h quoted`,
+            hasIncrease: dto.requestedIncrease > 0,
+            increaseBadge: `increase +${this._formatHours(dto.requestedIncrease)}h`,
+            ageDisplay: this._ageDisplay(dto.submittedAt),
+            isSelected: this.selectedIds.includes(dto.requestId),
+            isChangeOpen: isActive && this.activeMode === MODE_CHANGE,
+            isDeclineOpen: isActive && this.activeMode === MODE_DECLINE,
+            hasProposalNote,
+            isProposalOpen,
+            proposalNote: dto.latestProposalNote || "",
+            proposalToggleLabel: isProposalOpen
+                ? "Hide why this estimate"
+                : "Why this estimate"
+        };
     }
 
     // ── State flags ──────────────────────────────────────────────
@@ -180,7 +227,24 @@ export default class DeliveryApprovalQueue extends NavigationMixin(LightningElem
     }
 
     handleBulkApprove() {
-        const ids = this._selectedPendingIds();
+        this._approveIds(this._selectedPendingIds());
+    }
+
+    // Approve every pending request under one epic section in a single bulk
+    // call — the section's ids are derived live from the feed so a row decided
+    // elsewhere (and refreshed away) is never re-submitted.
+    handleApproveSection(event) {
+        const sectionKey = event.currentTarget.dataset.sectionKey;
+        if (!sectionKey) {
+            return;
+        }
+        const ids = this.pendingRaw
+            .filter((dto) => (dto.parentWorkItemId || "__ungrouped__") === sectionKey)
+            .map((dto) => dto.requestId);
+        this._approveIds(ids);
+    }
+
+    _approveIds(ids) {
         if (ids.length === 0 || this.isSaving) {
             return;
         }


### PR DESCRIPTION
## What

The pending-approval queue was one **flat list** — an epic's children scattered across it, so an approver couldn't see or act on a whole workstream at once. This groups the queue **by parent epic**, with an **"Approve all in this epic"** action per section.

## Changes

- **`DeliveryWorkApprovalService`** — `PendingApprovalDTO` now carries `parentWorkItemId` + `parentLabel`, read from the existing `WorkItem.ParentWorkItemLookup__c`. **No new metadata** — just one more field on the existing join. `getPendingForApprover` selects the parent; `toPendingDto` maps it (label falls back parent brief → parent name).
- **`deliveryApprovalQueue` LWC** — rows group into epic **sections**, each with a header (epic name · item count · quoted-hours subtotal) and an **"Approve all (N)"** button that reuses the shipped `approveMany` over only that epic's pending ids. Items with no parent collect in an **"Ungrouped"** section that always sorts last. Section order otherwise follows the oldest-first feed, so the longest-waiting epic leads. Row-level approve / approve-with-change / decline / proposal-note and the top-level "Approve selected" bulk bar are unchanged.

## Deliberately out of scope

- **Reordering** — needs a persisted sort field (= metadata) and is a backlog/board behavior, not an approval one. Left for a separate decision.

## Tests

- Controller test pins the parent-epic join: a child surfaces `parentWorkItemId` + `parentLabel`, an orphan leaves them null.
- 2 jest tests: section grouping renders per-epic headers; "Approve all" on one epic calls `approveMany` with *only* that epic's request ids.
- All existing jest assertions stay green (rows still render, nested under their section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
