### PR TITLE
docs: pin install ids + current-release to 0.281.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ It is open source under the [BSL 1.1 license](LICENSE.md) and ships as an unlock
 
 ## Install
 
-**Current release**: [`release/0.276.0.2`](https://github.com/Nimba-Solutions/Delivery-Hub/releases) (production-promoted 2026-06-12). Completes the work-approval queue arc on top of 0.273's foundation (estimate → approve rails, pending-approval queue on Home, approval reports + agenda card, Deployed-to-Prod ship loop, NimbusGantt 0.204.0, de-cluttered Pacing view). 0.274 → 0.276 add: **approval pings** (submit notifies the approver, decisions notify the dev), **WorkLog cap enforcement** (over-cap logs flag by default, hard-block via `EnforceApprovalCapDateTime__c`), NimbusGantt **0.204.1** (empty-state fix), **approved-green forecast cohort** (greenlit tier = client-approved hours, not lane), **ETA write-back** on gantt apply (`CalculatedETADate__c`) + pace-divergence alerts, and the **approved-vs-total pitch stat** + backup approver + `global` `DeliveryWorkApprovalService`. See [GitHub Releases](https://github.com/Nimba-Solutions/Delivery-Hub/releases) for the full version history.
+**Current release**: [`release/0.281.0.1`](https://github.com/Nimba-Solutions/Delivery-Hub/releases) (production-promoted 2026-06-13). Builds on the work-approval queue arc (estimate → approve rails, pending-approval queue on Home, approval reports + agenda card, Deployed-to-Prod ship loop, WorkLog cap enforcement via `EnforceApprovalCapDateTime__c`, pace-divergence alerts). 0.277 → 0.281 add: **Home active-count truth fixes** (Exec/active counts exclude terminal + archived + non-activated items), the **worklog-relay sync fix** (relays now mint under the guest REST path), **terminal-stage unification** (one cross-workflow-type terminal set drives all active counts/forecast/watchers), and the **epic-sectioned approval queue** (requests group by parent epic with per-epic "Approve all"). See [GitHub Releases](https://github.com/Nimba-Solutions/Delivery-Hub/releases) for the full version history.
 
 | Environment | Link |
 |---|---|
-| **Production** | [![Install in Production](https://img.shields.io/badge/Install-Production-0070d2?logo=salesforce&style=for-the-badge)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000VyeDIAS) |
-| **Sandbox** | [![Install in Sandbox](https://img.shields.io/badge/Install-Sandbox-3e8b3e?logo=salesforce&style=for-the-badge)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000VyeDIAS) |
+| **Production** | [![Install in Production](https://img.shields.io/badge/Install-Production-0070d2?logo=salesforce&style=for-the-badge)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000W0GDIA0) |
+| **Sandbox** | [![Install in Sandbox](https://img.shields.io/badge/Install-Sandbox-3e8b3e?logo=salesforce&style=for-the-badge)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000W0GDIA0) |
 
 **Quickstart (≈5 minutes):**
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 This guide walks you through installing Delivery Hub, running the setup wizard, creating your first work item, and optionally configuring cross-org sync, document signing, and external API access.
 
-**Current release**: `release/0.248.0.3` (production-promoted 2026-05-25). See [GitHub Releases](https://github.com/Nimba-Solutions/Delivery-Hub/releases) for the full version history (CHANGELOG entries through 0.200 are PR-by-PR; later releases ship as named PRs tagged in GitHub Releases). For the install + smoke-test runbook, see [SETUP.md](SETUP.md). For the cockpit-era 8-layer architecture, see [COCKPIT.md](COCKPIT.md).
+**Current release**: `release/0.281.0.1` (production-promoted 2026-06-13). See [GitHub Releases](https://github.com/Nimba-Solutions/Delivery-Hub/releases) for the full version history (CHANGELOG entries through 0.200 are PR-by-PR; later releases ship as named PRs tagged in GitHub Releases). For the install + smoke-test runbook, see [SETUP.md](SETUP.md). For the cockpit-era 8-layer architecture, see [COCKPIT.md](COCKPIT.md).
 
 ---
 
@@ -12,8 +12,8 @@ Install Delivery Hub into your Salesforce org:
 
 | Environment | Link |
 |---|---|
-| **Production** | [Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000T0SrIAK) |
-| **Sandbox** | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000T0SrIAK) |
+| **Production** | [Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000W0GDIA0) |
+| **Sandbox** | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tQr000000W0GDIA0) |
 
 When prompted, select **Install for All Users** (recommended) or configure per-profile access. The install links always point to the latest promoted release; check `release/*` tags in the repo if you need a specific version.
 


### PR DESCRIPTION
Both install docs carried **different, both-stale** package ids — README `...VyeDIAS`, GETTING_STARTED `...T0SrIAK`, neither current. A stranger following either would install an old version. Pins both to the promoted **0.281.0.1** (`04tQr000000W0GDIA0`) and refreshes the stale "Current release" blurbs (README was on 0.276, GETTING_STARTED on 0.248). Docs-only.

Surfaced while verifying MF Claude's 6/13 state-of-the-machine audit, which flagged this drift as a this-week cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)