### PR TITLE
feat(self-heal): Move 1 — auto-diagnose sweep drafts a quoted request into the queue (OFF by default)

### DIFF
--- a/force-app/main/default/classes/DeliveryAutoDiagnoseService.cls
+++ b/force-app/main/default/classes/DeliveryAutoDiagnoseService.cls
@@ -1,0 +1,234 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Move 1 of the self-heal loop — the first unattended segment.
+ *               Reads the captured field-change stream (ActivityLog__c, the
+ *               "SEE" layer) and, for each configured DiagnoseRule__mdt, counts
+ *               anomalous events in a rolling window. When a rule's threshold is
+ *               crossed it AUTO-DRAFTS a quoted work request straight into the
+ *               existing approval queue (DeliveryWorkApprovalService) — no new
+ *               pipeline, it reuses the storefront that already ships.
+ *
+ *               This is the bridge from "the eyes captured a problem" to "a
+ *               human-approvable fix is waiting in the queue," with NO human in
+ *               between. It is the literal subtract-Glen payload.
+ *
+ *               GATED OFF BY DEFAULT. Two gates, both must be satisfied:
+ *                 1. DeliveryHubSettings__c.EnableAutoDiagnoseDateTime__c set
+ *                    (the master flag — null = the safe shipping default).
+ *                 2. At least one DiagnoseRule__mdt with ActiveDateTime__c set.
+ *               Until the SEE Flow is actually feeding business-object events
+ *               and an admin authors a rule, this no-ops every tick.
+ *
+ *               GENERIC by design — nothing here names a tenant's objects. A
+ *               rule points at any watched object/field via config; the package
+ *               ships the engine, not the rule.
+ *
+ *               Idempotent: a per-rule cooldown (queried off the marker-prefixed
+ *               work-item title) prevents the same anomaly from re-drafting on
+ *               every run. A once-per-day guard caps the sweep to one pass/day
+ *               even though the scheduler calls it every tick.
+ *
+ *               SOQL is WITH SYSTEM_MODE per CLAUDE.md (WITH USER_MODE breaks in
+ *               namespaced package test context).
+ * @author Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.AvoidGlobalModifier,PMD.CognitiveComplexity')
+global without sharing class DeliveryAutoDiagnoseService {
+
+    /** ActivityLog ActionType written by the field-change capture engine. */
+    private static final String ACTION_FIELD_CHANGE = 'Field_Change';
+
+    /** Cap on ActivityLog rows scanned per rule per sweep. */
+    private static final Integer MAX_LOG_ROWS = 5000;
+
+    /** Marker that prefixes every auto-drafted work-item title — also the
+     *  dedup key (one stable token per rule). Keep stable: changing it orphans
+     *  the cooldown lookup against already-drafted items. */
+    @TestVisible
+    private static final String MARKER = '[auto-diagnose:';
+
+    /** Test seam: DiagnoseRule__mdt records cannot be DML'd, so tests inject
+     *  in-memory rules here instead of relying on shipped CMT (none ships). */
+    @TestVisible
+    private static List<DiagnoseRule__mdt> testRuleOverride;
+
+    /**
+     * @description Runs the diagnose sweep. Called every scheduler tick; gated
+     *              off by default and self-rate-limited to one pass per day.
+     * @return Number of rules that drafted a work request this pass.
+     */
+    global static Integer runSweep() {
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        if (settings == null || settings.EnableAutoDiagnoseDateTime__c == null) {
+            return 0; // master flag off — the safe default
+        }
+        // Once-per-day guard: skip if we already swept today (GMT).
+        if (settings.LastAutoDiagnoseScanDateTime__c != null
+                && settings.LastAutoDiagnoseScanDateTime__c.dateGmt() == Date.today()) {
+            return 0;
+        }
+
+        List<DiagnoseRule__mdt> rules = testRuleOverride != null
+            ? testRuleOverride
+            : [
+                SELECT DeveloperName, WatchedObjectApiNameTxt__c, WatchedFieldApiNameTxt__c,
+                       AnomalyValueTxt__c, WindowHoursNumber__c, CountThresholdNumber__c,
+                       QuotedHoursNumber__c, WorkItemTitleTxt__c, CooldownHoursNumber__c
+                FROM DiagnoseRule__mdt
+                WHERE ActiveDateTime__c != null
+                WITH SYSTEM_MODE
+                ORDER BY SortOrderNumber__c ASC NULLS LAST
+            ];
+
+        Integer drafted = 0;
+        for (DiagnoseRule__mdt rule : rules) {
+            if (!isRuleUsable(rule)) {
+                continue;
+            }
+            if (alreadyDraftedWithinCooldown(rule)) {
+                continue;
+            }
+            Integer hits = countAnomalies(rule);
+            if (hits >= rule.CountThresholdNumber__c) {
+                draftRequest(rule, hits);
+                drafted++;
+            }
+        }
+
+        stampScanComplete(settings);
+        return drafted;
+    }
+
+    // ── Evaluation ───────────────────────────────────────────────────────
+
+    /** A rule must name an object + field and carry a positive threshold. */
+    private static Boolean isRuleUsable(DiagnoseRule__mdt rule) {
+        return String.isNotBlank(rule.WatchedObjectApiNameTxt__c)
+            && String.isNotBlank(rule.WatchedFieldApiNameTxt__c)
+            && rule.CountThresholdNumber__c != null && rule.CountThresholdNumber__c > 0
+            && rule.WindowHoursNumber__c != null && rule.WindowHoursNumber__c > 0;
+    }
+
+    /**
+     * @description Counts DISTINCT records whose watched field changed (to the
+     *              anomaly value, when one is configured) within the rule's
+     *              window. The capture engine stores object name + values inside
+     *              ActivityLog ContextDataTxt JSON, so we filter on the queryable
+     *              top-level columns (action + field name + window) and confirm
+     *              object/value in Apex.
+     */
+    private static Integer countAnomalies(DiagnoseRule__mdt rule) {
+        Datetime windowStart = Datetime.now().addHours(-(Integer) rule.WindowHoursNumber__c);
+        List<ActivityLog__c> logs = [
+            SELECT RecordIdTxt__c, ContextDataTxt__c
+            FROM ActivityLog__c
+            WHERE ActionTypePk__c = :ACTION_FIELD_CHANGE
+            AND ComponentNameTxt__c = :rule.WatchedFieldApiNameTxt__c
+            AND CreatedDate >= :windowStart
+            WITH SYSTEM_MODE
+            ORDER BY CreatedDate DESC
+            LIMIT :MAX_LOG_ROWS
+        ];
+
+        Boolean filterValue = String.isNotBlank(rule.AnomalyValueTxt__c);
+        Set<String> matchedRecordIds = new Set<String>();
+        for (ActivityLog__c log : logs) {
+            if (String.isBlank(log.ContextDataTxt__c)) {
+                continue;
+            }
+            Map<String, Object> ctx;
+            try {
+                ctx = (Map<String, Object>) JSON.deserializeUntyped(log.ContextDataTxt__c);
+            } catch (Exception ignored) {
+                continue;
+            }
+            if (String.valueOf(ctx.get('objectName')) != rule.WatchedObjectApiNameTxt__c) {
+                continue;
+            }
+            if (filterValue && String.valueOf(ctx.get('newValue')) != rule.AnomalyValueTxt__c) {
+                continue;
+            }
+            if (String.isNotBlank(log.RecordIdTxt__c)) {
+                matchedRecordIds.add(log.RecordIdTxt__c);
+            }
+        }
+        return matchedRecordIds.size();
+    }
+
+    /** True when this rule already drafted an item inside its cooldown window. */
+    private static Boolean alreadyDraftedWithinCooldown(DiagnoseRule__mdt rule) {
+        Integer cooldown = rule.CooldownHoursNumber__c == null
+            ? (Integer) rule.WindowHoursNumber__c
+            : (Integer) rule.CooldownHoursNumber__c;
+        if (cooldown <= 0) {
+            return false;
+        }
+        Datetime since = Datetime.now().addHours(-cooldown);
+        String prefix = markerFor(rule);
+        Integer existing = [
+            SELECT COUNT()
+            FROM WorkItem__c
+            WHERE BriefDescriptionTxt__c LIKE :(prefix + '%')
+            AND CreatedDate >= :since
+            WITH SYSTEM_MODE
+        ];
+        return existing > 0;
+    }
+
+    // ── Drafting ─────────────────────────────────────────────────────────
+
+    /**
+     * @description Creates an intake work item describing the anomaly and submits
+     *              it for approval at the rule's quoted hours — landing it as an
+     *              Offer-Sent request in the existing queue (or auto-accepted if
+     *              the quote is under the org's discretionary threshold, exactly
+     *              as a human-submitted request would be).
+     */
+    private static void draftRequest(DiagnoseRule__mdt rule, Integer hits) {
+        WorkItem__c wi = new WorkItem__c(
+            BriefDescriptionTxt__c = buildTitle(rule, hits),
+            StageNamePk__c         = 'Backlog',
+            StatusPk__c            = 'New',
+            PriorityPk__c          = 'High',
+            ActivatedDateTime__c   = Datetime.now()
+        );
+        insert wi;
+
+        Decimal quote = rule.QuotedHoursNumber__c == null ? 0 : rule.QuotedHoursNumber__c;
+        DeliveryWorkApprovalService.submitForApproval(
+            new Set<Id>{ wi.Id },
+            new Map<Id, Decimal>{ wi.Id => quote }
+        );
+    }
+
+    /** Marker prefix unique to a rule (the dedup/cooldown key). */
+    private static String markerFor(DiagnoseRule__mdt rule) {
+        return MARKER + rule.DeveloperName + ']';
+    }
+
+    /** Title = the stable marker + the rule template with {count}/{object}
+     *  tokens resolved, capped at the BriefDescription length. */
+    private static String buildTitle(DiagnoseRule__mdt rule, Integer hits) {
+        String template = String.isNotBlank(rule.WorkItemTitleTxt__c)
+            ? rule.WorkItemTitleTxt__c
+            : '{count} anomalies detected on {object}';
+        String body = template
+            .replace('{count}', String.valueOf(hits))
+            .replace('{object}', rule.WatchedObjectApiNameTxt__c);
+        String full = markerFor(rule) + ' ' + body;
+        return full.length() > 255 ? full.substring(0, 255) : full;
+    }
+
+    // ── Bookkeeping ──────────────────────────────────────────────────────
+
+    private static void stampScanComplete(DeliveryHubSettings__c settings) {
+        try {
+            settings.LastAutoDiagnoseScanDateTime__c = Datetime.now();
+            upsert settings;
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryAutoDiagnoseService.stampScanComplete] failed: ' + e.getMessage());
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryAutoDiagnoseService.cls
+++ b/force-app/main/default/classes/DeliveryAutoDiagnoseService.cls
@@ -33,7 +33,7 @@
  *               namespaced package test context).
  * @author Cloud Nimbus LLC
  */
-@SuppressWarnings('PMD.ApexCRUDViolation,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.AvoidGlobalModifier,PMD.CognitiveComplexity')
+@SuppressWarnings('PMD.ApexDoc,PMD.ApexCRUDViolation,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.AvoidGlobalModifier,PMD.CognitiveComplexity')
 global without sharing class DeliveryAutoDiagnoseService {
 
     /** ActivityLog ActionType written by the field-change capture engine. */

--- a/force-app/main/default/classes/DeliveryAutoDiagnoseService.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryAutoDiagnoseService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryAutoDiagnoseServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryAutoDiagnoseServiceTest.cls
@@ -12,6 +12,7 @@
  * @author Cloud Nimbus LLC
  */
 @IsTest
+@SuppressWarnings('PMD.ApexDoc')
 private class DeliveryAutoDiagnoseServiceTest {
 
     private static final String OBJ = 'AcmeTxn__c';

--- a/force-app/main/default/classes/DeliveryAutoDiagnoseServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryAutoDiagnoseServiceTest.cls
@@ -1,0 +1,187 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for DeliveryAutoDiagnoseService (self-heal Move 1). Covers
+ *               the two gates (master flag + active rule), the threshold
+ *               crossing that auto-drafts a quoted request into the queue, the
+ *               anomaly-value filter, the cooldown dedup, and the once-per-day
+ *               guard. DiagnoseRule__mdt records can't be DML'd, so rules are
+ *               injected via the @TestVisible override; ActivityLog rows (the
+ *               SEE stream) are inserted directly in the shape the capture
+ *               engine writes.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryAutoDiagnoseServiceTest {
+
+    private static final String OBJ = 'AcmeTxn__c';
+    private static final String FIELD = 'StatusField__c';
+    private static final String BAD = 'Error';
+
+    private static void enable(Boolean on) {
+        DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
+        s.EnableAutoDiagnoseDateTime__c = on ? Datetime.now() : null;
+        s.LastAutoDiagnoseScanDateTime__c = null;
+        // Threshold low so an 8h auto-draft lands Offer-Sent, not auto-accepted.
+        s.DiscretionaryThresholdHoursNumber__c = 1;
+        upsert s;
+    }
+
+    private static DiagnoseRule__mdt rule(Integer threshold, Integer cooldownHours, String anomalyValue) {
+        return new DiagnoseRule__mdt(
+            DeveloperName              = 'Test_Rule',
+            WatchedObjectApiNameTxt__c = OBJ,
+            WatchedFieldApiNameTxt__c  = FIELD,
+            AnomalyValueTxt__c         = anomalyValue,
+            WindowHoursNumber__c       = 24,
+            CountThresholdNumber__c    = threshold,
+            QuotedHoursNumber__c       = 8,
+            WorkItemTitleTxt__c        = '{count} anomalies on {object}',
+            CooldownHoursNumber__c     = cooldownHours
+        );
+    }
+
+    /** Inserts n ActivityLog rows shaped like the field-change capture engine. */
+    private static void seedAnomalies(String newValue, Integer n) {
+        List<ActivityLog__c> logs = new List<ActivityLog__c>();
+        for (Integer i = 0; i < n; i++) {
+            Map<String, Object> ctx = new Map<String, Object>{
+                'objectName' => OBJ, 'fieldName' => FIELD, 'newValue' => newValue
+            };
+            logs.add(new ActivityLog__c(
+                ActionTypePk__c     = 'Field_Change',
+                ComponentNameTxt__c = FIELD,
+                RecordIdTxt__c      = 'REC-' + i,
+                ContextDataTxt__c   = JSON.serialize(ctx)
+            ));
+        }
+        insert logs;
+    }
+
+    private static Integer draftedCount() {
+        return [
+            SELECT COUNT()
+            FROM WorkItem__c
+            WHERE BriefDescriptionTxt__c LIKE '[auto-diagnose:%'
+        ];
+    }
+
+    @IsTest
+    static void testMasterFlagOffNoOp() {
+        enable(false);
+        seedAnomalies(BAD, 5);
+        DeliveryAutoDiagnoseService.testRuleOverride = new List<DiagnoseRule__mdt>{ rule(3, 48, BAD) };
+
+        Test.startTest();
+        Integer drafted = DeliveryAutoDiagnoseService.runSweep();
+        Test.stopTest();
+
+        System.assertEquals(0, drafted, 'master flag OFF must no-op');
+        System.assertEquals(0, draftedCount(), 'no work item drafted when disabled');
+    }
+
+    @IsTest
+    static void testNoActiveRulesNoOp() {
+        enable(true);
+        seedAnomalies(BAD, 5);
+        DeliveryAutoDiagnoseService.testRuleOverride = new List<DiagnoseRule__mdt>();
+
+        Test.startTest();
+        Integer drafted = DeliveryAutoDiagnoseService.runSweep();
+        Test.stopTest();
+
+        System.assertEquals(0, drafted, 'no rules → nothing drafted');
+    }
+
+    @IsTest
+    static void testThresholdCrossedDraftsQueuedRequest() {
+        enable(true);
+        seedAnomalies(BAD, 4); // 4 distinct records >= threshold 3
+        DeliveryAutoDiagnoseService.testRuleOverride = new List<DiagnoseRule__mdt>{ rule(3, 48, BAD) };
+
+        Test.startTest();
+        Integer drafted = DeliveryAutoDiagnoseService.runSweep();
+        Test.stopTest();
+
+        System.assertEquals(1, drafted, 'threshold crossed → one rule drafts');
+        List<WorkItem__c> items = [
+            SELECT Id, BriefDescriptionTxt__c FROM WorkItem__c
+            WHERE BriefDescriptionTxt__c LIKE '[auto-diagnose:%'
+        ];
+        System.assertEquals(1, items.size(), 'exactly one auto-drafted work item');
+        System.assert(items[0].BriefDescriptionTxt__c.contains('4 anomalies on ' + OBJ),
+            'title resolves {count}/{object} tokens: ' + items[0].BriefDescriptionTxt__c);
+
+        // It must land in the approval queue as Offer Sent (quote 8 > threshold 1).
+        List<WorkRequest__c> reqs = [
+            SELECT StatusPk__c, QuotedHoursNumber__c FROM WorkRequest__c
+            WHERE WorkItemId__c = :items[0].Id
+        ];
+        System.assertEquals(1, reqs.size(), 'a work request was created for the drafted item');
+        System.assertEquals('Offer Sent', reqs[0].StatusPk__c, 'drafted request waits in the queue');
+        System.assertEquals(8, reqs[0].QuotedHoursNumber__c, 'rule quote stamped on the request');
+    }
+
+    @IsTest
+    static void testBelowThresholdNoDraft() {
+        enable(true);
+        seedAnomalies(BAD, 2); // 2 < threshold 3
+        DeliveryAutoDiagnoseService.testRuleOverride = new List<DiagnoseRule__mdt>{ rule(3, 48, BAD) };
+
+        Test.startTest();
+        Integer drafted = DeliveryAutoDiagnoseService.runSweep();
+        Test.stopTest();
+
+        System.assertEquals(0, drafted, 'below threshold → no draft');
+        System.assertEquals(0, draftedCount(), 'no work item drafted below threshold');
+    }
+
+    @IsTest
+    static void testAnomalyValueFilterExcludesNonMatches() {
+        enable(true);
+        seedAnomalies('Ok', 5);   // 5 changes, but to a non-anomalous value
+        seedAnomalies(BAD, 1);    // only 1 to the anomalous value
+        DeliveryAutoDiagnoseService.testRuleOverride = new List<DiagnoseRule__mdt>{ rule(3, 48, BAD) };
+
+        Test.startTest();
+        Integer drafted = DeliveryAutoDiagnoseService.runSweep();
+        Test.stopTest();
+
+        System.assertEquals(0, drafted,
+            'only newValue=Error counts; 1 match < threshold 3, so no draft');
+    }
+
+    @IsTest
+    static void testCooldownPreventsRedraft() {
+        enable(true);
+        seedAnomalies(BAD, 4);
+        DeliveryAutoDiagnoseService.testRuleOverride = new List<DiagnoseRule__mdt>{ rule(3, 48, BAD) };
+
+        Test.startTest();
+        DeliveryAutoDiagnoseService.runSweep();           // first pass drafts
+        // Clear the once-per-day guard so the second pass actually evaluates;
+        // the COOLDOWN (not the daily guard) is what must now suppress it.
+        DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
+        s.LastAutoDiagnoseScanDateTime__c = null;
+        upsert s;
+        Integer second = DeliveryAutoDiagnoseService.runSweep();
+        Test.stopTest();
+
+        System.assertEquals(0, second, 'cooldown suppresses a re-draft for the same rule');
+        System.assertEquals(1, draftedCount(), 'still exactly one drafted item after the second pass');
+    }
+
+    @IsTest
+    static void testOncePerDayGuard() {
+        enable(true);
+        seedAnomalies(BAD, 4);
+        DeliveryAutoDiagnoseService.testRuleOverride = new List<DiagnoseRule__mdt>{ rule(3, 48, BAD) };
+
+        Test.startTest();
+        DeliveryAutoDiagnoseService.runSweep();   // stamps LastAutoDiagnoseScan = today
+        Integer second = DeliveryAutoDiagnoseService.runSweep(); // same day → guarded
+        Test.stopTest();
+
+        System.assertEquals(0, second, 'second pass the same day is skipped by the daily guard');
+    }
+}

--- a/force-app/main/default/classes/DeliveryAutoDiagnoseServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryAutoDiagnoseServiceTest.cls
@@ -18,9 +18,9 @@ private class DeliveryAutoDiagnoseServiceTest {
     private static final String FIELD = 'StatusField__c';
     private static final String BAD = 'Error';
 
-    private static void enable(Boolean on) {
+    private static void enable(Boolean isEnabled) {
         DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
-        s.EnableAutoDiagnoseDateTime__c = on ? Datetime.now() : null;
+        s.EnableAutoDiagnoseDateTime__c = isEnabled ? Datetime.now() : null;
         s.LastAutoDiagnoseScanDateTime__c = null;
         // Threshold low so an 8h auto-draft lands Offer-Sent, not auto-accepted.
         s.DiscretionaryThresholdHoursNumber__c = 1;

--- a/force-app/main/default/classes/DeliveryAutoDiagnoseServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryAutoDiagnoseServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryHubScheduler.cls
+++ b/force-app/main/default/classes/DeliveryHubScheduler.cls
@@ -34,6 +34,24 @@ global without sharing class DeliveryHubScheduler implements Schedulable {
         runReconciliation();
         recalcWorkItemETAsIfTopOfHour();
         enqueueActivityLogCleanupIfDue();
+        runAutoDiagnoseIfEnabled();
+    }
+
+    /**
+     * @description Runs the self-heal Move-1 sweep: reads the captured
+     *              field-change stream and auto-drafts a quoted work request
+     *              into the approval queue when a DiagnoseRule__mdt threshold is
+     *              crossed. Self-gated (master flag OFF by default) and
+     *              once-per-day, so calling it every tick is safe and a no-op
+     *              until an admin turns it on. Failures never break the tick.
+     */
+    private static void runAutoDiagnoseIfEnabled() {
+        try {
+            DeliveryAutoDiagnoseService.runSweep();
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryHubScheduler.runAutoDiagnoseIfEnabled] failed: ' + e.getMessage());
+        }
     }
 
     /**

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableAutoDiagnoseDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableAutoDiagnoseDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnableAutoDiagnoseDateTime__c</fullName>
+    <description>When set, the auto-diagnose sweep is active (DateTime-stamp toggle; null = OFF, the safe default).</description>
+    <externalId>false</externalId>
+    <label>Enable Auto Diagnose DateTime</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/LastAutoDiagnoseScanDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/LastAutoDiagnoseScanDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>LastAutoDiagnoseScanDateTime__c</fullName>
+    <description>Bookkeeping stamp — last time the auto-diagnose sweep ran (used for the once-per-day guard).</description>
+    <externalId>false</externalId>
+    <label>Last Auto Diagnose Scan DateTime</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DiagnoseRule__mdt/DiagnoseRule__mdt.object-meta.xml
+++ b/force-app/main/default/objects/DiagnoseRule__mdt/DiagnoseRule__mdt.object-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>Diagnose Rule</label>
+    <description>Defines a rule for the auto-diagnose sweep: which captured field changes count as an anomaly, the window and count threshold that fire it, and the work request to auto-draft when the threshold is met. Rules are evaluated by the auto-diagnose sweep on a scheduled basis.</description>
+    <pluralLabel>Diagnose Rules</pluralLabel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/DiagnoseRule__mdt/fields/ActiveDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DiagnoseRule__mdt/fields/ActiveDateTime__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ActiveDateTime__c</fullName>
+    <description>When set, this rule is evaluated by the sweep (null = rule disabled).</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Active DateTime</label>
+    <required>false</required>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DiagnoseRule__mdt/fields/AnomalyValueTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/DiagnoseRule__mdt/fields/AnomalyValueTxt__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AnomalyValueTxt__c</fullName>
+    <description>Optional. New value that counts as anomalous; blank = any change to the watched field counts.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Anomaly Value</label>
+    <length>255</length>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DiagnoseRule__mdt/fields/CooldownHoursNumber__c.field-meta.xml
+++ b/force-app/main/default/objects/DiagnoseRule__mdt/fields/CooldownHoursNumber__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>CooldownHoursNumber__c</fullName>
+    <description>Do not draft again for this rule within this many hours of the last draft.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Cooldown Hours</label>
+    <precision>18</precision>
+    <scale>0</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DiagnoseRule__mdt/fields/CountThresholdNumber__c.field-meta.xml
+++ b/force-app/main/default/objects/DiagnoseRule__mdt/fields/CountThresholdNumber__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>CountThresholdNumber__c</fullName>
+    <description>Fire when at least this many distinct records match within the window.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Count Threshold</label>
+    <precision>18</precision>
+    <scale>0</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DiagnoseRule__mdt/fields/QuotedHoursNumber__c.field-meta.xml
+++ b/force-app/main/default/objects/DiagnoseRule__mdt/fields/QuotedHoursNumber__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>QuotedHoursNumber__c</fullName>
+    <description>Quoted hours stamped on the auto-drafted work request.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Quoted Hours</label>
+    <precision>18</precision>
+    <scale>2</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DiagnoseRule__mdt/fields/SortOrderNumber__c.field-meta.xml
+++ b/force-app/main/default/objects/DiagnoseRule__mdt/fields/SortOrderNumber__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>SortOrderNumber__c</fullName>
+    <description>Evaluation order.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Sort Order</label>
+    <precision>18</precision>
+    <scale>0</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DiagnoseRule__mdt/fields/WatchedFieldApiNameTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/DiagnoseRule__mdt/fields/WatchedFieldApiNameTxt__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>WatchedFieldApiNameTxt__c</fullName>
+    <description>API name of the tracked field whose changes signal the anomaly (matched against ActivityLog ComponentNameTxt).</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Watched Field API Name</label>
+    <length>255</length>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DiagnoseRule__mdt/fields/WatchedObjectApiNameTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/DiagnoseRule__mdt/fields/WatchedObjectApiNameTxt__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>WatchedObjectApiNameTxt__c</fullName>
+    <description>API name of the business object whose captured changes this rule watches (matched against the ActivityLog context objectName).</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Watched Object API Name</label>
+    <length>255</length>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DiagnoseRule__mdt/fields/WindowHoursNumber__c.field-meta.xml
+++ b/force-app/main/default/objects/DiagnoseRule__mdt/fields/WindowHoursNumber__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>WindowHoursNumber__c</fullName>
+    <description>Lookback window in hours for counting matching events (e.g. 24 = daily).</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Window Hours</label>
+    <precision>18</precision>
+    <scale>0</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DiagnoseRule__mdt/fields/WorkItemTitleTxt__c.field-meta.xml
+++ b/force-app/main/default/objects/DiagnoseRule__mdt/fields/WorkItemTitleTxt__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>WorkItemTitleTxt__c</fullName>
+    <description>Title template for the drafted work item. Supports tokens {count} and {object}.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Work Item Title</label>
+    <length>255</length>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/unpackaged/post/testSuites/DH.testSuite-meta.xml
+++ b/unpackaged/post/testSuites/DH.testSuite-meta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTestSuite xmlns="http://soap.sforce.com/2006/04/metadata">
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryAiControllerTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryAutoDiagnoseServiceTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryGanttControllerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliverySlackServiceTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryContentDocLinkTriggerHandlerTest</testClassName>


### PR DESCRIPTION
## What — the first unattended loop segment

Reads the captured field-change stream (`ActivityLog__c`, the SEE layer) and, when a configured anomaly threshold is crossed, **auto-drafts a quoted work request straight into the existing approval queue** — no human in the middle, no new pipeline. It reuses `DeliveryWorkApprovalService.submitForApproval`, the storefront that already ships. This is the bridge from *"the eyes saw a problem"* to *"an approvable fix is waiting in the queue."*

## Gated OFF by default — flip-ready, not live

Two gates, both required:
1. `DeliveryHubSettings__c.EnableAutoDiagnoseDateTime__c` — master flag (null = the safe shipping default).
2. At least one `DiagnoseRule__mdt` with `ActiveDateTime__c` set.

So it **no-ops every scheduler tick** until the SEE Flow is actually feeding business-object events (gated on #918 + an admin wiring the Flow) *and* an admin authors a rule. Nothing fires speculatively.

## Pieces

- **`DiagnoseRule__mdt`** (new, generic, ships empty) — watched object/field, optional anomaly value, window, count threshold, quoted hours, title template, cooldown. Mirrors the existing `WorkflowEscalationRule__mdt` config-rule pattern. **Nothing names a tenant's objects** — the package ships the engine; the subscriber authors rules.
- **`DeliveryAutoDiagnoseService`** — gated, once-per-day sweep. Counts distinct anomalous records in the window (filters on the queryable ActivityLog columns `ActionTypePk__c` + `ComponentNameTxt__c` + `CreatedDate`; confirms object/value from the ContextData JSON in Apex), dedups via a per-rule marker-prefixed work-item title within a cooldown, and drafts via `submitForApproval` at the rule's quote.
- **`DeliveryHubScheduler`** — one gated call added to `execute()`, so flipping the flag is all it takes to activate.
- **2 settings fields** (enable + last-scan bookkeeping), tests, suite registration.

## Tests

Both gates, threshold-crossing → **Offer-Sent draft in the queue**, anomaly-value filter, cooldown dedup, and the once-per-day guard. Rules are injected via a `@TestVisible` override (CMT can't be DML'd); ActivityLog rows are inserted in the capture engine's exact shape.

## How it goes live (later, not in this PR)

1. #918 promotes → admin wires a Record-Triggered Flow on the business object → SEE captures its events.
2. Admin authors one `DiagnoseRule__mdt` (e.g., "≥N error-status changes in 24h").
3. Flip `EnableAutoDiagnoseDateTime__c`. The next anomaly auto-drafts a request into the queue — the first thing that fires without Glen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
