### PR TITLE
fix(gantt): nameless fallback team line — stop leaking staff names on unconfigured orgs

### DIFF
--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -1698,8 +1698,11 @@ public with sharing class DeliveryGanttController {
         return out;
     }
 
-    /** @description The nameless fallback team line used when TeamPoolTxt__c is
-     *              unset/unparseable, so NG never reaches its named vendor roster. */
+    /**
+     * @description The nameless fallback team line used when TeamPoolTxt__c is
+     *              unset/unparseable, so NG never reaches its named vendor roster.
+     * @return A single active, role-labelled (not person-named) pool member.
+     */
     private static TeamPoolMemberDTO defaultTeamMember() {
         TeamPoolMemberDTO m = new TeamPoolMemberDTO();
         m.name = 'Delivery Team';

--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -1658,35 +1658,59 @@ public with sharing class DeliveryGanttController {
         try {
             DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
             String raw = settings == null ? null : settings.TeamPoolTxt__c;
-            if (String.isBlank(raw)) {
-                return out;
-            }
-            for (String entry : raw.split(';')) {
-                List<String> parts = entry.trim().split('\\|');
-                if (parts.size() < 3) {
-                    continue;
+            if (String.isNotBlank(raw)) {
+                for (String entry : raw.split(';')) {
+                    List<String> parts = entry.trim().split('\\|');
+                    if (parts.size() < 3) {
+                        continue;
+                    }
+                    Decimal hours;
+                    try {
+                        hours = Decimal.valueOf(parts[2].trim());
+                    } catch (Exception e) {
+                        continue;
+                    }
+                    if (String.isBlank(parts[0].trim()) || hours <= 0) {
+                        continue;
+                    }
+                    TeamPoolMemberDTO m = new TeamPoolMemberDTO();
+                    m.name = parts[0].trim();
+                    m.role = parts[1].trim();
+                    m.hoursPerMonth = hours;
+                    m.active = true;
+                    out.add(m);
                 }
-                Decimal hours;
-                try {
-                    hours = Decimal.valueOf(parts[2].trim());
-                } catch (Exception e) {
-                    continue;
-                }
-                if (String.isBlank(parts[0].trim()) || hours <= 0) {
-                    continue;
-                }
-                TeamPoolMemberDTO m = new TeamPoolMemberDTO();
-                m.name = parts[0].trim();
-                m.role = parts[1].trim();
-                m.hoursPerMonth = hours;
-                m.active = true;
-                out.add(m);
             }
         } catch (Exception e) {
             System.debug(LoggingLevel.WARN,
                 '[DeliveryGanttController.getTeamPool] parse failed: ' + e.getMessage());
             out.clear();
         }
+        // Never hand the gantt an EMPTY pool. An empty options.team makes NG fall
+        // back to its vendored vendor-default roster — real, named Cloud Nimbus
+        // staff at 170h/mo — which leaks those names + hours to EVERY subscriber
+        // that hasn't seeded TeamPoolTxt__c (a live demo-exposure risk). A single
+        // NAMELESS role line keeps the forecast denominator sane and exposes
+        // nobody; the org overrides it the moment it seeds TeamPoolTxt__c.
+        if (out.isEmpty()) {
+            out.add(defaultTeamMember());
+        }
         return out;
     }
+
+    /** @description The nameless fallback team line used when TeamPoolTxt__c is
+     *              unset/unparseable, so NG never reaches its named vendor roster. */
+    private static TeamPoolMemberDTO defaultTeamMember() {
+        TeamPoolMemberDTO m = new TeamPoolMemberDTO();
+        m.name = 'Delivery Team';
+        m.role = 'Delivery';
+        m.hoursPerMonth = DEFAULT_TEAM_CAPACITY_HOURS;
+        m.active = true;
+        return m;
+    }
+
+    /** @description Baseline monthly capacity for the nameless fallback team
+     *              line. A sane denominator only — the Pace dial (1x/2x/3x) is
+     *              the real staffing lever; seed TeamPoolTxt__c to replace it. */
+    private static final Decimal DEFAULT_TEAM_CAPACITY_HOURS = 160;
 }

--- a/force-app/main/default/classes/DeliveryGanttControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryGanttControllerTest.cls
@@ -1291,15 +1291,20 @@ private class DeliveryGanttControllerTest {
     }
 
     /**
-     * @description Blank/unset TeamPoolTxt__c resolves to an empty pool so the
-     *              LWC omits options.team and NG applies its own fallback.
+     * @description Blank/unset TeamPoolTxt__c resolves to a single NAMELESS
+     *              fallback line (not empty) so the LWC always passes options.team
+     *              and NG never reaches its named vendor roster — no staff names
+     *              leak to an unconfigured subscriber.
      */
     @IsTest
-    static void testGetTeamPoolBlankSettingReturnsEmpty() {
+    static void testGetTeamPoolBlankSettingReturnsNamelessDefault() {
         Test.startTest();
         List<DeliveryGanttController.TeamPoolMemberDTO> pool = DeliveryGanttController.getTeamPool();
         Test.stopTest();
-        System.assertEquals(0, pool.size(), 'unconfigured setting yields an empty pool, never an exception');
+        System.assertEquals(1, pool.size(), 'unconfigured setting yields one nameless fallback line');
+        System.assertEquals('Delivery Team', pool[0].name, 'fallback line is a role label, not a person');
+        System.assert(pool[0].hoursPerMonth > 0, 'fallback carries a sane capacity denominator');
+        System.assertEquals(true, pool[0].active, 'fallback line is active so NG counts it');
     }
 
 }


### PR DESCRIPTION
## The leak

On the 6/14 live walk, the **Team Capacity modal** showed real internal staff — **Glen / Mahi / Antima at 170h/mo** — to anyone who opened it. Cause: when `TeamPoolTxt__c` is unset, `getTeamPool()` returned an empty list → the LWC omitted `options.team` → **NG fell back to its vendored vendor-default roster** (named Cloud Nimbus staff). Every subscriber that hasn't seeded the setting hits this; in a client demo it exposes the vendor's team.

## The fix (consumer-side, no NG fork)

`getTeamPool()` now **never returns an empty pool**. When `TeamPoolTxt__c` is blank or unparseable it returns a single **nameless** role line — `Delivery Team`, 160h/mo baseline — so `options.team` is always set and NG never reaches its named fallback. The org overrides it the instant it seeds `TeamPoolTxt__c`; the **Pace dial (1×/2×/3×)** stays the real staffing lever, so the baseline number is just a sane denominator.

Respects the NG-substrate / DH-consumer layering — fixes it by feeding NG correct data, not forking the gantt.

## Test

`testGetTeamPoolBlankSettingReturnsEmpty` → `...ReturnsNamelessDefault`: asserts one member, name `Delivery Team` (a role, not a person), sane capacity, active. The parse + malformed-skip tests are unchanged (non-empty input still wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)