### PR TITLE
fix(approvals): agenda Pending tile reconciles to the approval queue

### DIFF
--- a/force-app/main/default/classes/DeliveryApprovalSummaryController.cls
+++ b/force-app/main/default/classes/DeliveryApprovalSummaryController.cls
@@ -131,10 +131,20 @@ public with sharing class DeliveryApprovalSummaryController {
      * @param dto DTO to fill (pendingCount / pendingQuotedHours).
      */
     private static void fillPendingAggregates(ApprovalSummaryDTO dto) {
+        // Scope to the SAME approver set the queue feed uses
+        // (DeliveryWorkApprovalService.getPendingForApprover) so this tile always
+        // reconciles to the queue card shown directly below it. Counting every
+        // Offer-Sent request org-wide made the agenda over-count the moment a
+        // request was assigned to a different approver — the numbers stopped
+        // matching the queue and the card lost trust.
+        Set<Id> approverIds =
+            DeliveryWorkApprovalService.resolveQueueApproverIds(UserInfo.getUserId());
         AggregateResult row = [
             SELECT COUNT(Id) cnt, SUM(QuotedHoursNumber__c) quoted
             FROM WorkRequest__c
             WHERE StatusPk__c = :REQUEST_OFFER_SENT
+              AND (ApproverUserLookup__c IN :approverIds
+                   OR ApproverUserLookup__c = NULL)
             WITH SYSTEM_MODE
         ];
         Integer cnt = (Integer) row.get('cnt');

--- a/force-app/main/default/classes/DeliveryApprovalSummaryControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryApprovalSummaryControllerTest.cls
@@ -14,6 +14,7 @@
  * @author Cloud Nimbus LLC
  */
 @IsTest
+@SuppressWarnings('PMD.ApexDoc')
 private class DeliveryApprovalSummaryControllerTest {
 
     /**

--- a/force-app/main/default/classes/DeliveryApprovalSummaryControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryApprovalSummaryControllerTest.cls
@@ -107,6 +107,68 @@ private class DeliveryApprovalSummaryControllerTest {
     }
 
     /**
+     * @description The pending tile must reconcile to the approval QUEUE: the
+     *              queue only shows the running approver's + unassigned requests,
+     *              so a request assigned to a DIFFERENT approver must be excluded
+     *              from the agenda's pending count too. (Pre-fix the agenda
+     *              counted every Offer-Sent request org-wide and silently
+     *              over-counted vs. the queue card directly below it.)
+     */
+    @IsTest
+    static void testPendingReconcilesToApproverScopedQueue() {
+        Id otherApprover = otherActiveUserId();
+        WorkItem__c mine = seedItem('Ready for Final Approval', null);
+        WorkItem__c theirs = seedItem('Ready for Final Approval', null);
+        // Unassigned → visible in both the queue and the agenda.
+        seedRequest(mine.Id, new Map<String, Object>{
+            'StatusPk__c' => 'Offer Sent',
+            'QuotedHoursNumber__c' => 10
+        });
+        // Assigned to another approver → in NEITHER this user's queue nor agenda.
+        seedRequest(theirs.Id, new Map<String, Object>{
+            'StatusPk__c' => 'Offer Sent',
+            'QuotedHoursNumber__c' => 99,
+            'ApproverUserLookup__c' => otherApprover
+        });
+
+        Test.startTest();
+        DeliveryApprovalSummaryController.ApprovalSummaryDTO dto =
+            DeliveryApprovalSummaryController.getApprovalSummary();
+        Test.stopTest();
+
+        System.assertEquals(1, dto.pendingCount,
+            'only the unassigned request counts — the other approver\'s is excluded, matching the queue');
+        System.assertEquals(10, dto.pendingQuotedHours,
+            'quoted-hours total excludes the other approver\'s request');
+    }
+
+    /** An active user other than the running user (created if the org has none). */
+    private static Id otherActiveUserId() {
+        List<User> others = [
+            SELECT Id FROM User
+            WHERE IsActive = true AND Id != :UserInfo.getUserId()
+            LIMIT 1
+        ];
+        if (!others.isEmpty()) {
+            return others[0].Id;
+        }
+        Profile p = [SELECT Id FROM Profile WHERE Name = 'Standard User' LIMIT 1];
+        String uniq = String.valueOf(Crypto.getRandomInteger()).replace('-', '')
+            + String.valueOf(Datetime.now().getTime());
+        User u = new User(
+            FirstName = 'Other', LastName = 'Approver', Alias = 'oappr',
+            Email = 'other.approver@example.com',
+            Username = 'other.approver.' + uniq + '@example.com',
+            ProfileId = p.Id, TimeZoneSidKey = 'America/New_York',
+            LocaleSidKey = 'en_US', EmailEncodingKey = 'UTF-8', LanguageLocaleKey = 'en_US'
+        );
+        System.runAs(new User(Id = UserInfo.getUserId())) {
+            insert u;
+        }
+        return u.Id;
+    }
+
+    /**
      * @description In-flight aggregate requires BOTH a positive client cap
      *              AND a stage inside the dev → deploying band: a capped
      *              Backlog item and an uncapped In-Development item are

--- a/force-app/main/default/classes/DeliveryWorkApprovalService.cls
+++ b/force-app/main/default/classes/DeliveryWorkApprovalService.cls
@@ -872,7 +872,7 @@ global with sharing class DeliveryWorkApprovalService {
      * @param approverId The user the queue is being fetched for.
      * @return Non-empty set of assignee ids to match ApproverUserLookup__c.
      */
-    private static Set<Id> resolveQueueApproverIds(Id approverId) {
+    public static Set<Id> resolveQueueApproverIds(Id approverId) {
         Set<Id> approverIds = new Set<Id>{ approverId };
         DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
         Id primaryId = resolveDefaultApproverId(settings);


### PR DESCRIPTION
## The distrust, root-caused

Glen flagged in the 6/15 standup that he doesn't trust the Approval Agenda numbers. Found it: the agenda's **Pending** tile counts every Offer-Sent request **org-wide**, but the queue card directly below it scopes to the running approver's (or unassigned) requests. They match on MF today only by luck — everything's assigned to Jose or unassigned. The moment a request is assigned to a different approver, the agenda over-counts and the two cards disagree.

## Fix

Scope the agenda's pending aggregate to the **same approver set the queue uses** (`resolveQueueApproverIds`, now exposed). The agenda Pending tile now always equals the queue card below it. Unassigned requests still count, so no change where they already reconciled.

Regression test pins it: an Offer-Sent request assigned to another approver is excluded from the agenda, matching the queue.

This is the Wednesday-safe agenda fix — it makes the number Jose stares at trustworthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)