### PR TITLE
feat(forecast+workspace): capacity slider + durable buyer-surface tabs (Approvals/Forecast)

### DIFF
--- a/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsController.cls
@@ -516,6 +516,95 @@ global with sharing class DeliveryHoursAnalyticsController {
     }
 
     /**
+     * @description One in-scope WorkItem as the capacity-forecast slider
+     *              (deliveryCapacityForecast LWC) consumes it: the flat,
+     *              leaf-only, board-active item with its estimate, logged,
+     *              remaining, dates, and commitment tier. The slider's
+     *              client-side greedy packer reflows these against a
+     *              dev-count ceiling to show when work lands per pace.
+     *
+     *              BUYER-FACING: this DTO is shown to the client. It carries
+     *              NO person identity — ItemSchedule.assignee
+     *              (DeveloperLookup__r.Name) is deliberately NOT mapped here.
+     *              `name` is the work-item label (BriefDescriptionTxt__c, else
+     *              the T-NNNN auto-number), never a developer. Keep it that way
+     *              in pass two — do not re-add assignee.
+     */
+    public class ForecastItemDTO {
+        @AuraEnabled public Id id;
+        @AuraEnabled public String name;
+        @AuraEnabled public String stage;
+        @AuraEnabled public Decimal estimate;
+        @AuraEnabled public Decimal logged;
+        /** estimate - logged, floored at 0 — the hours the packer schedules. */
+        @AuraEnabled public Decimal remaining;
+        @AuraEnabled public Date startDate;
+        @AuraEnabled public Date endDate;
+        /** PacingSegment.id (greenlit / predicted / ...) — same tier the stacked
+         *  forecast colors by; greenlit = client-approved (drains first). */
+        @AuraEnabled public String tier;
+        /** Terminal-stage (Done/Cancelled/...) — real history, no forward work;
+         *  the packer skips these so they never inflate the future schedule. */
+        @AuraEnabled public Boolean isTerminal;
+    }
+
+    /**
+     * @description The flat in-scope item list backing the capacity-forecast
+     *              slider — the SAME active portfolio scope, leaf-only counting,
+     *              terminal-stage handling, and tier resolution the stacked
+     *              forecast (getPacing) uses, exposed as raw items so the LWC
+     *              can repack them client-side against a dev-count ceiling
+     *              without an Apex round-trip per drag. Reuses
+     *              queryActiveRootIds + collectPortfolioTree + rollupPortfolioTotals
+     *              (which populates portfolioItemSchedules as it computes the
+     *              rollup) so this list and the headline forecast can never drift.
+     *
+     *              NOT cacheable — same live-edit / reprioritize staleness
+     *              landmine documented on getPacing below: the slider issues
+     *              reorder writes (updateWorkItemSortOrder) and the list must
+     *              reflect them on the next read, not serve a stale LDS cache.
+     * @return Every board-active leaf WorkItem in scope as a ForecastItemDTO
+     *         (estimate / logged / remaining / dates / tier); empty when none.
+     */
+    @AuraEnabled
+    public static List<ForecastItemDTO> getForecastItems() {
+        try {
+            Set<Id> rootIds = queryActiveRootIds();
+            Set<Id> portfolioIds = collectPortfolioTree(rootIds);
+            PortfolioPacingDTO dto = new PortfolioPacingDTO();
+            // Side effect: populates the static portfolioItemSchedules with the
+            // leaf-only, tier-resolved per-item schedules we map below.
+            rollupPortfolioTotals(dto, portfolioIds);
+
+            List<ForecastItemDTO> out = new List<ForecastItemDTO>();
+            for (ItemSchedule s : portfolioItemSchedules) {
+                ForecastItemDTO d = new ForecastItemDTO();
+                d.id = s.workItemId;
+                d.name = s.name;
+                d.stage = s.stage;
+                d.estimate = s.estimate == null ? 0 : s.estimate;
+                d.logged = s.logged == null ? 0 : s.logged;
+                Decimal rem = d.estimate - d.logged;
+                d.remaining = rem > 0 ? rem : 0;
+                d.startDate = s.startDate;
+                d.endDate = s.endDate;
+                d.tier = s.tier;
+                d.isTerminal = String.isNotBlank(s.stage)
+                    && terminalStages.contains(s.stage);
+                // s.assignee intentionally dropped — buyer-facing, no names.
+                out.add(d);
+            }
+            return out;
+        } catch (AuraHandledException ahe) {
+            throw ahe;
+        } catch (Exception e) {
+            AuraHandledException ahe = new AuraHandledException(e.getMessage());
+            ahe.setMessage(e.getMessage());
+            throw ahe;
+        }
+    }
+
+    /**
      * @description Serializes getPortfolioPacing into nimbus-gantt's render-ready
      *              PacingData shape (the DH->NG forecast contract,
      *              nimbus-gantt/docs/dispatch-pacing-view-0195.md) and returns it

--- a/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHoursAnalyticsControllerTest.cls
@@ -1489,4 +1489,93 @@ private class DeliveryHoursAnalyticsControllerTest {
         }
         System.assertEquals(0, totalItemHours, 'No placed item hours for an unscheduled item');
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    // getForecastItems — flat leaf-only item feed for the capacity slider
+    // ════════════════════════════════════════════════════════════════════
+
+    /** @description Indexes a ForecastItemDTO list by WorkItem id. */
+    private static Map<Id, DeliveryHoursAnalyticsController.ForecastItemDTO> byId(
+        List<DeliveryHoursAnalyticsController.ForecastItemDTO> items
+    ) {
+        Map<Id, DeliveryHoursAnalyticsController.ForecastItemDTO> out =
+            new Map<Id, DeliveryHoursAnalyticsController.ForecastItemDTO>();
+        for (DeliveryHoursAnalyticsController.ForecastItemDTO d : items) {
+            out.put(d.id, d);
+        }
+        return out;
+    }
+
+    @IsTest
+    static void testForecastItemsLeafOnlyWithRemainingAndTier() {
+        // Container parent (excluded by leaf-only) + leaf child, a greenlit leaf, and
+        // a partially-logged leaf so remaining = estimate - logged.
+        WorkItem__c parent = insertWi('FiParent', 200, Date.today(), Date.today().addMonths(2), null);
+        WorkItem__c child = insertWi('FiChild', 60, Date.today(), Date.today().addMonths(1), parent.Id);
+        WorkItem__c greenlit = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'FiGreenlit',
+            'EstimatedHoursNumber__c' => 40,
+            'EstimatedStartDevDate__c' => Date.today(),
+            'EstimatedEndDevDate__c' => Date.today().addMonths(1),
+            'ClientPreApprovedHoursNumber__c' => 40
+        });
+        insert buildLog(child.Id, 25, Date.today()); // child remaining = 60 - 25 = 35
+
+        Test.startTest();
+        List<DeliveryHoursAnalyticsController.ForecastItemDTO> items =
+            DeliveryHoursAnalyticsController.getForecastItems();
+        Test.stopTest();
+
+        Map<Id, DeliveryHoursAnalyticsController.ForecastItemDTO> m = byId(items);
+        System.assert(!m.containsKey(parent.Id),
+            'Leaf-only: the container parent must be excluded (its work is counted via the child)');
+        System.assert(m.containsKey(child.Id), 'The leaf child is in scope');
+        System.assert(m.containsKey(greenlit.Id), 'The greenlit leaf is in scope');
+
+        System.assertEquals(35, m.get(child.Id).remaining,
+            'remaining = estimate(60) - logged(25)');
+        System.assertEquals(false, m.get(child.Id).isTerminal, 'Backlog stage is not terminal');
+        System.assertEquals('greenlit', m.get(greenlit.Id).tier,
+            'ClientPreApprovedHoursNumber__c > 0 → greenlit tier (drains first in the packer)');
+        System.assertEquals(40, m.get(greenlit.Id).remaining,
+            'remaining floors at estimate when nothing is logged');
+    }
+
+    @IsTest
+    static void testForecastItemsRemainingFlooredAndTerminalFlagged() {
+        // Over-logged item → remaining floored at 0. A terminal-stage item only stays
+        // in scope as a non-root CHILD (queryActiveRootIds filters terminal ROOTS out),
+        // so the Done item hangs under an active parent and is flagged terminal there.
+        WorkItem__c overLogged = insertWi('FiOver', 10, Date.today(), Date.today().addMonths(1), null);
+        WorkItem__c termParent = insertWi('FiTermParent', 100, Date.today(), Date.today().addMonths(2), null);
+        WorkItem__c doneItem = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'BriefDescriptionTxt__c' => 'FiDone',
+            'EstimatedHoursNumber__c' => 30,
+            'StageNamePk__c' => 'Done',
+            'ParentWorkItemLookup__c' => termParent.Id
+        });
+        insert buildLog(overLogged.Id, 18, Date.today()); // 10 - 18 → floored to 0
+
+        Test.startTest();
+        List<DeliveryHoursAnalyticsController.ForecastItemDTO> items =
+            DeliveryHoursAnalyticsController.getForecastItems();
+        Test.stopTest();
+
+        Map<Id, DeliveryHoursAnalyticsController.ForecastItemDTO> m = byId(items);
+        System.assertEquals(0, m.get(overLogged.Id).remaining,
+            'remaining never goes negative — floored at 0');
+        System.assertEquals(true, m.get(doneItem.Id).isTerminal,
+            'Done is a terminal stage — the packer skips it so it never inflates the future');
+    }
+
+    @IsTest
+    static void testForecastItemsEmptyScopeReturnsEmptyList() {
+        Test.startTest();
+        List<DeliveryHoursAnalyticsController.ForecastItemDTO> items =
+            DeliveryHoursAnalyticsController.getForecastItems();
+        Test.stopTest();
+
+        System.assertNotEquals(null, items, 'Never null — empty list when no active items');
+        System.assertEquals(0, items.size(), 'No active portfolio items → empty');
+    }
 }

--- a/force-app/main/default/lwc/deliveryCapacityForecast/__tests__/deliveryCapacityForecast.test.js
+++ b/force-app/main/default/lwc/deliveryCapacityForecast/__tests__/deliveryCapacityForecast.test.js
@@ -1,0 +1,145 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryCapacityForecast: the client-side
+ *               staffing-ramp packer (greenlit drains first, build-out packs,
+ *               terminal / zero-remaining items dropped), the per-month vs
+ *               cumulative toggle (cumulative totals never decrease), the live
+ *               "lands by" readout, and the empty / error states. Mirrors the
+ *               prototype buildSchedule the slider productizes.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from "lwc";
+import DeliveryCapacityForecast from "c/deliveryCapacityForecast";
+import getForecastItems from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHoursAnalyticsController.getForecastItems";
+
+function item(overrides = {}) {
+    return {
+        id: overrides.id || "a00000000000001AAA",
+        name: overrides.name || "Item",
+        tier: overrides.tier || "predicted",
+        remaining: overrides.remaining != null ? overrides.remaining : 40,
+        startDate: overrides.startDate || "2026-06-01",
+        isTerminal: overrides.isTerminal || false
+    };
+}
+
+function createComponent() {
+    const element = createElement("c-delivery-capacity-forecast", {
+        is: DeliveryCapacityForecast
+    });
+    document.body.appendChild(element);
+    return element;
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function columnTotals(element) {
+    return Array.from(element.shadowRoot.querySelectorAll(".chart .col .total")).map(
+        (n) => parseInt(n.textContent, 10)
+    );
+}
+
+describe("c-delivery-capacity-forecast", () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it("renders staffing-ramped stacked bars from the wire data", async () => {
+        const element = createComponent();
+        getForecastItems.emit([
+            item({ id: "a01", remaining: 300, tier: "predicted" }),
+            item({ id: "a02", remaining: 200, tier: "greenlit" })
+        ]);
+        await flushPromises();
+
+        const cols = element.shadowRoot.querySelectorAll(".chart .col");
+        expect(cols.length).toBeGreaterThan(0);
+        // The greenlit pool produces a committed band somewhere in the stack.
+        const committed = element.shadowRoot.querySelector('.seg[title^="Greenlit"]');
+        expect(committed).not.toBeNull();
+        // Ramp: month one total is below the full 3-dev ceiling (480h) — it climbs.
+        const totals = columnTotals(element);
+        expect(totals[0]).toBeLessThan(480);
+        expect(totals.every((t) => Number.isFinite(t))).toBe(true);
+    });
+
+    it("drops terminal and zero-remaining items from the schedule", async () => {
+        const element = createComponent();
+        getForecastItems.emit([
+            item({ id: "a01", remaining: 100, isTerminal: true }),
+            item({ id: "a02", remaining: 0 })
+        ]);
+        await flushPromises();
+
+        // Nothing forward to pack → empty state, not a chart.
+        expect(element.shadowRoot.querySelector(".chart")).toBeNull();
+        expect(element.shadowRoot.textContent).toContain("No active work in scope");
+    });
+
+    it("shows a live 'lands by' readout", async () => {
+        const element = createComponent();
+        getForecastItems.emit([item({ id: "a01", remaining: 120, tier: "predicted" })]);
+        await flushPromises();
+
+        expect(element.shadowRoot.textContent).toContain("Everything lands by");
+    });
+
+    it("cumulative toggle makes per-column totals non-decreasing", async () => {
+        const element = createComponent();
+        getForecastItems.emit([
+            item({ id: "a01", remaining: 600, tier: "predicted" }),
+            item({ id: "a02", remaining: 300, tier: "greenlit" })
+        ]);
+        await flushPromises();
+
+        const toggle = element.shadowRoot.querySelector("lightning-button");
+        toggle.dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+
+        const totals = columnTotals(element);
+        for (let i = 1; i < totals.length; i++) {
+            expect(totals[i]).toBeGreaterThanOrEqual(totals[i - 1]);
+        }
+    });
+
+    it("reflows when the dev-count slider changes", async () => {
+        const element = createComponent();
+        getForecastItems.emit([item({ id: "a01", remaining: 800, tier: "predicted" })]);
+        await flushPromises();
+
+        // Month 0 always exists; raising the dev ceiling lifts its packed total.
+        const before = columnTotals(element)[0];
+        const slider = element.shadowRoot.querySelector(".dev-slider");
+        slider.value = 6;
+        slider.dispatchEvent(new CustomEvent("change"));
+        await flushPromises();
+
+        const after = columnTotals(element)[0];
+        // More devs → a taller stack in the first month (steeper ramp ceiling).
+        expect(after).toBeGreaterThan(before);
+    });
+
+    it("shows the empty state when no items are in scope", async () => {
+        const element = createComponent();
+        getForecastItems.emit([]);
+        await flushPromises();
+
+        expect(element.shadowRoot.textContent).toContain("No active work in scope");
+        expect(element.shadowRoot.querySelector(".chart")).toBeNull();
+    });
+
+    it("shows an error when the wire errors", async () => {
+        const element = createComponent();
+        getForecastItems.error();
+        await flushPromises();
+
+        expect(element.shadowRoot.querySelector(".slds-text-color_error")).not.toBeNull();
+        expect(element.shadowRoot.querySelector(".chart")).toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/deliveryCapacityForecast/deliveryCapacityForecast.css
+++ b/force-app/main/default/lwc/deliveryCapacityForecast/deliveryCapacityForecast.css
@@ -1,0 +1,68 @@
+.dev-slider {
+    width: 100%;
+    accent-color: #1b1b3a;
+}
+
+.lands {
+    color: #b45309;
+    font-weight: 700;
+}
+
+.legend-item {
+    display: inline-flex;
+    align-items: center;
+    font-size: 0.75rem;
+    color: #514f4d;
+    margin-bottom: 0.25rem;
+}
+
+.swatch {
+    display: inline-block;
+    width: 0.7rem;
+    height: 0.7rem;
+    border-radius: 2px;
+    margin-right: 0.35rem;
+}
+
+.chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.4rem;
+    height: 280px;
+    overflow-x: auto;
+}
+
+.col {
+    display: flex;
+    flex: 1 0 2.2rem;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+.total {
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #514f4d;
+    margin-bottom: 0.25rem;
+}
+
+.bar {
+    display: flex;
+    flex-direction: column-reverse;
+    width: 100%;
+    border-radius: 3px 3px 0 0;
+    overflow: hidden;
+}
+
+.seg {
+    width: 100%;
+}
+
+.mlabel {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #706e6b;
+    margin-top: 0.4rem;
+    white-space: nowrap;
+}

--- a/force-app/main/default/lwc/deliveryCapacityForecast/deliveryCapacityForecast.html
+++ b/force-app/main/default/lwc/deliveryCapacityForecast/deliveryCapacityForecast.html
@@ -1,0 +1,86 @@
+<template>
+    <lightning-card title="Capacity forecast — you set the pace" icon-name="utility:trending">
+        <div class="slds-p-horizontal_medium slds-p-bottom_medium">
+
+            <template if:true={loading}>
+                <lightning-spinner alternative-text="Loading forecast" size="small"></lightning-spinner>
+            </template>
+
+            <template if:true={error}>
+                <div class="slds-text-color_error slds-p-vertical_small">{error}</div>
+            </template>
+
+            <template if:true={isEmpty}>
+                <div class="slds-text-color_weak slds-p-vertical_small">
+                    No active work in scope to forecast yet.
+                </div>
+            </template>
+
+            <template if:true={hasItems}>
+                <!-- Pace dial -->
+                <div class="slds-grid slds-grid_align-spread slds-grid_vertical-align-end slds-wrap">
+                    <div>
+                        <p class="slds-text-title_caps slds-text-color_weak">Your pace ceiling</p>
+                        <p class="slds-text-heading_medium">{devLabel}</p>
+                        <p class="slds-text-body_small slds-text-color_weak">{paceHint}</p>
+                    </div>
+                    <div class="slds-text-align_right">
+                        <p class="slds-text-title_caps slds-text-color_weak">Everything lands by</p>
+                        <p class="slds-text-heading_medium lands">{landsBy}</p>
+                    </div>
+                </div>
+
+                <input
+                    type="range"
+                    min="1"
+                    max="6"
+                    step="1"
+                    value={devs}
+                    onchange={handleDevs}
+                    class="slds-slider__range slds-m-top_small dev-slider"
+                />
+                <div class="slds-grid slds-grid_align-spread slds-text-body_small slds-text-color_weak">
+                    <span>1 dev</span><span>6 devs</span>
+                </div>
+
+                <!-- View toggle + legend -->
+                <div class="slds-grid slds-grid_align-spread slds-grid_vertical-align-center slds-wrap slds-m-top_medium">
+                    <div class="slds-grid slds-wrap slds-grid_vertical-align-center legend">
+                        <template for:each={legend} for:item="l">
+                            <span key={l.key} class="slds-m-right_small legend-item">
+                                <span class="swatch" style={l.swatch}></span>{l.label}
+                            </span>
+                        </template>
+                    </div>
+                    <lightning-button
+                        label={cumulativeLabel}
+                        variant="neutral"
+                        onclick={toggleCumulative}
+                        title="Toggle per-month vs cumulative"
+                    ></lightning-button>
+                </div>
+
+                <!-- Stacked bars -->
+                <div class="chart slds-m-top_medium">
+                    <template for:each={chartMonths} for:item="mo">
+                        <div key={mo.key} class="col">
+                            <span class="total">{mo.total}h</span>
+                            <div class="bar" style={mo.barStyle}>
+                                <template for:each={mo.segments} for:item="seg">
+                                    <div key={seg.key} class="seg" style={seg.style} title={seg.title}></div>
+                                </template>
+                            </div>
+                            <span class="mlabel">{mo.label}</span>
+                        </div>
+                    </template>
+                </div>
+
+                <p class="slds-text-body_small slds-text-color_weak slds-m-top_small">
+                    Set the ceiling → the schedule reflows → the dates appear. The stack climbs to your
+                    pace as the team staffs up. Greenlit work drains first; build-out packs into what’s
+                    left. Maintenance and run-point are modeled reserves, not a board figure.
+                </p>
+            </template>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/deliveryCapacityForecast/deliveryCapacityForecast.js
+++ b/force-app/main/default/lwc/deliveryCapacityForecast/deliveryCapacityForecast.js
@@ -1,0 +1,220 @@
+import { LightningElement, wire, track } from 'lwc';
+import { NavigationMixin } from 'lightning/navigation';
+import getForecastItems from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHoursAnalyticsController.getForecastItems';
+
+// ── Scheduler constants (synthesized bands; no DH data home yet — pass two may
+//    model maintenance/run-point as real fields). Ported 1:1 from the prototype
+//    cloudnimbusllc.com/src/app/glen/mf-forecast-stack-0607/MfForecastStack0607.tsx.
+const MAINT = 90; // measured maintenance run-rate, h/mo, reserved off the top
+const HOURS_PER_DEV = 160; // ~1 developer-month
+const ORCH_START = 0.35; // run-point load as a fraction of output during spin-up
+const ORCH_FLOOR = 0.1; // steady-state run-point fraction once the team absorbs it
+const HORIZON = 18; // months drawn
+
+const GREENLIT = 'greenlit';
+
+// Stacked bands, drawn bottom→top. committed + conditional are REAL DH items
+// (split by tier); maintenance + run-point are synthesized constants.
+const LAYERS = [
+    { key: 'committed', label: 'Greenlit / in-motion', color: '#10b981' },
+    { key: 'maintenance', label: 'Predictable maintenance', color: '#6366f1' },
+    { key: 'conditional', label: 'Build-out (scoped, pending)', color: '#f59e0b' },
+    { key: 'orchestration', label: 'Run-point (tapering)', color: '#475569' }
+];
+
+const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+export default class DeliveryCapacityForecast extends NavigationMixin(LightningElement) {
+    @track items = [];
+    devs = 3;
+    cumulative = false;
+    error;
+    loading = true;
+
+    @wire(getForecastItems)
+    wiredItems({ data, error }) {
+        this.loading = false;
+        if (data) {
+            // Only forward work packs: drop terminal-stage items and anything with
+            // no remaining hours — they are history, not future schedule.
+            this.items = data
+                .filter((d) => !d.isTerminal && (d.remaining || 0) > 0)
+                .map((d) => ({
+                    id: d.id,
+                    name: d.name,
+                    tier: d.tier,
+                    remaining: d.remaining || 0,
+                    startDate: d.startDate
+                }));
+            this.error = undefined;
+        } else if (error) {
+            this.error = (error.body && error.body.message) || 'Unable to load forecast items.';
+            this.items = [];
+        }
+    }
+
+    // ── Slider / toggle handlers ────────────────────────────────────────────
+    handleDevs(event) {
+        this.devs = parseInt(event.target.value, 10);
+    }
+
+    toggleCumulative() {
+        this.cumulative = !this.cumulative;
+    }
+
+    get ceiling() {
+        return this.devs * HOURS_PER_DEV;
+    }
+
+    get devLabel() {
+        return `${this.devs} developer${this.devs > 1 ? 's' : ''} · ~${this.ceiling} h/mo`;
+    }
+
+    get cumulativeLabel() {
+        return this.cumulative ? 'Cumulative' : 'Per month';
+    }
+
+    get hasItems() {
+        return !this.loading && !this.error && this.items.length > 0;
+    }
+
+    get isEmpty() {
+        return !this.loading && !this.error && this.items.length === 0;
+    }
+
+    // ── Greedy scheduler with a staffing ramp ───────────────────────────────
+    // Ported from buildSchedule(ceiling, devs): effective ceiling climbs over the
+    // first ~2 months (you can't hire instantly), committed work drains first,
+    // build-out packs into what's left, run-point rides on top as a declining
+    // fraction of output. Runs client-side so the slider reflows with no Apex hop.
+    get schedule() {
+        const ceiling = this.ceiling;
+        const devs = this.devs;
+        const declinePerMonth = 0.02 + (devs - 1) * 0.012;
+
+        // committed (greenlit) drains first as one pool; build-out items pack in
+        // order (start date, then largest first) — pass two wires drag-reorder.
+        let committedLeft = 0;
+        const build = [];
+        for (const it of this.items) {
+            if (it.tier === GREENLIT) {
+                committedLeft += it.remaining;
+            } else {
+                build.push({ ...it, left: it.remaining });
+            }
+        }
+        build.sort((a, b) => {
+            const ad = a.startDate || '9999-12-31';
+            const bd = b.startDate || '9999-12-31';
+            if (ad !== bd) return ad < bd ? -1 : 1;
+            return b.left - a.left;
+        });
+
+        const months = [];
+        let ip = 0;
+        let mi = 0;
+        let landsIndex = -1;
+        while ((committedLeft > 0.01 || ip < build.length) && mi < HORIZON) {
+            const rampFactor = Math.min(1, 0.45 + mi * 0.275);
+            const effCeiling = ceiling * rampFactor;
+            let a = Math.max(20, effCeiling - MAINT);
+
+            const cAlloc = Math.min(committedLeft, a);
+            committedLeft -= cAlloc;
+            a -= cAlloc;
+
+            let bAlloc = 0;
+            const allocs = [];
+            while (ip < build.length && a > 0.01) {
+                const it = build[ip];
+                const take = Math.min(it.left, a);
+                it.left -= take;
+                a -= take;
+                bAlloc += take;
+                if (take > 0.01) allocs.push({ id: it.id, name: it.name, hours: Math.round(take) });
+                if (it.left <= 0.01) {
+                    landsIndex = mi;
+                    ip++;
+                }
+            }
+            if (cAlloc > 0.01 && landsIndex < mi && committedLeft <= 0.01) landsIndex = mi;
+
+            const output = cAlloc + MAINT + bAlloc;
+            const glenRate = Math.max(ORCH_FLOOR, ORCH_START - mi * declinePerMonth);
+            months.push({
+                index: mi,
+                committed: Math.round(cAlloc),
+                maintenance: MAINT,
+                conditional: Math.round(bAlloc),
+                orchestration: Math.round(glenRate * output),
+                allocs
+            });
+            mi++;
+        }
+        const overflow = committedLeft > 0.01 || ip < build.length;
+        return { months, overflow, landsIndex };
+    }
+
+    // ── Render model: per-month (or cumulative) stacked bars scaled to peak ──
+    get chartMonths() {
+        const sched = this.schedule;
+        const running = { committed: 0, maintenance: 0, conditional: 0, orchestration: 0 };
+
+        const rows = sched.months.map((mo) => {
+            const vals = {};
+            let total = 0;
+            for (const l of LAYERS) {
+                let v = mo[l.key];
+                if (this.cumulative) {
+                    running[l.key] += v;
+                    v = running[l.key];
+                }
+                vals[l.key] = v;
+                total += v;
+            }
+            return { ...mo, vals, total };
+        });
+
+        const peak = Math.max(1, ...rows.map((r) => r.total));
+        return rows.map((r) => ({
+            key: `m${r.index}`,
+            label: this.monthLabel(r.index),
+            total: r.total,
+            segments: LAYERS.filter((l) => r.vals[l.key] > 0).map((l) => ({
+                key: l.key,
+                color: l.color,
+                style: `height:${((r.vals[l.key] / r.total) * 100).toFixed(2)}%;background:${l.color};`,
+                title: `${l.label}: ${r.vals[l.key]}h`
+            })),
+            barStyle: `height:${((r.total / peak) * 230).toFixed(0)}px;`
+        }));
+    }
+
+    get legend() {
+        return LAYERS.map((l) => ({ key: l.key, label: l.label, swatch: `background:${l.color};` }));
+    }
+
+    get landsBy() {
+        const sched = this.schedule;
+        if (sched.overflow || sched.landsIndex < 0) return `beyond ${HORIZON} mo`;
+        return this.monthLabel(sched.landsIndex);
+    }
+
+    get paceHint() {
+        if (this.devs <= 2) return 'Conservative — protect cash, slower build';
+        if (this.devs === 3) return '≈ today’s pace';
+        if (this.devs <= 4) return 'Leaning in — important work pulls forward';
+        return 'Full throttle — fastest path to the milestones';
+    }
+
+    // Month label N months from the current month. Watermark/last-worklog anchoring
+    // is a pass-two refinement; pass one anchors on the current month.
+    monthLabel(offset) {
+        const base = new Date();
+        const m = base.getMonth() + offset;
+        const year = base.getFullYear() + Math.floor(m / 12);
+        const name = MONTH_NAMES[((m % 12) + 12) % 12];
+        const yy = String(year).slice(2);
+        return year === base.getFullYear() ? name : `${name} ’${yy}`;
+    }
+}

--- a/force-app/main/default/lwc/deliveryCapacityForecast/deliveryCapacityForecast.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryCapacityForecast/deliveryCapacityForecast.js-meta.xml
@@ -2,7 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
     <masterLabel>Delivery Capacity Forecast</masterLabel>
-    <description>Buyer-facing capacity-forecast slider: drag the developer-count ceiling and the active portfolio reflows into a staffing-ramped per-month (or cumulative) stacked forecast with a live "everything lands by" date. Aggregate hours and commitment tiers only — no developer names or rates.</description>
+    <description>Buyer-facing capacity-forecast slider: drag the developer-count ceiling and the active portfolio reflows into a staffing-ramped per-month or cumulative stacked forecast with a live "lands by" date. Aggregate hours and tiers only — no names.</description>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__AppPage</target>

--- a/force-app/main/default/lwc/deliveryCapacityForecast/deliveryCapacityForecast.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryCapacityForecast/deliveryCapacityForecast.js-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <masterLabel>Delivery Capacity Forecast</masterLabel>
+    <description>Buyer-facing capacity-forecast slider: drag the developer-count ceiling and the active portfolio reflows into a staffing-ramped per-month (or cumulative) stacked forecast with a live "everything lands by" date. Aggregate hours and commitment tiers only — no developer names or rates.</description>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightning__Tab</target>
+    </targets>
+</LightningComponentBundle>

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHoursAnalyticsController.getForecastItems.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHoursAnalyticsController.getForecastItems.js
@@ -1,0 +1,8 @@
+/**
+ * Wire adapter mock for DeliveryHoursAnalyticsController.getForecastItems.
+ * Used by the c-delivery-capacity-forecast jest tests.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+
+const getForecastItems = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getForecastItems };


### PR DESCRIPTION
## What
Two related buyer-surface changes shipped as one release:

### 1. Capacity-forecast slider (`deliveryCapacityForecast`)
Productizes the `mf-forecast-stack-0607` prototype: a buyer-facing dev-allocation slider wired to live WorkItems. Drag "# of devs" → the portfolio reflows into a staffing-ramped per-month/cumulative stacked forecast with a live "lands by" date.
- **Apex `getForecastItems()`** (additive, NOT cacheable, does not touch `getPacing`) exposes the leaf-only, tier-resolved item list `rollupPortfolioTotals` already computes. `ForecastItemDTO` drops `assignee` — aggregate hours + tiers only, never names.
- LWC ports the **real `buildSchedule` packer 1:1** (ramp, greenlit-drains-first, run-point taper), client-side reflow. 3 Apex + 7 jest tests.

### 2. Durable buyer-surface fix (the nimba blocker)
Three-agent review found the root cause of "the approval queue doesn't show in subscriber orgs": the package **already** sets `DeliveryHubHome` as the app Home, but a subscriber's **activated custom Home overrides it and survives upgrades** — so no Home-based placement is durable. `deliveryCapacityForecast` was also orphaned (on no surface).

**Fix:** host the buyer surfaces inside `deliveryHubWorkspace` (the LWC behind the package-owned "Delivery" tab), whose inner tabs ship + upgrade with the package and are immune to subscriber Home/nav customization:
- **Approvals** tab → `deliveryApprovalSummaryCard` + `deliveryApprovalQueue` (ungated; Apex scopes to the approver).
- **Forecast** tab → `deliveryPacingForecast` + `deliveryCapacityForecast`.

All four children verified self-contained (no required `@api`). Default tab stays `board` — no behavior change for existing users. No new metadata, no app/FlexiPage edits.

## Why it matters
The approval queue now reaches every subscriber via the Delivery tab regardless of their custom Home — no per-org App-Builder placement, which was the un-durable manual step.

## Tests
3 Apex + 7 jest (all green locally). apex-scan + namespaced feature-test green pre-workspace-commit; re-running with the workspace edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
