### PR TITLE
feat(workspace): durable buyer surfaces — Approvals + Forecast tabs in the Delivery tab

### DIFF
--- a/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
+++ b/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
@@ -21,6 +21,22 @@
             <c-delivery-guide></c-delivery-guide>
         </lightning-tab>
 
+        <!-- Buyer-facing surfaces, hosted here (the package-owned "Delivery" tab) so they
+             survive subscriber Home-page overrides — a subscriber-activated custom Home
+             hides the package Home FlexiPage on upgrade, but cannot touch these inner tabs.
+             Ungated: the Apex layer (getPendingForApprover / getApprovalSummary) already
+             scopes data to the running approver, so a non-approver simply sees an empty
+             queue rather than being blocked. -->
+        <lightning-tab label="Approvals" value="approvals" icon-name="standard:approval">
+            <c-delivery-approval-summary-card></c-delivery-approval-summary-card>
+            <c-delivery-approval-queue></c-delivery-approval-queue>
+        </lightning-tab>
+
+        <lightning-tab label="Forecast" value="forecast" icon-name="standard:trending">
+            <c-delivery-pacing-forecast></c-delivery-pacing-forecast>
+            <c-delivery-capacity-forecast></c-delivery-capacity-forecast>
+        </lightning-tab>
+
         <template lwc:if={isAdmin}>
             <lightning-tab label="Templates" value="templates" icon-name="standard:template">
                 <c-delivery-template-manager></c-delivery-template-manager>

--- a/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
+++ b/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
@@ -32,7 +32,7 @@
             <c-delivery-approval-queue></c-delivery-approval-queue>
         </lightning-tab>
 
-        <lightning-tab label="Forecast" value="forecast" icon-name="standard:trending">
+        <lightning-tab label="Forecast" value="forecast" icon-name="standard:forecasts">
             <c-delivery-pacing-forecast></c-delivery-pacing-forecast>
             <c-delivery-capacity-forecast></c-delivery-capacity-forecast>
         </lightning-tab>

--- a/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.js
+++ b/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.js
@@ -14,15 +14,24 @@ import isAdminUser from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboar
 export default class DeliveryHubWorkspace extends LightningElement {
     @track activeTab = 'board';
     @track isAdmin = false;
+    _userPicked = false;
 
     @wire(isAdminUser)
     wiredAdmin({ data }) {
         if (data === true || data === false) {
             this.isAdmin = data;
+            // Buyers (non-admins) land on Approvals — the actionable surface for the
+            // approver persona — so the Delivery tab opens useful instead of on the
+            // client-filtered Board (which reads empty for a buyer). Admins/devs keep
+            // Board. Only applies before the user has picked a tab themselves.
+            if (!this._userPicked && data === false) {
+                this.activeTab = 'approvals';
+            }
         }
     }
 
     handleTabChange(event) {
+        this._userPicked = true;
         this.activeTab = event.target.value;
     }
 }


### PR DESCRIPTION
## What
Adds **Approvals** and **Forecast** tabs to `deliveryHubWorkspace` (the LWC behind the package-owned "Delivery" tab). Follow-up to #923 (which shipped the capacity slider but raced ahead of these two commits at merge — they were stranded on the old branch).

- **Approvals** tab → `deliveryApprovalSummaryCard` + `deliveryApprovalQueue` (ungated; Apex scopes to the running approver).
- **Forecast** tab → `deliveryPacingForecast` + `deliveryCapacityForecast` (fixes the orphaned slider from #923).
- **Buyers default to the Approvals tab** (admins keep Board) so the Delivery tab opens on the actionable surface, not the client-filtered Board. Honors a manual tab pick thereafter.

## Why
Three-agent review found the root cause of "the approval queue never shows in subscriber orgs": the package already sets `DeliveryHubHome` as the app Home, but a subscriber's **activated custom Home overrides it and survives upgrades**, so no Home-based placement is durable. The workspace tab's inner tabs ship + upgrade with the package and are **immune to subscriber Home/nav customization** — so the queue reaches every subscriber regardless of their custom Home, with no per-org App-Builder placement.

All four child LWCs verified self-contained (no required `@api`). No new metadata, no app/FlexiPage edits.

## Scope
Pure LWC (html + js), 25 lines. No Apex change. The slider's Apex/tests already landed in #923.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
