### PR TITLE
fix(forecast): render the capacity slider — call getForecastItems imperatively (not @wire)

### DIFF
--- a/force-app/main/default/lwc/deliveryCapacityForecast/__tests__/deliveryCapacityForecast.test.js
+++ b/force-app/main/default/lwc/deliveryCapacityForecast/__tests__/deliveryCapacityForecast.test.js
@@ -6,7 +6,10 @@
  *               terminal / zero-remaining items dropped), the per-month vs
  *               cumulative toggle (cumulative totals never decrease), the live
  *               "lands by" readout, and the empty / error states. Mirrors the
- *               prototype buildSchedule the slider productizes.
+ *               prototype buildSchedule the slider productizes. getForecastItems
+ *               is called IMPERATIVELY (the Apex is non-cacheable by design, so
+ *               it cannot be @wired) — the mock is a jest.fn resolved/rejected
+ *               per case before the component mounts.
  * @author       Cloud Nimbus LLC
  */
 import { createElement } from "lwc";
@@ -50,12 +53,12 @@ describe("c-delivery-capacity-forecast", () => {
         jest.clearAllMocks();
     });
 
-    it("renders staffing-ramped stacked bars from the wire data", async () => {
-        const element = createComponent();
-        getForecastItems.emit([
+    it("renders staffing-ramped stacked bars from the apex data", async () => {
+        getForecastItems.mockResolvedValue([
             item({ id: "a01", remaining: 300, tier: "predicted" }),
             item({ id: "a02", remaining: 200, tier: "greenlit" })
         ]);
+        const element = createComponent();
         await flushPromises();
 
         const cols = element.shadowRoot.querySelectorAll(".chart .col");
@@ -70,11 +73,11 @@ describe("c-delivery-capacity-forecast", () => {
     });
 
     it("drops terminal and zero-remaining items from the schedule", async () => {
-        const element = createComponent();
-        getForecastItems.emit([
+        getForecastItems.mockResolvedValue([
             item({ id: "a01", remaining: 100, isTerminal: true }),
             item({ id: "a02", remaining: 0 })
         ]);
+        const element = createComponent();
         await flushPromises();
 
         // Nothing forward to pack → empty state, not a chart.
@@ -83,19 +86,19 @@ describe("c-delivery-capacity-forecast", () => {
     });
 
     it("shows a live 'lands by' readout", async () => {
+        getForecastItems.mockResolvedValue([item({ id: "a01", remaining: 120, tier: "predicted" })]);
         const element = createComponent();
-        getForecastItems.emit([item({ id: "a01", remaining: 120, tier: "predicted" })]);
         await flushPromises();
 
         expect(element.shadowRoot.textContent).toContain("Everything lands by");
     });
 
     it("cumulative toggle makes per-column totals non-decreasing", async () => {
-        const element = createComponent();
-        getForecastItems.emit([
+        getForecastItems.mockResolvedValue([
             item({ id: "a01", remaining: 600, tier: "predicted" }),
             item({ id: "a02", remaining: 300, tier: "greenlit" })
         ]);
+        const element = createComponent();
         await flushPromises();
 
         const toggle = element.shadowRoot.querySelector("lightning-button");
@@ -109,8 +112,8 @@ describe("c-delivery-capacity-forecast", () => {
     });
 
     it("reflows when the dev-count slider changes", async () => {
+        getForecastItems.mockResolvedValue([item({ id: "a01", remaining: 800, tier: "predicted" })]);
         const element = createComponent();
-        getForecastItems.emit([item({ id: "a01", remaining: 800, tier: "predicted" })]);
         await flushPromises();
 
         // Month 0 always exists; raising the dev ceiling lifts its packed total.
@@ -126,17 +129,17 @@ describe("c-delivery-capacity-forecast", () => {
     });
 
     it("shows the empty state when no items are in scope", async () => {
+        getForecastItems.mockResolvedValue([]);
         const element = createComponent();
-        getForecastItems.emit([]);
         await flushPromises();
 
         expect(element.shadowRoot.textContent).toContain("No active work in scope");
         expect(element.shadowRoot.querySelector(".chart")).toBeNull();
     });
 
-    it("shows an error when the wire errors", async () => {
+    it("shows an error when the apex call fails", async () => {
+        getForecastItems.mockRejectedValue({ body: { message: "boom" } });
         const element = createComponent();
-        getForecastItems.error();
         await flushPromises();
 
         expect(element.shadowRoot.querySelector(".slds-text-color_error")).not.toBeNull();

--- a/force-app/main/default/lwc/deliveryCapacityForecast/deliveryCapacityForecast.js
+++ b/force-app/main/default/lwc/deliveryCapacityForecast/deliveryCapacityForecast.js
@@ -1,4 +1,4 @@
-import { LightningElement, wire, track } from 'lwc';
+import { LightningElement, track } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
 import getForecastItems from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHoursAnalyticsController.getForecastItems';
 
@@ -31,26 +31,40 @@ export default class DeliveryCapacityForecast extends NavigationMixin(LightningE
     error;
     loading = true;
 
-    @wire(getForecastItems)
-    wiredItems({ data, error }) {
-        this.loading = false;
-        if (data) {
-            // Only forward work packs: drop terminal-stage items and anything with
-            // no remaining hours — they are history, not future schedule.
-            this.items = data
-                .filter((d) => !d.isTerminal && (d.remaining || 0) > 0)
-                .map((d) => ({
-                    id: d.id,
-                    name: d.name,
-                    tier: d.tier,
-                    remaining: d.remaining || 0,
-                    startDate: d.startDate
-                }));
-            this.error = undefined;
-        } else if (error) {
-            this.error = (error.body && error.body.message) || 'Unable to load forecast items.';
-            this.items = [];
-        }
+    // getForecastItems is non-cacheable by design (it must reflect reorder
+    // writes on the next read, never a stale LDS cache), so it cannot be @wired
+    // — a wired Apex method must be @AuraEnabled(cacheable=true), and wiring a
+    // plain @AuraEnabled method throws "Apex methods that are to be cached must
+    // be marked as @AuraEnabled(cacheable=true)" at render. Call it imperatively
+    // on mount instead; the slider then reflows client-side with no further hops.
+    connectedCallback() {
+        this.loadItems();
+    }
+
+    loadItems() {
+        this.loading = true;
+        getForecastItems()
+            .then((data) => {
+                // Only forward work packs: drop terminal-stage items and anything
+                // with no remaining hours — they are history, not future schedule.
+                this.items = (data || [])
+                    .filter((d) => !d.isTerminal && (d.remaining || 0) > 0)
+                    .map((d) => ({
+                        id: d.id,
+                        name: d.name,
+                        tier: d.tier,
+                        remaining: d.remaining || 0,
+                        startDate: d.startDate
+                    }));
+                this.error = undefined;
+            })
+            .catch((error) => {
+                this.error = (error && error.body && error.body.message) || 'Unable to load forecast items.';
+                this.items = [];
+            })
+            .finally(() => {
+                this.loading = false;
+            });
     }
 
     // ── Slider / toggle handlers ────────────────────────────────────────────

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHoursAnalyticsController.getForecastItems.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHoursAnalyticsController.getForecastItems.js
@@ -1,8 +1,9 @@
 /**
- * Wire adapter mock for DeliveryHoursAnalyticsController.getForecastItems.
- * Used by the c-delivery-capacity-forecast jest tests.
+ * Imperative Apex mock for DeliveryHoursAnalyticsController.getForecastItems.
+ * The c-delivery-capacity-forecast LWC calls this imperatively (the method is
+ * non-cacheable by design, so it cannot be @wired), so the mock is a plain
+ * jest.fn the tests resolve/reject per case via mockResolvedValue /
+ * mockRejectedValue. Defaults to resolving an empty list.
  */
-const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
-
-const getForecastItems = createApexTestWireAdapter(jest.fn());
+const getForecastItems = jest.fn(() => Promise.resolve([]));
 module.exports = { default: getForecastItems };


### PR DESCRIPTION
## The bug (reproduced live on MF-Prod 0.285)
The #923 **"you set the pace" capacity slider** (`deliveryCapacityForecast`) — the marquee feature behind the `/delivery-experience` marketing page — **threw on render in every real org** instead of painting:

> Apex methods that are to be cached must be marked as `@AuraEnabled(cacheable=true)`

Found while validating the marketing claims against live MF Delivery Hub (`dispatch-DH-forecast-slider-bug-0616.md`). The workspace, Approvals tab, and Portfolio Pacing chart all render fine — only the capacity slider was dead.

## Root cause
The LWC `@wire`d `DeliveryHoursAnalyticsController.getForecastItems`, but that method is **deliberately non-cacheable** (its doc comment: it must reflect reorder writes on the next read, never a stale LDS cache). A `@wire`d Apex method **must** be `@AuraEnabled(cacheable=true)` — so the wire threw at render. Jest stayed green only because the mocked wire adapter doesn't enforce the cacheable contract.

## Fix
Keep the Apex **non-cacheable** (preserving the documented freshness intent — important for the pass-2 drag-reorder re-fetch) and **call it imperatively** from `connectedCallback`. Imperative Apex calls don't run through the cacheable check, so removing `@wire` removes the exact error by construction. **No Apex change.**

- `deliveryCapacityForecast.js`: `@wire(getForecastItems)` → imperative `loadItems()` (then/catch/finally)
- jest mock: wire adapter → `jest.fn` (resolved/rejected per case)
- test: `.emit()/.error()` after mount → `mockResolvedValue/mockRejectedValue` before mount

## Verification
- `deliveryCapacityForecast` jest **7/7 green**; zero Apex touched (PMD unaffected).
- ⚠️ **Correct by construction + tests green, but jest cannot prove the live render** (the mock is exactly why it stayed green while broken). Real confirmation = loading Delivery → Forecast → Capacity on a real org after install.
- Reaches MF-Prod only via merge → promote (0.286) → install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)