### PR TITLE
fix(gantt): drop terminal-stage items from the default timeline

### DIFF
--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -147,18 +147,26 @@ public with sharing class DeliveryGanttController {
                 + 'FROM WorkItem__c '
                 + 'WHERE TemplateMarkedDateTime__c = null ';
 
+            // Stages with no remaining schedulable effort (cross-type terminal union
+            // plus 'Deployed to Prod'). The default timeline is "active work", so these
+            // must be excluded. Pre-fix this set was computed for bar styling but never
+            // filtered on, so Done/Cancelled/Deployed-to-Prod items lingered on the
+            // buyer timeline forever — disagreeing with every other active-work surface.
+            Set<String> stageFilter = terminalStages;
+
             if (showCompleted == true) {
                 // Active items always show; inactive items must be recently modified.
                 query += 'AND (ActivatedDateTime__c != null '
                     + 'OR LastModifiedDate >= LAST_N_DAYS:' + DEFAULT_STALE_CUTOFF_DAYS + ') ';
             } else {
-                // Default view: canonical active scope — activated AND not archived.
-                // Pre-fix the archived filter was missing, so archived items still
-                // rendered on the timeline and its count disagreed with every other
-                // "active items" surface on Home. (showCompleted=true deliberately
-                // keeps archived/inactive items, bounded by the freshness window.)
+                // Default view: canonical active scope — activated, not archived, and
+                // not in a terminal/effort-complete stage. (showCompleted=true
+                // deliberately keeps archived/inactive items, bounded by freshness.)
                 query += 'AND ActivatedDateTime__c != null '
                     + 'AND ArchivedDateTime__c = null ';
+                if (!stageFilter.isEmpty()) {
+                    query += 'AND StageNamePk__c NOT IN :stageFilter ';
+                }
             }
 
             query += 'WITH SYSTEM_MODE '
@@ -1103,14 +1111,21 @@ public with sharing class DeliveryGanttController {
                 + 'FROM WorkItem__c '
                 + 'WHERE TemplateMarkedDateTime__c = null ';
 
+            // No remaining schedulable effort — exclude from the default "active work"
+            // timeline (mirrors getGanttData; was computed for styling but not filtered).
+            Set<String> stageFilter = terminalStages;
+
             if (showCompleted == true) {
                 query += 'AND (ActivatedDateTime__c != null '
                     + 'OR LastModifiedDate >= LAST_N_DAYS:' + DEFAULT_STALE_CUTOFF_DAYS + ') ';
             } else {
-                // Default view: canonical active scope — activated AND not archived
-                // (mirrors getGanttData; pre-fix archived items still rendered).
+                // Default view: canonical active scope — activated, not archived, and
+                // not in a terminal/effort-complete stage (mirrors getGanttData).
                 query += 'AND ActivatedDateTime__c != null '
                     + 'AND ArchivedDateTime__c = null ';
+                if (!stageFilter.isEmpty()) {
+                    query += 'AND StageNamePk__c NOT IN :stageFilter ';
+                }
             }
 
             // SortOrderNumber__c is the primary sort — drag-to-reorder writes it,

--- a/force-app/main/default/classes/DeliveryGanttControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryGanttControllerTest.cls
@@ -251,6 +251,68 @@ private class DeliveryGanttControllerTest {
         }
     }
 
+    /**
+     * @description Regression guard for the terminal-stage filter fix. The default
+     *              (showCompleted=false) timeline is "active work", so items in a
+     *              terminal / effort-complete stage (Done, Cancelled, Deployed to
+     *              Prod) must NOT render even when still activated and un-archived.
+     *              Pre-fix the Gantt computed getAllEffortTerminalStageValues() only
+     *              to style bars and never filtered the query by it, so these items
+     *              lingered on the buyer timeline forever. 'Resolved' is intentionally
+     *              NOT in the effort-terminal set (terminal for Operations but an
+     *              active stage for Support_Triage), so an active 'Resolved' item must
+     *              still render — guarded on the live config so it can't flake.
+     */
+    @IsTest
+    static void testDefaultViewExcludesActiveTerminalStages() {
+        System.runAs(testUser) {
+            insert new List<WorkItem__c>{
+                new WorkItem__c(BriefDescriptionTxt__c = 'Active Done',
+                    StageNamePk__c = 'Done', ActivatedDateTime__c = Datetime.now()),
+                new WorkItem__c(BriefDescriptionTxt__c = 'Active Deployed',
+                    StageNamePk__c = 'Deployed to Prod', ActivatedDateTime__c = Datetime.now()),
+                new WorkItem__c(BriefDescriptionTxt__c = 'Active Cancelled',
+                    StageNamePk__c = 'Cancelled', ActivatedDateTime__c = Datetime.now()),
+                new WorkItem__c(BriefDescriptionTxt__c = 'Active Resolved',
+                    StageNamePk__c = 'Resolved', ActivatedDateTime__c = Datetime.now())
+            };
+
+            Test.startTest();
+            List<DeliveryGanttController.GanttTask> gantt =
+                DeliveryGanttController.getGanttData(false);
+            List<DeliveryGanttController.ProFormaTimelineRow> rows =
+                DeliveryGanttController.getProFormaTimelineData(false);
+            Test.stopTest();
+
+            Set<String> ganttTitles = new Set<String>();
+            for (DeliveryGanttController.GanttTask t : gantt) { ganttTitles.add(t.description); }
+            Set<String> rowTitles = new Set<String>();
+            for (DeliveryGanttController.ProFormaTimelineRow r : rows) { rowTitles.add(r.title); }
+
+            for (String terminal : new List<String>{ 'Active Done', 'Active Deployed', 'Active Cancelled' }) {
+                System.assert(!ganttTitles.contains(terminal),
+                    terminal + ' (terminal stage) must be excluded from the default Gantt view');
+                System.assert(!rowTitles.contains(terminal),
+                    terminal + ' (terminal stage) must be excluded from the default Pro Forma timeline');
+            }
+
+            // Active non-terminal work must still render (both methods).
+            System.assert(ganttTitles.contains('Build login page'),
+                'Active non-terminal work must still render (Gantt)');
+            System.assert(rowTitles.contains('Build login page'),
+                'Active non-terminal work must still render (Pro Forma)');
+
+            // 'Resolved' must NOT be treated as effort-terminal — confirm against the
+            // live config, then assert it still renders (the #915 cross-type collision).
+            Set<String> effortTerminal =
+                DeliveryWorkflowConfigService.getAllEffortTerminalStageValues();
+            System.assert(!effortTerminal.contains('Resolved'),
+                'Resolved must be excluded from the effort-terminal set (active for Support_Triage)');
+            System.assert(ganttTitles.contains('Active Resolved'),
+                'Active Resolved must still render — it is not effort-terminal');
+        }
+    }
+
     @IsTest
     static void testGetGanttDataIncludesCompleted() {
         System.runAs(testUser) {


### PR DESCRIPTION
## The bug
The buyer **Timeline/Gantt is "still broken"** — terminal items never leave it. Both default-view query branches filter only `ActivatedDateTime != null AND ArchivedDateTime = null`, **never on stage**. The terminal-stage set was already computed (`terminalStages` → `getAllEffortTerminalStageValues()`, which includes `Deployed to Prod`) but used **only for bar styling**, never to filter the query — so Done / Cancelled / Deployed-to-Prod items stay on the timeline forever.

Live MF-Prod: **62 of 155** active, un-archived WorkItems are in a terminal stage (Done 36, Deployed to Prod 15, Cancelled 11) and are wrongly rendering today.

## The fix
Add `AND StageNamePk__c NOT IN :stageFilter` to the **default (`showCompleted=false`)** branch of both `getGanttData` and `getProFormaTimelineData`, where `stageFilter = terminalStages`. Guarded by `!isEmpty()`.

- `showCompleted=true` is **unchanged** (it deliberately shows completed work, bounded by the freshness window).
- **Deploy-to-Prod items leave the *timeline* but stay in the #893 ship/acceptance report** — this is the proper fix that a blanket data-archive would break.
- `Resolved` is intentionally **not** in the effort-terminal set (terminal for Operations, active for Support_Triage), so an active `Resolved` item still renders — covered by the test (guarded on the live config).

## Test
`testDefaultViewExcludesActiveTerminalStages` — inserts active (activated, un-archived) Done / Deployed-to-Prod / Cancelled / Resolved items and asserts the three terminal stages are excluded from **both** methods while non-terminal work and `Resolved` still render.

## PMD
Ran `sf scanner run --engine pmd --pmdconfig pmd-rules.xml` on both files: **no new violations**. The only findings are pre-existing class-size/complexity metrics (class line 12) and `updateWorkItemFields` (untouched).

## Context
Part of the 6/16 Delivery Hub remediation (`docs/plans/delivery-hub-remediation-plan-2026-06-16.md`). This is the one true code bug behind the "timeline broken" symptom; the approval-queue symptoms were data/config. Forecast-tab standardization + doc-drift corrections follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)