### PR TITLE
fix(workspace): one buyer forecast surface + correct stale status docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ current guidance.
 | [DESIGN_PRINCIPLES.md](DESIGN_PRINCIPLES.md) | Product/engineering design principles. |
 | [COCKPIT.md](COCKPIT.md) | Operator cockpit / admin surface overview. |
 | [FLOW_REFERENCE.md](FLOW_REFERENCE.md) | Flow reference. |
-| [depth-charge-architecture.md](depth-charge-architecture.md) | Audit-chain ("depth-charge") feature architecture (scaffold shipped; recursive probe is a follow-on). |
+| [depth-charge-architecture.md](depth-charge-architecture.md) | Audit-chain ("depth-charge") feature architecture (scaffold + recursive cross-org probe BOTH shipped — #760, #769, #772). |
 
 ## Conventions & integrity
 
@@ -52,7 +52,7 @@ current guidance.
 
 | Doc | What it covers |
 |-----|----------------|
-| [plans/phase-2-watcher-design.md](plans/phase-2-watcher-design.md) | Design-only recon for the Watcher v1 aggregation layer (not yet implemented). |
+| [plans/phase-2-watcher-design.md](plans/phase-2-watcher-design.md) | Original design recon for the Watcher v1 aggregation layer (now SHIPPED at 0.246 — #807/#809/#810; kept for design history). |
 
 ## Archive
 

--- a/docs/depth-charge-architecture.md
+++ b/docs/depth-charge-architecture.md
@@ -1,6 +1,6 @@
 # Depth-charge audit architecture
 
-**Status:** scaffold shipped in PR #760 (schema + local-segment assembly). Recursive cross-org probe + response handling is a follow-on PR — see "Follow-on PR" section below.
+**Status:** ✅ Fully shipped — scaffold in #760 (schema + local-segment assembly), and the recursive cross-org probe + response handling in #769/#772 (`DeliveryDepthProbeService` with `invokePeerProbe`, `MAX_DEPTH`, per-probe callout budget, re-probe window, and `ActivityLog__c` audit writes). The "Follow-on PR" section below is the original plan and is now historical. Only the CloudNimbus-side visualization remains out of package scope.
 
 ## What it is
 

--- a/docs/plans/phase-2-watcher-design.md
+++ b/docs/plans/phase-2-watcher-design.md
@@ -1,6 +1,6 @@
 # Phase 2 Watcher v1 — Design (2026-05-18)
 
-> **Status:** Design-only recon. No production logic in the PR that introduces this doc. Read, weigh in on the **Open Questions for Glen** at the bottom, then a follow-on PR implements.
+> **Status:** ✅ SHIPPED at 0.246 (#807/#809/#810) — `DeliveryWatcherService`, the `WatcherDigest__c` object, `DeliveryWatcherDigestFormatter`, the setup LWC, and the top-3 live signals plus 4 stubbed signals all exist in the package. This document is the original design recon, retained for history; it is no longer "design-only / not implemented." (The 4 stub signals remain gated behind their own `Enable…DateTime__c` flags.)
 
 > **Parent plan:** `C:\Users\globa\.claude\plans\wild-roaming-rocket.md` — Phase 2 (Watcher v1 ~14h, top 3 signals implemented + 4 stubs, Slack + WatcherDigest__c audit record, Glen-only via `WatcherDigestRecipientUserIdsTxt__c`).
 

--- a/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
+++ b/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
@@ -32,8 +32,10 @@
             <c-delivery-approval-queue></c-delivery-approval-queue>
         </lightning-tab>
 
+        <!-- Buyer forecast = the "you set the pace" capacity slider (the controllable
+             forward projection). The retrospective pacing card is now admin-only (moved
+             to the Velocity tab) so buyers have ONE forecast surface, not two stacked. -->
         <lightning-tab label="Forecast" value="forecast" icon-name="standard:forecasts">
-            <c-delivery-pacing-forecast></c-delivery-pacing-forecast>
             <c-delivery-capacity-forecast></c-delivery-capacity-forecast>
         </lightning-tab>
 
@@ -48,6 +50,9 @@
 
             <lightning-tab label="Velocity" value="velocity" icon-name="standard:metrics">
                 <c-delivery-velocity-dashboard></c-delivery-velocity-dashboard>
+                <!-- Retrospective portfolio pacing (logged-vs-target) — admin-only;
+                     buyers see the forward capacity slider on the Forecast tab. -->
+                <c-delivery-pacing-forecast></c-delivery-pacing-forecast>
             </lightning-tab>
 
             <lightning-tab label="Settings" value="settings" icon-name="standard:settings">


### PR DESCRIPTION
Follow-up to #926, part of the 6/16 Delivery Hub remediation.

## 1. Buyer Forecast tab → one surface
The package-owned **Delivery → Forecast** tab stacked *two* forecast components (`deliveryPacingForecast` + `deliveryCapacityForecast`). Standardize the buyer surface on the **capacity slider** — the "you set the pace" forward projection the buyer controls — and move the retrospective **pacing card** (logged-vs-target) to the **admin-only Velocity tab**. Buyers get one forecast surface, not two; pacing stays reachable in the package-owned workspace for admins (and remains on the AdminHome FlexiPage).

## 2. Doc-drift corrections (the "and then some")
Two architecture docs under-claimed shipped work — corrected to SHIPPED with PR refs, kept for design history:
- **Watcher** (`plans/phase-2-watcher-design.md` + `README`) said "design-only / not implemented" — actually shipped at **0.246** (#807/#809/#810): `DeliveryWatcherService`, `WatcherDigest__c`, formatter, setup LWC, 3 live signals + 4 gated stubs.
- **Depth-charge** (`depth-charge-architecture.md` + `README`) marked the recursive cross-org probe a "follow-on PR" — actually shipped in **#769/#772** (`DeliveryDepthProbeService.invokePeerProbe`, depth/callout budgets, audit writes).

## Scope / risk
LWC template + docs only — **no Apex**. `feature-test` validates the workspace template deploys; both referenced components (`c-delivery-capacity-forecast`, `c-delivery-pacing-forecast`) still exist. The roadmap's branding over-claim (#687 vs the live TODO) is recorded in the remediation plan but not edited here (dated historical snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)