### PR TITLE
fix(sync): audit-insert non-fatal + scope admin retry to outbound

### DIFF
--- a/force-app/main/default/classes/DeliverySyncRetryController.cls
+++ b/force-app/main/default/classes/DeliverySyncRetryController.cls
@@ -100,9 +100,13 @@ global with sharing class DeliverySyncRetryController {
     }
 
     /**
-     * @description Resets all non-dismissed failed SyncItem__c records to Queued
-     *              so the scheduler retries them. Dismissed items are intentionally
-     *              skipped — admins must restore them first if a retry is desired.
+     * @description Resets non-dismissed failed OUTBOUND SyncItem__c records to Queued so
+     *              the scheduler re-pushes them. Inbound failures are intentionally excluded:
+     *              the processor only dispatches Outbound, so flipping an inbound row to
+     *              Queued strands it AND removes it from the pending-resolver's self-heal
+     *              scan (recoverFailedWithResolvedParent), which resets inbound rows to
+     *              Pending once their parent arrives. Dismissed items are skipped — admins
+     *              must restore them first if a retry is desired.
      */
     @AuraEnabled
     global static void retryFailed() {
@@ -111,6 +115,7 @@ global with sharing class DeliverySyncRetryController {
             FROM SyncItem__c
             WHERE StatusPk__c = 'Failed'
             AND DismissedDateTime__c = NULL
+            AND DirectionPk__c = 'Outbound'
             WITH SYSTEM_MODE
             LIMIT 200
         ];

--- a/force-app/main/default/classes/DeliverySyncRetryControllerTest.cls
+++ b/force-app/main/default/classes/DeliverySyncRetryControllerTest.cls
@@ -104,6 +104,34 @@ private class DeliverySyncRetryControllerTest {
     }
 
     @IsTest
+    static void testRetryFailedExcludesInbound() {
+        System.runAs(testUser) {
+            WorkItem__c wi = [SELECT Id FROM WorkItem__c LIMIT 1];
+            // An inbound Failed item (e.g. a comment whose parent hasn't synced yet) must
+            // NOT be reset by admin retry — the processor only dispatches Outbound, so
+            // flipping it to Queued strands it and removes it from the pending-resolver's
+            // self-heal scan (recoverFailedWithResolvedParent).
+            SyncItem__c inbound = new SyncItem__c(
+                ObjectTypePk__c     = 'WorkItem__c',
+                LocalRecordIdTxt__c = wi.Id,
+                WorkItemLookup__c   = wi.Id,
+                DirectionPk__c      = 'Inbound',
+                StatusPk__c         = 'Failed',
+                ErrorLogTxt__c      = 'Parent WorkItem did not arrive within 10 retry attempts.'
+            );
+            insert inbound;
+
+            Test.startTest();
+            DeliverySyncRetryController.retryFailed();
+            Test.stopTest();
+
+            SyncItem__c after = [SELECT StatusPk__c FROM SyncItem__c WHERE Id = :inbound.Id];
+            System.assertEquals('Failed', after.StatusPk__c,
+                'Inbound Failed items must stay Failed — retryFailed is Outbound-only so it does not strand them.');
+        }
+    }
+
+    @IsTest
     static void testDismissFailedEndpoint() {
         System.runAs(testUser) {
             List<SyncItem__c> failed = [SELECT Id FROM SyncItem__c WHERE StatusPk__c = 'Failed'];

--- a/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
@@ -520,6 +520,12 @@ public without sharing class DeliveryWorkItemTriggerHandler {
         }
     }
 
+    /**
+     * @description Before-insert defaults for new WorkItems: stamps ActivatedDateTime__c
+     *              (unless the inbound-sync ingestor owns it), defaults StageEnteredDateTime__c,
+     *              and mints a bounty token when the item is published as a bounty.
+     * @param newWorkItems List of WorkItem__c records being inserted.
+     */
     public static void handleBeforeInsert(List<WorkItem__c> newWorkItems) {
         Datetime now = Datetime.now();
         // When the inbound-sync ingestor is performing the insert, the source
@@ -742,7 +748,18 @@ public without sharing class DeliveryWorkItemTriggerHandler {
         }
 
         if (!logs.isEmpty()) {
-            Database.insert(logs, AccessLevel.SYSTEM_MODE);
+            // Audit logging is best-effort. A failure here — e.g. STORAGE_LIMIT_EXCEEDED on a
+            // receiving org during cross-org sync — must NEVER roll back the core WorkItem
+            // write or drop a billable synced item from the invoice. Partial-success +
+            // swallow, mirroring the guarded pattern in DeliveryFieldChangeService.
+            try {
+                Database.insert(logs, false, AccessLevel.SYSTEM_MODE);
+            } catch (Exception e) {
+                System.debug(
+                    LoggingLevel.WARN,
+                    'logStageChanges audit insert failed (non-fatal): ' + e.getMessage()
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## The bug (why invoices from dh-prod keep missing synced items)
Cross-org sync silently drops billable items. When a billable WorkItem/WorkLog syncs **into** a receiving org, the AfterUpdate trigger writes a stage-change **audit** row (`logStageChanges`). That insert was **unguarded** (`Database.insert(logs, AccessLevel.SYSTEM_MODE)`, allOrNone=true, no try/catch). On a full org it throws `STORAGE_LIMIT_EXCEEDED`, which **rolls back the entire WorkItem write** → the item never lands → it's missing at invoice time. A non-critical audit log was taking down billable data. (Live failure caught 6/17: nimba `SI-006027`, `logStageChanges:745`.)

## Fixes
1. **`DeliveryWorkItemTriggerHandler.logStageChanges`** — best-effort audit insert (`Database.insert(logs, false, …)` + try/catch). Audit-log failure can no longer roll back the core WorkItem write or drop a synced item. Mirrors the already-guarded `DeliveryFieldChangeService.captureFieldChanges`. *Protects all WorkItem updates, not just synced ones.*
2. **`DeliverySyncRetryController.retryFailed`** — scoped to `DirectionPk__c = 'Outbound'`. The admin "Retry" button was flipping **inbound** Failed rows to Queued — a dead state for inbound (the processor only dispatches Outbound) that also removed them from the pending-resolver self-heal scan (`recoverFailedWithResolvedParent`), **permanently stranding** them. Inbound failures now recover only via the self-heal path, as designed.
3. Restored lost ApexDoc on `handleBeforeInsert` (regression from the 6/10 rework).

## Tests
- New: `testRetryFailedExcludesInbound` — inbound Failed items stay Failed through `retryFailed` (don't get stranded). Existing outbound retry/dismiss tests unaffected (they already seed `Outbound`).
- PMD clean (apex-scan) on all three files.

## Verified-NOT-bugs (don't chase)
- Orphan inbound comments **already self-heal** (`queuePendingChild` → `recoverFailedWithResolvedParent`) — the 10 Failed comments are downstream of the rollback bug (parent couldn't write), not a separate defect.
- Replay/dead-letter **already exists** (scheduler auto-requeue, reconciler, admin retry/dismiss).

## Still open (separate work, not this PR)
- **ContentVersion/file sync dispatch hole** (hub-mode CV items match no dispatch query → never attempted). Needs direction confirmation first.
- **Operational:** a receiving org (the hub) is out of storage — clear/bump + replay to reconverge the orgs.
- Real-time cross-org push is wired (push-on-change + live event) but only when the connection's `IntegrationEndpointUrlTxt__c` is set; blank → 15-min poll fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)