### PR TITLE
feat(notifications): gate approver bell pings through NotificationPreference__c

### DIFF
--- a/force-app/main/default/classes/DeliveryNotificationService.cls
+++ b/force-app/main/default/classes/DeliveryNotificationService.cls
@@ -39,6 +39,15 @@
 @SuppressWarnings('PMD.ApexCRUDViolation,PMD.AvoidGlobalModifier,PMD.CyclomaticComplexity,PMD.StdCyclomaticComplexity,PMD.ExcessivePublicCount')
 global with sharing class DeliveryNotificationService {
 
+    // Per-event notification control (Stage 1 convergence onto the
+    // NotificationPreference__c model — see DeliveryNotificationPreferenceService,
+    // the pattern DeliveryForecastAlertService already follows). Opt-out:
+    // shouldNotify returns true (send) when no preference row exists, so this
+    // changes NO current behavior until an approver opts a specific event out.
+    @TestVisible private static final String CHANNEL_BELL = 'Bell';
+    @TestVisible private static final String EVENT_APPROVAL_REQUEST = 'Approval_Request';
+    @TestVisible private static final String EVENT_SHIP_VERIFICATION = 'Ship_Verification';
+
     // ────────────────────────────────────────────────────────────────────
     // FEATURE TOGGLE
     // ────────────────────────────────────────────────────────────────────
@@ -193,6 +202,12 @@ global with sharing class DeliveryNotificationService {
             if (approverId == null) {
                 return;
             }
+            // Per-event control: a disabled Bell/Ship_Verification preference
+            // suppresses the deploy-verify ping for this approver (opt-out).
+            if (!DeliveryNotificationPreferenceService.shouldNotify(
+                    approverId, CHANNEL_BELL, EVENT_SHIP_VERIFICATION)) {
+                return;
+            }
             Integer count = workItemIds.size();
             String title = 'Deployed to production';
             String body = count + ' item(s) deployed to production ' + '\u2014' + ' please verify.';
@@ -254,7 +269,17 @@ global with sharing class DeliveryNotificationService {
                 return;
             }
             Map<Id, List<WorkRequest__c>> byApprover = groupRequestsByApprover(rows);
+            // Per-event control: honor each approver's Bell/Approval_Request
+            // preference (bulk-checked in ONE SOQL to stay governor-safe when
+            // several distinct approvers are involved). Opt-out: a missing row
+            // means send, so this changes nothing until an approver opts out.
+            Map<String, Boolean> prefs = DeliveryNotificationPreferenceService.shouldNotifyBulk(
+                byApprover.keySet(), new Set<String>{ CHANNEL_BELL }, EVENT_APPROVAL_REQUEST);
             for (Id approverId : byApprover.keySet()) {
+                if (!DeliveryNotificationPreferenceService.shouldNotifyFromMap(
+                        prefs, approverId, CHANNEL_BELL)) {
+                    continue;
+                }
                 sendApproverDigest(approverId, byApprover.get(approverId));
             }
         } catch (Exception e) {

--- a/force-app/main/default/classes/DeliveryShipVerificationTest.cls
+++ b/force-app/main/default/classes/DeliveryShipVerificationTest.cls
@@ -202,4 +202,34 @@ private class DeliveryShipVerificationTest {
         System.assertEquals(asyncBefore, asyncAfter,
             'null list, empty list, and blank setting must not enqueue a notification');
     }
+
+    /**
+     * @description Per-event control (Stage 1): a disabled
+     *              Bell / Ship_Verification preference for the configured
+     *              approver suppresses the deploy-verify ping — no queueable
+     *              enqueued — even though the approver IS configured and would
+     *              otherwise be notified. This is the surgical mute that lets a
+     *              buyer-persona approver keep approval pings while dropping
+     *              deploy-confirmation noise.
+     */
+    @IsTest
+    static void testShipVerificationSuppressedByDisabledPreference() {
+        setApproverSetting(String.valueOf(UserInfo.getUserId()));
+        insert new NotificationPreference__c(
+            UserIdTxt__c = String.valueOf(UserInfo.getUserId()).left(18),
+            ChannelPk__c = 'Bell',
+            EventTypePk__c = 'Ship_Verification',
+            EnabledDateTime__c = null // disabled = opted out of this event on this channel
+        );
+        WorkItem__c wi = seedItemAt(STAGE_DEPLOYING);
+
+        Test.startTest();
+        Integer asyncBefore = [SELECT COUNT() FROM AsyncApexJob WHERE JobType = 'Queueable'];
+        DeliveryNotificationService.notifyDeployedToProd(new List<Id>{ wi.Id });
+        Integer asyncAfter = [SELECT COUNT() FROM AsyncApexJob WHERE JobType = 'Queueable'];
+        Test.stopTest();
+
+        System.assertEquals(asyncBefore, asyncAfter,
+            'a disabled Ship_Verification Bell preference must suppress the deploy ping');
+    }
 }

--- a/force-app/main/default/classes/DeliveryWorkApprovalServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryWorkApprovalServiceTest.cls
@@ -1488,4 +1488,42 @@ private class DeliveryWorkApprovalServiceTest {
         System.assertEquals(asyncBefore, asyncAfter,
             'null, empty, and missing-record inputs must never enqueue or throw');
     }
+
+    /**
+     * @description Per-event control (Stage 1): a disabled
+     *              Bell / Approval_Request preference for the assigned approver
+     *              suppresses the "approval needed" ping — no queueable
+     *              enqueued — even with an Offer-Sent request assigned to them.
+     *              Guards test validity by asserting the request is genuinely
+     *              Offer Sent before acting (so a status-flip trigger can't make
+     *              the suppression assertion pass vacuously).
+     */
+    @IsTest
+    static void testApprovalSubmitSuppressedByDisabledPreference() {
+        WorkItem__c wi = TestDataFactory.createWorkItem(null);
+        WorkRequest__c wr = TestDataFactory.createWorkRequest(wi.Id, new Map<String, Object>{
+            'StatusPk__c' => 'Offer Sent',
+            'ApproverUserLookup__c' => UserInfo.getUserId(),
+            'QuotedHoursNumber__c' => 10
+        });
+        System.assertEquals('Offer Sent',
+            [SELECT StatusPk__c FROM WorkRequest__c WHERE Id = :wr.Id].StatusPk__c,
+            'setup guard: the request must be Offer Sent for this test to mean anything');
+
+        insert new NotificationPreference__c(
+            UserIdTxt__c = String.valueOf(UserInfo.getUserId()).left(18),
+            ChannelPk__c = 'Bell',
+            EventTypePk__c = 'Approval_Request',
+            EnabledDateTime__c = null // disabled = opted out
+        );
+
+        Test.startTest();
+        Integer asyncBefore = [SELECT COUNT() FROM AsyncApexJob WHERE JobType = 'Queueable'];
+        DeliveryNotificationService.notifyWorkApprovalSubmitted(new List<Id>{ wr.Id });
+        Integer asyncAfter = [SELECT COUNT() FROM AsyncApexJob WHERE JobType = 'Queueable'];
+        Test.stopTest();
+
+        System.assertEquals(asyncBefore, asyncAfter,
+            'a disabled Approval_Request Bell preference must suppress the approval ping');
+    }
 }

--- a/force-app/main/default/objects/NotificationPreference__c/fields/EventTypePk__c.field-meta.xml
+++ b/force-app/main/default/objects/NotificationPreference__c/fields/EventTypePk__c.field-meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>EventTypePk__c</fullName>
-    <description>Type of event this preference applies to (e.g., Stage_Change, Escalation, Document_Action, Comment, Assignment).</description>
+    <description>Type of event this preference applies to (e.g., Stage_Change, Escalation, Document_Action, Comment, Assignment, Approval_Request, Ship_Verification).</description>
     <externalId>false</externalId>
     <label>Event Type</label>
     <required>false</required>
@@ -19,6 +19,8 @@
             <value><fullName>Comment</fullName><default>false</default><label>Comment</label></value>
             <value><fullName>Assignment</fullName><default>false</default><label>Assignment</label></value>
             <value><fullName>Forecast_Risk</fullName><default>false</default><label>Forecast Risk</label></value>
+            <value><fullName>Approval_Request</fullName><default>false</default><label>Approval Request</label></value>
+            <value><fullName>Ship_Verification</fullName><default>false</default><label>Ship Verification</label></value>
         </valueSetDefinition>
     </valueSet>
 </CustomField>


### PR DESCRIPTION
## What & why

The configured approver (e.g. Jose on MF-Prod) receives two bell / mobile-push notifications from the package:

1. **"Approval needed: N item(s)"** — when work moves to *Offer Sent* in the approval queue.
2. **"N item(s) deployed to production — verify"** — when a work item enters *Deployed to Prod*.

These were the **only sends in `DeliveryNotificationService` with no gating at all** — they ignored both the org notification toggles *and* the per-user `NotificationPreference__c` model. There was **no way to suppress them**, even though the package already has a per-user / per-event / per-channel preference model (`DeliveryNotificationPreferenceService`) that exactly one path — `DeliveryForecastAlertService` — already uses correctly.

This is **Stage 1** of converging the bell fanout onto that preference pattern.

## Changes

- **Event types** — add `Approval_Request` + `Ship_Verification` to `NotificationPreference__c.EventTypePk__c` (non-restricted value set → additive and upgrade-safe).
- **`notifyDeployedToProd`** — gated on `shouldNotify(approver, 'Bell', 'Ship_Verification')`.
- **`notifyWorkApprovalSubmitted`** — gated per-approver via `shouldNotifyBulk(approvers, {'Bell'}, 'Approval_Request')` (one SOQL, governor-safe across multiple approvers).

## Behavior / scope notes

- **Opt-out semantics, zero behavior change by default.** `shouldNotify` returns *send* when no preference row exists, so nothing changes until an approver opts a specific event out — e.g. a buyer-persona approver muting `Ship_Verification` while keeping `Approval_Request`.
- **Deliberately NOT gated on the org master toggle** (`EnableNotificationsDateTime__c`). Gating on it would risk over-muting the approval pings in orgs where the master is unset. Master/coarse convergence is a later stage.
- **To actually quiet an approver** (the real-world goal), seed a disabled `NotificationPreference__c` row for them — no redeploy. A self-serve preference UI is the deferred Stage 2.

## Tests

- `DeliveryShipVerificationTest.testShipVerificationSuppressedByDisabledPreference` — a disabled `Bell/Ship_Verification` pref suppresses the deploy ping (no queueable enqueued) even with the approver configured.
- `DeliveryWorkApprovalServiceTest.testApprovalSubmitSuppressedByDisabledPreference` — a disabled `Bell/Approval_Request` pref suppresses the approval ping; guards test validity by asserting the request is genuinely *Offer Sent* first.

Both assert the suppression seam the codebase already uses (queueable-job count equality), which is robust under the managed/packaging test context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
