### PR TITLE
feat(workitem): hours burn-up card on WorkItem record page

### DIFF
--- a/force-app/main/default/flexipages/DeliveryWorkItemRecordPage.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryWorkItemRecordPage.flexipage-meta.xml
@@ -1059,6 +1059,12 @@
         </itemInstances>
         <itemInstances>
             <componentInstance>
+                <componentName>deliveryHoursBurnup</componentName>
+                <identifier>c_deliveryHoursBurnup</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
                 <componentName>deliveryScore</componentName>
                 <identifier>c_deliveryScore</identifier>
             </componentInstance>

--- a/force-app/main/default/lwc/deliveryHoursBurnup/__tests__/burnupModel.test.js
+++ b/force-app/main/default/lwc/deliveryHoursBurnup/__tests__/burnupModel.test.js
@@ -1,0 +1,84 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Unit spec for the pure burn-up model (no DOM mount). Anchors the
+ *               adaptive-block math, the nested shipped⊆approved⊆estimated bands,
+ *               health thresholds, the over-cap (red) overflow, and the empty
+ *               state. The component is a thin SLDS shell over this function.
+ * @author       Cloud Nimbus LLC
+ */
+import { computeBurnup } from "../burnupModel";
+
+const sumSegments = (s) =>
+    s.shippedPct +
+    s.overCapPct +
+    s.approvedRemainingPct +
+    s.estimatedBeyondPct +
+    s.headroomPct;
+
+describe("computeBurnup", () => {
+    it("is empty when no approved and no estimated ceiling exists", () => {
+        const m = computeBurnup({ estimated: 0, approved: 0, logged: 0 });
+        expect(m.empty).toBe(true);
+        expect(m.health).toBe("empty");
+    });
+
+    it("uses approved hours as the ceiling and leaves visible headroom when nothing exceeds it", () => {
+        const m = computeBurnup({ estimated: 8, approved: 10, logged: 4 });
+        expect(m.empty).toBe(false);
+        expect(m.ceiling).toBe(10);
+        expect(m.ceilingSource).toBe("approved");
+        expect(m.health).toBe("healthy");
+        // ceiling sits below the right edge so headroom shows
+        expect(m.ceilingPct).toBeGreaterThan(0);
+        expect(m.ceilingPct).toBeLessThan(100);
+        expect(m.segments.headroomPct).toBeGreaterThan(0);
+        expect(m.segments.overCapPct).toBe(0);
+        expect(Math.round(sumSegments(m.segments))).toBe(100);
+    });
+
+    it("falls back to the estimate as the ceiling when nothing is approved", () => {
+        const m = computeBurnup({ estimated: 10, approved: 0, logged: 3 });
+        expect(m.ceiling).toBe(10);
+        expect(m.ceilingSource).toBe("estimated");
+    });
+
+    it("renders logged hours past the cap as a red over-cap band and flags health=over", () => {
+        const m = computeBurnup({ estimated: 4, approved: 4, logged: 8 });
+        expect(m.health).toBe("over");
+        expect(m.segments.overCapPct).toBeGreaterThan(0);
+        expect(m.segments.approvedRemainingPct).toBe(0);
+        // bar fills to the overflow edge → no headroom
+        expect(m.segments.headroomPct).toBe(0);
+        expect(Math.round(sumSegments(m.segments))).toBe(100);
+    });
+
+    it("flags health=approaching when scope (estimate) exceeds the approved cap", () => {
+        const m = computeBurnup({ estimated: 20, approved: 10, logged: 2 });
+        expect(m.health).toBe("approaching");
+        expect(m.segments.estimatedBeyondPct).toBeGreaterThan(0);
+    });
+
+    it("flags health=approaching when logged is within 15% of the cap", () => {
+        const m = computeBurnup({ estimated: 10, approved: 10, logged: 9 });
+        expect(m.health).toBe("approaching");
+    });
+
+    it("keeps blocks literal (1h) for small items", () => {
+        const m = computeBurnup({ estimated: 8, approved: 12, logged: 4 });
+        expect(m.blockUnit).toBe(1);
+    });
+
+    it("rescales the block unit so a large item stays ~20-30 blocks", () => {
+        const m = computeBurnup({ estimated: 0, approved: 400, logged: 200 });
+        expect(m.blockUnit).toBeGreaterThan(1);
+        expect(m.scaleMax / m.blockUnit).toBeLessThanOrEqual(30);
+        expect(m.scaleMax / m.blockUnit).toBeGreaterThan(8);
+    });
+
+    it("coerces null/garbage inputs to zero rather than NaN", () => {
+        const m = computeBurnup({ estimated: null, approved: undefined, logged: "x" });
+        expect(m.empty).toBe(true);
+        expect(Number.isNaN(m.scaleMax)).toBe(false);
+    });
+});

--- a/force-app/main/default/lwc/deliveryHoursBurnup/__tests__/deliveryHoursBurnup.test.js
+++ b/force-app/main/default/lwc/deliveryHoursBurnup/__tests__/deliveryHoursBurnup.test.js
@@ -1,0 +1,83 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Mount coverage for deliveryHoursBurnup: empty state when no ceiling,
+ *               a rendered bar with a ceiling line when hours exist, and the red
+ *               over-cap band surfacing when logged exceeds the approved cap. The
+ *               geometry math itself is covered in burnupModel.test.js.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from "lwc";
+import DeliveryHoursBurnup from "c/deliveryHoursBurnup";
+import { getRecord } from "lightning/uiRecordApi";
+
+jest.mock(
+    "lightning/uiRecordApi",
+    () => {
+        const { createTestWireAdapter } = require("@salesforce/sfdx-lwc-jest");
+        const bareName = (field) => {
+            if (typeof field === "string") {
+                const parts = field.split(".");
+                return parts[parts.length - 1];
+            }
+            return field && field.fieldApiName;
+        };
+        return {
+            getRecord: createTestWireAdapter(jest.fn()),
+            getFieldValue: (record, field) =>
+                record && record.fields ? record.fields[bareName(field)] : undefined
+        };
+    },
+    { virtual: true }
+);
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function mountWith({ estimated, approved, logged }) {
+    const element = createElement("c-delivery-hours-burnup", { is: DeliveryHoursBurnup });
+    element.recordId = "a00000000000001AAA";
+    document.body.appendChild(element);
+    getRecord.emit({
+        data: {
+            fields: {
+                EstimatedHoursNumber__c: estimated,
+                ClientPreApprovedHoursNumber__c: approved,
+                TotalLoggedHoursSum__c: logged
+            }
+        },
+        error: undefined
+    });
+    await flushPromises();
+    return element;
+}
+
+describe("c-delivery-hours-burnup", () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it("shows the empty state when no ceiling is set", async () => {
+        const element = await mountWith({ estimated: 0, approved: 0, logged: 0 });
+        expect(element.shadowRoot.querySelector(".bu-track")).toBeNull();
+        expect(element.shadowRoot.textContent).toMatch(/No ceiling set yet/i);
+    });
+
+    it("renders a bar with a ceiling line when hours exist", async () => {
+        const element = await mountWith({ estimated: 8, approved: 10, logged: 4 });
+        expect(element.shadowRoot.querySelector(".bu-track")).not.toBeNull();
+        expect(element.shadowRoot.querySelector(".bu-ceiling")).not.toBeNull();
+        expect(element.shadowRoot.querySelector(".burnup--healthy")).not.toBeNull();
+    });
+
+    it("surfaces the red over-cap band and over-cap state when logged exceeds the cap", async () => {
+        const element = await mountWith({ estimated: 4, approved: 4, logged: 8 });
+        expect(element.shadowRoot.querySelector(".burnup--over")).not.toBeNull();
+        const over = element.shadowRoot.querySelector(".bu-fill_over");
+        expect(over.style.width).not.toBe("0%");
+    });
+});

--- a/force-app/main/default/lwc/deliveryHoursBurnup/burnupModel.js
+++ b/force-app/main/default/lwc/deliveryHoursBurnup/burnupModel.js
@@ -1,0 +1,117 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Pure burn-up model for the WorkItem hours card. Given estimated /
+ *               approved / logged hours, returns the bar geometry (segment widths,
+ *               ceiling position), an adaptive block unit, and a health band — all
+ *               as plain numbers so it unit-tests without a DOM mount. No LWC, no
+ *               platform APIs here; the component is a thin SLDS shell over this.
+ *
+ *               Model: the ceiling is the hours you set (approved if present, else
+ *               the estimate). Work fills toward it as three nested shades —
+ *               shipped ⊆ approved ⊆ estimated — with logged hours past the cap
+ *               drawn red. Headroom (dashed) only renders when nothing exceeds the
+ *               ceiling, so the cap line sits mid-bar exactly when it's been broken.
+ * @author       Cloud Nimbus LLC
+ */
+
+const NICE_UNITS = [1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000];
+const TARGET_BLOCKS = 30; // pick the smallest nice unit that keeps us at/under this
+
+function num(v) {
+    const n = Number(v);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+function clampPct(h, scaleMax) {
+    if (scaleMax <= 0) return 0;
+    const p = (h / scaleMax) * 100;
+    if (p < 0) return 0;
+    if (p > 100) return 100;
+    return p;
+}
+
+function pickBlockUnit(scaleMax) {
+    if (scaleMax <= TARGET_BLOCKS) return 1;
+    for (let i = 0; i < NICE_UNITS.length; i++) {
+        if (scaleMax / NICE_UNITS[i] <= TARGET_BLOCKS) return NICE_UNITS[i];
+    }
+    return NICE_UNITS[NICE_UNITS.length - 1];
+}
+
+/**
+ * @param {{estimated:number, approved:number, logged:number}} input
+ * @returns burn-up model (see file header)
+ */
+export function computeBurnup(input) {
+    const estimated = num(input && input.estimated);
+    const approved = num(input && input.approved);
+    const logged = num(input && input.logged);
+
+    const ceiling = approved > 0 ? approved : estimated > 0 ? estimated : 0;
+    const ceilingSource =
+        approved > 0 ? "approved" : estimated > 0 ? "estimated" : "none";
+
+    if (ceiling <= 0) {
+        return {
+            empty: true,
+            health: "empty",
+            ceiling: 0,
+            ceilingSource,
+            scaleMax: 0,
+            blockUnit: 1,
+            ceilingPct: 0,
+            segments: {
+                shippedPct: 0,
+                overCapPct: 0,
+                approvedRemainingPct: 0,
+                estimatedBeyondPct: 0,
+                headroomPct: 0
+            },
+            estimated,
+            approved,
+            logged
+        };
+    }
+
+    const cap = ceiling;
+    const fillMax = Math.max(approved, estimated, logged);
+    // Only pad in headroom when nothing has exceeded the ceiling; otherwise the
+    // overflow defines the right edge and the cap line sits mid-bar.
+    const scaleMax = fillMax <= cap ? cap * 1.2 : fillMax;
+
+    const shippedWithinCap = Math.min(logged, cap);
+    const overCap = Math.max(0, logged - cap);
+    const approvedRemaining = Math.max(0, cap - logged);
+    const estimatedBeyond = Math.max(0, estimated - Math.max(cap, logged));
+    const headroom = Math.max(0, scaleMax - Math.max(cap, logged, estimated));
+
+    let health;
+    if (overCap > 0) {
+        health = "over";
+    } else if (estimated > cap || logged >= cap * 0.85) {
+        health = "approaching";
+    } else {
+        health = "healthy";
+    }
+
+    return {
+        empty: false,
+        health,
+        ceiling,
+        ceilingSource,
+        scaleMax,
+        blockUnit: pickBlockUnit(scaleMax),
+        ceilingPct: clampPct(cap, scaleMax),
+        segments: {
+            shippedPct: clampPct(shippedWithinCap, scaleMax),
+            overCapPct: clampPct(overCap, scaleMax),
+            approvedRemainingPct: clampPct(approvedRemaining, scaleMax),
+            estimatedBeyondPct: clampPct(estimatedBeyond, scaleMax),
+            headroomPct: clampPct(headroom, scaleMax)
+        },
+        estimated,
+        approved,
+        logged
+    };
+}

--- a/force-app/main/default/lwc/deliveryHoursBurnup/deliveryHoursBurnup.css
+++ b/force-app/main/default/lwc/deliveryHoursBurnup/deliveryHoursBurnup.css
@@ -1,0 +1,105 @@
+/* Burn-up bar — SLDS-native palette, green family for the nested fills, red for
+   over-cap. The whole thing scales with the block-texture overlay so 8h and 800h
+   render identically. */
+
+.bu-track {
+    position: relative;
+    display: flex;
+    width: 100%;
+    height: 1.75rem;
+    border-radius: 0.25rem;
+    overflow: hidden;
+    background: #f3f3f3;
+    box-shadow: inset 0 0 0 1px #e5e5e5;
+}
+
+.bu-fill {
+    height: 100%;
+    flex: 0 0 auto;
+    transition: width 0.35s ease;
+}
+
+/* shipped ⊆ approved ⊆ estimated — three green shades, dark → light */
+.bu-fill_shipped {
+    background: #16a34a; /* darkest: done + logged */
+}
+.bu-fill_approved {
+    background: #86efac; /* medium: approved, in flight */
+}
+.bu-fill_estimated {
+    background: #dcfce7; /* lightest: scoped, not yet approved */
+}
+.bu-fill_over {
+    background: #dc2626; /* logged past the cap */
+}
+.bu-fill_headroom {
+    background: transparent;
+    background-image: repeating-linear-gradient(
+        45deg,
+        #e5e7eb 0,
+        #e5e7eb 1px,
+        transparent 1px,
+        transparent 6px
+    );
+}
+
+/* block separators — drawn over the fills, period set inline from blockUnit */
+.bu-blocks {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+}
+
+/* the ceiling you set */
+.bu-ceiling {
+    position: absolute;
+    top: -2px;
+    bottom: -2px;
+    width: 2px;
+    background: #b91c1c;
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.6);
+}
+
+/* health accent on the track border */
+.burnup--over .bu-track {
+    box-shadow: inset 0 0 0 1px #fca5a5;
+}
+.burnup--approaching .bu-track {
+    box-shadow: inset 0 0 0 1px #fcd34d;
+}
+
+/* legend */
+.bu-legend {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    font-size: 0.75rem;
+    color: #514f4d;
+}
+.bu-legend li {
+    display: inline-flex;
+    align-items: center;
+}
+.bu-key {
+    display: inline-block;
+    width: 0.7rem;
+    height: 0.7rem;
+    border-radius: 0.15rem;
+    margin-right: 0.3rem;
+}
+.bu-key_shipped {
+    background: #16a34a;
+}
+.bu-key_approved {
+    background: #86efac;
+}
+.bu-key_estimated {
+    background: #dcfce7;
+    box-shadow: inset 0 0 0 1px #bbf7d0;
+}
+.bu-key_over {
+    background: #dc2626;
+}

--- a/force-app/main/default/lwc/deliveryHoursBurnup/deliveryHoursBurnup.html
+++ b/force-app/main/default/lwc/deliveryHoursBurnup/deliveryHoursBurnup.html
@@ -1,0 +1,57 @@
+<template>
+    <lightning-card icon-name="utility:progress_ring" title="Hours Burn-Up">
+        <div class="slds-p-horizontal_medium slds-p-bottom_medium">
+            <!-- Empty state: no ceiling to draw -->
+            <template if:true={isEmpty}>
+                <div class="slds-text-color_weak slds-text-body_small slds-p-vertical_small">
+                    No ceiling set yet — add <b>Client Pre-Approved</b> or <b>Estimated Hours</b> to
+                    see work fill toward it.
+                </div>
+            </template>
+
+            <template if:true={hasBar}>
+                <div class={rootClass}>
+                    <!-- status line -->
+                    <div class="slds-grid slds-grid_align-spread slds-grid_vertical-align-center slds-m-bottom_x-small">
+                        <span class="bu-status slds-grid slds-grid_vertical-align-center">
+                            <lightning-icon
+                                icon-name={health.icon}
+                                size="x-small"
+                                variant={health.variant}
+                                class="slds-m-right_xx-small"
+                            ></lightning-icon>
+                            <span class="slds-text-title_caps">{health.label}</span>
+                        </span>
+                        <span class="slds-text-body_small slds-text-color_weak">{ceilingLabel}: {ceilingHoursLabel}h</span>
+                    </div>
+
+                    <!-- the bar -->
+                    <div class="bu-track">
+                        <div class="bu-fill bu-fill_shipped" style={shippedStyle}></div>
+                        <div class="bu-fill bu-fill_over" style={overCapStyle}></div>
+                        <div class="bu-fill bu-fill_approved" style={approvedRemainingStyle}></div>
+                        <div class="bu-fill bu-fill_estimated" style={estimatedBeyondStyle}></div>
+                        <div class="bu-fill bu-fill_headroom" style={headroomStyle}></div>
+                        <!-- block texture overlay -->
+                        <div class="bu-blocks" style={blockOverlayStyle}></div>
+                        <!-- the ceiling you set -->
+                        <div class="bu-ceiling" style={ceilingLineStyle}></div>
+                    </div>
+
+                    <!-- legend + numbers -->
+                    <div class="slds-grid slds-grid_align-spread slds-m-top_x-small slds-wrap">
+                        <ul class="bu-legend slds-grid slds-wrap">
+                            <li class="slds-m-right_small"><span class="bu-key bu-key_shipped"></span>Shipped {loggedLabel}h</li>
+                            <li class="slds-m-right_small"><span class="bu-key bu-key_approved"></span>Approved {approvedLabel}h</li>
+                            <li class="slds-m-right_small"><span class="bu-key bu-key_estimated"></span>Estimated {estimatedLabel}h</li>
+                            <template if:true={hasOverCap}>
+                                <li class="slds-m-right_small"><span class="bu-key bu-key_over"></span>Over cap</li>
+                            </template>
+                        </ul>
+                        <span class="slds-text-body_small slds-text-color_weak">{blockCaption}</span>
+                    </div>
+                </div>
+            </template>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/deliveryHoursBurnup/deliveryHoursBurnup.js
+++ b/force-app/main/default/lwc/deliveryHoursBurnup/deliveryHoursBurnup.js
@@ -1,0 +1,144 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  "Fill toward the ceiling" burn-up card for the WorkItem__c record
+ *               page. Reads Estimated / Client-Pre-Approved / Total-Logged hours via
+ *               lightning/uiRecordApi (no Apex round-trip) and draws a single bar in
+ *               which work fills toward the ceiling you set: shipped (logged) in the
+ *               darkest shade, approved-in-flight medium, estimated-beyond-cap light,
+ *               with anything logged past the cap drawn red and dashed headroom past
+ *               the ceiling line. All geometry comes from the pure burnupModel.
+ *
+ *               Fields are imported via @salesforce/schema (bare object/field names,
+ *               NO %%%NAMESPACE_DOT%%% tokens) so the platform resolves the namespace
+ *               at compile time — the same pattern deliveryHoursPills documents after
+ *               the 2026-05-29 LDS "object api names: [WorkItem__c]" fix.
+ * @author       Cloud Nimbus LLC
+ */
+import { LightningElement, api, wire } from "lwc";
+import { getRecord, getFieldValue } from "lightning/uiRecordApi";
+import ESTIMATED_FIELD from "@salesforce/schema/WorkItem__c.EstimatedHoursNumber__c";
+import APPROVED_FIELD from "@salesforce/schema/WorkItem__c.ClientPreApprovedHoursNumber__c";
+import LOGGED_FIELD from "@salesforce/schema/WorkItem__c.TotalLoggedHoursSum__c";
+import { computeBurnup } from "./burnupModel";
+
+const FIELDS = [ESTIMATED_FIELD, APPROVED_FIELD, LOGGED_FIELD];
+
+const HEALTH_META = {
+    healthy: { label: "On track", icon: "utility:success", variant: "success" },
+    approaching: { label: "Approaching cap", icon: "utility:warning", variant: "warning" },
+    over: { label: "Over cap", icon: "utility:error", variant: "error" },
+    empty: { label: "", icon: "", variant: "" }
+};
+
+export default class DeliveryHoursBurnup extends LightningElement {
+    @api recordId;
+    record;
+    errorMessage = "";
+
+    @wire(getRecord, { recordId: "$recordId", fields: FIELDS })
+    wiredRecord({ data, error }) {
+        if (data) {
+            this.record = data;
+            this.errorMessage = "";
+        } else if (error) {
+            this.errorMessage = error.body ? error.body.message : error.message;
+        }
+    }
+
+    get model() {
+        return computeBurnup({
+            estimated: getFieldValue(this.record, ESTIMATED_FIELD),
+            approved: getFieldValue(this.record, APPROVED_FIELD),
+            logged: getFieldValue(this.record, LOGGED_FIELD)
+        });
+    }
+
+    get hasData() {
+        return !!this.record && !this.errorMessage;
+    }
+
+    get isEmpty() {
+        return !this.hasData || this.model.empty;
+    }
+
+    get hasBar() {
+        return !this.isEmpty;
+    }
+
+    // ── header / status ───────────────────────────────────────────
+    get health() {
+        return HEALTH_META[this.model.health] || HEALTH_META.empty;
+    }
+
+    get rootClass() {
+        return `burnup burnup--${this.model.health}`;
+    }
+
+    get ceilingLabel() {
+        return this.model.ceilingSource === "approved"
+            ? "Approved ceiling"
+            : "Estimated ceiling — not yet approved";
+    }
+
+    // ── numeric readout ───────────────────────────────────────────
+    get loggedLabel() {
+        return this._fmt(this.model.logged);
+    }
+    get approvedLabel() {
+        return this._fmt(this.model.approved);
+    }
+    get estimatedLabel() {
+        return this._fmt(this.model.estimated);
+    }
+    get ceilingHoursLabel() {
+        return this._fmt(this.model.ceiling);
+    }
+
+    get blockCaption() {
+        return this.model.blockUnit > 1 ? `each block ≈ ${this.model.blockUnit}h` : "";
+    }
+
+    get hasOverCap() {
+        return this.model.segments.overCapPct > 0;
+    }
+
+    // ── inline bar geometry (getters, not template ternaries) ─────
+    get shippedStyle() {
+        return `width:${this.model.segments.shippedPct}%`;
+    }
+    get overCapStyle() {
+        return `width:${this.model.segments.overCapPct}%`;
+    }
+    get approvedRemainingStyle() {
+        return `width:${this.model.segments.approvedRemainingPct}%`;
+    }
+    get estimatedBeyondStyle() {
+        return `width:${this.model.segments.estimatedBeyondPct}%`;
+    }
+    get headroomStyle() {
+        return `width:${this.model.segments.headroomPct}%`;
+    }
+    get ceilingLineStyle() {
+        return `left:${this.model.ceilingPct}%`;
+    }
+    get blockOverlayStyle() {
+        const m = this.model;
+        const periodPct = m.scaleMax > 0 ? (m.blockUnit / m.scaleMax) * 100 : 100;
+        // a 2px light separator every block-period → the "blocks" texture, at any scale
+        return (
+            "background-image:repeating-linear-gradient(to right," +
+            "rgba(255,255,255,0.6) 0 2px,transparent 2px " +
+            periodPct +
+            "%)"
+        );
+    }
+
+    _fmt(num) {
+        const n = Number(num);
+        if (!Number.isFinite(n)) return "0";
+        if (Math.abs(n) >= 100) return n.toFixed(0);
+        if (Math.abs(n) >= 10) return n.toFixed(1);
+        return String(Math.round(n * 100) / 100);
+    }
+}

--- a/force-app/main/default/lwc/deliveryHoursBurnup/deliveryHoursBurnup.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryHoursBurnup/deliveryHoursBurnup.js-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <masterLabel>Delivery Hours Burn-Up</masterLabel>
+    <description>Fill-toward-the-ceiling burn-up bar for a WorkItem: shipped/approved/estimated hours vs the approved ceiling, over-cap drawn red.</description>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordPage</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordPage">
+            <objects>
+                <object>WorkItem__c</object>
+            </objects>
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>


### PR DESCRIPTION
Adds **deliveryHoursBurnup** — a "fill toward the ceiling" burn-up bar on the `WorkItem__c` record page.

## What
Reads Estimated / Client-Pre-Approved / Total-Logged hours via `lightning/uiRecordApi` (zero Apex — no cacheable-getter landmine) and draws nested shipped⊆approved⊆estimated bands toward the approved ceiling, with over-cap logged hours in red and dashed headroom past the line.

- Pure `burnupModel.js` holds all geometry (segment widths, ceiling position, adaptive block unit, health band) — unit-tested without a DOM mount.
- Adaptive block texture scales 8h and 800h identically; real numbers always shown.
- Empty state when no ceiling is set.
- Schema imports use bare `WorkItem__c` field names (no namespace token) per the `deliveryHoursPills` LDS fix; placed next to it on the record page.

## Tests / verification
- **12 jest tests green** (9 model + 3 mount).
- Deployed clean to a live non-namespaced scratch org (`cci task run deploy` → Succeeded) — compiles against real fields.

## Related
Partly addresses the F9 budget-metric confusion (this card shows logged-toward-ceiling correctly, e.g. 14/60 = 23%, vs the old On-Budget pill's 429%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)