### PR TITLE
fix(workitem): correct inverted On-Budget % (F9)

### DIFF
--- a/force-app/main/default/lwc/deliveryHoursPills/__tests__/deliveryHoursPills.test.js
+++ b/force-app/main/default/lwc/deliveryHoursPills/__tests__/deliveryHoursPills.test.js
@@ -71,10 +71,10 @@ describe("c-delivery-hours-pills", () => {
         jest.clearAllMocks();
     });
 
-    it("shows a neutral placeholder (not Infinity / a huge %) when hours logged is 0", async () => {
+    it("shows 0% (not Infinity / a huge %) when hours logged is 0", async () => {
         const element = await mountWith({ estimated: 8, logged: 0, eta: "2099-01-01" });
         const [onBudget] = badgeTexts(element);
-        expect(onBudget).toBe("—");
+        expect(onBudget).toBe("0%"); // 0 logged / 8 estimated = 0% of budget used
         expect(onBudget).not.toMatch(/infinity/i);
         expect(onBudget).not.toMatch(/\d{4,}/); // no runaway 8,000,000% style number
     });
@@ -88,7 +88,7 @@ describe("c-delivery-hours-pills", () => {
     it("flags over-budget when logged exceeds estimate", async () => {
         const element = await mountWith({ estimated: 4, logged: 8, eta: "2099-01-01" });
         const [onBudget] = badgeTexts(element);
-        expect(onBudget).toBe("50%");
+        expect(onBudget).toBe("200%"); // 8 logged / 4 estimated = 200% of budget used
     });
 
     it("shows a neutral placeholder when no estimate is set", async () => {

--- a/force-app/main/default/lwc/deliveryHoursPills/deliveryHoursPills.js
+++ b/force-app/main/default/lwc/deliveryHoursPills/deliveryHoursPills.js
@@ -79,26 +79,23 @@ export default class DeliveryHoursPills extends LightningElement {
         if (this._estimated <= 0) {
             return this._pill("On-Budget", "—", "neutral", "No estimate set", "No data");
         }
-        // Guard divide-by-zero BEFORE computing the ratio. The old
-        // `this._estimated / (this._logged || 0.0001)` produced a ~8,000,000%
-        // label when no hours were logged — rendered as a nonsense
-        // "Infinity"-looking figure on MF prod. With nothing logged there is
-        // no budget signal yet, so show a neutral placeholder.
-        if (this._logged <= 0) {
-            return this._pill("On-Budget", "—", "neutral", "No hours logged yet",
-                `Est ${this._formatHours(this._estimated)}h · Logged 0h`);
-        }
-        const pct = Math.round((this._estimated / this._logged) * 100);
+        // Budget consumed = logged / estimated. Estimated is guaranteed > 0 here
+        // (guarded above), so there is no divide-by-zero, and logged = 0 reads as
+        // a correct 0% used. This previously computed estimated / logged, which
+        // INVERTED the ratio — 14h logged against a 60h estimate rendered "429%"
+        // under an "On-Budget" label instead of the correct 23% (F9). The label
+        // means "percent of the estimate consumed," so over 100% is over budget.
+        const pct = Math.round((this._logged / this._estimated) * 100);
         let band, tooltip;
-        if (pct >= 100) {
-            band = "green";
-            tooltip = `Earning ${pct}% of estimated hours per actual hour — at or under budget.`;
+        if (pct > 100) {
+            band = "red";
+            tooltip = `${pct}% of the estimated budget used — over budget.`;
         } else if (pct >= 80) {
             band = "yellow";
-            tooltip = `Earning ${pct}% of estimated hours per actual hour — drifting over.`;
+            tooltip = `${pct}% of the estimated budget used — approaching the estimate.`;
         } else {
-            band = "red";
-            tooltip = `Earning only ${pct}% of estimated hours per actual hour — significantly over budget.`;
+            band = "green";
+            tooltip = `${pct}% of the estimated budget used — under budget.`;
         }
         return this._pill("On-Budget", `${pct}%`, band, tooltip,
             `Est ${this._formatHours(this._estimated)}h · Logged ${this._formatHours(this._logged)}h`);


### PR DESCRIPTION
## Problem
The WorkItem record-page **On-Budget** pill showed **429%** for a card with Est 60h / Logged 14h — it computed `estimated / logged` (60/14) instead of `logged / estimated` (14/60 = 23%). The label means "percent of the estimate consumed," so the ratio was inverted and read alarmingly wrong.

Found + arithmetic-confirmed during the live two-org validation pass (logged as **F9** in `docs/flow/`).

## Fix
- Flip to `logged / estimated`; bands: **<80% green · 80–100% yellow · >100% red**.
- `estimated` is already guarded `> 0`, so `logged = 0` → **0%** (no divide-by-zero, no Infinity — preserves the old zero-guard intent).
- jest updated: logged-0 → `0%` (was `—`); est 4 / logged 8 → `200%` (was `50%`). **5/5 green.**

LWC-only — does not touch the PMD (Apex) scanner.
🤖 Generated with [Claude Code](https://claude.com/claude-code)