### PR TITLE
test(sync): bare-name smoke-cross-org scripts for non-namespaced orgs (F6)

### DIFF
--- a/scripts/apex/README-smoke-cross-org.md
+++ b/scripts/apex/README-smoke-cross-org.md
@@ -53,3 +53,10 @@ The **payload-carries-X** flags catch the namespace-stripping bug class (PR #742
 ## Promote/install gate
 
 Run sender → wait → receiver after every install on each org pair. If any leg fails, hold the promote rollout to the rest of the orgs until the underlying outbound or ingestor bug is fixed.
+
+## Non-namespaced (dev scratch) orgs
+
+The scripts above are `delivery__`-prefixed for **subscriber/managed** orgs. On a
+**non-namespaced dev scratch org** they fail to compile (`Invalid type:
+delivery__WorkRequest__c`). Use the `*-unmanaged.apex` variants in this folder
+instead (same logic, namespace prefix stripped). Keep the two in sync.

--- a/scripts/apex/smoke-cross-org-cleanup-unmanaged.apex
+++ b/scripts/apex/smoke-cross-org-cleanup-unmanaged.apex
@@ -1,0 +1,38 @@
+// AUTO-VARIANT of smoke-cross-org-cleanup.apex with the delivery__ namespace stripped.
+// Use this on NON-NAMESPACED dev scratch orgs (the managed-prefixed original fails to
+// compile there: 'Invalid type: delivery__WorkRequest__c'). Keep both in sync.
+//
+// =============================================================================
+// Cross-org sync smoke test — CLEANUP
+//
+// Run on the sender org to delete the most recent SMOKE_-tagged records
+// (and their downstream sync ledger). Receiver-side rows tombstone via
+// the cross-org sync DELETE flow.
+//
+// Usage:
+//   sf apex run --target-org <sender> --file scripts/apex/smoke-cross-org-cleanup.apex
+// =============================================================================
+
+List<WorkItem__c> smokeWis = [
+    SELECT Id, BriefDescriptionTxt__c
+    FROM WorkItem__c
+    WHERE BriefDescriptionTxt__c LIKE 'SMOKE_%'
+];
+if (smokeWis.isEmpty()) {
+    System.debug('NOTE | No SMOKE_ WorkItems on this org. Nothing to clean up.');
+    return;
+}
+
+System.debug('=== Found ' + smokeWis.size() + ' SMOKE_ WorkItem(s) to remove ===');
+for (WorkItem__c wi : smokeWis) {
+    System.debug('  - ' + wi.Id + ' | ' + wi.BriefDescriptionTxt__c);
+}
+
+// Children cascade-delete on master-detail; lookup child WorkRequests + Comments + WorkLogs need explicit cleanup
+Set<Id> wiIds = new Map<Id, WorkItem__c>(smokeWis).keySet();
+delete [SELECT Id FROM WorkLog__c WHERE WorkItemLookup__c IN :wiIds];
+delete [SELECT Id FROM WorkItemComment__c WHERE WorkItemId__c IN :wiIds];
+delete [SELECT Id FROM WorkRequest__c WHERE WorkItemId__c IN :wiIds];
+delete smokeWis;
+
+System.debug('=== CLEANUP COMPLETE ===');

--- a/scripts/apex/smoke-cross-org-receiver-unmanaged.apex
+++ b/scripts/apex/smoke-cross-org-receiver-unmanaged.apex
@@ -1,0 +1,164 @@
+// AUTO-VARIANT of smoke-cross-org-receiver.apex with the delivery__ namespace stripped.
+// Use this on NON-NAMESPACED dev scratch orgs (the managed-prefixed original fails to
+// compile there: 'Invalid type: delivery__WorkRequest__c'). Keep both in sync.
+//
+// =============================================================================
+// Cross-org sync smoke test — RECEIVER side
+//
+// Run on the receiver org (e.g. Nimba, dh-prod, MF-Prod) AFTER sending from the
+// sender side. Looks for the most recent SMOKE_ tag and asserts each record
+// landed locally with full data + has an Inbound SyncItem ledger entry.
+//
+// Usage:
+//   sf apex run --target-org <receiver> --file scripts/apex/smoke-cross-org-receiver.apex
+//
+// PASS criteria per leg:
+//   - Local record exists on this org (sender's Outbound dispatched + ingestor accepted)
+//   - The actual field value (description / body / hours) propagated, not just the row
+//   - An Inbound SyncItem with StatusPk__c='Synced' exists for the local record's Id
+//
+// FAIL signals:
+//   - Local record missing → outbound never dispatched OR ingestor rejected pre-insert
+//     (check sender for a Failed Outbound SyncItem with the smoke tag in PayloadTxt__c)
+//   - Local record exists but field is empty → namespace-stripping bug in outbound
+//     payload builder (PR #742 class) OR receiver mapFields path
+//   - No Inbound SyncItem → record was created by a non-sync path (manual, local trigger)
+//
+// Routing note:
+//   WorkItem fans out BOTH ways (Hub via parent's ClientNetworkEntity AND Push via
+//   the bridge WorkRequest), so it lands on multiple receivers. WorkLog and Comment
+//   typically only Hub-route to the parent WI's ClientNetworkEntity. If you point
+//   the receiver script at the wrong org for the leg, you'll see a real PASS
+//   somewhere else and a missing-record FAIL here. That's not the test failing —
+//   it's the test telling you about the route.
+// =============================================================================
+
+// 1. Find the most recent SMOKE_ tag on this org via the WorkItem
+List<WorkItem__c> smokeWis = [
+    SELECT Id, BriefDescriptionTxt__c, CreatedDate
+    FROM WorkItem__c
+    WHERE BriefDescriptionTxt__c LIKE 'SMOKE_%'
+    ORDER BY CreatedDate DESC
+    LIMIT 1
+];
+if (smokeWis.isEmpty()) {
+    System.debug('FAIL | No SMOKE_ WorkItem on this org. Sender may not have routed here, or sync still in flight.');
+    System.debug('       Wait 30 sec after sender ran, then re-run this script.');
+    return;
+}
+WorkItem__c wi = smokeWis[0];
+String tag = wi.BriefDescriptionTxt__c.substringBefore(' ').trim();
+System.debug('=== Found SMOKE tag on receiver: ' + tag + ' ===');
+System.debug('     Receiver WorkItem.Id      = ' + wi.Id);
+System.debug('     Receiver WorkItem.Created = ' + wi.CreatedDate);
+
+// 2. WorkItem assertions — local record + Inbound SyncItem
+String wiIdString = (String) wi.Id;
+SyncItem__c wiSync = null;
+for (SyncItem__c si : [
+    SELECT Id, StatusPk__c, GlobalSourceIdTxt__c, CreatedDate
+    FROM SyncItem__c
+    WHERE DirectionPk__c = 'Inbound'
+    AND ObjectTypePk__c = 'WorkItem__c'
+    AND LocalRecordIdTxt__c = :wiIdString
+    ORDER BY CreatedDate DESC
+    LIMIT 1
+]) {
+    wiSync = si;
+}
+Boolean wiHasField = wi.BriefDescriptionTxt__c != null
+    && wi.BriefDescriptionTxt__c.contains(tag);
+if (wiSync == null) {
+    System.debug('FAIL | WorkItem | local record exists but no Inbound SyncItem (created locally?)');
+} else if (wiSync.StatusPk__c != 'Synced') {
+    System.debug('FAIL | WorkItem | Inbound status=' + wiSync.StatusPk__c
+        + ' | senderId=' + wiSync.GlobalSourceIdTxt__c);
+} else if (!wiHasField) {
+    System.debug('FAIL | WorkItem | Inbound Synced but BriefDescriptionTxt__c did not propagate. ' +
+        'Likely outbound-payload bug class (PR #742). senderId=' + wiSync.GlobalSourceIdTxt__c);
+} else {
+    System.debug('PASS | WorkItem | Inbound Synced + description carries tag | senderId=' +
+        wiSync.GlobalSourceIdTxt__c + ' | inboundCreated=' + wiSync.CreatedDate);
+}
+
+// 3. Comment assertions — walk children of the smoke WI
+List<WorkItemComment__c> comments = [
+    SELECT Id, BodyTxt__c
+    FROM WorkItemComment__c
+    WHERE WorkItemId__c = :wi.Id
+    ORDER BY CreatedDate DESC
+    LIMIT 1
+];
+if (comments.isEmpty()) {
+    System.debug('SKIP | Comment | No matching record on this org. ' +
+        'May have routed to a different receiver (Hub-routed via parent network).');
+} else {
+    String commentIdString = (String) comments[0].Id;
+    SyncItem__c commentSync = null;
+    for (SyncItem__c si : [
+        SELECT Id, StatusPk__c
+        FROM SyncItem__c
+        WHERE DirectionPk__c = 'Inbound'
+        AND ObjectTypePk__c = 'WorkItemComment__c'
+        AND LocalRecordIdTxt__c = :commentIdString
+        ORDER BY CreatedDate DESC
+        LIMIT 1
+    ]) {
+        commentSync = si;
+    }
+    Boolean bodyHasTag = comments[0].BodyTxt__c != null
+        && comments[0].BodyTxt__c.contains(tag);
+    if (commentSync == null) {
+        System.debug('FAIL | Comment | local record exists but no Inbound SyncItem');
+    } else if (commentSync.StatusPk__c != 'Synced') {
+        System.debug('FAIL | Comment | Inbound status=' + commentSync.StatusPk__c);
+    } else if (!bodyHasTag) {
+        System.debug('FAIL | Comment | Inbound Synced but BodyTxt__c did not propagate.');
+    } else {
+        System.debug('PASS | Comment | Inbound Synced + body carries tag');
+    }
+}
+
+// 4. WorkLog assertions — walk children of the smoke WI
+List<WorkLog__c> logs = [
+    SELECT Id, WorkDescriptionTxt__c, HoursLoggedNumber__c
+    FROM WorkLog__c
+    WHERE WorkItemLookup__c = :wi.Id
+    ORDER BY CreatedDate DESC
+    LIMIT 1
+];
+if (logs.isEmpty()) {
+    System.debug('SKIP | WorkLog | No matching record on this org. ' +
+        'May have routed to a different receiver (Hub-routed via parent network).');
+} else {
+    String logIdString = (String) logs[0].Id;
+    SyncItem__c logSync = null;
+    for (SyncItem__c si : [
+        SELECT Id, StatusPk__c
+        FROM SyncItem__c
+        WHERE DirectionPk__c = 'Inbound'
+        AND ObjectTypePk__c = 'WorkLog__c'
+        AND LocalRecordIdTxt__c = :logIdString
+        ORDER BY CreatedDate DESC
+        LIMIT 1
+    ]) {
+        logSync = si;
+    }
+    Boolean descHasTag = logs[0].WorkDescriptionTxt__c != null
+        && logs[0].WorkDescriptionTxt__c.contains(tag);
+    Boolean hoursPopulated = logs[0].HoursLoggedNumber__c != null
+        && logs[0].HoursLoggedNumber__c > 0;
+    if (logSync == null) {
+        System.debug('FAIL | WorkLog | local record exists but no Inbound SyncItem');
+    } else if (logSync.StatusPk__c != 'Synced') {
+        System.debug('FAIL | WorkLog | Inbound status=' + logSync.StatusPk__c);
+    } else if (!descHasTag || !hoursPopulated) {
+        System.debug('FAIL | WorkLog | Inbound Synced but data did not propagate. ' +
+            'descHasTag=' + descHasTag + ' hoursPopulated=' + hoursPopulated);
+    } else {
+        System.debug('PASS | WorkLog | Inbound Synced + description carries tag + hours populated');
+    }
+}
+
+System.debug('=== RECEIVER COMPLETE for ' + tag + ' ===');
+System.debug('Run smoke-cross-org-cleanup.apex on the SENDER org when satisfied.');

--- a/scripts/apex/smoke-cross-org-sender-unmanaged.apex
+++ b/scripts/apex/smoke-cross-org-sender-unmanaged.apex
@@ -1,0 +1,105 @@
+// AUTO-VARIANT of smoke-cross-org-sender.apex with the delivery__ namespace stripped.
+// Use this on NON-NAMESPACED dev scratch orgs (the managed-prefixed original fails to
+// compile there: 'Invalid type: delivery__WorkRequest__c'). Keep both in sync.
+//
+// =============================================================================
+// Cross-org sync smoke test — SENDER side
+//
+// Run on the sender org (e.g. MF-Prod). Inserts a tagged WorkItem + Comment +
+// WorkLog under an existing routed WorkRequest, then prints the GlobalSourceIds
+// for the receiver-side script to look up.
+//
+// Usage:
+//   sf apex run --target-org MF-Prod --file scripts/apex/smoke-cross-org-sender.apex
+//
+// Pair with smoke-cross-org-receiver.apex on the receiver org.
+//
+// Tag: SMOKE_<UTC_TIMESTAMP> — unique per run, written into BriefDescriptionTxt__c
+// + WorkItemComment.BodyTxt__c + WorkLog.WorkDescriptionTxt__c so all three can be
+// found on the receiver side via simple LIKE queries.
+//
+// Cleanup: the script does NOT delete the records. Run scripts/apex/smoke-
+// cross-org-cleanup.apex (uses the SMOKE_ prefix) to remove them once you're
+// satisfied with the round-trip.
+// =============================================================================
+
+String tag = 'SMOKE_' + Datetime.now().formatGmt('yyyyMMdd_HHmmss');
+System.debug('=== SMOKE TAG: ' + tag + ' ===');
+
+// 1. Find an active routed WorkRequest so the WI fans out to the configured Vendor
+// Mirror DeliverySyncEngine.captureChanges connection filter: any status
+// except Inactive, vendor entity with endpoint, Active+Connected.
+List<WorkRequest__c> reqs = [
+    SELECT Id, WorkItemId__c, DeliveryEntityLookup__c
+    FROM WorkRequest__c
+    WHERE StatusPk__c != 'Inactive'
+    AND DeliveryEntityLookup__c != NULL
+    AND DeliveryEntityLookup__r.StatusPk__c = 'Active'
+    AND DeliveryEntityLookup__r.ConnectionStatusPk__c = 'Connected'
+    AND DeliveryEntityLookup__r.EntityTypePk__c IN ('Vendor', 'Both')
+    AND DeliveryEntityLookup__r.IntegrationEndpointUrlTxt__c != NULL
+    LIMIT 1
+];
+if (reqs.isEmpty()) {
+    System.debug('FAIL | No active routed WorkRequest found. Sync fan-out cannot fire. Aborting.');
+    return;
+}
+WorkRequest__c req = reqs[0];
+System.debug('PASS | Found routed WorkRequest: ' + req.Id);
+
+// 2. Insert a tagged WorkItem under that request's parent WI's network
+WorkItem__c parentWi = [
+    SELECT Id, ClientNetworkEntityLookup__c
+    FROM WorkItem__c
+    WHERE Id = :req.WorkItemId__c
+    LIMIT 1
+];
+WorkItem__c smokeWi = new WorkItem__c(
+    BriefDescriptionTxt__c = tag + ' — smoke test WorkItem',
+    StageNamePk__c = 'Backlog',
+    StatusPk__c = 'New',
+    ClientNetworkEntityLookup__c = parentWi.ClientNetworkEntityLookup__c
+);
+insert smokeWi;
+System.debug('PASS | Inserted WorkItem ' + smokeWi.Id + ' under network ' + parentWi.ClientNetworkEntityLookup__c);
+
+// 3. Bridge it to the same vendor so it actually fans out
+WorkRequest__c smokeReq = new WorkRequest__c(
+    WorkItemId__c = smokeWi.Id,
+    DeliveryEntityLookup__c = req.DeliveryEntityLookup__c,
+    StatusPk__c = 'Active'
+);
+insert smokeReq;
+System.debug('PASS | Inserted bridge WorkRequest ' + smokeReq.Id);
+
+// 4. Insert a tagged Comment + WorkLog
+WorkItemComment__c smokeComment = new WorkItemComment__c(
+    WorkItemId__c = smokeWi.Id,
+    BodyTxt__c = tag + ' — smoke test Comment',
+    SourcePk__c = 'Client',
+    AuthorTxt__c = 'Smoke Test'
+);
+insert smokeComment;
+System.debug('PASS | Inserted Comment ' + smokeComment.Id);
+
+WorkLog__c smokeLog = new WorkLog__c(
+    WorkItemLookup__c = smokeWi.Id,
+    RequestId__c = smokeReq.Id,
+    HoursLoggedNumber__c = 0.25,
+    WorkDateDate__c = Date.today(),
+    WorkDescriptionTxt__c = tag + ' — smoke test WorkLog',
+    StatusPk__c = 'Approved'
+);
+insert smokeLog;
+System.debug('PASS | Inserted WorkLog ' + smokeLog.Id);
+
+// 5. Report what to look for on receiver side
+System.debug('=== SENDER COMPLETE ===');
+System.debug('TAG: ' + tag);
+System.debug('WorkItem GlobalSourceId: ' + smokeWi.Id);
+System.debug('Comment GlobalSourceId : ' + smokeComment.Id);
+System.debug('WorkLog GlobalSourceId : ' + smokeLog.Id);
+System.debug('');
+System.debug('On receiver org, run:');
+System.debug('  sf apex run --target-org <receiver> --file scripts/apex/smoke-cross-org-receiver.apex');
+System.debug('  (it will pick up the most recent SMOKE_ tag automatically)');


### PR DESCRIPTION
## Problem
The `scripts/apex/smoke-cross-org-*.apex` round-trip scripts are `delivery__`-prefixed (managed-org form). On a **non-namespaced dev scratch org** they fail to compile — `Invalid type: delivery__WorkRequest__c` — so the two-org sync test in the runbook couldn't be run as written. Logged as **F6** during the live validation pass.

## Fix
- Add `*-unmanaged.apex` variants (sender/receiver/cleanup) with the namespace prefix stripped, each with a header pointing back to the managed original.
- README note on which to use where.

Verified live: the bare-name sender/receiver passed a real child→parent round-trip — all three legs (WorkItem/Comment/WorkLog) Inbound Synced.

Scripts only — no package metadata, no PMD/test impact.
🤖 Generated with [Claude Code](https://claude.com/claude-code)