### PR TITLE
fix(board): surface create-work-item errors instead of failing silently (F11)

### DIFF
--- a/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.html
+++ b/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.html
@@ -619,11 +619,17 @@
                     </template>
                     
                     <template lwc:if={isNotAiProcessing}>
-                        <lightning-record-edit-form object-api-name="%%%NAMESPACE_DOT%%%WorkItem__c" 
-                            default-field-values={createDefaults} 
+                        <lightning-record-edit-form object-api-name="%%%NAMESPACE_DOT%%%WorkItem__c"
+                            default-field-values={createDefaults}
                             onsubmit={handleCreateSubmit}
-                            onsuccess={handleCreateSuccess}>
-                            
+                            onsuccess={handleCreateSuccess}
+                            onerror={handleCreateError}>
+
+                            <!-- Surfaces page-level DML/validation/trigger errors inline so a
+                                 rejected create never fails silently (F11): without this the
+                                 modal would stay open with no record and no feedback. -->
+                            <lightning-messages></lightning-messages>
+
                             <lightning-input-field field-name="%%%NAMESPACE_DOT%%%BriefDescriptionTxt__c" required onchange={handleFieldChange} value={createWorkItemTitle}></lightning-input-field>
                             <lightning-input-field field-name="%%%NAMESPACE_DOT%%%DetailsTxt__c" onchange={handleFieldChange} value={createWorkItemDescription}></lightning-input-field>
                             <lightning-input-field field-name="%%%NAMESPACE_DOT%%%PriorityPk__c" value={createDefaults.PriorityPk__c}></lightning-input-field>

--- a/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.js
+++ b/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.js
@@ -1324,7 +1324,26 @@ export default class DeliveryHubBoard extends NavigationMixin(LightningElement) 
 
         this.refreshWorkItems();
     }
-    
+
+    handleCreateError(event) {
+        // F11: the create form previously had no onerror handler, so a rejected
+        // create (validation rule, a required field not on the form, a trigger
+        // addError, or a duplicate rule) failed silently — the modal stayed open
+        // with no record and no feedback, which read as a frozen/broken Create.
+        // Surface it: keep the modal open so the user can correct, and toast the
+        // platform's own reason. <lightning-messages> in the form shows the
+        // field-level detail inline.
+        this.isAiProcessing = false;
+        const detail = event && event.detail ? event.detail : {};
+        let message = detail.message || 'Could not create the work item. Please review the fields and try again.';
+        const errors = detail.output && detail.output.errors ? detail.output.errors : [];
+        const specific = errors.map((e) => e && e.message).filter(Boolean);
+        if (specific.length > 0) {
+            message = specific.join(' ');
+        }
+        this.showToast('Could not create work item', message, 'error');
+    }
+
     // ... [Search Handlers & AI Handlers (handleFieldChange, handleAiEnhance, applyAiSuggestions, setFieldValue, dismissAiSuggestions)] ...
     
     handleFieldChange(event) {


### PR DESCRIPTION
## What

Fixes **F11** (2026-06-23 validation campaign): the board's "Create New Work Item" flow appeared frozen — Create wouldn't dismiss the modal, no record was created, and there was no error feedback.

## Root cause (confirmed from source)

The create `lightning-record-edit-form` (deliveryHubBoard.html) had `onsubmit` + `onsuccess` but **no `onerror` handler and no `<lightning-messages>`** — unlike its sibling *transition* form right below it, which has `onerror={handleTransitionError}`. So any insert rejection (validation rule, a required field not on the form, a trigger `addError`, or a duplicate rule) fired an error event that nothing handled, with no inline message → modal stays open, no record, no toast. That's the exact silent-freeze symptom.

## Fix

- Add `onerror={handleCreateError}` + `<lightning-messages>` to the create form.
- New `handleCreateError(event)` keeps the modal open (so the user can correct) and toasts the platform's own error message; `<lightning-messages>` renders field-level detail inline.

This resolves the silent-failure **mechanism** regardless of which rule triggered the rejection — and importantly, it now **surfaces the underlying reason**, so if there is a deeper validation/required-field issue it becomes visible (next step: live re-test to read that message).

## Testing

`deliveryHubBoard` has **no existing jest harness**, so no unit test is added here (standing one up for a single additive handler would be disproportionate; flagged as tech-debt). The change is additive — the success path is unchanged. Validation is a live re-test of the create flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)