### PR TITLE
feat(billing): missing-billable detector — health check for invoices needing re-bill

### DIFF
--- a/force-app/main/default/classes/DeliveryHubHealthService.cls
+++ b/force-app/main/default/classes/DeliveryHubHealthService.cls
@@ -12,6 +12,10 @@ public with sharing class DeliveryHubHealthService {
 
     private static final Integer STALE_FAILED_DAYS = 7;
     private static final Integer ENDPOINT_REACHABILITY_LIMIT = 5;
+    // Bound the per-invoice snapshot rebuilds (each calls DeliveryDocGenerationService.buildSnapshot,
+    // ~5-6 SOQL) so the stale-invoice check stays well under the synchronous query ceiling alongside
+    // the other checks. The scan is most-recent-first; the cap is surfaced in the result message.
+    private static final Integer INVOICE_SCAN_LIMIT = 10;
 
     /**
      * @description Run every check and return their results in a stable order.
@@ -33,6 +37,7 @@ public with sharing class DeliveryHubHealthService {
         out.add(safe('mothershipHandshake', 'Mothership Handshake', new MothershipCheck()));
         out.add(safe('inboundWebhookProviders', 'Inbound Webhook Providers', new InboundWebhookCheck()));
         out.add(safe('sortOrderHealth', 'SortOrder Integrity', new SortOrderCheck()));
+        out.add(safe('staleInvoices', 'Invoices Pending Re-bill', new StaleInvoiceCheck()));
         return out;
     }
 
@@ -101,6 +106,64 @@ public with sharing class DeliveryHubHealthService {
             return DeliveryHubHealthCheckResult.warn(key, label,
                 count + ' SyncItem__c rows have been Failed for over ' + STALE_FAILED_DAYS + ' days.',
                 'requeueFailedSyncs');
+        }
+    }
+
+    /**
+     * @description Flags issued invoices that have accrued billable hours AFTER
+     *              they were generated. Invoices freeze a tamper-evident snapshot
+     *              at generation; if an in-period billable WorkLog lands later
+     *              (e.g. a delayed time entry or a cross-org relay), nothing tells
+     *              the biller to regenerate, so the client is under-billed silently.
+     *              This is the missing-billable detector for the Phase F billing gap.
+     *
+     *              Method: for each recent non-superseded Invoice, rebuild the
+     *              period snapshot with the SAME scoping the generator uses
+     *              (DeliveryDocGenerationService.buildSnapshot + calculateTotalHours)
+     *              and compare the current period hours to the frozen
+     *              TotalHoursNumber__c. A positive delta means unbilled time exists.
+     *              Reusing the generator's own scoping guarantees the detector can
+     *              never diverge from how the invoice was actually computed.
+     */
+    public class StaleInvoiceCheck implements IHealthCheck {
+        public DeliveryHubHealthCheckResult run(String key, String label) {
+            List<DeliveryDocument__c> invoices = [
+                SELECT Id, Name, NetworkEntityId__c, PeriodStartDate__c,
+                       PeriodEndDate__c, TotalHoursNumber__c
+                FROM DeliveryDocument__c
+                WHERE TemplatePk__c = 'Invoice'
+                AND StatusPk__c NOT IN ('Superseded', 'Void', 'Paid')
+                AND NetworkEntityId__c != NULL
+                AND PeriodStartDate__c != NULL
+                AND PeriodEndDate__c != NULL
+                WITH SYSTEM_MODE
+                ORDER BY CreatedDate DESC
+                LIMIT :INVOICE_SCAN_LIMIT
+            ];
+
+            List<String> stale = new List<String>();
+            for (DeliveryDocument__c inv : invoices) {
+                Map<String, Object> snap = DeliveryDocGenerationService.buildSnapshot(
+                    inv.NetworkEntityId__c, 'Invoice', inv.PeriodStartDate__c, inv.PeriodEndDate__c);
+                Decimal currentHours = DeliveryDocGenerationService.calculateTotalHours(snap);
+                Decimal frozen = inv.TotalHoursNumber__c != null ? inv.TotalHoursNumber__c : 0;
+                // Tolerance guards against Decimal scale noise; only a real positive delta counts.
+                if (currentHours - frozen > 0.001) {
+                    stale.add(inv.Name + ' (+' + (currentHours - frozen).setScale(2) + 'h unbilled)');
+                }
+            }
+
+            String scope = invoices.size() == INVOICE_SCAN_LIMIT
+                ? ' (checked ' + INVOICE_SCAN_LIMIT + ' most recent)'
+                : '';
+            if (stale.isEmpty()) {
+                return DeliveryHubHealthCheckResult.pass(key, label,
+                    'No issued invoices have billable hours logged after generation' + scope + '.');
+            }
+            return DeliveryHubHealthCheckResult.warn(key, label,
+                stale.size() + ' invoice(s) have billable hours logged after generation — '
+                + 'regenerate to capture: ' + String.join(stale, '; ') + scope + '.',
+                null);
         }
     }
 

--- a/force-app/main/default/classes/DeliveryStaleInvoiceCheckTest.cls
+++ b/force-app/main/default/classes/DeliveryStaleInvoiceCheckTest.cls
@@ -1,0 +1,125 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Tests the missing-billable detector
+ *              (DeliveryHubHealthService.StaleInvoiceCheck). An invoice freezes a
+ *              tamper-evident snapshot at generation; if an in-period billable
+ *              WorkLog lands afterward, nothing tells the biller to regenerate and
+ *              the client is silently under-billed. The check rebuilds each
+ *              invoice's period snapshot with the generator's own scoping and warns
+ *              when current period hours exceed the frozen TotalHoursNumber__c.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryStaleInvoiceCheckTest {
+
+    private static final String CHECK_KEY = 'staleInvoices';
+    private static final String CHECK_LABEL = 'Invoices Pending Re-bill';
+
+    /**
+     * @description Builds a Client entity + one WorkItem with the supplied approved
+     *              in-period billable logs. Mirrors DeliveryDocGenerationServiceTest's
+     *              proven setup so the generator scopes the data correctly.
+     * @param hours Hours for each approved WorkLog to create.
+     * @param pStart Period start the logs are dated within.
+     * @return The inserted Client NetworkEntity__c.
+     */
+    private static NetworkEntity__c seedClientWithLogs(List<Decimal> hours, Date pStart) {
+        NetworkEntity__c client = new NetworkEntity__c(
+            Name = 'Stale Invoice Client',
+            EntityTypePk__c = 'Client',
+            StatusPk__c = 'Active',
+            DefaultHourlyRateCurrency__c = 150
+        );
+        insert client;
+
+        WorkItem__c item = new WorkItem__c(
+            BriefDescriptionTxt__c = 'Billable WI',
+            StageNamePk__c = 'In Development',
+            StatusPk__c = 'Active',
+            PriorityPk__c = 'High',
+            ActivatedDateTime__c = Datetime.now(),
+            ClientNetworkEntityLookup__c = client.Id
+        );
+        insert item;
+
+        List<WorkLog__c> logs = new List<WorkLog__c>();
+        Integer i = 0;
+        for (Decimal h : hours) {
+            logs.add(new WorkLog__c(
+                WorkItemLookup__c = item.Id,
+                HoursLoggedNumber__c = h,
+                WorkDateDate__c = pStart.addDays(5 + i),
+                WorkDescriptionTxt__c = 'work',
+                StatusPk__c = 'Approved'
+            ));
+            i++;
+        }
+        insert logs;
+        return client;
+    }
+
+    @IsTest
+    static void testWarnsWhenBillableLogsAfterGeneration() {
+        DeliveryTriggerControl.disableAfterLogic();
+        Date pStart = Date.newInstance(2026, 1, 1);
+        Date pEnd = Date.newInstance(2026, 1, 31);
+        NetworkEntity__c client = seedClientWithLogs(new List<Decimal>{ 5 }, pStart);
+        DeliveryTriggerControl.enableAfterLogic();
+
+        Test.startTest();
+        // Freeze the invoice at the current 5h.
+        DeliveryDocGenerationService.generateDocument(client.Id, 'Invoice', pStart, pEnd, null);
+
+        // A late billable lands in-period AFTER the invoice froze.
+        DeliveryTriggerControl.disableAfterLogic();
+        WorkItem__c wi = [SELECT Id FROM WorkItem__c WHERE ClientNetworkEntityLookup__c = :client.Id LIMIT 1];
+        insert new WorkLog__c(
+            WorkItemLookup__c = wi.Id,
+            HoursLoggedNumber__c = 3,
+            WorkDateDate__c = pStart.addDays(20),
+            WorkDescriptionTxt__c = 'late entry',
+            StatusPk__c = 'Approved'
+        );
+        DeliveryTriggerControl.enableAfterLogic();
+
+        DeliveryHubHealthCheckResult r = new DeliveryHubHealthService.StaleInvoiceCheck()
+            .run(CHECK_KEY, CHECK_LABEL);
+        Test.stopTest();
+
+        System.assertEquals('warn', r.statusPk,
+            'An invoice with 3h logged after generation should warn. Detail: ' + r.detail);
+        System.assert(r.detail.containsIgnoreCase('unbilled'),
+            'Detail should flag unbilled hours. Was: ' + r.detail);
+    }
+
+    @IsTest
+    static void testPassesWhenInvoiceFullyBilled() {
+        DeliveryTriggerControl.disableAfterLogic();
+        Date pStart = Date.newInstance(2026, 1, 1);
+        Date pEnd = Date.newInstance(2026, 1, 31);
+        NetworkEntity__c client = seedClientWithLogs(new List<Decimal>{ 8 }, pStart);
+        DeliveryTriggerControl.enableAfterLogic();
+
+        Test.startTest();
+        // Freeze at 8h with no later billables — fully reconciled.
+        DeliveryDocGenerationService.generateDocument(client.Id, 'Invoice', pStart, pEnd, null);
+        DeliveryHubHealthCheckResult r = new DeliveryHubHealthService.StaleInvoiceCheck()
+            .run(CHECK_KEY, CHECK_LABEL);
+        Test.stopTest();
+
+        System.assertEquals('pass', r.statusPk,
+            'A fully-billed invoice should pass. Detail: ' + r.detail);
+    }
+
+    @IsTest
+    static void testNoInvoicesPasses() {
+        Test.startTest();
+        DeliveryHubHealthCheckResult r = new DeliveryHubHealthService.StaleInvoiceCheck()
+            .run(CHECK_KEY, CHECK_LABEL);
+        Test.stopTest();
+
+        System.assertEquals('pass', r.statusPk,
+            'With no invoices present the check should pass. Detail: ' + r.detail);
+    }
+}

--- a/force-app/main/default/classes/DeliveryStaleInvoiceCheckTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryStaleInvoiceCheckTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
## What

Implements the **missing-billable detector** — build-queue #2 from the validation campaign, and the genuinely-real, bounded part of the Phase F / T11 billing story.

## Why

Invoices freeze a tamper-evident snapshot at generation (by design). But if an **in-period billable WorkLog lands after** the invoice froze — a delayed time entry, or a cross-org WorkLog relay arriving late — **nothing flags it**, so the client is silently under-billed and the biller never knows to regenerate. (Confirmed during the campaign: no such detector existed.)

## How

New `DeliveryHubHealthService.StaleInvoiceCheck` (plugs into the existing `IHealthCheck` dashboard):
- For each recent non-superseded Invoice, rebuild the period snapshot using the generator's **own** scoping — `DeliveryDocGenerationService.buildSnapshot` + `calculateTotalHours` — and compare current period hours to the frozen `TotalHoursNumber__c`.
- A positive delta ⇒ unbilled time ⇒ **warn** ("regenerate to capture: DOC-xxxx (+3.00h unbilled)").
- Reusing the generator's scoping guarantees the detector can **never diverge** from how the invoice was actually computed.
- The per-invoice snapshot rebuild (~5–6 SOQL each) is **bounded** by `INVOICE_SCAN_LIMIT` (most-recent-first) to stay well under the synchronous SOQL ceiling alongside the other checks; the cap is **surfaced in the message** (no silent truncation).

## Tests

`DeliveryStaleInvoiceCheckTest` — reuses the proven `generateDocument` path + the existing data-setup pattern:
- warn when a 3h billable is logged **after** generation
- pass when the invoice is fully billed
- pass when no invoices exist

## Scope

This is the **detector** only (surfaces the gap on the health dashboard). It deliberately does **not** auto-regenerate (no `repairKey`) — regeneration supersedes a signed document, so it stays a human decision. Distinct from F13 (the WORK-ITEMS all-time period-scoping clarity issue), which is held pending a billing-vs-context intent call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)