### PR TITLE
fix(billing): period-scope the invoice WORK ITEMS section so line items reconcile (F13)

### DIFF
--- a/force-app/main/default/classes/DeliveryDocGenerationService.cls
+++ b/force-app/main/default/classes/DeliveryDocGenerationService.cls
@@ -231,6 +231,41 @@ public with sharing class DeliveryDocGenerationService {
         }
         snapshot.put('workLogs', serializeWorkLogs(logs));
 
+        // F13: period-scope the WORK ITEMS section for money templates. The
+        // workItems query above is entity-wide, so each item carries its ALL-TIME
+        // TotalLoggedHoursSum__c — which over-states a period invoice (e.g. 108h
+        // all-time displayed as line items against a 60h period total, so the
+        // line items don't reconcile to the bill). Rewrite each item's displayed
+        // hours to its in-period billable sum and drop items with no period
+        // activity. The dollar figures are computed downstream as hours x rate,
+        // so correcting the hours corrects the line-item dollars too. This is
+        // display-only: calculateTotalHours sums workLogs and calculateTotalCost
+        // reads only the rate from workItems, so the (already-correct) totals are
+        // unchanged — the fix purely makes the line items tie out to the total.
+        if (templateType == 'Invoice' || templateType == 'Daily_Hours_Summary') {
+            Map<Id, Decimal> periodHoursByWi = new Map<Id, Decimal>();
+            for (WorkLog__c wl : logs) {
+                if (wl.WorkItemLookup__c != null && wl.HoursLoggedNumber__c != null) {
+                    Decimal acc = periodHoursByWi.containsKey(wl.WorkItemLookup__c)
+                        ? periodHoursByWi.get(wl.WorkItemLookup__c) : 0;
+                    periodHoursByWi.put(wl.WorkItemLookup__c, acc + wl.HoursLoggedNumber__c);
+                }
+            }
+            List<Map<String, Object>> scopedItems = new List<Map<String, Object>>();
+            for (Object itemObj : (List<Object>) snapshot.get('workItems')) {
+                Map<String, Object> m = (Map<String, Object>) itemObj;
+                Id wiId = (Id) m.get('id');
+                Decimal periodHours = periodHoursByWi.containsKey(wiId) ? periodHoursByWi.get(wiId) : 0;
+                if (periodHours <= 0) {
+                    // No billable hours in this period — omit from the invoice line items.
+                    continue;
+                }
+                m.put('totalLoggedHours', periodHours);
+                scopedItems.add(m);
+            }
+            snapshot.put('workItems', scopedItems);
+        }
+
         // Work requests (for rates and status). Scope to the work items that
         // actually carry logged time in the period for money/hours templates.
         // Previously this pulled EVERY WorkRequest ever linked to the entity (no

--- a/force-app/main/default/classes/DeliveryInvoiceWorkItemScopeTest.cls
+++ b/force-app/main/default/classes/DeliveryInvoiceWorkItemScopeTest.cls
@@ -1,0 +1,82 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description Tests the F13 fix: an Invoice's WORK ITEMS section must display
+ *              period-scoped hours (so the line items reconcile to the billed
+ *              period total), not each work item's all-time TotalLoggedHoursSum__c.
+ *              Work items with no billable hours in the period are omitted entirely.
+ * @author Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryInvoiceWorkItemScopeTest {
+
+    @IsTest
+    static void testWorkItemsSectionIsPeriodScopedAndReconciles() {
+        DeliveryTriggerControl.disableAfterLogic();
+        Date pStart = Date.newInstance(2026, 3, 1);
+        Date pEnd = Date.newInstance(2026, 3, 31);
+
+        NetworkEntity__c client = new NetworkEntity__c(
+            Name = 'Scope Test Client',
+            EntityTypePk__c = 'Client',
+            StatusPk__c = 'Active',
+            DefaultHourlyRateCurrency__c = 150
+        );
+        insert client;
+
+        // WI1: 8h in-period + 4h before the period → all-time 12h, in-period 8h.
+        WorkItem__c wi1 = new WorkItem__c(
+            BriefDescriptionTxt__c = 'In-period WI',
+            StageNamePk__c = 'In Development',
+            StatusPk__c = 'Active',
+            PriorityPk__c = 'High',
+            ActivatedDateTime__c = Datetime.now(),
+            ClientNetworkEntityLookup__c = client.Id,
+            BillableRateCurrency__c = 150
+        );
+        // WI2: only out-of-period hours → in-period 0h, must be omitted from the invoice.
+        WorkItem__c wi2 = new WorkItem__c(
+            BriefDescriptionTxt__c = 'Out-of-period WI',
+            StageNamePk__c = 'In Development',
+            StatusPk__c = 'Active',
+            PriorityPk__c = 'Medium',
+            ActivatedDateTime__c = Datetime.now(),
+            ClientNetworkEntityLookup__c = client.Id,
+            BillableRateCurrency__c = 150
+        );
+        insert new List<WorkItem__c>{ wi1, wi2 };
+
+        insert new List<WorkLog__c>{
+            new WorkLog__c(WorkItemLookup__c = wi1.Id, HoursLoggedNumber__c = 8,
+                WorkDateDate__c = Date.newInstance(2026, 3, 10), WorkDescriptionTxt__c = 'in', StatusPk__c = 'Approved'),
+            new WorkLog__c(WorkItemLookup__c = wi1.Id, HoursLoggedNumber__c = 4,
+                WorkDateDate__c = Date.newInstance(2026, 2, 10), WorkDescriptionTxt__c = 'before', StatusPk__c = 'Approved'),
+            new WorkLog__c(WorkItemLookup__c = wi2.Id, HoursLoggedNumber__c = 5,
+                WorkDateDate__c = Date.newInstance(2026, 2, 15), WorkDescriptionTxt__c = 'before', StatusPk__c = 'Approved')
+        };
+        DeliveryTriggerControl.enableAfterLogic();
+
+        Test.startTest();
+        Map<String, Object> snap = DeliveryDocGenerationService.buildSnapshot(
+            client.Id, 'Invoice', pStart, pEnd);
+        Test.stopTest();
+
+        List<Object> items = (List<Object>) snap.get('workItems');
+        System.assertEquals(1, items.size(),
+            'Only the work item with in-period billable hours should appear on the invoice (out-of-period WI omitted)');
+
+        Map<String, Object> shown = (Map<String, Object>) items[0];
+        System.assertEquals(wi1.Id, (Id) shown.get('id'),
+            'The in-period work item should be the one shown');
+        Decimal shownHours = (Decimal) shown.get('totalLoggedHours');
+        System.assert(shownHours == 8,
+            'WORK ITEMS hours must be period-scoped (8h), not all-time (12h). Got: ' + shownHours);
+
+        // Reconciliation: the line-item hours now tie out to the period total.
+        Decimal periodTotal = DeliveryDocGenerationService.calculateTotalHours(snap);
+        System.assert(periodTotal == 8,
+            'Period total should be the 8 in-period hours. Got: ' + periodTotal);
+        System.assert(periodTotal == shownHours,
+            'WORK ITEMS line item must reconcile to the period total (' + periodTotal + ' vs ' + shownHours + ')');
+    }
+}

--- a/force-app/main/default/classes/DeliveryInvoiceWorkItemScopeTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryInvoiceWorkItemScopeTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
## What

Fixes **F13** (live validation): a generated invoice's **WORK ITEMS** section showed each item's **all-time** hours (e.g. 108h of line items) instead of period-scoped hours, so the per-item lines — and their hours×rate dollars — didn't reconcile to the billed period total (60h).

## Root cause

`buildSnapshot` queries work items **entity-wide** (no period filter) and `serializeWorkItems` emits `totalLoggedHours = TotalLoggedHoursSum__c` (all-time). The worklogs and the totals are period-scoped, but the WORK ITEMS display section was not.

## Important: the Total Due was never wrong

Verified against a live invoice snapshot: **Total Due = current charges + prior-balance A/R** (e.g. $9,000 + $1,500 = $10,500) — correct invoicing, not a math bug. The only real defect was the WORK ITEMS section's hours basis. This PR addresses exactly that.

## Fix

After the period worklogs are queried, for money templates (`Invoice` / `Daily_Hours_Summary`): rewrite each work item's displayed hours to its **in-period** billable sum and **omit** items with no period activity. Dollars are computed downstream as hours×rate, so fixing the hours fixes the line-item dollars.

**Display-only — totals unchanged:** `calculateTotalHours` sums worklogs and `calculateTotalCost` reads only the *rate* from work items, so the (already-correct) totals are untouched. The fix purely makes the line items tie out. Existing frozen invoices keep their snapshot+hash; only new/regenerated invoices get the corrected display.

## Tests

`DeliveryInvoiceWorkItemScopeTest`: a WI with 8h in-period + 4h before the period shows **8h** (not 12h) and reconciles to the period total; a WI with only out-of-period hours is **omitted**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)