### PR TITLE
feat(workspace): surface request-create entry as a New Request workspace tab (F12)

### DIFF
--- a/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
+++ b/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
@@ -5,6 +5,10 @@
             <c-delivery-hub-board></c-delivery-hub-board>
         </lightning-tab>
 
+        <lightning-tab label="New Request" value="newRequest" icon-name="standard:work_order_item">
+            <c-delivery-quick-request embedded={requestEmbedded}></c-delivery-quick-request>
+        </lightning-tab>
+
         <lightning-tab label="Timeline" value="timeline" icon-name="standard:date_input">
             <c-delivery-pro-forma-timeline></c-delivery-pro-forma-timeline>
         </lightning-tab>

--- a/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.js
+++ b/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.js
@@ -15,6 +15,10 @@ export default class DeliveryHubWorkspace extends LightningElement {
     @track activeTab = 'board';
     @track isAdmin = false;
     _userPicked = false;
+    // Tells the embedded Quick Request component to reset-in-place on submit
+    // rather than fire CloseActionScreenEvent (which only applies in the global
+    // action modal). Bound as a property so the boolean reaches the child as true.
+    requestEmbedded = true;
 
     @wire(isAdminUser)
     wiredAdmin({ data }) {

--- a/force-app/main/default/lwc/deliveryQuickRequest/deliveryQuickRequest.js
+++ b/force-app/main/default/lwc/deliveryQuickRequest/deliveryQuickRequest.js
@@ -6,12 +6,19 @@
  *               acceptance criteria, and hour estimates.
  * @author Cloud Nimbus LLC
  */
-import { LightningElement, track } from 'lwc';
+import { LightningElement, api, track } from 'lwc';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import { CloseActionScreenEvent } from 'lightning/actions';
 import createWorkRequest from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryQuickRequestController.createWorkRequest';
 
 export default class DeliveryQuickRequest extends LightningElement {
+    // When placed on a page/workspace tab (vs. the global quick-action modal) set
+    // embedded=true: on submit/cancel the form resets in place instead of firing
+    // CloseActionScreenEvent (which only makes sense inside an action modal).
+    // Defaults false so the global-action behavior is unchanged (and avoids LWC1503,
+    // which forbids a boolean @api defaulting to true).
+    @api embedded = false;
+
     @track title = '';
     @track priority = 'Medium';
     @track description = '';
@@ -52,7 +59,20 @@ export default class DeliveryQuickRequest extends LightningElement {
     }
 
     handleCancel() {
-        this.dispatchEvent(new CloseActionScreenEvent());
+        this.closeOrReset();
+    }
+
+    // Close the action modal when launched as a quick action; reset the form in
+    // place when embedded on a page/workspace tab.
+    closeOrReset() {
+        if (this.embedded) {
+            this.title = '';
+            this.description = '';
+            this.priority = 'Medium';
+            this.showDescription = false;
+        } else {
+            this.dispatchEvent(new CloseActionScreenEvent());
+        }
     }
 
     handleCreate() {
@@ -87,7 +107,7 @@ export default class DeliveryQuickRequest extends LightningElement {
                 : `Created ${result.recordName}`;
 
             this.showToast('Work Request Created', message, 'success');
-            this.dispatchEvent(new CloseActionScreenEvent());
+            this.closeOrReset();
         } catch (error) {
             const msg = error.body ? error.body.message : error.message;
             this.showToast('Error', msg, 'error');

--- a/force-app/main/default/lwc/deliveryQuickRequest/deliveryQuickRequest.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryQuickRequest/deliveryQuickRequest.js-meta.xml
@@ -6,5 +6,8 @@
     <description>Global Quick Action for creating work requests from any page in Salesforce, with optional AI enhancement.</description>
     <targets>
         <target>lightning__GlobalAction</target>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <target>lightning__Tab</target>
     </targets>
 </LightningComponentBundle>


### PR DESCRIPTION
## What

Fixes **F12** (live validation): the estimate→submit loop has **no working entry point on a clean install**. The request-create component (`deliveryQuickRequest`, which creates *and submits* a `WorkRequest`) shipped only as the `NewWorkRequest` **global quick action** — and that action is on **no packaged layout** (the package ships no Global Publisher Layout), so it never appears in the global "+" menu. A user literally can't start the loop.

## Why not just add it to the global publisher layout

That's the non-durable override trap (same class as the buyer-surface saga): a package can't reliably own the subscriber's standard Global Layout, and subscriber customizations survive upgrades. The durable home is the **package-owned workspace**.

## Fix

- Add a **"New Request"** tab to `deliveryHubWorkspace` (the package-owned, install-default workspace), right after Board, hosting `deliveryQuickRequest`.
- Made the component **tab-capable**: new `@api embedded` flag (defaults `false`, so the global-action modal behavior is unchanged — and no LWC1503, since the default isn't `true`). When `embedded`, it **resets the form in place** on submit/cancel instead of firing `CloseActionScreenEvent` (which only applies inside an action modal). The workspace passes `embedded` as a bound property so the boolean reaches the child reliably.

Net: on a clean install, a user can now open the workspace → **New Request** → submit → the WorkRequest lands in the **Approvals** tab. Working loop entry, durable placement, and the global quick action still works for those who wire it.

## Tests

`deliveryQuickRequest`/`deliveryHubWorkspace` have no jest harness; the change is additive (default preserves existing modal behavior). The feature-test deploy-validates the LWC + workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)