### PR TITLE
feat(triage): Intake + Close Outs queue tabs for the workspace

### DIFF
--- a/force-app/main/default/classes/DeliveryTriageController.cls
+++ b/force-app/main/default/classes/DeliveryTriageController.cls
@@ -143,8 +143,8 @@ public with sharing class DeliveryTriageController {
                 rows.add(dto);
             }
         } catch (Exception e) {
-            System.debug(LoggingLevel.WARN,
-                '[DeliveryTriageController.getCloseOutItems] failed: ' + e.getMessage());
+            // No System.debug — AvoidDebugStatements is strictly enforced by the
+            // CI PMD scan; the AuraHandledException carries the operator-facing text.
             throw new AuraHandledException('Unable to load the close-out queue.');
         }
         return rows;
@@ -189,8 +189,8 @@ public with sharing class DeliveryTriageController {
                 rows.add(dto);
             }
         } catch (Exception e) {
-            System.debug(LoggingLevel.WARN,
-                '[DeliveryTriageController.getIntakeItems] failed: ' + e.getMessage());
+            // No System.debug — AvoidDebugStatements is strictly enforced by the
+            // CI PMD scan; the AuraHandledException carries the operator-facing text.
             throw new AuraHandledException('Unable to load the intake queue.');
         }
         return rows;
@@ -274,11 +274,11 @@ public with sharing class DeliveryTriageController {
      * @param workItemIds Requested ids.
      * @param stage       Stage value to write.
      * @param developerUserId Developer lookup to set (ignored when routeToDev=false).
-     * @param activate    When true, set DeveloperLookup__c + stamp ActivatedDateTime__c.
+     * @param doActivate  When true, set DeveloperLookup__c + stamp ActivatedDateTime__c.
      * @return BulkResultDTO.
      */
     private static BulkResultDTO applyStageUpdate(
-        List<Id> workItemIds, String stage, Id developerUserId, Boolean activate
+        List<Id> workItemIds, String stage, Id developerUserId, Boolean doActivate
     ) {
         BulkResultDTO result = new BulkResultDTO();
         if (workItemIds == null || workItemIds.isEmpty()) {
@@ -307,7 +307,7 @@ public with sharing class DeliveryTriageController {
         List<WorkItem__c> toUpdate = new List<WorkItem__c>();
         for (WorkItem__c wi : found.values()) {
             wi.StageNamePk__c = stage;
-            if (activate) {
+            if (doActivate) {
                 wi.DeveloperLookup__c = developerUserId;
                 wi.ActivatedDateTime__c = now;
             }

--- a/force-app/main/default/classes/DeliveryTriageController.cls
+++ b/force-app/main/default/classes/DeliveryTriageController.cls
@@ -69,7 +69,10 @@ public with sharing class DeliveryTriageController {
     // DTOs
     // ────────────────────────────────────────────────────────────────────
 
-    /** One row in the close-out queue (Deployed to Prod, awaiting verification). */
+    /**
+     * @description One row in the close-out queue (Deployed to Prod, awaiting
+     *              verification).
+     */
     public class CloseOutItemDTO {
         @AuraEnabled public Id workItemId;
         @AuraEnabled public String name;
@@ -79,7 +82,10 @@ public with sharing class DeliveryTriageController {
         @AuraEnabled public Id developerId;
     }
 
-    /** One row in the intake queue (arrived, not yet activated onto the timeline). */
+    /**
+     * @description One row in the intake queue (arrived, not yet activated onto
+     *              the timeline).
+     */
     public class IntakeItemDTO {
         @AuraEnabled public Id workItemId;
         @AuraEnabled public String name;
@@ -89,21 +95,31 @@ public with sharing class DeliveryTriageController {
         @AuraEnabled public String currentStage;
     }
 
-    /** Per-row failure entry for a bulk mutation. */
+    /**
+     * @description Per-row failure entry for a bulk mutation.
+     */
     public class FailureDTO {
         @AuraEnabled public Id workItemId;
         @AuraEnabled public String error;
+        /**
+         * @description Builds a per-row failure entry.
+         * @param workItemId The work item id that failed.
+         * @param error The failure message to surface.
+         */
         public FailureDTO(Id workItemId, String error) {
             this.workItemId = workItemId;
             this.error = error;
         }
     }
 
-    /** Result of a bulk mutation: which items landed and one entry per failure. */
+    /**
+     * @description Result of a bulk mutation: which items landed and one entry
+     *              per failure, plus convenience counts so the LWC never has to
+     *              length-check nulls.
+     */
     public class BulkResultDTO {
         @AuraEnabled public List<Id> succeededIds = new List<Id>();
         @AuraEnabled public List<FailureDTO> failures = new List<FailureDTO>();
-        /** Convenience counts so the LWC never has to length-check nulls. */
         @AuraEnabled public Integer succeededCount = 0;
         @AuraEnabled public Integer failedCount = 0;
     }
@@ -317,18 +333,27 @@ public with sharing class DeliveryTriageController {
         // allOrNone=false: one bad row never blocks the rest.
         Database.SaveResult[] saveResults =
             Database.update(toUpdate, false, AccessLevel.SYSTEM_MODE);
+        recordSaveResults(result, saveResults, toUpdate);
+
+        finalizeCounts(result);
+        return result;
+    }
+
+    // Splits a parallel SaveResult[] / row list into the result's succeeded ids
+    // and per-row failures. Extracted from applyStageUpdate to keep that method
+    // under the cyclomatic-complexity gate.
+    private static void recordSaveResults(
+        BulkResultDTO result, Database.SaveResult[] saveResults, List<WorkItem__c> rows
+    ) {
         for (Integer i = 0; i < saveResults.size(); i++) {
             Database.SaveResult sr = saveResults[i];
-            Id rowId = toUpdate[i].Id;
+            Id rowId = rows[i].Id;
             if (sr.isSuccess()) {
                 result.succeededIds.add(rowId);
             } else {
                 result.failures.add(new FailureDTO(rowId, firstError(sr)));
             }
         }
-
-        finalizeCounts(result);
-        return result;
     }
 
     private static String firstError(Database.SaveResult sr) {

--- a/force-app/main/default/classes/DeliveryTriageController.cls
+++ b/force-app/main/default/classes/DeliveryTriageController.cls
@@ -1,0 +1,345 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Triage controller backing the two workspace queue tabs Jose
+ *               runs to drive both ends of the work-item pipeline:
+ *
+ *               getCloseOutItems()  — back of pipe. WorkItems sitting in
+ *                 'Deployed to Prod' awaiting the triager's verification /
+ *                 close-out. Makes the "Deployed to Prod – Awaiting
+ *                 Verification" report actionable from inside the workspace.
+ *               getIntakeItems()    — front of pipe. WorkItems that have
+ *                 arrived but were never activated onto the timeline
+ *                 (ActivatedDateTime__c = NULL → invisible on the board/Gantt,
+ *                 which filter ActivatedDateTime != null). This tab is the
+ *                 only surface that shows them.
+ *
+ *               Mutations are all bulk + partial-failure-safe, mirroring
+ *               DeliveryWorkApprovalService.approveMany: every id is processed,
+ *               failures (including ids that resolve to no record) are
+ *               collected per row, and both lists come back in BulkResultDTO —
+ *               one bad row never blocks the rest of the batch, and the counts
+ *               always reconcile to the input.
+ *
+ *               SOQL is WITH SYSTEM_MODE per CLAUDE.md (WITH USER_MODE breaks
+ *               in namespaced package test context). Picklist values are passed
+ *               as safe known literals (the picklist-allowlist trigger is a
+ *               documented no-op; the fields accept known values). Report ids
+ *               are resolved by DeveloperName the same way
+ *               DeliveryApprovalSummaryController does — bare names are safe
+ *               because Report DeveloperNames are not namespace-prefixed on
+ *               subscriber installs.
+ * @author       Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation')
+public with sharing class DeliveryTriageController {
+
+    /** Stage a work item sits in once deployed, awaiting close-out verification. */
+    private static final String STAGE_DEPLOYED_TO_PROD =
+        DeliveryWorkflowConfigService.STAGE_DEPLOYED_TO_PROD;
+
+    /** Stage routeToDev moves an intake item into (and activates it). */
+    private static final String STAGE_READY_FOR_DEVELOPMENT = 'Ready for Development';
+
+    /** Terminal value markDone / dismissIntake fall back to. */
+    private static final String STAGE_DONE = 'Done';
+    private static final String STAGE_CANCELLED = 'Cancelled';
+
+    /** Report DeveloperName backing the close-out tab's "open full report" link. */
+    private static final String REPORT_CLOSE_OUT =
+        'Deployed_To_Prod_Awaiting_Verification';
+
+    /**
+     * @description WorkItem__c stages excluded from the intake scope — a
+     * CMT-driven terminal union (defaults to Done/Cancelled when CMT empty) so
+     * a dismissed/closed item never reappears at the front of the pipe.
+     */
+    @TestVisible
+    private static Set<String> terminalStages {
+        get {
+            if (terminalStages == null) {
+                terminalStages = DeliveryWorkflowConfigService.getAllTerminalStageValues();
+            }
+            return terminalStages;
+        }
+        set;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // DTOs
+    // ────────────────────────────────────────────────────────────────────
+
+    /** One row in the close-out queue (Deployed to Prod, awaiting verification). */
+    public class CloseOutItemDTO {
+        @AuraEnabled public Id workItemId;
+        @AuraEnabled public String name;
+        @AuraEnabled public String briefDescription;
+        @AuraEnabled public Datetime stageEnteredAt;
+        @AuraEnabled public String developerName;
+        @AuraEnabled public Id developerId;
+    }
+
+    /** One row in the intake queue (arrived, not yet activated onto the timeline). */
+    public class IntakeItemDTO {
+        @AuraEnabled public Id workItemId;
+        @AuraEnabled public String name;
+        @AuraEnabled public String briefDescription;
+        @AuraEnabled public Datetime createdDate;
+        @AuraEnabled public String requestedByName;
+        @AuraEnabled public String currentStage;
+    }
+
+    /** Per-row failure entry for a bulk mutation. */
+    public class FailureDTO {
+        @AuraEnabled public Id workItemId;
+        @AuraEnabled public String error;
+        public FailureDTO(Id workItemId, String error) {
+            this.workItemId = workItemId;
+            this.error = error;
+        }
+    }
+
+    /** Result of a bulk mutation: which items landed and one entry per failure. */
+    public class BulkResultDTO {
+        @AuraEnabled public List<Id> succeededIds = new List<Id>();
+        @AuraEnabled public List<FailureDTO> failures = new List<FailureDTO>();
+        /** Convenience counts so the LWC never has to length-check nulls. */
+        @AuraEnabled public Integer succeededCount = 0;
+        @AuraEnabled public Integer failedCount = 0;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Read getters (cacheable)
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Back of pipe: WorkItems in 'Deployed to Prod' awaiting the
+     *              triager's close-out verification. Oldest-in-stage first so
+     *              the longest-waiting items lead.
+     * @return CloseOutItemDTO rows (empty list when none).
+     */
+    @AuraEnabled(cacheable=true)
+    public static List<CloseOutItemDTO> getCloseOutItems() {
+        List<CloseOutItemDTO> rows = new List<CloseOutItemDTO>();
+        try {
+            for (WorkItem__c wi : [
+                SELECT Id, Name, BriefDescriptionTxt__c, StageEnteredDateTime__c,
+                       DeveloperLookup__c, DeveloperLookup__r.Name
+                FROM WorkItem__c
+                WHERE StageNamePk__c = :STAGE_DEPLOYED_TO_PROD
+                  AND ArchivedDateTime__c = NULL
+                  AND TemplateMarkedDateTime__c = NULL
+                WITH SYSTEM_MODE
+                ORDER BY StageEnteredDateTime__c ASC NULLS FIRST
+            ]) {
+                CloseOutItemDTO dto = new CloseOutItemDTO();
+                dto.workItemId = wi.Id;
+                dto.name = wi.Name;
+                dto.briefDescription = wi.BriefDescriptionTxt__c;
+                dto.stageEnteredAt = wi.StageEnteredDateTime__c;
+                dto.developerId = wi.DeveloperLookup__c;
+                dto.developerName = wi.DeveloperLookup__r != null
+                    ? wi.DeveloperLookup__r.Name : null;
+                rows.add(dto);
+            }
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryTriageController.getCloseOutItems] failed: ' + e.getMessage());
+            throw new AuraHandledException('Unable to load the close-out queue.');
+        }
+        return rows;
+    }
+
+    /**
+     * @description Front of pipe: WorkItems that arrived but were never
+     *              activated onto the timeline. The board/Gantt require
+     *              ActivatedDateTime__c != null, so un-activated items are
+     *              invisible everywhere else — this is the gap the tab fills.
+     *              Scope mirrors the board's exclusions (not archived, not a
+     *              template) and drops terminal items so a dismissed inbound
+     *              never reappears. Oldest arrivals first.
+     * @return IntakeItemDTO rows (empty list when none).
+     */
+    @AuraEnabled(cacheable=true)
+    public static List<IntakeItemDTO> getIntakeItems() {
+        List<IntakeItemDTO> rows = new List<IntakeItemDTO>();
+        try {
+            for (WorkItem__c wi : [
+                SELECT Id, Name, BriefDescriptionTxt__c, CreatedDate,
+                       StageNamePk__c, ExternalRequesterEmail__c, CreatedBy.Name
+                FROM WorkItem__c
+                WHERE ActivatedDateTime__c = NULL
+                  AND ArchivedDateTime__c = NULL
+                  AND TemplateMarkedDateTime__c = NULL
+                  AND StageNamePk__c NOT IN :terminalStages
+                WITH SYSTEM_MODE
+                ORDER BY CreatedDate ASC
+            ]) {
+                IntakeItemDTO dto = new IntakeItemDTO();
+                dto.workItemId = wi.Id;
+                dto.name = wi.Name;
+                dto.briefDescription = wi.BriefDescriptionTxt__c;
+                dto.createdDate = wi.CreatedDate;
+                dto.currentStage = wi.StageNamePk__c;
+                // Prefer the external requester (email-to-case intake) when
+                // present; otherwise fall back to who created the record.
+                dto.requestedByName = String.isNotBlank(wi.ExternalRequesterEmail__c)
+                    ? wi.ExternalRequesterEmail__c
+                    : (wi.CreatedBy != null ? wi.CreatedBy.Name : null);
+                rows.add(dto);
+            }
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN,
+                '[DeliveryTriageController.getIntakeItems] failed: ' + e.getMessage());
+            throw new AuraHandledException('Unable to load the intake queue.');
+        }
+        return rows;
+    }
+
+    /**
+     * @description Resolves the close-out report's record id by DeveloperName
+     *              so the LWC can link to the full report without hardcoding an
+     *              org-specific id. Returns null (LWC disables the link) when
+     *              the report is absent in the org.
+     * @return The Deployed-to-Prod-Awaiting-Verification report id, or null.
+     */
+    @AuraEnabled(cacheable=true)
+    public static String getCloseOutReportId() {
+        for (Report r : [
+            SELECT Id FROM Report
+            WHERE DeveloperName = :REPORT_CLOSE_OUT
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ]) {
+            return r.Id;
+        }
+        return null;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Bulk mutations (non-cacheable, partial-failure-safe)
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Close out the selected deployed items — moves each to the
+     *              'Done' terminal stage. Bulk, partial-failure-safe.
+     * @param workItemIds Items to mark done.
+     * @return BulkResultDTO with succeeded ids and per-row failures.
+     */
+    @AuraEnabled
+    public static BulkResultDTO markDone(List<Id> workItemIds) {
+        return applyStageUpdate(workItemIds, STAGE_DONE, null, false);
+    }
+
+    /**
+     * @description Route the selected intake items to a developer: assign the
+     *              developer lookup, move to 'Ready for Development', and stamp
+     *              ActivatedDateTime__c = now() so each becomes visible on the
+     *              timeline. Bulk, partial-failure-safe.
+     * @param workItemIds   Items to route.
+     * @param developerUserId The User to assign (may be null to route unassigned).
+     * @return BulkResultDTO with succeeded ids and per-row failures.
+     */
+    @AuraEnabled
+    public static BulkResultDTO routeToDev(List<Id> workItemIds, Id developerUserId) {
+        return applyStageUpdate(workItemIds, STAGE_READY_FOR_DEVELOPMENT, developerUserId, true);
+    }
+
+    /**
+     * @description Jose resolves an inbound item himself — moves it to a
+     *              terminal stage ('Cancelled' when that value is in the
+     *              terminal set, else 'Done'). Bulk, partial-failure-safe.
+     * @param workItemIds Items to dismiss.
+     * @return BulkResultDTO with succeeded ids and per-row failures.
+     */
+    @AuraEnabled
+    public static BulkResultDTO dismissIntake(List<Id> workItemIds) {
+        String dismissStage = terminalStages.contains(STAGE_CANCELLED)
+            ? STAGE_CANCELLED : STAGE_DONE;
+        return applyStageUpdate(workItemIds, dismissStage, null, false);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Internals
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Shared bulk-update engine. Loads the requested ids, applies
+     *              the stage (and optionally the developer + activation stamp),
+     *              runs an allOrNone=false update, and assembles a BulkResultDTO
+     *              where: rows that updated land in succeededIds, rows that
+     *              failed the DML become failures, AND ids that resolved to no
+     *              record become not-found failures — so the returned counts
+     *              always reconcile to the input list.
+     * @param workItemIds Requested ids.
+     * @param stage       Stage value to write.
+     * @param developerUserId Developer lookup to set (ignored when routeToDev=false).
+     * @param activate    When true, set DeveloperLookup__c + stamp ActivatedDateTime__c.
+     * @return BulkResultDTO.
+     */
+    private static BulkResultDTO applyStageUpdate(
+        List<Id> workItemIds, String stage, Id developerUserId, Boolean activate
+    ) {
+        BulkResultDTO result = new BulkResultDTO();
+        if (workItemIds == null || workItemIds.isEmpty()) {
+            throw new AuraHandledException('No items were selected.');
+        }
+
+        // De-dupe and load.
+        Set<Id> requested = new Set<Id>(workItemIds);
+        Map<Id, WorkItem__c> found = new Map<Id, WorkItem__c>([
+            SELECT Id FROM WorkItem__c WHERE Id IN :requested WITH SYSTEM_MODE
+        ]);
+
+        // Ids that don't resolve to a record are deterministic failures.
+        for (Id reqId : requested) {
+            if (!found.containsKey(reqId)) {
+                result.failures.add(new FailureDTO(reqId, 'Work item not found.'));
+            }
+        }
+
+        if (found.isEmpty()) {
+            finalizeCounts(result);
+            return result;
+        }
+
+        Datetime now = System.now();
+        List<WorkItem__c> toUpdate = new List<WorkItem__c>();
+        for (WorkItem__c wi : found.values()) {
+            wi.StageNamePk__c = stage;
+            if (activate) {
+                wi.DeveloperLookup__c = developerUserId;
+                wi.ActivatedDateTime__c = now;
+            }
+            toUpdate.add(wi);
+        }
+
+        // allOrNone=false: one bad row never blocks the rest.
+        Database.SaveResult[] saveResults =
+            Database.update(toUpdate, false, AccessLevel.SYSTEM_MODE);
+        for (Integer i = 0; i < saveResults.size(); i++) {
+            Database.SaveResult sr = saveResults[i];
+            Id rowId = toUpdate[i].Id;
+            if (sr.isSuccess()) {
+                result.succeededIds.add(rowId);
+            } else {
+                result.failures.add(new FailureDTO(rowId, firstError(sr)));
+            }
+        }
+
+        finalizeCounts(result);
+        return result;
+    }
+
+    private static String firstError(Database.SaveResult sr) {
+        if (sr.getErrors() != null && !sr.getErrors().isEmpty()) {
+            return sr.getErrors()[0].getMessage();
+        }
+        return 'Update failed.';
+    }
+
+    private static void finalizeCounts(BulkResultDTO result) {
+        result.succeededCount = result.succeededIds.size();
+        result.failedCount = result.failures.size();
+    }
+}

--- a/force-app/main/default/classes/DeliveryTriageController.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryTriageController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryTriageControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryTriageControllerTest.cls
@@ -1,0 +1,209 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for the triage controller: the close-out feed (Deployed
+ *               to Prod only, oldest-in-stage first, archived/template
+ *               excluded, developer + stage-entered surfaced), the intake feed
+ *               (un-activated only — the timeline-invisible gap — with
+ *               archived/template/terminal excluded and the requestedBy
+ *               fallback), and the three bulk mutations (markDone, routeToDev,
+ *               dismissIntake) including the partial-failure contract: a real
+ *               id succeeds while a not-found id is collected as a failure so
+ *               the counts reconcile to the input. Report-id resolution is
+ *               shape-only (the report may be absent in a bare scratch org).
+ * @author       Cloud Nimbus LLC
+ */
+@IsTest
+@SuppressWarnings('PMD.ApexDoc')
+private class DeliveryTriageControllerTest {
+
+    /** A non-resolving but well-formed WorkItem__c id for failure-path tests. */
+    private static Id phantomWorkItemId() {
+        return Id.valueOf(
+            WorkItem__c.SObjectType.getDescribe().getKeyPrefix() + '000000000000'
+        );
+    }
+
+    private static WorkItem__c seedDeployed(Datetime stageEntered, Id developerId) {
+        return TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'Deployed to Prod',
+            'StageEnteredDateTime__c' => stageEntered,
+            'DeveloperLookup__c' => developerId
+        });
+    }
+
+    /** An intake item: arrived but never activated onto the timeline. */
+    private static WorkItem__c seedIntake(Map<String, Object> extra) {
+        Map<String, Object> overrides = new Map<String, Object>{
+            'StageNamePk__c' => 'Backlog',
+            'StatusPk__c' => 'New',
+            'ActivatedDateTime__c' => null
+        };
+        if (extra != null) {
+            overrides.putAll(extra);
+        }
+        return TestDataFactory.createWorkItem(overrides);
+    }
+
+    // ── Close-out feed ───────────────────────────────────────────────
+
+    @IsTest
+    static void testCloseOutReturnsDeployedOldestFirst() {
+        WorkItem__c newer = seedDeployed(Datetime.now().addDays(-1), UserInfo.getUserId());
+        WorkItem__c older = seedDeployed(Datetime.now().addDays(-9), UserInfo.getUserId());
+        // Noise that must NOT appear in the feed.
+        TestDataFactory.createWorkItem(new Map<String, Object>{ 'StageNamePk__c' => 'In Development' });
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'Deployed to Prod',
+            'ArchivedDateTime__c' => Datetime.now()
+        });
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'Deployed to Prod',
+            'TemplateMarkedDateTime__c' => Datetime.now()
+        });
+
+        Test.startTest();
+        List<DeliveryTriageController.CloseOutItemDTO> rows =
+            DeliveryTriageController.getCloseOutItems();
+        Test.stopTest();
+
+        System.assertEquals(2, rows.size(),
+            'only non-archived, non-template Deployed-to-Prod items appear');
+        System.assertEquals(older.Id, rows[0].workItemId,
+            'oldest-in-stage item leads the queue');
+        System.assertEquals(newer.Id, rows[1].workItemId, 'newer item follows');
+        System.assertNotEquals(null, rows[0].name, 'auto-number name surfaced');
+        System.assertEquals(UserInfo.getUserId(), rows[0].developerId, 'developer id surfaced');
+        System.assertNotEquals(null, rows[0].developerName, 'developer name surfaced');
+    }
+
+    @IsTest
+    static void testCloseOutReportIdShapeOnly() {
+        Test.startTest();
+        // The report may or may not be deployed in a bare scratch org — the
+        // call must simply not throw and return a String or null.
+        DeliveryTriageController.getCloseOutReportId();
+        Test.stopTest();
+        System.assert(true, 'report-id resolution did not throw');
+    }
+
+    // ── Intake feed ──────────────────────────────────────────────────
+
+    @IsTest
+    static void testIntakeReturnsUnactivatedOnly() {
+        WorkItem__c external = seedIntake(new Map<String, Object>{
+            'ExternalRequesterEmail__c' => 'client@example.com'
+        });
+        seedIntake(null); // requestedBy falls back to CreatedBy.Name
+        // Noise that must NOT appear.
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'Backlog',
+            'ActivatedDateTime__c' => Datetime.now()
+        }); // activated — visible on the timeline already
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'Done',
+            'ActivatedDateTime__c' => null
+        }); // terminal — excluded
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'Backlog',
+            'ActivatedDateTime__c' => null,
+            'ArchivedDateTime__c' => Datetime.now()
+        }); // archived — excluded
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'Backlog',
+            'ActivatedDateTime__c' => null,
+            'TemplateMarkedDateTime__c' => Datetime.now()
+        }); // template — excluded
+
+        Test.startTest();
+        List<DeliveryTriageController.IntakeItemDTO> rows =
+            DeliveryTriageController.getIntakeItems();
+        Test.stopTest();
+
+        System.assertEquals(2, rows.size(),
+            'only un-activated, non-terminal, non-archived, non-template items appear');
+        Map<Id, DeliveryTriageController.IntakeItemDTO> byId =
+            new Map<Id, DeliveryTriageController.IntakeItemDTO>();
+        for (DeliveryTriageController.IntakeItemDTO dto : rows) {
+            byId.put(dto.workItemId, dto);
+        }
+        System.assertEquals('client@example.com', byId.get(external.Id).requestedByName,
+            'external requester email is used when present');
+        System.assertNotEquals(null, byId.get(external.Id).currentStage, 'current stage surfaced');
+    }
+
+    // ── markDone ─────────────────────────────────────────────────────
+
+    @IsTest
+    static void testMarkDonePartialFailureReconciles() {
+        WorkItem__c wi = seedDeployed(Datetime.now().addDays(-2), null);
+
+        Test.startTest();
+        DeliveryTriageController.BulkResultDTO result =
+            DeliveryTriageController.markDone(new List<Id>{ wi.Id, phantomWorkItemId() });
+        Test.stopTest();
+
+        System.assertEquals(1, result.succeededCount, 'the real item succeeded');
+        System.assertEquals(1, result.failedCount, 'the phantom id is a not-found failure');
+        System.assertEquals(wi.Id, result.succeededIds[0], 'succeeded id is the real item');
+        WorkItem__c after = [SELECT StageNamePk__c FROM WorkItem__c WHERE Id = :wi.Id];
+        System.assertEquals('Done', after.StageNamePk__c, 'item moved to the Done terminal stage');
+    }
+
+    // ── routeToDev ───────────────────────────────────────────────────
+
+    @IsTest
+    static void testRouteToDevAssignsActivatesAndAdvances() {
+        WorkItem__c wi = seedIntake(null);
+        Id dev = UserInfo.getUserId();
+
+        Test.startTest();
+        DeliveryTriageController.BulkResultDTO result =
+            DeliveryTriageController.routeToDev(new List<Id>{ wi.Id }, dev);
+        Test.stopTest();
+
+        System.assertEquals(1, result.succeededCount, 'the item routed');
+        WorkItem__c after = [
+            SELECT StageNamePk__c, DeveloperLookup__c, ActivatedDateTime__c
+            FROM WorkItem__c WHERE Id = :wi.Id
+        ];
+        System.assertEquals('Ready for Development', after.StageNamePk__c, 'advanced to dev');
+        System.assertEquals(dev, after.DeveloperLookup__c, 'developer assigned');
+        System.assertNotEquals(null, after.ActivatedDateTime__c,
+            'activated so it becomes visible on the timeline');
+    }
+
+    // ── dismissIntake ────────────────────────────────────────────────
+
+    @IsTest
+    static void testDismissIntakeMovesToTerminalStage() {
+        WorkItem__c wi = seedIntake(null);
+
+        Test.startTest();
+        DeliveryTriageController.BulkResultDTO result =
+            DeliveryTriageController.dismissIntake(new List<Id>{ wi.Id });
+        Test.stopTest();
+
+        System.assertEquals(1, result.succeededCount, 'the item was dismissed');
+        WorkItem__c after = [SELECT StageNamePk__c FROM WorkItem__c WHERE Id = :wi.Id];
+        System.assert(
+            DeliveryWorkflowConfigService.getAllTerminalStageValues().contains(after.StageNamePk__c),
+            'dismissed item lands in a terminal stage'
+        );
+    }
+
+    // ── Guard ────────────────────────────────────────────────────────
+
+    @IsTest
+    static void testEmptySelectionThrows() {
+        Test.startTest();
+        Boolean threw = false;
+        try {
+            DeliveryTriageController.markDone(new List<Id>());
+        } catch (AuraHandledException e) {
+            threw = true; // never assert on the (generic) managed-package message
+        }
+        Test.stopTest();
+        System.assert(threw, 'an empty selection is rejected');
+    }
+}

--- a/force-app/main/default/classes/DeliveryTriageControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryTriageControllerTest.cls
@@ -138,6 +138,10 @@ private class DeliveryTriageControllerTest {
     static void testMarkDonePartialFailureReconciles() {
         WorkItem__c wi = seedDeployed(Datetime.now().addDays(-2), null);
 
+        // Isolate the controller's stage flip from unrelated WorkItem update-
+        // trigger side-effects (the same flag the factory uses); the static
+        // persists into the controller's DML.
+        DeliveryWorkItemTriggerHandler.triggerDisabled = true;
         Test.startTest();
         DeliveryTriageController.BulkResultDTO result =
             DeliveryTriageController.markDone(new List<Id>{ wi.Id, phantomWorkItemId() });
@@ -157,6 +161,7 @@ private class DeliveryTriageControllerTest {
         WorkItem__c wi = seedIntake(null);
         Id dev = UserInfo.getUserId();
 
+        DeliveryWorkItemTriggerHandler.triggerDisabled = true;
         Test.startTest();
         DeliveryTriageController.BulkResultDTO result =
             DeliveryTriageController.routeToDev(new List<Id>{ wi.Id }, dev);
@@ -179,6 +184,7 @@ private class DeliveryTriageControllerTest {
     static void testDismissIntakeMovesToTerminalStage() {
         WorkItem__c wi = seedIntake(null);
 
+        DeliveryWorkItemTriggerHandler.triggerDisabled = true;
         Test.startTest();
         DeliveryTriageController.BulkResultDTO result =
             DeliveryTriageController.dismissIntake(new List<Id>{ wi.Id });

--- a/force-app/main/default/classes/DeliveryTriageControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryTriageControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/deliveryCloseOutQueue/__tests__/deliveryCloseOutQueue.test.js
+++ b/force-app/main/default/lwc/deliveryCloseOutQueue/__tests__/deliveryCloseOutQueue.test.js
@@ -1,0 +1,199 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryCloseOutQueue: wire-driven rows
+ *               (name, brief, waiting age, developer fallback), the headline
+ *               count, the "Open full report" button enabled/disabled by the
+ *               resolved report id, the bulk + per-row Mark Done flows
+ *               (markDone call shape, success + partial-failure toasts), and
+ *               the caught-up empty state.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from "lwc";
+import DeliveryCloseOutQueue from "c/deliveryCloseOutQueue";
+import getCloseOutItems from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getCloseOutItems";
+import getCloseOutReportId from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getCloseOutReportId";
+import markDone from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.markDone";
+
+const ITEM_ONE = "a42000000000001AAA";
+const ITEM_TWO = "a42000000000002AAA";
+
+function sampleItems() {
+    return [
+        {
+            workItemId: ITEM_ONE,
+            name: "T-0041",
+            briefDescription: "Stripe webhook close-out",
+            stageEnteredAt: new Date(Date.now() - 5 * 86400000).toISOString(),
+            developerName: "Dana Dev",
+            developerId: "005000000000001AAA"
+        },
+        {
+            workItemId: ITEM_TWO,
+            name: "T-0042",
+            briefDescription: null,
+            stageEnteredAt: new Date().toISOString(),
+            developerName: null,
+            developerId: null
+        }
+    ];
+}
+
+function createComponent() {
+    const element = createElement("c-delivery-close-out-queue", {
+        is: DeliveryCloseOutQueue
+    });
+    document.body.appendChild(element);
+    return element;
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function findButtonByLabel(element, label) {
+    return Array.from(element.shadowRoot.querySelectorAll("lightning-button")).find(
+        (b) => b.label === label
+    );
+}
+
+function findInputByLabel(element, label) {
+    return Array.from(element.shadowRoot.querySelectorAll("lightning-input")).find(
+        (i) => i.label === label
+    );
+}
+
+function setCheckbox(input, checked) {
+    input.checked = checked;
+    input.dispatchEvent(new CustomEvent("change"));
+}
+
+describe("c-delivery-close-out-queue", () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it("renders rows with name, brief, developer fallback, and headline", async () => {
+        const element = createComponent();
+        getCloseOutItems.emit(sampleItems());
+        await flushPromises();
+
+        const rows = element.shadowRoot.querySelectorAll(".queue-row");
+        expect(rows.length).toBe(2);
+
+        const text = element.shadowRoot.textContent;
+        expect(text).toContain("T-0041");
+        expect(text).toContain("Stripe webhook close-out");
+        expect(text).toContain("Dana Dev");
+        expect(text).toContain("Unassigned"); // developerName null fallback
+        expect(text).toContain("2 deployed items, awaiting your verification");
+    });
+
+    it("disables Open full report until a report id resolves", async () => {
+        const element = createComponent();
+        getCloseOutItems.emit(sampleItems());
+        await flushPromises();
+
+        let reportButton = findButtonByLabel(element, "Open full report");
+        expect(reportButton).toBeTruthy();
+        expect(reportButton.disabled).toBe(true);
+
+        getCloseOutReportId.emit("00O000000000001EAA");
+        await flushPromises();
+
+        reportButton = findButtonByLabel(element, "Open full report");
+        expect(reportButton.disabled).toBe(false);
+    });
+
+    it("selection toggles drive the bulk button label and disabled state", async () => {
+        const element = createComponent();
+        getCloseOutItems.emit(sampleItems());
+        await flushPromises();
+
+        let bulkButton = findButtonByLabel(element, "Mark Done (0)");
+        expect(bulkButton).toBeTruthy();
+        expect(bulkButton.disabled).toBe(true);
+
+        setCheckbox(findInputByLabel(element, "Select item"), true);
+        await flushPromises();
+
+        bulkButton = findButtonByLabel(element, "Mark Done (1)");
+        expect(bulkButton).toBeTruthy();
+        expect(bulkButton.disabled).toBe(false);
+
+        setCheckbox(findInputByLabel(element, "Select all"), true);
+        await flushPromises();
+        expect(findButtonByLabel(element, "Mark Done (2)")).toBeTruthy();
+    });
+
+    it("bulk Mark Done calls apex with the selected ids and toasts the success count", async () => {
+        markDone.mockResolvedValue({
+            succeededIds: [ITEM_ONE, ITEM_TWO],
+            failures: [],
+            succeededCount: 2,
+            failedCount: 0
+        });
+        const element = createComponent();
+        const toastHandler = jest.fn();
+        element.addEventListener("lightning__showtoast", toastHandler);
+
+        getCloseOutItems.emit(sampleItems());
+        await flushPromises();
+
+        setCheckbox(findInputByLabel(element, "Select all"), true);
+        await flushPromises();
+
+        findButtonByLabel(element, "Mark Done (2)").dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+        await flushPromises();
+
+        expect(markDone).toHaveBeenCalledWith({ workItemIds: [ITEM_ONE, ITEM_TWO] });
+        const toastDetail = toastHandler.mock.calls[0][0].detail;
+        expect(toastDetail.variant).toBe("success");
+        expect(toastDetail.message).toContain("2 items closed out");
+    });
+
+    it("per-row Mark Done calls apex with just that row and warns on partial failure", async () => {
+        markDone.mockResolvedValue({
+            succeededIds: [ITEM_ONE],
+            failures: [{ workItemId: ITEM_TWO, error: "x" }],
+            succeededCount: 1,
+            failedCount: 1
+        });
+        const element = createComponent();
+        const toastHandler = jest.fn();
+        element.addEventListener("lightning__showtoast", toastHandler);
+
+        getCloseOutItems.emit(sampleItems());
+        await flushPromises();
+
+        findButtonByLabel(element, "Mark Done").dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+        await flushPromises();
+
+        expect(markDone).toHaveBeenCalledWith({ workItemIds: [ITEM_ONE] });
+        const toastDetail = toastHandler.mock.calls[0][0].detail;
+        expect(toastDetail.variant).toBe("warning");
+        expect(toastDetail.message).toContain("1 closed out, 1 failed");
+    });
+
+    it("shows the caught-up empty state when nothing is awaiting close-out", async () => {
+        const element = createComponent();
+        getCloseOutItems.emit([]);
+        await flushPromises();
+
+        expect(element.shadowRoot.textContent).toContain("Nothing awaiting close-out");
+        expect(element.shadowRoot.querySelector(".queue-row")).toBeNull();
+    });
+
+    it("shows an error when the wire errors", async () => {
+        const element = createComponent();
+        getCloseOutItems.error();
+        await flushPromises();
+
+        expect(element.shadowRoot.querySelector(".queue-error")).not.toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/deliveryCloseOutQueue/deliveryCloseOutQueue.css
+++ b/force-app/main/default/lwc/deliveryCloseOutQueue/deliveryCloseOutQueue.css
@@ -1,0 +1,190 @@
+:host {
+    display: block;
+}
+
+.queue-card {
+    background: #ffffff;
+    border-radius: 0.75rem;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    font-size: 0.8125rem;
+}
+
+.queue-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.125rem 1.5rem;
+    border-bottom: 1px solid #e5e7eb;
+    background: linear-gradient(135deg, #ecfdf5 0%, #eff6ff 100%);
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.queue-header-left {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.queue-header-icon {
+    color: #059669;
+}
+
+.queue-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0 0 0.15rem 0;
+}
+
+.queue-subtitle {
+    font-size: 0.75rem;
+    color: #6b7280;
+    margin: 0;
+}
+
+.queue-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.queue-loading {
+    padding: 2rem;
+    display: flex;
+    justify-content: center;
+}
+
+.queue-error {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 1rem 1.5rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    background: #fef2f2;
+    border: 1px solid #fca5a5;
+    color: #991b1b;
+}
+
+.queue-headline-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.75rem 1.5rem;
+    border-bottom: 1px solid #f3f4f6;
+    flex-wrap: wrap;
+}
+
+.queue-headline {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #374151;
+}
+
+.queue-bulk-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.5rem 1.5rem;
+    border-bottom: 1px solid #f3f4f6;
+    background: #f9fafb;
+    flex-wrap: wrap;
+}
+
+.queue-row-select {
+    flex: 0 0 auto;
+}
+
+.queue-list {
+    list-style: none;
+    margin: 0;
+    padding: 0.25rem 0;
+}
+
+.queue-row {
+    padding: 0.875rem 1.5rem;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.queue-row:last-child {
+    border-bottom: none;
+}
+
+.queue-row-main {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.queue-row-info {
+    min-width: 14rem;
+    flex: 1 1 14rem;
+}
+
+.queue-item-link {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #4338ca;
+    text-align: left;
+}
+
+.queue-item-link:hover {
+    text-decoration: underline;
+    color: #312e81;
+}
+
+.queue-row-brief {
+    font-size: 0.8125rem;
+    color: #4b5563;
+    margin-top: 0.2rem;
+}
+
+.queue-row-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: 0.25rem;
+    flex-wrap: wrap;
+}
+
+.queue-dev {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #374151;
+}
+
+.queue-age {
+    font-size: 0.6875rem;
+    color: #9ca3af;
+}
+
+.queue-row-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+}
+
+.queue-empty {
+    padding: 3rem 2rem;
+    text-align: center;
+    color: #6b7280;
+}
+
+.queue-empty-icon {
+    color: #a7f3d0;
+    margin-bottom: 0.75rem;
+}

--- a/force-app/main/default/lwc/deliveryCloseOutQueue/deliveryCloseOutQueue.html
+++ b/force-app/main/default/lwc/deliveryCloseOutQueue/deliveryCloseOutQueue.html
@@ -1,0 +1,112 @@
+<template>
+    <div class="queue-card">
+
+        <div class="queue-header">
+            <div class="queue-header-left">
+                <lightning-icon icon-name="standard:task2" alternative-text="Close-out queue" size="small" class="queue-header-icon"></lightning-icon>
+                <div>
+                    <h2 class="queue-title">Close Outs</h2>
+                    <p class="queue-subtitle">Deployed to Prod &mdash; verify and mark done</p>
+                </div>
+            </div>
+            <div class="queue-controls">
+                <lightning-button-icon
+                    icon-name="utility:refresh"
+                    variant="border-filled"
+                    alternative-text="Refresh"
+                    title="Refresh"
+                    onclick={handleRefresh}>
+                </lightning-button-icon>
+            </div>
+        </div>
+
+        <template lwc:if={isLoading}>
+            <div class="queue-loading">
+                <lightning-spinner alternative-text="Loading close-out queue..." size="small"></lightning-spinner>
+            </div>
+        </template>
+
+        <template lwc:if={hasError}>
+            <div class="queue-error">
+                <lightning-icon icon-name="utility:error" size="x-small"></lightning-icon>
+                <span>{errorMessage}</span>
+            </div>
+        </template>
+
+        <template lwc:if={hasRows}>
+            <div class="queue-headline-row">
+                <span class="queue-headline">{headlineDisplay}</span>
+                <lightning-button
+                    variant="neutral"
+                    label="Open full report"
+                    icon-name="utility:new_window"
+                    disabled={hasNoReport}
+                    onclick={handleOpenReport}>
+                </lightning-button>
+            </div>
+
+            <div class="queue-bulk-bar">
+                <lightning-input
+                    type="checkbox"
+                    label="Select all"
+                    checked={isAllSelected}
+                    onchange={handleSelectAll}
+                    class="queue-select-all">
+                </lightning-input>
+                <lightning-button
+                    variant="brand"
+                    label={bulkDoneLabel}
+                    disabled={isBulkDoneDisabled}
+                    onclick={handleBulkDone}>
+                </lightning-button>
+            </div>
+
+            <ul class="queue-list">
+                <template for:each={rows} for:item="row">
+                <li key={row.key} class="queue-row">
+                    <div class="queue-row-main">
+                        <lightning-input
+                            type="checkbox"
+                            label="Select item"
+                            variant="label-hidden"
+                            data-work-item-id={row.key}
+                            checked={row.isSelected}
+                            onchange={handleRowSelect}
+                            class="queue-row-select">
+                        </lightning-input>
+                        <div class="queue-row-info">
+                            <button class="queue-item-link"
+                                    data-work-item-id={row.workItemId}
+                                    onclick={handleItemClick}>{row.name}</button>
+                            <template lwc:if={row.hasBrief}>
+                                <div class="queue-row-brief">{row.briefDescription}</div>
+                            </template>
+                            <div class="queue-row-meta">
+                                <span class="queue-dev">{row.developerDisplay}</span>
+                                <span class="queue-age">{row.waitingDisplay}</span>
+                            </div>
+                        </div>
+                        <div class="queue-row-actions">
+                            <lightning-button
+                                variant="brand"
+                                label="Mark Done"
+                                data-work-item-id={row.key}
+                                disabled={isSaving}
+                                onclick={handleRowDone}>
+                            </lightning-button>
+                        </div>
+                    </div>
+                </li>
+                </template>
+            </ul>
+        </template>
+
+        <template lwc:if={isEmpty}>
+            <div class="queue-empty">
+                <lightning-icon icon-name="utility:success" size="medium" class="queue-empty-icon"></lightning-icon>
+                <p>Nothing awaiting close-out &mdash; you&rsquo;re caught up.</p>
+            </div>
+        </template>
+
+    </div>
+</template>

--- a/force-app/main/default/lwc/deliveryCloseOutQueue/deliveryCloseOutQueue.js
+++ b/force-app/main/default/lwc/deliveryCloseOutQueue/deliveryCloseOutQueue.js
@@ -1,0 +1,269 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Close-out queue card for the workspace "Close Outs" tab — the
+ *               back of the pipeline. Wires
+ *               DeliveryTriageController.getCloseOutItems and renders each
+ *               WorkItem sitting in 'Deployed to Prod' awaiting the triager's
+ *               verification, with row checkboxes + select-all feeding a bulk
+ *               "Mark Done (N)" action and a per-row "Mark Done", both calling
+ *               DeliveryTriageController.markDone imperatively (mutations are
+ *               non-cacheable, never @wired). After any decision the wire is
+ *               refreshed and a toast confirms the outcome using OUR labels
+ *               (AuraHandledException messages come back generic inside the
+ *               managed package). A header "Open full report" button links to
+ *               the Deployed-to-Prod-Awaiting-Verification report via the id
+ *               the controller resolves by DeveloperName (namespace-safe); the
+ *               button is disabled when the report is absent in the org.
+ *               Clicking an item name navigates to the WorkItem__c record via
+ *               NavigationMixin + @salesforce/schema so the object API name
+ *               stays namespace-safe.
+ * @author       Cloud Nimbus LLC
+ */
+import { LightningElement, wire } from "lwc";
+import { NavigationMixin } from "lightning/navigation";
+import { refreshApex } from "@salesforce/apex";
+import { ShowToastEvent } from "lightning/platformShowToastEvent";
+import WORK_ITEM_OBJECT from "@salesforce/schema/WorkItem__c";
+import getCloseOutItems from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getCloseOutItems";
+import getCloseOutReportId from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getCloseOutReportId";
+import markDoneApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.markDone";
+
+const MS_PER_DAY = 86400000;
+
+export default class DeliveryCloseOutQueue extends NavigationMixin(LightningElement) {
+    itemsRaw = [];
+    errorMessage = "";
+    isLoading = true;
+    isSaving = false;
+    reportId = "";
+
+    // Work item ids ticked for "Mark Done".
+    selectedIds = [];
+
+    wiredResult;
+
+    @wire(getCloseOutItems)
+    wiredItems(result) {
+        this.wiredResult = result;
+        if (result.data) {
+            this.itemsRaw = result.data;
+            this.errorMessage = "";
+            this.isLoading = false;
+        } else if (result.error) {
+            this.errorMessage = this._errorText(result.error, "Unable to load the close-out queue.");
+            this.itemsRaw = [];
+            this.isLoading = false;
+        }
+    }
+
+    @wire(getCloseOutReportId)
+    wiredReportId({ data }) {
+        if (data) {
+            this.reportId = data;
+        }
+    }
+
+    // ── Row shaping (templates can't do ternaries — precompute) ──
+
+    get rows() {
+        return this.itemsRaw.map((dto) => ({
+            key: dto.workItemId,
+            workItemId: dto.workItemId,
+            name: dto.name || "(unnamed item)",
+            briefDescription: dto.briefDescription || "",
+            hasBrief: Boolean(dto.briefDescription),
+            waitingDisplay: this._ageDisplay(dto.stageEnteredAt),
+            developerDisplay: dto.developerName || "Unassigned",
+            isSelected: this.selectedIds.includes(dto.workItemId)
+        }));
+    }
+
+    // ── State flags ──────────────────────────────────────────────
+
+    get hasRows() {
+        return !this.isLoading && !this.errorMessage && this.itemsRaw.length > 0;
+    }
+
+    get isEmpty() {
+        return !this.isLoading && !this.errorMessage && this.itemsRaw.length === 0;
+    }
+
+    get hasError() {
+        return !this.isLoading && this.errorMessage.length > 0;
+    }
+
+    get hasReport() {
+        return Boolean(this.reportId);
+    }
+
+    get hasNoReport() {
+        return !this.reportId;
+    }
+
+    // ── Headline + bulk state ────────────────────────────────────
+
+    get headlineDisplay() {
+        const n = this.itemsRaw.length;
+        const noun = n === 1 ? "item" : "items";
+        return `${n} deployed ${noun}, awaiting your verification`;
+    }
+
+    get selectedCount() {
+        return this._selectedPresentIds().length;
+    }
+
+    get bulkDoneLabel() {
+        return `Mark Done (${this.selectedCount})`;
+    }
+
+    get isBulkDoneDisabled() {
+        return this.isSaving || this.selectedCount === 0;
+    }
+
+    get isAllSelected() {
+        return this.itemsRaw.length > 0 && this.selectedCount === this.itemsRaw.length;
+    }
+
+    // ── Navigation ───────────────────────────────────────────────
+
+    handleItemClick(event) {
+        const workItemId = event.currentTarget.dataset.workItemId;
+        if (!workItemId) {
+            return;
+        }
+        this[NavigationMixin.Navigate]({
+            type: "standard__recordPage",
+            attributes: {
+                recordId: workItemId,
+                objectApiName: WORK_ITEM_OBJECT.objectApiName,
+                actionName: "view"
+            }
+        });
+    }
+
+    handleOpenReport() {
+        if (!this.reportId) {
+            return;
+        }
+        this[NavigationMixin.Navigate]({
+            type: "standard__recordPage",
+            attributes: {
+                recordId: this.reportId,
+                objectApiName: "Report",
+                actionName: "view"
+            }
+        });
+    }
+
+    // ── Selection ────────────────────────────────────────────────
+
+    handleRowSelect(event) {
+        const workItemId = event.target.dataset.workItemId;
+        if (!workItemId) {
+            return;
+        }
+        const next = this.selectedIds.filter((id) => id !== workItemId);
+        if (event.target.checked) {
+            next.push(workItemId);
+        }
+        this.selectedIds = next;
+    }
+
+    handleSelectAll(event) {
+        this.selectedIds = event.target.checked
+            ? this.itemsRaw.map((dto) => dto.workItemId)
+            : [];
+    }
+
+    // ── Mark Done ────────────────────────────────────────────────
+
+    handleBulkDone() {
+        this._markDoneIds(this._selectedPresentIds());
+    }
+
+    handleRowDone(event) {
+        const workItemId = event.currentTarget.dataset.workItemId;
+        if (!workItemId) {
+            return;
+        }
+        this._markDoneIds([workItemId]);
+    }
+
+    handleRefresh() {
+        if (this.wiredResult) {
+            refreshApex(this.wiredResult);
+        }
+    }
+
+    _markDoneIds(ids) {
+        if (ids.length === 0 || this.isSaving) {
+            return;
+        }
+        this.isSaving = true;
+        markDoneApex({ workItemIds: ids })
+            .then((result) => {
+                this.isSaving = false;
+                this.selectedIds = [];
+                this._toastBulkOutcome(result, "closed out", "Marked done");
+                return refreshApex(this.wiredResult);
+            })
+            .catch((err) => {
+                this.isSaving = false;
+                this._toast(
+                    "Mark done failed",
+                    this._errorText(err, "The selected items could not be closed out."),
+                    "error"
+                );
+            });
+    }
+
+    // ── Internals ────────────────────────────────────────────────
+
+    _selectedPresentIds() {
+        const present = new Set(this.itemsRaw.map((dto) => dto.workItemId));
+        return this.selectedIds.filter((id) => present.has(id));
+    }
+
+    _toastBulkOutcome(result, verb, successTitle) {
+        const succeeded = result && result.succeededCount ? result.succeededCount : 0;
+        const failed = result && result.failedCount ? result.failedCount : 0;
+        if (failed === 0) {
+            const noun = succeeded === 1 ? "item" : "items";
+            this._toast(successTitle, `${succeeded} ${noun} ${verb}.`, "success");
+        } else if (succeeded === 0) {
+            this._toast(`${successTitle} failed`, `0 ${verb}, ${failed} failed.`, "error");
+        } else {
+            this._toast("Partially complete", `${succeeded} ${verb}, ${failed} failed.`, "warning");
+        }
+    }
+
+    _toast(title, message, variant) {
+        this.dispatchEvent(new ShowToastEvent({ title, message, variant }));
+    }
+
+    _errorText(err, fallback) {
+        if (err && err.body && err.body.message) {
+            return err.body.message;
+        }
+        return fallback;
+    }
+
+    _ageDisplay(stageEnteredAt) {
+        if (!stageEnteredAt) {
+            return "waiting";
+        }
+        const entered = new Date(stageEnteredAt).getTime();
+        if (!Number.isFinite(entered)) {
+            return "waiting";
+        }
+        const days = Math.max(0, Math.floor((Date.now() - entered) / MS_PER_DAY));
+        if (days === 0) {
+            return "waiting since today";
+        }
+        if (days === 1) {
+            return "waiting 1 day";
+        }
+        return `waiting ${days} days`;
+    }
+}

--- a/force-app/main/default/lwc/deliveryCloseOutQueue/deliveryCloseOutQueue.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryCloseOutQueue/deliveryCloseOutQueue.js-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__HomePage</target>
+        <target>lightning__AppPage</target>
+        <target>lightning__Tab</target>
+    </targets>
+    <masterLabel>Delivery Close-Out Queue</masterLabel>
+    <description>Close-out queue: every WorkItem in Deployed to Prod awaiting the triager's verification, with bulk and per-row Mark Done, click-through to the WorkItem, and a link to the Deployed-to-Prod awaiting-verification report.</description>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
+++ b/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
@@ -21,6 +21,15 @@
             <c-delivery-guide></c-delivery-guide>
         </lightning-tab>
 
+        <!-- Front of the pipeline: inbound work that arrived but was never activated
+             onto the timeline (ActivatedDateTime = null → invisible on the board/Gantt).
+             The triager routes each item to a dev (assign + advance + activate) or
+             resolves it. Ungated like Approvals — the Apex scopes the data, so a
+             non-triager just sees an empty queue. -->
+        <lightning-tab label="Intake" value="intake" icon-name="standard:work_queue">
+            <c-delivery-intake-queue></c-delivery-intake-queue>
+        </lightning-tab>
+
         <!-- Buyer-facing surfaces, hosted here (the package-owned "Delivery" tab) so they
              survive subscriber Home-page overrides — a subscriber-activated custom Home
              hides the package Home FlexiPage on upgrade, but cannot touch these inner tabs.
@@ -30,6 +39,13 @@
         <lightning-tab label="Approvals" value="approvals" icon-name="standard:approval">
             <c-delivery-approval-summary-card></c-delivery-approval-summary-card>
             <c-delivery-approval-queue></c-delivery-approval-queue>
+        </lightning-tab>
+
+        <!-- Back of the pipeline: items in 'Deployed to Prod' awaiting the triager's
+             close-out verification. Makes the Deployed-to-Prod awaiting-verification
+             report actionable from inside the workspace. Ungated like Approvals. -->
+        <lightning-tab label="Close Outs" value="closeouts" icon-name="standard:task2">
+            <c-delivery-close-out-queue></c-delivery-close-out-queue>
         </lightning-tab>
 
         <!-- Buyer forecast = the "you set the pace" capacity slider (the controllable

--- a/force-app/main/default/lwc/deliveryIntakeQueue/__tests__/deliveryIntakeQueue.test.js
+++ b/force-app/main/default/lwc/deliveryIntakeQueue/__tests__/deliveryIntakeQueue.test.js
@@ -1,0 +1,197 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryIntakeQueue: wire-driven rows (name,
+ *               brief, stage, requester, arrived age), the bulk "Route to dev"
+ *               selection/label/disabled state, the route flow carrying the
+ *               developer chosen in the inline picker, the per-row route and
+ *               dismiss flows (call shapes + toasts), and the empty/error
+ *               states.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from "lwc";
+import DeliveryIntakeQueue from "c/deliveryIntakeQueue";
+import getIntakeItems from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getIntakeItems";
+import routeToDev from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.routeToDev";
+import dismissIntake from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.dismissIntake";
+
+const ITEM_ONE = "a42000000000001AAA";
+const ITEM_TWO = "a42000000000002AAA";
+const DEV_ID = "005000000000099AAA";
+
+function sampleItems() {
+    return [
+        {
+            workItemId: ITEM_ONE,
+            name: "T-0050",
+            briefDescription: "New client portal request",
+            createdDate: new Date(Date.now() - 2 * 86400000).toISOString(),
+            requestedByName: "client@example.com",
+            currentStage: "Backlog"
+        },
+        {
+            workItemId: ITEM_TWO,
+            name: "T-0051",
+            briefDescription: null,
+            createdDate: new Date().toISOString(),
+            requestedByName: null,
+            currentStage: "Backlog"
+        }
+    ];
+}
+
+function createComponent() {
+    const element = createElement("c-delivery-intake-queue", {
+        is: DeliveryIntakeQueue
+    });
+    document.body.appendChild(element);
+    return element;
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function findButtonByLabel(element, label) {
+    return Array.from(element.shadowRoot.querySelectorAll("lightning-button")).find(
+        (b) => b.label === label
+    );
+}
+
+function findInputByLabel(element, label) {
+    return Array.from(element.shadowRoot.querySelectorAll("lightning-input")).find(
+        (i) => i.label === label
+    );
+}
+
+function setCheckbox(input, checked) {
+    input.checked = checked;
+    input.dispatchEvent(new CustomEvent("change"));
+}
+
+describe("c-delivery-intake-queue", () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it("renders rows with name, brief, stage, requester, and arrived age", async () => {
+        const element = createComponent();
+        getIntakeItems.emit(sampleItems());
+        await flushPromises();
+
+        const rows = element.shadowRoot.querySelectorAll(".queue-row");
+        expect(rows.length).toBe(2);
+
+        const text = element.shadowRoot.textContent;
+        expect(text).toContain("T-0050");
+        expect(text).toContain("New client portal request");
+        expect(text).toContain("client@example.com");
+        expect(text).toContain("2 inbound items to triage");
+    });
+
+    it("bulk Route to dev is gated by selection and carries the picked developer", async () => {
+        routeToDev.mockResolvedValue({
+            succeededIds: [ITEM_ONE, ITEM_TWO],
+            failures: [],
+            succeededCount: 2,
+            failedCount: 0
+        });
+        const element = createComponent();
+        const toastHandler = jest.fn();
+        element.addEventListener("lightning__showtoast", toastHandler);
+
+        getIntakeItems.emit(sampleItems());
+        await flushPromises();
+
+        let bulkButton = findButtonByLabel(element, "Route to dev (0)");
+        expect(bulkButton.disabled).toBe(true);
+
+        // Choose a developer in the inline picker.
+        const picker = element.shadowRoot.querySelector("lightning-record-picker");
+        picker.dispatchEvent(new CustomEvent("change", { detail: { recordId: DEV_ID } }));
+        await flushPromises();
+
+        // Select all -> (2), enabled.
+        setCheckbox(findInputByLabel(element, "Select all"), true);
+        await flushPromises();
+
+        bulkButton = findButtonByLabel(element, "Route to dev (2)");
+        expect(bulkButton.disabled).toBe(false);
+        bulkButton.dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+        await flushPromises();
+
+        expect(routeToDev).toHaveBeenCalledWith({
+            workItemIds: [ITEM_ONE, ITEM_TWO],
+            developerUserId: DEV_ID
+        });
+        const toastDetail = toastHandler.mock.calls[0][0].detail;
+        expect(toastDetail.variant).toBe("success");
+        expect(toastDetail.message).toContain("2 items routed to dev");
+    });
+
+    it("per-row Route to dev routes just that row with a null developer when none picked", async () => {
+        routeToDev.mockResolvedValue({
+            succeededIds: [ITEM_ONE],
+            failures: [],
+            succeededCount: 1,
+            failedCount: 0
+        });
+        const element = createComponent();
+        getIntakeItems.emit(sampleItems());
+        await flushPromises();
+
+        findButtonByLabel(element, "Route to dev").dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+        await flushPromises();
+
+        expect(routeToDev).toHaveBeenCalledWith({
+            workItemIds: [ITEM_ONE],
+            developerUserId: null
+        });
+    });
+
+    it("per-row Dismiss calls dismissIntake for that row", async () => {
+        dismissIntake.mockResolvedValue({
+            succeededIds: [ITEM_ONE],
+            failures: [],
+            succeededCount: 1,
+            failedCount: 0
+        });
+        const element = createComponent();
+        const toastHandler = jest.fn();
+        element.addEventListener("lightning__showtoast", toastHandler);
+
+        getIntakeItems.emit(sampleItems());
+        await flushPromises();
+
+        findButtonByLabel(element, "Dismiss").dispatchEvent(new CustomEvent("click"));
+        await flushPromises();
+        await flushPromises();
+
+        expect(dismissIntake).toHaveBeenCalledWith({ workItemIds: [ITEM_ONE] });
+        const toastDetail = toastHandler.mock.calls[0][0].detail;
+        expect(toastDetail.variant).toBe("success");
+        expect(toastDetail.message).toContain("1 item dismissed");
+    });
+
+    it("shows the empty state when there is no inbound work", async () => {
+        const element = createComponent();
+        getIntakeItems.emit([]);
+        await flushPromises();
+
+        expect(element.shadowRoot.textContent).toContain("No new inbound items to triage");
+        expect(element.shadowRoot.querySelector(".queue-row")).toBeNull();
+    });
+
+    it("shows an error when the wire errors", async () => {
+        const element = createComponent();
+        getIntakeItems.error();
+        await flushPromises();
+
+        expect(element.shadowRoot.querySelector(".queue-error")).not.toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/deliveryIntakeQueue/deliveryIntakeQueue.css
+++ b/force-app/main/default/lwc/deliveryIntakeQueue/deliveryIntakeQueue.css
@@ -1,0 +1,214 @@
+:host {
+    display: block;
+}
+
+.queue-card {
+    background: #ffffff;
+    border-radius: 0.75rem;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    font-size: 0.8125rem;
+}
+
+.queue-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.125rem 1.5rem;
+    border-bottom: 1px solid #e5e7eb;
+    background: linear-gradient(135deg, #eff6ff 0%, #fef3c7 100%);
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.queue-header-left {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.queue-header-icon {
+    color: #2563eb;
+}
+
+.queue-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0 0 0.15rem 0;
+}
+
+.queue-subtitle {
+    font-size: 0.75rem;
+    color: #6b7280;
+    margin: 0;
+}
+
+.queue-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.queue-loading {
+    padding: 2rem;
+    display: flex;
+    justify-content: center;
+}
+
+.queue-error {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 1rem 1.5rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    background: #fef2f2;
+    border: 1px solid #fca5a5;
+    color: #991b1b;
+}
+
+.queue-headline-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.75rem 1.5rem;
+    border-bottom: 1px solid #f3f4f6;
+    flex-wrap: wrap;
+}
+
+.queue-headline {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #374151;
+}
+
+.queue-bulk-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.5rem 1.5rem;
+    border-bottom: 1px solid #f3f4f6;
+    background: #f9fafb;
+    flex-wrap: wrap;
+}
+
+.queue-bulk-left {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.queue-dev-picker {
+    min-width: 16rem;
+}
+
+.queue-select-all {
+    flex: 0 0 auto;
+}
+
+.queue-row-select {
+    flex: 0 0 auto;
+}
+
+.queue-list {
+    list-style: none;
+    margin: 0;
+    padding: 0.25rem 0;
+}
+
+.queue-row {
+    padding: 0.875rem 1.5rem;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.queue-row:last-child {
+    border-bottom: none;
+}
+
+.queue-row-main {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.queue-row-info {
+    min-width: 14rem;
+    flex: 1 1 14rem;
+}
+
+.queue-item-link {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #4338ca;
+    text-align: left;
+}
+
+.queue-item-link:hover {
+    text-decoration: underline;
+    color: #312e81;
+}
+
+.queue-row-brief {
+    font-size: 0.8125rem;
+    color: #4b5563;
+    margin-top: 0.2rem;
+}
+
+.queue-row-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: 0.25rem;
+    flex-wrap: wrap;
+}
+
+.queue-stage {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: #374151;
+    padding: 0.1rem 0.5rem;
+    border-radius: 9999px;
+    background: #eef2ff;
+    border: 1px solid #c7d2fe;
+}
+
+.queue-requester {
+    font-size: 0.75rem;
+    color: #6b7280;
+}
+
+.queue-age {
+    font-size: 0.6875rem;
+    color: #9ca3af;
+}
+
+.queue-row-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+}
+
+.queue-empty {
+    padding: 3rem 2rem;
+    text-align: center;
+    color: #6b7280;
+}
+
+.queue-empty-icon {
+    color: #a7f3d0;
+    margin-bottom: 0.75rem;
+}

--- a/force-app/main/default/lwc/deliveryIntakeQueue/deliveryIntakeQueue.html
+++ b/force-app/main/default/lwc/deliveryIntakeQueue/deliveryIntakeQueue.html
@@ -1,0 +1,126 @@
+<template>
+    <div class="queue-card">
+
+        <div class="queue-header">
+            <div class="queue-header-left">
+                <lightning-icon icon-name="standard:work_queue" alternative-text="Intake queue" size="small" class="queue-header-icon"></lightning-icon>
+                <div>
+                    <h2 class="queue-title">Intake</h2>
+                    <p class="queue-subtitle">New inbound work &mdash; route onto the timeline or resolve</p>
+                </div>
+            </div>
+            <div class="queue-controls">
+                <lightning-button-icon
+                    icon-name="utility:refresh"
+                    variant="border-filled"
+                    alternative-text="Refresh"
+                    title="Refresh"
+                    onclick={handleRefresh}>
+                </lightning-button-icon>
+            </div>
+        </div>
+
+        <template lwc:if={isLoading}>
+            <div class="queue-loading">
+                <lightning-spinner alternative-text="Loading intake queue..." size="small"></lightning-spinner>
+            </div>
+        </template>
+
+        <template lwc:if={hasError}>
+            <div class="queue-error">
+                <lightning-icon icon-name="utility:error" size="x-small"></lightning-icon>
+                <span>{errorMessage}</span>
+            </div>
+        </template>
+
+        <template lwc:if={hasRows}>
+            <div class="queue-headline-row">
+                <span class="queue-headline">{headlineDisplay}</span>
+            </div>
+
+            <div class="queue-bulk-bar">
+                <div class="queue-bulk-left">
+                    <lightning-input
+                        type="checkbox"
+                        label="Select all"
+                        checked={isAllSelected}
+                        onchange={handleSelectAll}
+                        class="queue-select-all">
+                    </lightning-input>
+                    <lightning-record-picker
+                        label="Developer"
+                        placeholder="Assign a developer (optional)"
+                        object-api-name="User"
+                        variant="label-hidden"
+                        value={developerId}
+                        onchange={handleDeveloperChange}
+                        class="queue-dev-picker">
+                    </lightning-record-picker>
+                </div>
+                <lightning-button
+                    variant="brand"
+                    label={bulkRouteLabel}
+                    disabled={isBulkRouteDisabled}
+                    onclick={handleBulkRoute}>
+                </lightning-button>
+            </div>
+
+            <ul class="queue-list">
+                <template for:each={rows} for:item="row">
+                <li key={row.key} class="queue-row">
+                    <div class="queue-row-main">
+                        <lightning-input
+                            type="checkbox"
+                            label="Select item"
+                            variant="label-hidden"
+                            data-work-item-id={row.key}
+                            checked={row.isSelected}
+                            onchange={handleRowSelect}
+                            class="queue-row-select">
+                        </lightning-input>
+                        <div class="queue-row-info">
+                            <button class="queue-item-link"
+                                    data-work-item-id={row.workItemId}
+                                    onclick={handleItemClick}>{row.name}</button>
+                            <template lwc:if={row.hasBrief}>
+                                <div class="queue-row-brief">{row.briefDescription}</div>
+                            </template>
+                            <div class="queue-row-meta">
+                                <span class="queue-stage">{row.stageDisplay}</span>
+                                <template lwc:if={row.hasRequestedBy}>
+                                    <span class="queue-requester">{row.requestedByDisplay}</span>
+                                </template>
+                                <span class="queue-age">{row.arrivedDisplay}</span>
+                            </div>
+                        </div>
+                        <div class="queue-row-actions">
+                            <lightning-button
+                                variant="brand"
+                                label="Route to dev"
+                                data-work-item-id={row.key}
+                                disabled={isSaving}
+                                onclick={handleRowRoute}>
+                            </lightning-button>
+                            <lightning-button
+                                variant="destructive-text"
+                                label="Dismiss"
+                                data-work-item-id={row.key}
+                                disabled={isSaving}
+                                onclick={handleRowDismiss}>
+                            </lightning-button>
+                        </div>
+                    </div>
+                </li>
+                </template>
+            </ul>
+        </template>
+
+        <template lwc:if={isEmpty}>
+            <div class="queue-empty">
+                <lightning-icon icon-name="utility:success" size="medium" class="queue-empty-icon"></lightning-icon>
+                <p>No new inbound items to triage.</p>
+            </div>
+        </template>
+
+    </div>
+</template>

--- a/force-app/main/default/lwc/deliveryIntakeQueue/deliveryIntakeQueue.js
+++ b/force-app/main/default/lwc/deliveryIntakeQueue/deliveryIntakeQueue.js
@@ -1,0 +1,280 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Intake queue card for the workspace "Intake" tab — the front
+ *               of the pipeline. Wires DeliveryTriageController.getIntakeItems
+ *               and renders each WorkItem that arrived but was never activated
+ *               onto the timeline (ActivatedDateTime__c = NULL → invisible on
+ *               the board/Gantt, which require it to be set). Jose triages each
+ *               row two ways: "Route to dev" (assign the developer chosen in
+ *               the inline picker, advance to Ready for Development, and stamp
+ *               ActivatedDateTime so it appears on the timeline) via
+ *               routeToDev, or "Dismiss" (resolve it himself to a terminal
+ *               stage) via dismissIntake — both bulk-capable and called
+ *               imperatively (mutations are non-cacheable). After any action
+ *               the wire is refreshed and a toast confirms the outcome using
+ *               OUR labels (managed-package AuraHandledException messages come
+ *               back generic). Clicking an item name navigates to the
+ *               WorkItem__c record via NavigationMixin + @salesforce/schema so
+ *               the object API name stays namespace-safe.
+ * @author       Cloud Nimbus LLC
+ */
+import { LightningElement, wire } from "lwc";
+import { NavigationMixin } from "lightning/navigation";
+import { refreshApex } from "@salesforce/apex";
+import { ShowToastEvent } from "lightning/platformShowToastEvent";
+import WORK_ITEM_OBJECT from "@salesforce/schema/WorkItem__c";
+import getIntakeItems from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getIntakeItems";
+import routeToDevApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.routeToDev";
+import dismissIntakeApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.dismissIntake";
+
+const MS_PER_DAY = 86400000;
+
+export default class DeliveryIntakeQueue extends NavigationMixin(LightningElement) {
+    itemsRaw = [];
+    errorMessage = "";
+    isLoading = true;
+    isSaving = false;
+
+    // Developer chosen in the inline picker (null = route unassigned).
+    developerId = null;
+
+    // Work item ids ticked for a bulk action.
+    selectedIds = [];
+
+    wiredResult;
+
+    @wire(getIntakeItems)
+    wiredItems(result) {
+        this.wiredResult = result;
+        if (result.data) {
+            this.itemsRaw = result.data;
+            this.errorMessage = "";
+            this.isLoading = false;
+        } else if (result.error) {
+            this.errorMessage = this._errorText(result.error, "Unable to load the intake queue.");
+            this.itemsRaw = [];
+            this.isLoading = false;
+        }
+    }
+
+    // ── Row shaping (templates can't do ternaries — precompute) ──
+
+    get rows() {
+        return this.itemsRaw.map((dto) => ({
+            key: dto.workItemId,
+            workItemId: dto.workItemId,
+            name: dto.name || "(unnamed item)",
+            briefDescription: dto.briefDescription || "",
+            hasBrief: Boolean(dto.briefDescription),
+            arrivedDisplay: this._ageDisplay(dto.createdDate),
+            stageDisplay: dto.currentStage || "",
+            requestedByDisplay: dto.requestedByName || "",
+            hasRequestedBy: Boolean(dto.requestedByName),
+            isSelected: this.selectedIds.includes(dto.workItemId)
+        }));
+    }
+
+    // ── State flags ──────────────────────────────────────────────
+
+    get hasRows() {
+        return !this.isLoading && !this.errorMessage && this.itemsRaw.length > 0;
+    }
+
+    get isEmpty() {
+        return !this.isLoading && !this.errorMessage && this.itemsRaw.length === 0;
+    }
+
+    get hasError() {
+        return !this.isLoading && this.errorMessage.length > 0;
+    }
+
+    // ── Headline + bulk state ────────────────────────────────────
+
+    get headlineDisplay() {
+        const n = this.itemsRaw.length;
+        const noun = n === 1 ? "item" : "items";
+        return `${n} inbound ${noun} to triage`;
+    }
+
+    get selectedCount() {
+        return this._selectedPresentIds().length;
+    }
+
+    get bulkRouteLabel() {
+        return `Route to dev (${this.selectedCount})`;
+    }
+
+    get isBulkRouteDisabled() {
+        return this.isSaving || this.selectedCount === 0;
+    }
+
+    get isAllSelected() {
+        return this.itemsRaw.length > 0 && this.selectedCount === this.itemsRaw.length;
+    }
+
+    // ── Navigation ───────────────────────────────────────────────
+
+    handleItemClick(event) {
+        const workItemId = event.currentTarget.dataset.workItemId;
+        if (!workItemId) {
+            return;
+        }
+        this[NavigationMixin.Navigate]({
+            type: "standard__recordPage",
+            attributes: {
+                recordId: workItemId,
+                objectApiName: WORK_ITEM_OBJECT.objectApiName,
+                actionName: "view"
+            }
+        });
+    }
+
+    // ── Developer picker + selection ─────────────────────────────
+
+    handleDeveloperChange(event) {
+        // lightning-record-picker emits the chosen record id in detail.
+        this.developerId = (event.detail && event.detail.recordId) || null;
+    }
+
+    handleRowSelect(event) {
+        const workItemId = event.target.dataset.workItemId;
+        if (!workItemId) {
+            return;
+        }
+        const next = this.selectedIds.filter((id) => id !== workItemId);
+        if (event.target.checked) {
+            next.push(workItemId);
+        }
+        this.selectedIds = next;
+    }
+
+    handleSelectAll(event) {
+        this.selectedIds = event.target.checked
+            ? this.itemsRaw.map((dto) => dto.workItemId)
+            : [];
+    }
+
+    // ── Route to dev ─────────────────────────────────────────────
+
+    handleBulkRoute() {
+        this._routeIds(this._selectedPresentIds());
+    }
+
+    handleRowRoute(event) {
+        const workItemId = event.currentTarget.dataset.workItemId;
+        if (!workItemId) {
+            return;
+        }
+        this._routeIds([workItemId]);
+    }
+
+    _routeIds(ids) {
+        if (ids.length === 0 || this.isSaving) {
+            return;
+        }
+        this.isSaving = true;
+        routeToDevApex({ workItemIds: ids, developerUserId: this.developerId })
+            .then((result) => {
+                this.isSaving = false;
+                this.selectedIds = [];
+                this._toastBulkOutcome(result, "routed to dev", "Routed");
+                return refreshApex(this.wiredResult);
+            })
+            .catch((err) => {
+                this.isSaving = false;
+                this._toast(
+                    "Route failed",
+                    this._errorText(err, "The selected items could not be routed."),
+                    "error"
+                );
+            });
+    }
+
+    // ── Dismiss ──────────────────────────────────────────────────
+
+    handleRowDismiss(event) {
+        const workItemId = event.currentTarget.dataset.workItemId;
+        if (!workItemId) {
+            return;
+        }
+        this._dismissIds([workItemId]);
+    }
+
+    _dismissIds(ids) {
+        if (ids.length === 0 || this.isSaving) {
+            return;
+        }
+        this.isSaving = true;
+        dismissIntakeApex({ workItemIds: ids })
+            .then((result) => {
+                this.isSaving = false;
+                this.selectedIds = [];
+                this._toastBulkOutcome(result, "dismissed", "Dismissed");
+                return refreshApex(this.wiredResult);
+            })
+            .catch((err) => {
+                this.isSaving = false;
+                this._toast(
+                    "Dismiss failed",
+                    this._errorText(err, "The selected items could not be dismissed."),
+                    "error"
+                );
+            });
+    }
+
+    handleRefresh() {
+        if (this.wiredResult) {
+            refreshApex(this.wiredResult);
+        }
+    }
+
+    // ── Internals ────────────────────────────────────────────────
+
+    _selectedPresentIds() {
+        const present = new Set(this.itemsRaw.map((dto) => dto.workItemId));
+        return this.selectedIds.filter((id) => present.has(id));
+    }
+
+    _toastBulkOutcome(result, verb, successTitle) {
+        const succeeded = result && result.succeededCount ? result.succeededCount : 0;
+        const failed = result && result.failedCount ? result.failedCount : 0;
+        if (failed === 0) {
+            const noun = succeeded === 1 ? "item" : "items";
+            this._toast(successTitle, `${succeeded} ${noun} ${verb}.`, "success");
+        } else if (succeeded === 0) {
+            this._toast(`${successTitle} failed`, `0 ${verb}, ${failed} failed.`, "error");
+        } else {
+            this._toast("Partially complete", `${succeeded} ${verb}, ${failed} failed.`, "warning");
+        }
+    }
+
+    _toast(title, message, variant) {
+        this.dispatchEvent(new ShowToastEvent({ title, message, variant }));
+    }
+
+    _errorText(err, fallback) {
+        if (err && err.body && err.body.message) {
+            return err.body.message;
+        }
+        return fallback;
+    }
+
+    _ageDisplay(createdDate) {
+        if (!createdDate) {
+            return "just arrived";
+        }
+        const created = new Date(createdDate).getTime();
+        if (!Number.isFinite(created)) {
+            return "just arrived";
+        }
+        const days = Math.max(0, Math.floor((Date.now() - created) / MS_PER_DAY));
+        if (days === 0) {
+            return "arrived today";
+        }
+        if (days === 1) {
+            return "arrived 1 day ago";
+        }
+        return `arrived ${days} days ago`;
+    }
+}

--- a/force-app/main/default/lwc/deliveryIntakeQueue/deliveryIntakeQueue.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryIntakeQueue/deliveryIntakeQueue.js-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__HomePage</target>
+        <target>lightning__AppPage</target>
+        <target>lightning__Tab</target>
+    </targets>
+    <masterLabel>Delivery Intake Queue</masterLabel>
+    <description>Intake queue: WorkItems that arrived but were never activated onto the timeline, with an inline developer picker to route them to development (assign + advance + activate) or dismiss them to a terminal stage.</description>
+</LightningComponentBundle>

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.dismissIntake.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.dismissIntake.js
@@ -1,0 +1,4 @@
+/**
+ * Mock for DeliveryTriageController.dismissIntake (imperative).
+ */
+module.exports = { default: jest.fn() };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getCloseOutItems.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getCloseOutItems.js
@@ -1,0 +1,8 @@
+/**
+ * Wire adapter mock for DeliveryTriageController.getCloseOutItems.
+ * Used by the triage queue jest tests.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+
+const getCloseOutItems = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getCloseOutItems };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getCloseOutReportId.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getCloseOutReportId.js
@@ -1,0 +1,8 @@
+/**
+ * Wire adapter mock for DeliveryTriageController.getCloseOutReportId.
+ * Used by the triage queue jest tests.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+
+const getCloseOutReportId = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getCloseOutReportId };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getIntakeItems.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getIntakeItems.js
@@ -1,0 +1,8 @@
+/**
+ * Wire adapter mock for DeliveryTriageController.getIntakeItems.
+ * Used by the triage queue jest tests.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+
+const getIntakeItems = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getIntakeItems };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.markDone.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.markDone.js
@@ -1,0 +1,4 @@
+/**
+ * Mock for DeliveryTriageController.markDone (imperative).
+ */
+module.exports = { default: jest.fn() };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.routeToDev.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.routeToDev.js
@@ -1,0 +1,4 @@
+/**
+ * Mock for DeliveryTriageController.routeToDev (imperative).
+ */
+module.exports = { default: jest.fn() };


### PR DESCRIPTION
## What

Two new triager-facing queue tabs in the package-owned **Delivery** workspace (`deliveryHubWorkspace`), letting the triager persona (Jose) drive **both ends** of the work-item pipeline without leaving the workspace. They mirror the existing **Approvals** tab pattern exactly (cacheable `@wire` getter → DTO rows → row checkboxes + select-all → imperative bulk mutation → `ShowToastEvent` with our labels → `refreshApex`).

Tab order follows the pipeline: **Intake** (before Approvals — front of pipe) · Approvals · **Close Outs** (after Approvals — back of pipe).

### Intake tab — the gap it fills
WorkItems that arrived but were **never activated onto the timeline**. The board/Gantt filter `ActivatedDateTime__c != null`, so un-activated items are invisible everywhere else — this tab is the only surface that shows them. Per-row + bulk actions:
- **Route to dev** — assign the developer chosen in an inline `lightning-record-picker` (User), advance to `Ready for Development`, and stamp `ActivatedDateTime__c = now()` so the item becomes visible on the timeline.
- **Dismiss** — resolve it to a terminal stage (`Cancelled` when in the terminal set, else `Done`).

### Close Outs tab — the gap it fills
WorkItems sitting in `Deployed to Prod` awaiting the triager's verification. Makes the **Deployed-to-Prod – Awaiting Verification** report actionable from inside the workspace:
- Per-row + bulk **Mark Done** (→ `Done` terminal stage).
- Header "Open full report" button linking to the report (id resolved by DeveloperName `Deployed_To_Prod_Awaiting_Verification`); disabled when the report is absent in the org.

## New Apex — `DeliveryTriageController` (`with sharing`)
- `getCloseOutItems()` / `getIntakeItems()` / `getCloseOutReportId()` — `@AuraEnabled(cacheable=true)` reads, `WITH SYSTEM_MODE`.
- `markDone` / `routeToDev` / `dismissIntake` — non-cacheable bulk mutations, `allOrNone=false`, **partial-failure-safe**: every id is processed, DML failures *and* ids that resolve to no record are collected per-row in `BulkResultDTO` (succeeded ids + failures + reconciling counts), mirroring `DeliveryWorkApprovalService.approveMany`. Picklist values passed as safe known literals (allowlist trigger is a documented no-op).

## Additive / no behavior change
- No schema changes. No changes to existing tabs' behavior or the buyer default-tab logic.
- New tabs are **ungated** like Approvals — the Apex scopes the data, so a non-triager just sees an empty queue.

## Field-API / definition decisions
- **Developer field**: `DeveloperLookup__c` (label "Developer", `referenceTo` User) — confirmed from object metadata, not guessed.
- **Intake definition**: settled on `ActivatedDateTime__c = NULL AND not archived AND not template AND stage NOT IN terminal`. Deliberately did **not** add `OR StatusPk__c = 'New'`: `ActivatedDateTime = NULL` already captures every un-activated New item, and the OR would only add *activated*-New items, which are already visible on the timeline (double-surfacing). Matches the board's canonical `ActivatedDateTime != null` scope.
- **`requestedByName`**: prefers `ExternalRequesterEmail__c` (email-to-case intake) when present, else `CreatedBy.Name`.
- Other fields confirmed from metadata: `BriefDescriptionTxt__c`, `StageEnteredDateTime__c`, `StageNamePk__c`, `Name` (AutoNumber `T-{0000}`). Stage literals (`Deployed to Prod`, `Ready for Development`, `Done`, `Cancelled`) all confirmed present in the `StageNamePk__c` value set; terminal set via `DeliveryWorkflowConfigService.getAllTerminalStageValues()`.

## Tests
- **Jest**: 13 new tests across `deliveryCloseOutQueue` (7) and `deliveryIntakeQueue` (6) — all green. Added the matching apex jest-mocks (wire adapters + imperative fns).
- **Apex**: `DeliveryTriageControllerTest` — close-out ordering/exclusions, intake exclusions + requestedBy fallback, and each mutation including the deterministic partial-failure path (`[realId, phantomId]` → 1 succeeded / 1 failed). Not deployed to any org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)