### PR TITLE
chore(gantt): mark NG app bundle binary — fix CRLF md5 drift

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+force-app/main/default/staticresources/nimbusganttapp.resource binary


### PR DESCRIPTION
## Problem
`core.autocrlf=true` line-ending-converts `nimbusganttapp.resource` on checkout. The git blob is the correct `ac493513`, but every checkout (including CI's package build) materializes a CRLF variant (`d306ee36`). The JS runs identically, but the deployed md5 no longer matches NG's published `ac493513` — breaking the bundle-verification check.

## Fix
Scoped `.gitattributes` entry marking the file `binary` so git never converts it. Working tree + CI checkout + package are now all byte-exact `ac493513`. Restored the working-tree bundle to the exact NG bytes.

## Why it matters now
Without this, the package promoted from `c82d4c97` would carry the CRLF bundle, and a post-install md5 check would read `d306ee36` and look wrong. This makes the promote byte-faithful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)