### PR TITLE
fix(tests): set required WorkLog master-detail in invoice tests — unblock beta_create

### DIFF
--- a/force-app/main/default/classes/DeliveryInvoiceWorkItemScopeTest.cls
+++ b/force-app/main/default/classes/DeliveryInvoiceWorkItemScopeTest.cls
@@ -46,13 +46,16 @@ private class DeliveryInvoiceWorkItemScopeTest {
         );
         insert new List<WorkItem__c>{ wi1, wi2 };
 
+        // buildWorkLog auto-mints the required WorkRequest__c master (RequestId__c)
+        // per WI and caches it — a raw `new WorkLog__c` omits that master-detail and
+        // fails REQUIRED_FIELD_MISSING during package-version test runs.
         insert new List<WorkLog__c>{
-            new WorkLog__c(WorkItemLookup__c = wi1.Id, HoursLoggedNumber__c = 8,
-                WorkDateDate__c = Date.newInstance(2026, 3, 10), WorkDescriptionTxt__c = 'in', StatusPk__c = 'Approved'),
-            new WorkLog__c(WorkItemLookup__c = wi1.Id, HoursLoggedNumber__c = 4,
-                WorkDateDate__c = Date.newInstance(2026, 2, 10), WorkDescriptionTxt__c = 'before', StatusPk__c = 'Approved'),
-            new WorkLog__c(WorkItemLookup__c = wi2.Id, HoursLoggedNumber__c = 5,
-                WorkDateDate__c = Date.newInstance(2026, 2, 15), WorkDescriptionTxt__c = 'before', StatusPk__c = 'Approved')
+            TestDataFactory.buildWorkLog(wi1.Id, 8, Date.newInstance(2026, 3, 10),
+                new Map<String, Object>{ 'WorkDescriptionTxt__c' => 'in', 'StatusPk__c' => 'Approved' }),
+            TestDataFactory.buildWorkLog(wi1.Id, 4, Date.newInstance(2026, 2, 10),
+                new Map<String, Object>{ 'WorkDescriptionTxt__c' => 'before', 'StatusPk__c' => 'Approved' }),
+            TestDataFactory.buildWorkLog(wi2.Id, 5, Date.newInstance(2026, 2, 15),
+                new Map<String, Object>{ 'WorkDescriptionTxt__c' => 'before', 'StatusPk__c' => 'Approved' })
         };
         DeliveryTriggerControl.enableAfterLogic();
 

--- a/force-app/main/default/classes/DeliveryStaleInvoiceCheckTest.cls
+++ b/force-app/main/default/classes/DeliveryStaleInvoiceCheckTest.cls
@@ -43,15 +43,18 @@ private class DeliveryStaleInvoiceCheckTest {
         );
         insert item;
 
+        // buildWorkLog auto-mints+caches the required WorkRequest__c master
+        // (RequestId__c) for the WI; a raw `new WorkLog__c` omits it and fails
+        // REQUIRED_FIELD_MISSING during package-version test runs.
         List<WorkLog__c> logs = new List<WorkLog__c>();
         Integer i = 0;
         for (Decimal h : hours) {
-            logs.add(new WorkLog__c(
-                WorkItemLookup__c = item.Id,
-                HoursLoggedNumber__c = h,
-                WorkDateDate__c = pStart.addDays(5 + i),
-                WorkDescriptionTxt__c = 'work',
-                StatusPk__c = 'Approved'
+            logs.add(TestDataFactory.buildWorkLog(
+                item.Id, h, pStart.addDays(5 + i),
+                new Map<String, Object>{
+                    'WorkDescriptionTxt__c' => 'work',
+                    'StatusPk__c' => 'Approved'
+                }
             ));
             i++;
         }
@@ -74,12 +77,12 @@ private class DeliveryStaleInvoiceCheckTest {
         // A late billable lands in-period AFTER the invoice froze.
         DeliveryTriggerControl.disableAfterLogic();
         WorkItem__c wi = [SELECT Id FROM WorkItem__c WHERE ClientNetworkEntityLookup__c = :client.Id LIMIT 1];
-        insert new WorkLog__c(
-            WorkItemLookup__c = wi.Id,
-            HoursLoggedNumber__c = 3,
-            WorkDateDate__c = pStart.addDays(20),
-            WorkDescriptionTxt__c = 'late entry',
-            StatusPk__c = 'Approved'
+        insert TestDataFactory.buildWorkLog(
+            wi.Id, 3, pStart.addDays(20),
+            new Map<String, Object>{
+                'WorkDescriptionTxt__c' => 'late entry',
+                'StatusPk__c' => 'Approved'
+            }
         );
         DeliveryTriggerControl.enableAfterLogic();
 


### PR DESCRIPTION
## The blocker
`upload-beta` (package version creation — runs the **full** Apex suite) has failed since the invoice tests landed (#936/#937, 6/24). Three test methods insert `WorkLog__c` via raw `new WorkLog__c(...)` **without `RequestId__c`**, which is a **required Master-Detail** to `WorkRequest__c`. They fail `REQUIRED_FIELD_MISSING` in the packaging org → **no promotable beta can be created.**

```
DeliveryInvoiceWorkItemScopeTest.testWorkItemsSectionIsPeriodScopedAndReconciles
DeliveryStaleInvoiceCheckTest.testPassesWhenInvoiceFullyBilled
DeliveryStaleInvoiceCheckTest.testWarnsWhenBillableLogsAfterGeneration
```

## Why CI missed it
feature-test runs only the `DH` ApexTestSuite (`run_tests test_suite_names: DH`). These new classes aren't in any suite, so they **never ran in PR CI** — only package creation runs the whole suite. A 2-day-old break went unnoticed.

## The fix
Route the three inserts through `TestDataFactory.buildWorkLog`, which auto-mints + caches the per-WI `WorkRequest__c` bridge and sets `RequestId__c` (the pattern every passing WorkLog test uses), preserving each test's field values via the overrides map.

## Validated on dh-parent
- `REQUIRED_FIELD_MISSING` is gone — all inserts succeed.
- Both `DeliveryStaleInvoiceCheckTest` methods **pass**.
- The third test only failed on dh-parent because it runs a **stale pre-F13** `DeliveryDocGenerationService`. F13 scopes the WORK ITEMS section by **in-period WorkLog hours** and ignores `WorkRequest`, so the bridge can't affect the assertion — it passes against current code.

## Note
This is the gate to promoting the F16 + Intake/Close-Outs + NG-0.207.1 bundle. Merging it triggers the `beta_create` that finally builds a promotable version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)