### PR TITLE
fix(dashboard): one canonical "active" definition across homepage tiles + reports

### DIFF
--- a/force-app/main/default/classes/DeliveryDashboardCardController.cls
+++ b/force-app/main/default/classes/DeliveryDashboardCardController.cls
@@ -8,11 +8,20 @@
 @SuppressWarnings('PMD.ApexDoc, PMD.AvoidGlobalModifier')
 global with sharing class DeliveryDashboardCardController {
 
-    /** @description Terminal stages excluded from active-scope card counts (CMT-driven cross-type union). */
+    /**
+     * @description Stages excluded from the canonical "active work item" scope used by
+     * every count tile on this controller. This is the EFFORT-terminal set —
+     * getAllTerminalStageValues() (Done, Cancelled, cross-type union) PLUS
+     * 'Deployed to Prod' — because a Deployed-to-Prod item carries no remaining
+     * delivery effort and belongs to the Close Outs tab, not the in-flight counts.
+     * Using the effort-terminal set here is the one decision that keeps the Exec
+     * activeWorkItems tile, System Pulse activeRequests, the What's-In-Flight phase
+     * buckets, and the In_Flight_Work_Items report all agreeing on one number.
+     */
     private static Set<String> terminalStages {
         get {
             if (terminalStages == null) {
-                terminalStages = DeliveryWorkflowConfigService.getAllTerminalStageValues();
+                terminalStages = DeliveryWorkflowConfigService.getAllEffortTerminalStageValues();
             }
             return terminalStages;
         }
@@ -50,12 +59,12 @@ global with sharing class DeliveryDashboardCardController {
             when 'activeWorkItems' {
                 // Canonical "active" definition, shared with System Pulse
                 // (DeliveryHubDashboardController.getBudgetMetrics.activeRequests):
-                // activated + non-archived + non-template + NON-TERMINAL stage.
-                // Pre-fix this count was missing the terminal-stage exclusion, so
-                // Done/Cancelled items still counted as "Active" and the Exec
-                // Dashboard disagreed with System Pulse (155 vs 110 on live data).
-                Set<String> terminalStages =
-                    DeliveryWorkflowConfigService.getTerminalStageValues('Software_Delivery');
+                // activated + non-archived + non-template + NON-EFFORT-TERMINAL stage.
+                // Uses the class-level effort-terminal set (Done, Cancelled, AND
+                // Deployed to Prod) — so a shipped-but-unverified item no longer counts
+                // as in-flight. Pre-fix this used the plain Software_Delivery terminal
+                // set, which excluded only Done/Cancelled, so Deployed-to-Prod inflated
+                // the "Active" headline and disagreed with the In_Flight report.
                 return [
                     SELECT COUNT() FROM WorkItem__c
                     WHERE ActivatedDateTime__c != NULL
@@ -138,6 +147,13 @@ global with sharing class DeliveryDashboardCardController {
                 return data;
             }
             when 'workItemsByPhase' {
+                // What's-In-Flight stage breakdown. Computed over the SAME canonical
+                // active universe as activeWorkItems (activated + non-archived +
+                // non-template + non-effort-terminal) so the per-stage buckets SUM
+                // EXACTLY to the headline Active count. Because the effort-terminal set
+                // excludes Deployed to Prod, no Deployment bucket of shipped items
+                // appears here. No LIMIT — stage values are bounded by the workflow CMT,
+                // and a LIMIT would silently drop stages and break the sum invariant.
                 List<Map<String, Object>> data = new List<Map<String, Object>>();
                 for (AggregateResult ar : [
                     SELECT StageNamePk__c label, COUNT(Id) cnt
@@ -145,10 +161,10 @@ global with sharing class DeliveryDashboardCardController {
                     WHERE ActivatedDateTime__c != NULL
                     AND ArchivedDateTime__c = NULL
                     AND TemplateMarkedDateTime__c = NULL
+                    AND StageNamePk__c NOT IN :terminalStages
                     WITH SYSTEM_MODE
                     GROUP BY StageNamePk__c
                     ORDER BY COUNT(Id) DESC
-                    LIMIT 10
                 ]) {
                     data.add(new Map<String, Object>{
                         'label' => ar.get('label'),

--- a/force-app/main/default/classes/DeliveryDashboardCardControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryDashboardCardControllerTest.cls
@@ -206,6 +206,57 @@ private class DeliveryDashboardCardControllerTest {
     }
 
     /**
+     * @description The discriminating test for the effort-terminal switch: an active
+     *              Deployed-to-Prod item must NOT count as active (it is shipped,
+     *              awaiting verification — Close Outs, not in-flight) and must NOT
+     *              appear in any What's-In-Flight stage bucket. Also proves the
+     *              invariant the whole fix exists to guarantee: the per-stage buckets
+     *              SUM EXACTLY to the headline activeWorkItems count.
+     */
+    @IsTest
+    static void testActiveExcludesDeployedAndPhaseBucketsSum() {
+        // Counted as ACTIVE: activated, non-archived, non-template, non-effort-terminal.
+        TestDataFactory.createWorkItem(new Map<String, Object>{ 'StageNamePk__c' => 'In Development' });
+        TestDataFactory.createWorkItem(new Map<String, Object>{ 'StageNamePk__c' => 'In Development' });
+        TestDataFactory.createWorkItem(new Map<String, Object>{ 'StageNamePk__c' => 'Ready for Tech Review' });
+        // Excluded — Deployed to Prod is EFFORT-terminal (shipped, awaiting verification).
+        TestDataFactory.createWorkItem(new Map<String, Object>{ 'StageNamePk__c' => 'Deployed to Prod' });
+        // Excluded — Done is terminal.
+        TestDataFactory.createWorkItem(new Map<String, Object>{ 'StageNamePk__c' => 'Done' });
+        // Excluded — archived.
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'In Development', 'ArchivedDateTime__c' => Datetime.now() });
+        // Excluded — template.
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'In Development', 'TemplateMarkedDateTime__c' => Datetime.now() });
+        // Excluded — unactivated (createWorkItem bypasses the auto-stamp trigger).
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'Backlog', 'ActivatedDateTime__c' => null });
+
+        Test.startTest();
+        Integer active = (Integer) DeliveryDashboardCardController.getCardData('activeWorkItems', null);
+        List<Object> phases = (List<Object>) DeliveryDashboardCardController.getCardData('workItemsByPhase', null);
+        Test.stopTest();
+
+        System.assertEquals(3, active,
+            'Active = 2 In Development + 1 Ready for Tech Review; excludes Deployed-to-Prod, Done, '
+            + 'archived, template, and unactivated rows');
+
+        Integer bucketSum = 0;
+        for (Object o : phases) {
+            Map<String, Object> bucket = (Map<String, Object>) o;
+            String label = (String) bucket.get('label');
+            System.assertNotEquals('Deployed to Prod', label,
+                'Deployed to Prod must not surface as an in-flight stage bucket');
+            System.assertNotEquals('Done', label,
+                'Done must not surface as an in-flight stage bucket');
+            bucketSum += (Integer) bucket.get('value');
+        }
+        System.assertEquals(active, bucketSum,
+            'Per-stage What\'s-In-Flight buckets must sum EXACTLY to the active headline count');
+    }
+
+    /**
      * @description Regression guard for the hoursThisMonth work-date fix: the card
      *              must sum by WorkDateDate__c (when the work happened) with a
      *              CreatedDate fallback only for rows where the work date is null —

--- a/force-app/main/default/classes/DeliveryHubDashboardController.cls
+++ b/force-app/main/default/classes/DeliveryHubDashboardController.cls
@@ -327,13 +327,22 @@ global with sharing class DeliveryHubDashboardController {
 
         // The What's-In-Flight tile is meant to show items that are CURRENTLY being
         // worked on. Computed over the SAME canonical active universe as activeRequests
-        // (activated + non-template + non-archived + non-EFFORT-terminal) so the
-        // per-phase counts SUM EXACTLY to the headline Active number. The effort-terminal
-        // set excludes Deployed to Prod, so the Deployment bucket reflects only pre-deploy
-        // work (Ready for Deployment / Deploying) — shipped items live in Close Outs, not
-        // in-flight. Pre-fix the SOQL only excluded the plain terminal stages and included
-        // unactivated/backlog, template, archived, AND Deployed-to-Prod items, which made
-        // the per-phase counts diverge from every other "active items" metric.
+        // (activated + non-template + non-archived + non-EFFORT-terminal). The effort-
+        // terminal set excludes Deployed to Prod, so the Deployment bucket reflects only
+        // pre-deploy work (Ready for Deployment / Deploying) — shipped items live in
+        // Close Outs, not in-flight. Pre-fix the SOQL only excluded the plain terminal
+        // stages and included unactivated/backlog, template, archived, AND Deployed-to-
+        // Prod items, which made the per-phase counts diverge from every other metric.
+        //
+        // CAVEAT (known gap, same root cause as the Approval bucket): these buckets sum
+        // to the active headline ONLY for stages that getStagePhaseMap maps to a phase
+        // (i.e. present in the Software_Delivery board CMT). Live StageNamePk values that
+        // are NOT in the CMT — notably "Ready for Final Approval" / "Final Approving",
+        // the real approval-queue stages the approval service writes — map to null and
+        // are dropped here while still counting in activeRequests, so the client phase
+        // card under-sums by the count of items in those unmapped stages. Closing this
+        // requires the CMT-vs-picklist remediation flagged in WorkItems_Approval, not a
+        // change here. (The Exec Items-by-Stage card groups by raw stage and always sums.)
         for (AggregateResult ar : [
             SELECT StageNamePk__c stage, Count(Id) cnt
             FROM WorkItem__c

--- a/force-app/main/default/classes/DeliveryHubDashboardController.cls
+++ b/force-app/main/default/classes/DeliveryHubDashboardController.cls
@@ -36,11 +36,14 @@ global with sharing class DeliveryHubDashboardController {
     global static Map<String, Object> getBudgetMetrics() {
         Map<String, Object> metrics = new Map<String, Object>();
 
-        // 1. Work Item Metrics (Active Count) — use CMT terminal stages so no hardcoded 'Closed'.
-        // Also requires the standard active-item filter set so this metric reconciles with
-        // every other dashboard count: must be activated, must not be a template, must not
-        // be archived. Pre-fix this query was missing the activated + archived checks.
-        Set<String> terminalStages = DeliveryWorkflowConfigService.getTerminalStageValues('Software_Delivery');
+        // 1. Work Item Metrics (Active Count) — use the canonical EFFORT-terminal set
+        // (Done, Cancelled, AND Deployed to Prod) so this number is identical to the
+        // Exec Dashboard's activeWorkItems tile and the In_Flight_Work_Items report.
+        // Requires the full active-item filter set so the metric reconciles with every
+        // other dashboard count: activated + non-template + non-archived + non-effort-
+        // terminal. Pre-fix this used the plain Software_Delivery terminal set, which
+        // excluded only Done/Cancelled, so Deployed-to-Prod counted as active here.
+        Set<String> terminalStages = DeliveryWorkflowConfigService.getAllEffortTerminalStageValues();
         AggregateResult[] workItemStats = [
             SELECT Count(Id) total
             FROM WorkItem__c
@@ -316,18 +319,21 @@ global with sharing class DeliveryHubDashboardController {
 
     private static List<PhaseItem> fetchPhaseList(String workflowType) {
         Map<String, String> stageToPhase = DeliveryWorkflowConfigService.getStagePhaseMap(workflowType);
-        Set<String> terminalStages = DeliveryWorkflowConfigService.getTerminalStageValues(workflowType);
+        Set<String> terminalStages = DeliveryWorkflowConfigService.getAllEffortTerminalStageValues();
         Map<String, Integer> phaseCounts = new Map<String, Integer>{
             'Planning' => 0, 'Approval' => 0, 'Development' => 0,
             'Testing' => 0, 'UAT' => 0, 'Deployment' => 0
         };
 
         // The What's-In-Flight tile is meant to show items that are CURRENTLY being
-        // worked on. Pre-fix the SOQL only excluded terminal stages — it included
-        // unactivated/backlog items, recurring-item templates, and archived items,
-        // which made the per-phase counts diverge from every other "active items"
-        // metric on the dashboard. Adding the standard active-item filters here so
-        // the breakdown reconciles with activeRequests, hoursThisMonth scoping, etc.
+        // worked on. Computed over the SAME canonical active universe as activeRequests
+        // (activated + non-template + non-archived + non-EFFORT-terminal) so the
+        // per-phase counts SUM EXACTLY to the headline Active number. The effort-terminal
+        // set excludes Deployed to Prod, so the Deployment bucket reflects only pre-deploy
+        // work (Ready for Deployment / Deploying) — shipped items live in Close Outs, not
+        // in-flight. Pre-fix the SOQL only excluded the plain terminal stages and included
+        // unactivated/backlog, template, archived, AND Deployed-to-Prod items, which made
+        // the per-phase counts diverge from every other "active items" metric.
         for (AggregateResult ar : [
             SELECT StageNamePk__c stage, Count(Id) cnt
             FROM WorkItem__c
@@ -472,7 +478,15 @@ global with sharing class DeliveryHubDashboardController {
         Datetime startDt = Datetime.newInstance(startDate, Time.newInstance(0, 0, 0, 0));
         Datetime endDt = endDate != null ? Datetime.newInstance(endDate, Time.newInstance(0, 0, 0, 0)) : null;
 
+        // Plain-terminal set (Done, Cancelled) for the "completed" metric — a
+        // Deployed-to-Prod item is awaiting verification, NOT completed, so it must
+        // not count as done here.
         Set<String> terminalStages = DeliveryWorkflowConfigService.getTerminalStageValues(workflowType);
+        // Effort-terminal set (Done, Cancelled, Deployed to Prod) for the active
+        // "In Progress" (moved) count so it reconciles with the canonical activeRequests
+        // headline and the What's-In-Flight phase buckets — all of which exclude
+        // Deployed-to-Prod from "active".
+        Set<String> effortTerminalStages = DeliveryWorkflowConfigService.getAllEffortTerminalStageValues();
 
         // Items completed in range — exclude templates so the count reflects real work.
         Integer completed;
@@ -498,10 +512,11 @@ global with sharing class DeliveryHubDashboardController {
 
         // Items modified (stage changed) in range — surfaced as the "In Progress"
         // tile. Requires the full canonical active-item filter set (activated +
-        // non-template + non-archived + non-terminal) so this count reconciles
+        // non-template + non-archived + non-EFFORT-terminal) so this count reconciles
         // with System Pulse's activeRequests and the What's-In-Flight phase
-        // tiles. Pre-fix the ActivatedDateTime__c check was missing, so
-        // unactivated backlog items modified in the window inflated the number.
+        // tiles. Pre-fix the ActivatedDateTime__c check was missing AND it used the
+        // plain terminal set, so unactivated backlog items and Deployed-to-Prod items
+        // modified in the window inflated the number above the active headline.
         Integer moved;
         if (endDt != null) {
             moved = [
@@ -509,7 +524,7 @@ global with sharing class DeliveryHubDashboardController {
                 FROM WorkItem__c
                 WHERE LastModifiedDate >= :startDt
                 AND LastModifiedDate < :endDt
-                AND StageNamePk__c NOT IN :terminalStages
+                AND StageNamePk__c NOT IN :effortTerminalStages
                 AND ActivatedDateTime__c != null
                 AND TemplateMarkedDateTime__c = null
                 AND ArchivedDateTime__c = null
@@ -519,7 +534,7 @@ global with sharing class DeliveryHubDashboardController {
                 SELECT COUNT()
                 FROM WorkItem__c
                 WHERE LastModifiedDate >= :startDt
-                AND StageNamePk__c NOT IN :terminalStages
+                AND StageNamePk__c NOT IN :effortTerminalStages
                 AND ActivatedDateTime__c != null
                 AND TemplateMarkedDateTime__c = null
                 AND ArchivedDateTime__c = null
@@ -546,18 +561,23 @@ global with sharing class DeliveryHubDashboardController {
         Decimal hours = hoursAgg[0].get('total') != null ? (Decimal)hoursAgg[0].get('total') : 0;
         metrics.put('hoursLogged', hours);
 
-        // Currently blocked items (not time-bounded — always current state)
-        Set<Id> blockedIds = new Set<Id>();
-        for (WorkItemDependency__c dep : [
-            SELECT BlockedWorkItemLookup__c
-            FROM WorkItemDependency__c
-            WHERE BlockingWorkItemLookup__c IN (
-                SELECT Id FROM WorkItem__c WHERE StageNamePk__c NOT IN :terminalStages
-            )
-        ]) {
-            blockedIds.add(dep.BlockedWorkItemLookup__c);
-        }
-        metrics.put('blocked', blockedIds.size());
+        // Currently blocked items (not time-bounded — always current state).
+        // DEFINITION FIX: this tile previously counted the dependency graph (items
+        // blocked by a non-terminal blocker) but its drill-through links to the
+        // Blocked_Work_Items report, which is a STAGE-based "stage contains Blocked"
+        // population — two different sets, so tile and report never matched. Aligned
+        // here to the report's definition: stage contains 'Blocked' + the canonical
+        // active guards (activated, non-archived, non-template). Now tile == report,
+        // and it also matches the Exec Dashboard's blockedItems tile.
+        Integer blocked = [
+            SELECT COUNT()
+            FROM WorkItem__c
+            WHERE StageNamePk__c LIKE '%Blocked%'
+            AND ActivatedDateTime__c != null
+            AND ArchivedDateTime__c = null
+            AND TemplateMarkedDateTime__c = null
+        ];
+        metrics.put('blocked', blocked);
 
         return metrics;
     }

--- a/force-app/main/default/classes/DeliveryHubDashboardControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHubDashboardControllerTest.cls
@@ -329,6 +329,10 @@ private class DeliveryHubDashboardControllerTest {
      *              from the Deployment bucket and (b) sum EXACTLY to the active headline.
      *              Also proves the phase mapping: an "In Client Approval" item lands in
      *              the Approval bucket (getStagePhaseMap contract the bucket reports rely on).
+     *              NOTE: the bucket-sum invariant proven here holds for stages that ARE in
+     *              the board CMT. Live stages absent from the CMT (e.g. "Ready for Final
+     *              Approval") map to null and under-sum — the documented Approval-bucket
+     *              gap whose fix is the separate CMT-vs-picklist remediation, not this PR.
      */
     @IsTest
     static void testPhaseBucketsExcludeDeployedAndSumToActiveWithApprovalMapping() {

--- a/force-app/main/default/classes/DeliveryHubDashboardControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHubDashboardControllerTest.cls
@@ -299,6 +299,110 @@ private class DeliveryHubDashboardControllerTest {
         }
     }
 
+    /**
+     * @description Canonical-definition guard for System Pulse: activeRequests must use
+     *              the EFFORT-terminal set, so a Deployed-to-Prod item (shipped, awaiting
+     *              verification) does NOT count as active — making this number identical
+     *              to the Exec Dashboard's activeWorkItems tile and the In_Flight report.
+     */
+    @IsTest
+    static void testActiveRequestsExcludesDeployedToProd() {
+        System.runAs(testUser) {
+            TestDataFactory.createWorkItem(new Map<String, Object>{ 'StageNamePk__c' => 'In Development' });
+            TestDataFactory.createWorkItem(new Map<String, Object>{ 'StageNamePk__c' => 'In Development' });
+            // Deployed to Prod — effort-terminal, must NOT count as active.
+            TestDataFactory.createWorkItem(new Map<String, Object>{ 'StageNamePk__c' => 'Deployed to Prod' });
+            // Done — terminal, must NOT count.
+            TestDataFactory.createWorkItem(new Map<String, Object>{ 'StageNamePk__c' => 'Done' });
+
+            Test.startTest();
+            Map<String, Object> metrics = DeliveryHubDashboardController.getBudgetMetrics();
+            Test.stopTest();
+
+            System.assertEquals(2, (Decimal) metrics.get('activeRequests'),
+                'activeRequests must exclude Deployed-to-Prod and Done — only the 2 In Development items are active');
+        }
+    }
+
+    /**
+     * @description The What's-In-Flight phase buckets must (a) exclude Deployed-to-Prod
+     *              from the Deployment bucket and (b) sum EXACTLY to the active headline.
+     *              Also proves the phase mapping: an "In Client Approval" item lands in
+     *              the Approval bucket (getStagePhaseMap contract the bucket reports rely on).
+     */
+    @IsTest
+    static void testPhaseBucketsExcludeDeployedAndSumToActiveWithApprovalMapping() {
+        System.runAs(testUser) {
+            TestDataFactory.createWorkItem(new Map<String, Object>{ 'StageNamePk__c' => 'In Development' });
+            TestDataFactory.createWorkItem(new Map<String, Object>{ 'StageNamePk__c' => 'Ready for Merge' }); // Deployment phase
+            TestDataFactory.createWorkItem(new Map<String, Object>{ 'StageNamePk__c' => 'In Client Approval' }); // Approval phase
+            // Deployed to Prod — effort-terminal: must NOT appear in the Deployment bucket.
+            TestDataFactory.createWorkItem(new Map<String, Object>{ 'StageNamePk__c' => 'Deployed to Prod' });
+
+            Test.startTest();
+            Map<String, Object> result = DeliveryHubDashboardController.getClientDashboard('thisWeek', 'Software_Delivery');
+            Map<String, Object> metrics = DeliveryHubDashboardController.getBudgetMetrics();
+            Test.stopTest();
+
+            List<DeliveryHubDashboardController.PhaseItem> phases =
+                (List<DeliveryHubDashboardController.PhaseItem>) result.get('phases');
+            Integer total = 0;
+            Integer approvalCount = 0;
+            Integer deploymentCount = 0;
+            for (DeliveryHubDashboardController.PhaseItem p : phases) {
+                Integer c = (p.count != null ? p.count : 0);
+                total += c;
+                if (p.label == 'Approval') { approvalCount = c; }
+                if (p.label == 'Deployment') { deploymentCount = c; }
+            }
+
+            System.assertEquals(3, total,
+                'Phase buckets must sum to the 3 active items (Deployed-to-Prod excluded)');
+            System.assertEquals(3, (Decimal) metrics.get('activeRequests'),
+                'activeRequests headline must equal the phase-bucket sum');
+            System.assertEquals(1, approvalCount,
+                'In Client Approval must bucket into the Approval phase (getStagePhaseMap contract)');
+            System.assertEquals(1, deploymentCount,
+                'Deployment bucket = the 1 Ready for Merge item; Deployed-to-Prod must be excluded');
+        }
+    }
+
+    /**
+     * @description Definition-bug fix: the client-dashboard "Blocked" tile must use the
+     *              SAME stage-based definition as the Blocked_Work_Items report it links to
+     *              (StageNamePk contains 'Blocked' + canonical guards) — NOT the dependency
+     *              graph it used before. A dependency-blocked item in a non-Blocked stage
+     *              must no longer count; a Blocked-stage item must.
+     */
+    @IsTest
+    static void testClientBlockedTileUsesStageDefinitionNotDependencyGraph() {
+        System.runAs(testUser) {
+            WorkItem__c blockedStage = TestDataFactory.createWorkItem(
+                new Map<String, Object>{ 'StageNamePk__c' => 'Dev Blocked' });
+            WorkItem__c blocker = TestDataFactory.createWorkItem(
+                new Map<String, Object>{ 'StageNamePk__c' => 'In Development' });
+            WorkItem__c depBlocked = TestDataFactory.createWorkItem(
+                new Map<String, Object>{ 'StageNamePk__c' => 'In Development' });
+            // depBlocked is graph-blocked by an active blocker but its STAGE is not Blocked.
+            // Under the old dependency-graph definition it counted; under the report-aligned
+            // stage definition it must NOT.
+            insert new WorkItemDependency__c(
+                BlockingWorkItemLookup__c = blocker.Id,
+                BlockedWorkItemLookup__c = depBlocked.Id,
+                TypePk__c = 'Blocks'
+            );
+
+            Test.startTest();
+            Map<String, Object> result = DeliveryHubDashboardController.getClientDashboard('thisWeek', 'Software_Delivery');
+            Test.stopTest();
+
+            Map<String, Object> thisWeek = (Map<String, Object>) result.get('thisWeek');
+            System.assertEquals(1, (Integer) thisWeek.get('blocked'),
+                'blocked must count only the Dev Blocked stage item (matching Blocked_Work_Items report), '
+                + 'not the dependency-graph-blocked item in a non-Blocked stage');
+        }
+    }
+
     @IsTest
     static void testGetClientDashboard() {
         System.runAs(testUser) {

--- a/force-app/main/default/reports/DeliveryHubPipeline/WorkItems_Approval.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubPipeline/WorkItems_Approval.report-meta.xml
@@ -24,7 +24,7 @@
     <columns>
         <field>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageEnteredDateTime__c</field>
     </columns>
-    <description>Active work items in the Approval phase: Ready for Tech Review, Tech Reviewing, Ready for Final Approval, Final Approving — the live StageNamePk values the approval service writes. NOTE: this report does NOT yet tie to the Approval phase TILE, because the Software_Delivery board CMT maps phase=Approval to stale stage names (Ready for Client Approval / In Client Approval) that no longer match these live picklist values. That CMT-vs-picklist drift is the root cause of the Approval bucket reading near-empty while items are pending, and is a separate workflow-config remediation (touches persona views, escalation rules, transitions). This report reflects the real pending-approval population.</description>
+    <description>Active work items in the Approval phase: Ready for Tech Review, Tech Reviewing, Ready for Final Approval, Final Approving. Reflects the real pending-approval population (the live stages the approval service writes).</description>
     <filter>
         <booleanFilter>1 AND 2 AND 3 AND 4</booleanFilter>
         <criteriaItems>

--- a/force-app/main/default/reports/DeliveryHubPipeline/WorkItems_Approval.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubPipeline/WorkItems_Approval.report-meta.xml
@@ -24,14 +24,36 @@
     <columns>
         <field>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageEnteredDateTime__c</field>
     </columns>
-    <description>Work items in the Approval phase: Tech Review through Final Approval.</description>
+    <description>Active work items in the Approval phase: Ready for Tech Review, Tech Reviewing, Ready for Final Approval, Final Approving — the live StageNamePk values the approval service writes. NOTE: this report does NOT yet tie to the Approval phase TILE, because the Software_Delivery board CMT maps phase=Approval to stale stage names (Ready for Client Approval / In Client Approval) that no longer match these live picklist values. That CMT-vs-picklist drift is the root cause of the Approval bucket reading near-empty while items are pending, and is a separate workflow-config remediation (touches persona views, escalation rules, transitions). This report reflects the real pending-approval population.</description>
     <filter>
+        <booleanFilter>1 AND 2 AND 3 AND 4</booleanFilter>
         <criteriaItems>
             <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageNamePk__c</column>
             <columnToColumn>false</columnToColumn>
             <isUnlocked>true</isUnlocked>
             <operator>equals</operator>
             <value>Ready for Tech Review,Tech Reviewing,Ready for Final Approval,Final Approving</value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ActivatedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>notEqual</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ArchivedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%TemplateMarkedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
         </criteriaItems>
     </filter>
     <format>Tabular</format>

--- a/force-app/main/default/reports/DeliveryHubPipeline/WorkItems_Deployment.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubPipeline/WorkItems_Deployment.report-meta.xml
@@ -21,14 +21,36 @@
     <columns>
         <field>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageEnteredDateTime__c</field>
     </columns>
-    <description>Work items in the Deployment phase: Merge through Deployed to Prod.</description>
+    <description>Active work items in the pre-deploy Deployment phase: Ready for Merge through Deploying. Excludes Deployed to Prod (effort-terminal, lives in Close Outs) so this matches the Deployment phase tile and the buckets sum to the Active count.</description>
     <filter>
+        <booleanFilter>1 AND 2 AND 3 AND 4</booleanFilter>
         <criteriaItems>
             <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageNamePk__c</column>
             <columnToColumn>false</columnToColumn>
             <isUnlocked>true</isUnlocked>
             <operator>equals</operator>
-            <value>Ready for Merge,Merging,Ready for Deployment,Deploying,Deployed to Prod</value>
+            <value>Ready for Merge,Merging,Ready for Deployment,Deploying</value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ActivatedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>notEqual</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ArchivedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%TemplateMarkedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
         </criteriaItems>
     </filter>
     <format>Tabular</format>

--- a/force-app/main/default/reports/DeliveryHubPipeline/WorkItems_Development.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubPipeline/WorkItems_Development.report-meta.xml
@@ -32,12 +32,34 @@
     </columns>
     <description>Work items in the Development phase: Ready for Development through Dev Blocked.</description>
     <filter>
+        <booleanFilter>1 AND 2 AND 3 AND 4</booleanFilter>
         <criteriaItems>
             <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageNamePk__c</column>
             <columnToColumn>false</columnToColumn>
             <isUnlocked>true</isUnlocked>
             <operator>equals</operator>
             <value>Ready for Development,In Development,Dev Clarification Requested,Providing Dev Clarification,Dev Blocked,Back For Development</value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ActivatedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>notEqual</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ArchivedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%TemplateMarkedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
         </criteriaItems>
     </filter>
     <format>Tabular</format>

--- a/force-app/main/default/reports/DeliveryHubPipeline/WorkItems_Planning.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubPipeline/WorkItems_Planning.report-meta.xml
@@ -26,12 +26,34 @@
     </columns>
     <description>Work items in the Planning phase: Backlog through Drafting Proposal.</description>
     <filter>
+        <booleanFilter>1 AND 2 AND 3 AND 4</booleanFilter>
         <criteriaItems>
             <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageNamePk__c</column>
             <columnToColumn>false</columnToColumn>
             <isUnlocked>true</isUnlocked>
             <operator>equals</operator>
             <value>Backlog,Scoping In Progress,Clarification Requested (Pre-Dev),Providing Clarification,Ready for Sizing,Sizing Underway,Ready for Prioritization,Prioritizing,Proposal Requested,Drafting Proposal</value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ActivatedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>notEqual</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ArchivedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%TemplateMarkedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
         </criteriaItems>
     </filter>
     <format>Tabular</format>

--- a/force-app/main/default/reports/DeliveryHubPipeline/WorkItems_Testing.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubPipeline/WorkItems_Testing.report-meta.xml
@@ -26,12 +26,34 @@
     </columns>
     <description>Work items in the Testing phase: Scratch Test through Internal UAT.</description>
     <filter>
+        <booleanFilter>1 AND 2 AND 3 AND 4</booleanFilter>
         <criteriaItems>
             <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageNamePk__c</column>
             <columnToColumn>false</columnToColumn>
             <isUnlocked>true</isUnlocked>
             <operator>equals</operator>
             <value>Ready for Scratch Test,Scratch Testing,Ready for QA,QA In Progress,Ready for Internal UAT,Internal UAT</value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ActivatedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>notEqual</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ArchivedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%TemplateMarkedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
         </criteriaItems>
     </filter>
     <format>Tabular</format>

--- a/force-app/main/default/reports/DeliveryHubPipeline/WorkItems_UAT.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubPipeline/WorkItems_UAT.report-meta.xml
@@ -23,12 +23,34 @@
     </columns>
     <description>Work items in the UAT phase: Client UAT through Sign-off.</description>
     <filter>
+        <booleanFilter>1 AND 2 AND 3 AND 4</booleanFilter>
         <criteriaItems>
             <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageNamePk__c</column>
             <columnToColumn>false</columnToColumn>
             <isUnlocked>true</isUnlocked>
             <operator>equals</operator>
             <value>Ready for Client UAT,In Client UAT,Ready for UAT Sign-off,Processing Sign-off</value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ActivatedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>notEqual</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ArchivedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%TemplateMarkedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
         </criteriaItems>
     </filter>
     <format>Tabular</format>

--- a/force-app/main/default/reports/DeliveryHubVendor/Blocked_Work_Items.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubVendor/Blocked_Work_Items.report-meta.xml
@@ -23,12 +23,34 @@
     </columns>
     <description>Work items currently in a Blocked stage. Use to triage and unblock stalled work.</description>
     <filter>
+        <booleanFilter>1 AND 2 AND 3 AND 4</booleanFilter>
         <criteriaItems>
             <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageNamePk__c</column>
             <columnToColumn>false</columnToColumn>
             <isUnlocked>true</isUnlocked>
             <operator>contains</operator>
             <value>Blocked</value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ActivatedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>notEqual</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ArchivedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%TemplateMarkedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
         </criteriaItems>
     </filter>
     <format>Tabular</format>

--- a/force-app/main/default/reports/DeliveryHubVendor/Failed_Items.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubVendor/Failed_Items.report-meta.xml
@@ -20,12 +20,20 @@
     </columns>
     <description>Failed sync items with error details. Click from "Failed" count on System Pulse.</description>
     <filter>
+        <booleanFilter>1 AND 2</booleanFilter>
         <criteriaItems>
             <column>%%%NAMESPACE%%%SyncItem__c$%%%NAMESPACE%%%StatusPk__c</column>
             <columnToColumn>false</columnToColumn>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>Failed</value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%SyncItem__c$%%%NAMESPACE%%%DismissedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>false</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
         </criteriaItems>
     </filter>
     <format>Summary</format>

--- a/force-app/main/default/reports/DeliveryHubVendor/In_Flight_Work_Items.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubVendor/In_Flight_Work_Items.report-meta.xml
@@ -27,9 +27,9 @@
     <columns>
         <field>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%CalculatedETADate__c</field>
     </columns>
-    <description>Active work items in non-terminal stages, modified this month. Matches the In Progress metric tile on the client dashboard.</description>
+    <description>Active work items: activated, not archived, not a template, and in a non-effort-terminal stage (excludes Done, Cancelled, and Deployed to Prod). Matches the Active Work Items count tile exactly — the canonical "active work item" definition. No date bound: the tile counts all active items, so the report must too.</description>
     <filter>
-        <booleanFilter>1 AND 2 AND 3</booleanFilter>
+        <booleanFilter>1 AND 2 AND 3 AND 4 AND 5 AND 6</booleanFilter>
         <criteriaItems>
             <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageNamePk__c</column>
             <columnToColumn>false</columnToColumn>
@@ -45,11 +45,32 @@
             <value>Cancelled</value>
         </criteriaItems>
         <criteriaItems>
-            <column>CUST_LAST_UPDATE</column>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageNamePk__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>notEqual</operator>
+            <value>Deployed to Prod</value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ActivatedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>notEqual</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ArchivedDateTime__c</column>
             <columnToColumn>false</columnToColumn>
             <isUnlocked>true</isUnlocked>
             <operator>equals</operator>
-            <value>THIS_MONTH</value>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%TemplateMarkedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
         </criteriaItems>
     </filter>
     <format>Tabular</format>

--- a/force-app/main/default/reports/DeliveryHubVendor/In_Flight_Work_Items.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubVendor/In_Flight_Work_Items.report-meta.xml
@@ -27,7 +27,7 @@
     <columns>
         <field>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%CalculatedETADate__c</field>
     </columns>
-    <description>Active work items: activated, not archived, not a template, and in a non-effort-terminal stage (excludes Done, Cancelled, and Deployed to Prod). Matches the Active Work Items count tile exactly — the canonical "active work item" definition. No date bound: the tile counts all active items, so the report must too.</description>
+    <description>Active work items: activated, not archived, not a template, non-effort-terminal (excludes Done, Cancelled, Deployed to Prod). Matches the Active Work Items tile exactly; no date bound so the tile and report agree.</description>
     <filter>
         <booleanFilter>1 AND 2 AND 3 AND 4 AND 5 AND 6</booleanFilter>
         <criteriaItems>

--- a/force-app/main/default/reports/DeliveryHubVendor/Recently_Completed.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubVendor/Recently_Completed.report-meta.xml
@@ -24,7 +24,7 @@
     <columns>
         <field>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%HoursVarianceNumber__c</field>
     </columns>
-    <description>Work items completed (Done stage), modified THIS MONTH. Intentionally broader than the "Completed (This Week)" tile, which counts only the current week — so this month report total is expected to be larger than the week tile. (Prior description wrongly claimed it matched the tile.)</description>
+    <description>Work items completed (Done), modified THIS MONTH. Broader than the Completed (This Week) tile, which counts only the current week, so this total is expected to exceed the week tile.</description>
     <filter>
         <booleanFilter>1 AND 2 AND 3</booleanFilter>
         <criteriaItems>

--- a/force-app/main/default/reports/DeliveryHubVendor/Recently_Completed.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubVendor/Recently_Completed.report-meta.xml
@@ -24,9 +24,9 @@
     <columns>
         <field>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%HoursVarianceNumber__c</field>
     </columns>
-    <description>Work items completed (Done stage) and modified this month. Matches the Completed metric tile on the client dashboard.</description>
+    <description>Work items completed (Done stage), modified THIS MONTH. Intentionally broader than the "Completed (This Week)" tile, which counts only the current week — so this month report total is expected to be larger than the week tile. (Prior description wrongly claimed it matched the tile.)</description>
     <filter>
-        <booleanFilter>1 AND 2</booleanFilter>
+        <booleanFilter>1 AND 2 AND 3</booleanFilter>
         <criteriaItems>
             <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageNamePk__c</column>
             <columnToColumn>false</columnToColumn>
@@ -40,6 +40,13 @@
             <isUnlocked>true</isUnlocked>
             <operator>equals</operator>
             <value>THIS_MONTH</value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%TemplateMarkedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
         </criteriaItems>
     </filter>
     <format>Tabular</format>

--- a/force-app/main/default/reports/DeliveryHubVendor/Synced_Items.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubVendor/Synced_Items.report-meta.xml
@@ -14,12 +14,20 @@
     </columns>
     <description>Successfully synced items. Click from "Synced" count on System Pulse.</description>
     <filter>
+        <booleanFilter>1 AND 2</booleanFilter>
         <criteriaItems>
             <column>%%%NAMESPACE%%%SyncItem__c$%%%NAMESPACE%%%StatusPk__c</column>
             <columnToColumn>false</columnToColumn>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>Synced</value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%SyncItem__c$%%%NAMESPACE%%%DismissedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>false</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
         </criteriaItems>
     </filter>
     <format>Summary</format>

--- a/force-app/main/default/reports/DeliveryHubVendor/Work_Item_Pipeline.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubVendor/Work_Item_Pipeline.report-meta.xml
@@ -12,7 +12,7 @@
     <columns>
         <field>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ClientNetworkEntityLookup__c</field>
     </columns>
-    <description>Count of ACTIVE work items at each stage of the delivery pipeline (activated, not archived, not a template, non-effort-terminal — excludes Done, Cancelled, Deployed to Prod). The per-stage counts sum to the Active Work Items tile and back the Items by Stage card. Use to monitor flow and identify bottlenecks.</description>
+    <description>Count of ACTIVE work items per pipeline stage (activated, not archived, not a template, non-effort-terminal; excludes Done, Cancelled, Deployed to Prod). Per-stage counts sum to the Active Work Items tile and back the Items by Stage card.</description>
     <filter>
         <booleanFilter>1 AND 2 AND 3 AND 4 AND 5 AND 6</booleanFilter>
         <criteriaItems>

--- a/force-app/main/default/reports/DeliveryHubVendor/Work_Item_Pipeline.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubVendor/Work_Item_Pipeline.report-meta.xml
@@ -12,7 +12,52 @@
     <columns>
         <field>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ClientNetworkEntityLookup__c</field>
     </columns>
-    <description>Count of work items at each stage of the delivery pipeline. Use to monitor flow and identify bottlenecks.</description>
+    <description>Count of ACTIVE work items at each stage of the delivery pipeline (activated, not archived, not a template, non-effort-terminal — excludes Done, Cancelled, Deployed to Prod). The per-stage counts sum to the Active Work Items tile and back the Items by Stage card. Use to monitor flow and identify bottlenecks.</description>
+    <filter>
+        <booleanFilter>1 AND 2 AND 3 AND 4 AND 5 AND 6</booleanFilter>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageNamePk__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>notEqual</operator>
+            <value>Done</value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageNamePk__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>notEqual</operator>
+            <value>Cancelled</value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%StageNamePk__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>notEqual</operator>
+            <value>Deployed to Prod</value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ActivatedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>notEqual</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%ArchivedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
+        </criteriaItems>
+        <criteriaItems>
+            <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%TemplateMarkedDateTime__c</column>
+            <columnToColumn>false</columnToColumn>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value></value>
+        </criteriaItems>
+    </filter>
     <format>Summary</format>
     <groupingsDown>
         <dateGranularity>Day</dateGranularity>


### PR DESCRIPTION
## Root cause
The 6/16 tile-hardening pass made the homepage count tiles use the **plain** terminal set (Done, Cancelled) for "active", so **Deployed-to-Prod silently counted as in-flight**. The reports those tiles link to were never aligned at all — and several never had the active guards in the first place. Result: tiles and reports drifted to different filters and showed different numbers (e.g. Active 109 vs its report 120).

## Canonical "active work item" (decided)
ALL of:
- `ActivatedDateTime__c != null`
- `ArchivedDateTime__c = null`
- `TemplateMarkedDateTime__c = null`
- `StageNamePk__c NOT IN DeliveryWorkflowConfigService.getAllEffortTerminalStageValues()` → **Done, Cancelled, Deployed to Prod**

Key decision: use the **EFFORT-terminal** set, not the plain terminal set, for "active". Deployed-to-Prod is shipped/awaiting-verification (Close Outs), not in-flight.

### Exact before/after — `activeWorkItems`
```
- terminalStages = getTerminalStageValues('Software_Delivery')   // Done, Cancelled
+ terminalStages = getAllEffortTerminalStageValues()             // Done, Cancelled, Deployed to Prod
  WHERE ActivatedDateTime__c != NULL AND ArchivedDateTime__c = NULL
    AND TemplateMarkedDateTime__c = NULL AND StageNamePk__c NOT IN :terminalStages
```

### Exact before/after — `In_Flight_Work_Items` report
- **Before:** `StageNamePk notEqual Done` AND `notEqual Cancelled` AND `LastModified = THIS_MONTH`
- **After:** `StageNamePk notEqual Done` AND `notEqual Cancelled` AND `notEqual Deployed to Prod` AND `ActivatedDateTime not-blank` AND `ArchivedDateTime blank` AND `TemplateMarkedDateTime blank` (THIS_MONTH removed — the tile has no date bound).

## Apex changes (count tiles)
- **DeliveryDashboardCardController** — class-level `terminalStages` getter now returns `getAllEffortTerminalStageValues()` (single source). `activeWorkItems` drops its local plain-terminal shadow. `workItemsByPhase` adds the effort-terminal exclusion **and removes `LIMIT 10`** so the per-stage buckets sum exactly to the headline. `overdueItems` / `projectHealthPills` ripple to effort-terminal via the getter (both active-scoped — correct).
- **DeliveryHubDashboardController.getBudgetMetrics** (`activeRequests` + last-activity) and **fetchPhaseList** switch to `getAllEffortTerminalStageValues()`; the **Deployment bucket no longer includes Deployed-to-Prod**. The "In Progress" (`moved`) tile also moves to effort-terminal; `completed` stays plain-terminal (Deployed is not "completed").
- **Client-dashboard "Blocked" tile — DEFINITION BUG fixed.** It counted the dependency graph (items blocked by a non-terminal blocker) but linked to a **stage-based** report — two different populations. Now uses `StageNamePk contains 'Blocked'` + canonical guards, so tile == `Blocked_Work_Items` report == Exec `blockedItems` tile.
- Hours metrics untouched (verified correct).

## Report changes (aligned to their tiles)
| Report | Change |
|---|---|
| In_Flight_Work_Items | + 3 guards, + `notEqual Deployed to Prod`, removed THIS_MONTH |
| Blocked_Work_Items | + 3 canonical guards (keeps stage contains Blocked) |
| Synced_Items / Failed_Items | + `DismissedDateTime = null` (tiles exclude dismissed) |
| Work_Item_Pipeline | + full canonical active filter (backs Items-by-Stage tile) |
| WorkItems_Planning / Development / Testing / UAT | + 3 canonical guards |
| WorkItems_Deployment | + guards, removed `Deployed to Prod` (matches tile) |
| Recently_Completed | left month-scoped (see below); fixed false "matches the tile" description; + Template guard |

Per-bucket tile→report routing confirmed via `DashboardCard__mdt.ClickThroughUrlTxt__c` (`report:DeveloperName`): Active→In_Flight, Blocked→Blocked_Work_Items, Items-by-Stage→Work_Item_Pipeline; the client phase tiles resolve WorkItems_* via `getReportIds`. UAT (already 1/1) is the proof the approach is right.

## Sum-to-headline scope (read this)
- **Exec "Items by Stage" card** (`workItemsByPhase`, groups by raw StageNamePk) — buckets **always sum** to the active headline. ✅
- **Client "What's In Flight" phase card** (`fetchPhaseList`, maps via board CMT) — buckets sum to the headline **only for stages present in the CMT**. Live stages NOT in the CMT (notably the real approval-queue stages "Ready for Final Approval" / "Final Approving") map to null and drop out while still counting in `activeRequests`, so this card **under-sums by the count of items in those unmapped stages**. Same root cause as the Approval bucket below; closed by the same CMT follow-up, not by this PR.

## Documented differences (intentionally NOT forced)
- **Completed (This Week) 6 vs 53** — the tile is week-scoped; `Recently_Completed` is month-scoped. This week-vs-month difference is intentional per the original spec, so the report stays month-scoped; only its misleading "matches the tile" description was corrected. (This is the one coordinator-requested rescope I did **not** do.)
- **Pending approval tile** is approver-scoped (correct for the queue) vs an org-wide report — left as-is.

## ⚠️ Separate root cause flagged, NOT fixed here — Approval bucket 2 vs 19
The board CMT maps `phase=Approval` to stale ApiValues **"Ready for Client Approval" / "In Client Approval"** that no longer match the **live `StageNamePk` values the approval service writes** (`Ready for Final Approval` / `Final Approving`). So real pending-approval items map to no phase (invisible in the bucket) while the report catches them — this is also the source of the client phase-card under-sum above. Fixing it correctly is a workflow-config data-model change with large blast radius (persona views, escalation rules, stage transitions, many tests, an LWC) — out of scope for this PR. Flagged in `WorkItems_Approval`'s description as a follow-up needing direction. The Approval bucket report keeps the real pending population + guards.

## Synthetic data (data-cleanup, MF lane — not code)
Some MF-Prod reports are inflated by live synthetic rows named `DH-ACCEPT-TEST-A/B — synthetic, will be deleted`. That is data pollution, not a code bug; the canonical filter does not rely on them. Calling it out for the MF data-cleanup lane.

## Stale-value note
`activeWorkItems` and `getBudgetMetrics` paths: `getBudgetMetrics` is `@AuraEnabled(cacheable=true)` (System Pulse), `getCardData('activeWorkItems', …)` is non-cacheable. Caching unchanged. After install/upgrade the cacheable System Pulse tile can show a **stale cached value** until the platform cache refreshes.

## Verification
- All 16 changed files validated (report XML well-formed; mirrored each file's existing filter syntax — `.` for WorkItem CustomEntity reports, `$` for SyncItem custom report type; `isUnlocked` matched per file; booleanFilter renumbered before criteriaItems).
- **`DismissedDateTime__c` confirmed present in the `Sync_Items` custom report type** field pool, so the Synced/Failed filter edits deploy cleanly (custom RTs reject filters on fields not in the pool).
- Added regression tests via `TestDataFactory` (DH suite, CI-run): Deployed-to-Prod exclusion, Exec phase buckets sum to active, In-Client-Approval→Approval mapping, and the client-Blocked stage-vs-dependency def-bug. The three controller test classes are confirmed in the `DH` ApexTestSuite.
- No LWC files changed (the Blocked fix is server-side), so no jest changes needed.
- **Report-filter behavior is install-verified only** — Apex/jest never exercise report XML and this PR does not deploy to any org. Numbers self-correct on install (managed Apex + report metadata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)