### PR TITLE
fix(dashboard): scope Recently_Completed to THIS_WEEK so tile=report

### DIFF
--- a/force-app/main/default/customMetadata/DashboardCard.Completed_This_Week.md-meta.xml
+++ b/force-app/main/default/customMetadata/DashboardCard.Completed_This_Week.md-meta.xml
@@ -16,5 +16,5 @@
     <values><field>ThresholdWarningNumber__c</field><value xsi:nil="true"/></values>
     <values><field>ThresholdCriticalNumber__c</field><value xsi:nil="true"/></values>
     <values><field>ClickThroughUrlTxt__c</field><value xsi:type="xsd:string">report:Recently_Completed</value></values>
-    <values><field>InfoPopoverTxt__c</field><value xsi:type="xsd:string">Counts non-template WorkItems whose stage is Done and that were last modified this week. Click the card to open the Recently Completed report (note: the report uses a this-MONTH window, so it can show more rows than this week's count).</value></values>
+    <values><field>InfoPopoverTxt__c</field><value xsi:type="xsd:string">Counts non-template WorkItems whose stage is Done and that were last modified this week. Click the card to open the Recently Completed report, which uses the same this-week window so its total matches this tile.</value></values>
 </CustomMetadata>

--- a/force-app/main/default/reports/DeliveryHubVendor/Recently_Completed.report-meta.xml
+++ b/force-app/main/default/reports/DeliveryHubVendor/Recently_Completed.report-meta.xml
@@ -24,7 +24,7 @@
     <columns>
         <field>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%HoursVarianceNumber__c</field>
     </columns>
-    <description>Work items completed (Done), modified THIS MONTH. Broader than the Completed (This Week) tile, which counts only the current week, so this total is expected to exceed the week tile.</description>
+    <description>Work items completed (Done), modified THIS WEEK. Matches the Completed (This Week) tile exactly.</description>
     <filter>
         <booleanFilter>1 AND 2 AND 3</booleanFilter>
         <criteriaItems>
@@ -39,7 +39,7 @@
             <columnToColumn>false</columnToColumn>
             <isUnlocked>true</isUnlocked>
             <operator>equals</operator>
-            <value>THIS_MONTH</value>
+            <value>THIS_WEEK</value>
         </criteriaItems>
         <criteriaItems>
             <column>%%%NAMESPACE%%%WorkItem__c.%%%NAMESPACE%%%TemplateMarkedDateTime__c</column>


### PR DESCRIPTION
## The last homepage mismatch
On MF-Prod 0.290, clicking **Completed This Week (6)** lands on the **Recently_Completed** report showing **~53** — because the tile counts `THIS_WEEK` while the report was filtered `THIS_MONTH`. It's the one tile #944 deliberately left (the report is shared).

## Fix
Both consumers of `Recently_Completed` are *this-week* tiles:
- the Exec `DashboardCard.Completed_This_Week` tile, and
- the client dashboard's completed tile (`deliveryClientDashboard.handleCompletedClick`).

So rescoping the report filter `CUST_LAST_UPDATE` from `THIS_MONTH` → `THIS_WEEK` makes **both** tiles match their report, with no collateral. Updated the card InfoPopover to drop the old "report uses a this-month window" caveat.

After install: Completed tile total == report total, closing the last homepage tile/report discrepancy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)