### PR TITLE
fix(board): ISO-datetime default breaks create form on managed/prod (F17)

### DIFF
--- a/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.html
+++ b/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.html
@@ -633,10 +633,9 @@
                             <lightning-input-field field-name="%%%NAMESPACE_DOT%%%BriefDescriptionTxt__c" required onchange={handleFieldChange} value={createWorkItemTitle}></lightning-input-field>
                             <lightning-input-field field-name="%%%NAMESPACE_DOT%%%DetailsTxt__c" onchange={handleFieldChange} value={createWorkItemDescription}></lightning-input-field>
                             <lightning-input-field field-name="%%%NAMESPACE_DOT%%%PriorityPk__c" value={createDefaults.PriorityPk__c}></lightning-input-field>
-                            
-                            <div class="slds-hide">
-                                <lightning-input-field field-name="%%%NAMESPACE_DOT%%%ActivatedDateTime__c" value={createDefaults.ActivatedDateTime__c}></lightning-input-field>
-                            </div>
+                            <!-- ActivatedDateTime__c is NOT rendered here: it's set in handleCreateSubmit
+                                 at submit. A hidden ISO-datetime input + default-field-value broke the
+                                 managed-object create-defaults wire on prod (F17). -->
 
                             <lightning-file-upload label="Attach files" record-id={currentUserId} onuploadfinished={handleFileUpload} multiple></lightning-file-upload>
                             

--- a/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.js
+++ b/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.js
@@ -456,16 +456,16 @@ export default class DeliveryHubBoard extends NavigationMixin(LightningElement) 
     }
 
     get createDefaults() {
+        // Only simple, always-valid defaults here. ActivatedDateTime__c (a
+        // DateTime) and StatusPk__c are deliberately NOT defaulted at render
+        // time: an ISO datetime in default-field-values makes the managed-object
+        // create-defaults wire fail (generic "You don't have access to this
+        // record", input-fields never render — F17, prod-only / namespaced).
+        // Both are set authoritatively in handleCreateSubmit at submit time.
         return {
             [FIELDS.STAGE]:     'Backlog',
             [FIELDS.SORT_ORDER]: this.nextSortOrder,
             [FIELDS.PRIORITY]:  'Medium',
-            // ActivatedDateTime__c is a DateTime "activated at" stamp (DH's
-            // DateTime-as-toggle pattern), NOT a Boolean. Stamp "now" to activate
-            // the new item — a Boolean here is rejected as an invalid date and
-            // silently broke the entire create flow (F16).
-            [FIELDS.IS_ACTIVE]: new Date().toISOString(),
-            [FIELDS.STATUS_PK]: 'New',
         };
     }
 


### PR DESCRIPTION
## The keystone create bug (F17)
After F16 (Boolean→ISO datetime), the board **"+ New Work Item"** modal *still* fails on MF-Prod v0.290: a generic **"You don't have access to this record"** banner and **no input-fields render** (the AI button + Attach files still show). It blocks creating a work item from the board.

## Not a permissions problem (ruled out via live MF-Prod)
- `DeliveryHubApp` permset grants **editable=true** on every create-form field; Glen **has** the permset.
- **Zero record types** on `WorkItem__c`.
- Admin has Modify All → object CRUD fine.

## Root cause — render-time `default-field-values`
`createDefaults` placed an **ISO `ActivatedDateTime__c`** (and `StatusPk__c`) into the form's `default-field-values`, plus a hidden `ActivatedDateTime__c` input-field. On a **managed** object, the `getRecordCreateDefaults` wire chokes on the ISO-datetime default and the `lightning-record-edit-form` fails to load field info → input-fields don't render → generic access banner. Non-namespaced **scratch orgs** take the lenient unmanaged path, so it falsely tested green there.

## Fix
`createDefaults` now carries only `Stage`/`SortOrder`/`Priority`. `ActivatedDateTime__c` + `StatusPk__c` are still set authoritatively at submit (`handleCreateSubmit`, unchanged). Removed the redundant hidden datetime input-field. **What gets saved is identical.**

## Verification
⚠️ Must be verified on a **namespaced** org (nimba) — does not reproduce on the non-namespaced scratch orgs. If it still fails there, pull the create-path debug log for the real server exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)