### PR TITLE
feat(intake): make Jose's inbound happy-path work + declutter the home

### DIFF
--- a/force-app/main/default/classes/DeliveryGanttController.cls
+++ b/force-app/main/default/classes/DeliveryGanttController.cls
@@ -1626,6 +1626,19 @@ public with sharing class DeliveryGanttController {
                 : null;
             String beforeTaskId = rp.get('beforeTaskId') == null ? null : String.valueOf(rp.get('beforeTaskId'));
             String afterTaskId = rp.get('afterTaskId') == null ? null : String.valueOf(rp.get('afterTaskId'));
+            // NG omits priorityGroup on a WITHIN-lane drag (the bucket didn't
+            // change), so a positional reorder can legitimately arrive without
+            // one. Derive the destination bucket from the task's own current
+            // effective group — the SAME computation loadBucketItems uses
+            // (explicit PriorityGroupPk__c, else derived from priority+stage) so
+            // we renumber exactly the bucket the row builder rendered. A
+            // cross-lane drag carries priorityGroup explicitly, so this
+            // derivation only fires for within-lane reorders.
+            if (String.isBlank(priorityGroup)) {
+                priorityGroup = resolveEffectiveGroup(taskId);
+            }
+            // Still blank means we genuinely can't determine the bucket — fail
+            // loud rather than renumber the wrong lane.
             if (String.isBlank(priorityGroup)) {
                 throw new IllegalArgumentException('reorder patch with position needs priorityGroup at index ' + patch.get('_index'));
             }
@@ -1638,6 +1651,35 @@ public with sharing class DeliveryGanttController {
             item.SortOrderNumber__c = (Decimal) rp.get('sortOrder');
             update item; //NOPMD - with sharing class handles CRUD
         }
+    }
+
+    /**
+     * @description Resolves a WorkItem's current effective priority bucket using
+     *              the SAME rule as loadBucketItems / the row builder: explicit
+     *              PriorityGroupPk__c when set, else derived from priority+stage.
+     *              Used by applyReorderPatch when a within-lane positional reorder
+     *              arrives without an explicit destination group.
+     * @param taskId The WorkItem record Id.
+     * @return The effective bucket name, or null when the record can't be read.
+     */
+    private static String resolveEffectiveGroup(String taskId) {
+        if (String.isBlank(taskId)) {
+            return null;
+        }
+        List<WorkItem__c> rows = [
+            SELECT PriorityPk__c, StageNamePk__c, PriorityGroupPk__c
+            FROM WorkItem__c
+            WHERE Id = :taskId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (rows.isEmpty()) {
+            return null;
+        }
+        WorkItem__c w = rows[0];
+        return String.isNotBlank(w.PriorityGroupPk__c)
+            ? w.PriorityGroupPk__c
+            : derivePriorityGroup(w.PriorityPk__c, w.StageNamePk__c);
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryGanttControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryGanttControllerTest.cls
@@ -1254,6 +1254,37 @@ private class DeliveryGanttControllerTest {
     }
 
     @IsTest
+    static void testCommitReorderWithoutPriorityGroupDerivesBucket() {
+        System.runAs(testUser) {
+            List<Id> ids = seedBucketItems();
+            // Within-lane drag: NG omits priorityGroup because the bucket didn't
+            // change. The committer must derive the destination bucket from the
+            // task's own effective group (resolveEffectiveGroup) instead of
+            // throwing 'reorder patch with position needs priorityGroup'.
+            String patchesJson = JSON.serialize(new List<Object>{
+                new Map<String, Object>{
+                    'taskId' => ids[3],
+                    'kind' => 'reorder',
+                    'reorderPayload' => new Map<String, Object>{
+                        'position' => 'above-all'
+                    }
+                }
+            });
+            Test.startTest();
+            Map<String, Object> result = DeliveryGanttController.commitGanttPatches(patchesJson, null);
+            Test.stopTest();
+
+            System.assertEquals(true, result.get('ok'), 'Within-lane reorder commits via the derived bucket');
+            System.assertEquals(1, result.get('committed'), 'One reorder patch committed');
+            Map<Id, WorkItem__c> updated = new Map<Id, WorkItem__c>(
+                [SELECT Id, SortOrderNumber__c FROM WorkItem__c WHERE Id IN :ids]
+            );
+            System.assertEquals(1, updated.get(ids[3]).SortOrderNumber__c,
+                'Moved item lands at position 1 in its derived (active) bucket');
+        }
+    }
+
+    @IsTest
     static void testReorderDenseBelowAllRenumbersBucketTo1N() {
         System.runAs(testUser) {
             List<Id> ids = seedBucketItems();

--- a/force-app/main/default/classes/DeliveryGhostController.cls
+++ b/force-app/main/default/classes/DeliveryGhostController.cls
@@ -87,14 +87,19 @@ global with sharing class DeliveryGhostController {
             t.DetailsTxt__c = fullDescription;
             t.PriorityPk__c = priority;
             t.StageNamePk__c = 'Backlog';
-            t.ActivatedDateTime__c = Datetime.now();
+            // Inbound requests are NOT activated on creation. Leaving
+            // ActivatedDateTime__c null routes the request into the Intake
+            // queue (front of pipe) for a triager to review and activate onto
+            // the Board — activation = stamping ActivatedDateTime__c, which is
+            // what makes the item appear on the Board/Gantt. Auto-activating
+            // here would skip Intake entirely (the item would land straight on
+            // the Board), which defeats the triage step.
             t.StatusPk__c = 'New';
 
-            if (Schema.sObjectType.WorkItem__c.isCreateable()) {
-                insert t;
-            } else {
-                throw new AuraHandledException('Insufficient permissions to create Work Item.');
-            }
+            // Insert honoring the intake-first org setting, then ping live
+            // subscribers so the new request pops into Intake — see
+            // persistInboundRequest.
+            persistInboundRequest(t);
 
             return t.Id;
 
@@ -107,6 +112,37 @@ global with sharing class DeliveryGhostController {
     }
 
     // ── Private Helpers ──────────────────────────────────────────────────
+
+    /**
+     * @description Inserts an inbound quick-request WorkItem honoring the
+     *              intake-first org setting, then pings live subscribers. When
+     *              EnableAutoActivateDateTime__c is null (default), the
+     *              before-insert trigger's auto-activate is suppressed for this
+     *              insert so the request lands un-activated in the Intake queue;
+     *              when set (e.g. post-quickstart) it auto-activates onto the
+     *              board as before. The suppress flag is reset in finally so it
+     *              never leaks to other DML in the request. The published
+     *              DeliveryWorkItemChange__e lets the Intake queue refresh live.
+     * @param t The WorkItem to insert (assigned its new Id in place).
+     */
+    private static void persistInboundRequest(WorkItem__c t) {
+        if (!Schema.sObjectType.WorkItem__c.isCreateable()) {
+            throw new AuraHandledException('Insufficient permissions to create Work Item.');
+        }
+        Boolean autoActivate = DeliveryHubSettings__c.getInstance().EnableAutoActivateDateTime__c != null;
+        if (!autoActivate) {
+            DeliveryTriggerControl.suppressAutoActivate = true;
+        }
+        try {
+            insert t; //NOPMD - with sharing class handles CRUD; isCreateable checked above
+        } finally {
+            DeliveryTriggerControl.suppressAutoActivate = false;
+        }
+        EventBus.publish(new DeliveryWorkItemChange__e(
+            WorkItemIdTxt__c = t.Id,
+            ChangeTypeTxt__c = 'intake_new'
+        ));
+    }
 
     private static void populateFromContext(ActivityLog__c log, String contextData) {
         try {

--- a/force-app/main/default/classes/DeliveryGhostControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryGhostControllerTest.cls
@@ -48,8 +48,36 @@ private class DeliveryGhostControllerTest {
             System.assertEquals('[Bug] Test Issue - Something is broken', t.BriefDescriptionTxt__c, 'Work Item Name should include [Bug] prefix and description');
             System.assertEquals('High', t.PriorityPk__c, 'Priority should match');
             System.assert(t.DetailsTxt__c.contains('Auto-Captured Context'), 'Details should contain context header');
-            System.assertNotEquals(null, t.ActivatedDateTime__c, 'Ghost Reporter workItem should be active');
+            // Intake-first is the default (EnableAutoActivateDateTime__c null in
+            // the test context): an inbound ghost request is NOT auto-activated —
+            // it stays un-activated so it lands in the Intake queue for triage.
+            System.assertEquals(null, t.ActivatedDateTime__c, 'Ghost Reporter workItem should be intake-first (un-activated) by default');
             System.assertEquals('New', t.StatusPk__c, 'Ghost Reporter workItem should have New status');
+        }
+    }
+
+    /**
+     * @description When EnableAutoActivateDateTime__c is set on the org, an
+     *              inbound ghost request IS auto-activated on creation (legacy /
+     *              post-quickstart behavior) and appears straight on the board
+     *              rather than waiting in Intake.
+     */
+    @IsTest
+    static void testCreateQuickRequestAutoActivateWhenEnabled() {
+        System.runAs(testUser) {
+            DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+            settings.EnableAutoActivateDateTime__c = Datetime.now();
+            upsert settings;
+
+            Test.startTest();
+            Id workItemId = DeliveryGhostController.createQuickRequest(
+                'Auto activate', 'desc', 'Medium', null, 'Bug'
+            );
+            Test.stopTest();
+
+            WorkItem__c t = [SELECT ActivatedDateTime__c FROM WorkItem__c WHERE Id = :workItemId LIMIT 1];
+            System.assertNotEquals(null, t.ActivatedDateTime__c,
+                'With auto-activate enabled, the inbound request should be activated onto the board');
         }
     }
 

--- a/force-app/main/default/classes/DeliveryHomeVisibilityController.cls
+++ b/force-app/main/default/classes/DeliveryHomeVisibilityController.cls
@@ -1,0 +1,105 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Per-component visibility toggles for the Delivery Hub app Home page.
+ *               Lets an admin hide individual home-page LWC widgets (so the Home page
+ *               only surfaces what works) via the Settings tab, fully reversibly.
+ *               Backed by inverted HideHome…DateTime__c fields on DeliveryHubSettings__c:
+ *               null = SHOWN (safe default), non-null = HIDDEN. The map this returns is
+ *               keyed by the LWC component name (e.g. 'deliveryBudgetSummary') so each
+ *               home-page component can ask "am I hidden?" with a single cacheable wire.
+ * @author       Cloud Nimbus LLC
+ */
+public with sharing class DeliveryHomeVisibilityController {
+
+    // Map of LWC component name → the inverted "hide" DateTime field that gates it.
+    // Order is the order the toggles render in the Settings card.
+    private static final Map<String, String> COMPONENT_TO_FIELD = new Map<String, String>{
+        'deliveryBudgetSummary'        => 'HideHomeBudgetSummaryDateTime__c',
+        'deliveryExecutiveDashboard'   => 'HideHomeExecutiveDashboardDateTime__c',
+        'deliveryFeatureApprovalInbox' => 'HideHomeFeatureApprovalInboxDateTime__c',
+        'deliveryGettingStarted'       => 'HideHomeGettingStartedDateTime__c',
+        'deliveryHubSetup'             => 'HideHomeHubSetupDateTime__c',
+        'deliveryPacingForecast'       => 'HideHomePacingForecastDateTime__c'
+    };
+
+    /**
+     * @description Returns which home-page components are currently hidden, keyed by
+     *              the LWC component name. A component is hidden when its matching
+     *              HideHome…DateTime__c field is non-null (inverted-default: null = shown).
+     *              Reads the hierarchy custom setting via getInstance().
+     * @return Map of component name → isHidden (true = hide on Home).
+     */
+    @AuraEnabled(cacheable=true)
+    public static Map<String, Boolean> getHiddenHomeComponents() {
+        return buildHiddenMap(DeliveryHubSettings__c.getInstance());
+    }
+
+    /**
+     * @description Persists the per-component Home visibility toggles. For each entry,
+     *              true = HIDE (stamps the HideHome…DateTime__c with now() if not already
+     *              set), false = SHOW (clears the field). Existing stamps are preserved so
+     *              the "active since" timestamp does not churn. Writes to the org-default
+     *              record. Returns the fresh hidden-map so the caller can refresh state
+     *              without hitting the cacheable read's stale cache.
+     * @param hidden Map of component name → desired isHidden state.
+     * @return Map of component name → isHidden after the save.
+     */
+    @AuraEnabled
+    public static Map<String, Boolean> setHiddenHomeComponents(Map<String, Boolean> hidden) {
+        try {
+            Map<String, Boolean> requested = hidden != null ? hidden : new Map<String, Boolean>();
+            DeliveryHubSettings__c settings = getOrCreateSettings();
+
+            for (String componentName : COMPONENT_TO_FIELD.keySet()) {
+                if (!requested.containsKey(componentName)) {
+                    continue;
+                }
+                String fieldApiName = COMPONENT_TO_FIELD.get(componentName);
+                Boolean shouldHide = requested.get(componentName) == true;
+                Datetime existing = (Datetime) settings.get(fieldApiName);
+                settings.put(fieldApiName, shouldHide ? (existing != null ? existing : Datetime.now()) : null);
+            }
+
+            SObjectAccessDecision decision = Security.stripInaccessible(
+                AccessType.UPSERTABLE, new List<DeliveryHubSettings__c>{ settings });
+            upsert decision.getRecords();
+
+            // Re-read from the org default so the returned map reflects what was persisted.
+            return buildHiddenMap(DeliveryHubSettings__c.getOrgDefaults());
+        } catch (Exception e) {
+            AuraHandledException ahe = new AuraHandledException(e.getMessage());
+            ahe.setMessage(e.getMessage());
+            throw ahe;
+        }
+    }
+
+    /**
+     * @description Builds the component → isHidden map from a settings record.
+     * @param settings The DeliveryHubSettings__c instance (may be a blank getInstance()).
+     * @return Map of component name → isHidden.
+     */
+    private static Map<String, Boolean> buildHiddenMap(DeliveryHubSettings__c settings) {
+        Map<String, Boolean> result = new Map<String, Boolean>();
+        for (String componentName : COMPONENT_TO_FIELD.keySet()) {
+            Boolean isHidden = false;
+            if (settings != null) {
+                isHidden = settings.get(COMPONENT_TO_FIELD.get(componentName)) != null;
+            }
+            result.put(componentName, isHidden);
+        }
+        return result;
+    }
+
+    /**
+     * @description Helper to get existing org-default settings or create a new default instance.
+     * @return DeliveryHubSettings__c settings record.
+     */
+    private static DeliveryHubSettings__c getOrCreateSettings() {
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        if (settings == null || settings.Id == null) {
+            settings = new DeliveryHubSettings__c(SetupOwnerId = UserInfo.getOrganizationId());
+        }
+        return settings;
+    }
+}

--- a/force-app/main/default/classes/DeliveryHomeVisibilityController.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryHomeVisibilityController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryHomeVisibilityControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHomeVisibilityControllerTest.cls
@@ -1,0 +1,83 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Unit tests for DeliveryHomeVisibilityController — the per-component
+ *               Home-page visibility toggles backed by inverted HideHome…DateTime__c
+ *               fields on DeliveryHubSettings__c (null = shown, non-null = hidden).
+ * @author       Cloud Nimbus LLC
+ */
+@isTest
+private class DeliveryHomeVisibilityControllerTest {
+
+    private static final String KEY_BUDGET = 'deliveryBudgetSummary';
+    private static final String KEY_PACING = 'deliveryPacingForecast';
+
+    @isTest
+    static void defaultsToAllShown() {
+        Test.startTest();
+        Map<String, Boolean> hidden = DeliveryHomeVisibilityController.getHiddenHomeComponents();
+        Test.stopTest();
+
+        System.assertEquals(6, hidden.size(), 'Expected all six components in the map');
+        for (String key : hidden.keySet()) {
+            System.assertEquals(false, hidden.get(key), 'No setting present → component should be shown (not hidden): ' + key);
+        }
+    }
+
+    @isTest
+    static void hidingStampsTheField() {
+        Map<String, Boolean> request = new Map<String, Boolean>{ KEY_BUDGET => true };
+
+        Test.startTest();
+        Map<String, Boolean> result = DeliveryHomeVisibilityController.setHiddenHomeComponents(request);
+        Test.stopTest();
+
+        System.assertEquals(true, result.get(KEY_BUDGET), 'Budget Summary should be hidden after stamping');
+        System.assertEquals(false, result.get(KEY_PACING), 'Untouched components stay shown');
+
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        System.assertNotEquals(null, settings.HideHomeBudgetSummaryDateTime__c, 'Hide field should be stamped');
+        System.assertEquals(null, settings.HideHomePacingForecastDateTime__c, 'Untouched field stays null');
+    }
+
+    @isTest
+    static void showingClearsTheField() {
+        // First hide, then show again — must clear the stamp (fully reversible).
+        DeliveryHomeVisibilityController.setHiddenHomeComponents(new Map<String, Boolean>{ KEY_BUDGET => true });
+
+        Test.startTest();
+        Map<String, Boolean> result = DeliveryHomeVisibilityController.setHiddenHomeComponents(
+            new Map<String, Boolean>{ KEY_BUDGET => false });
+        Test.stopTest();
+
+        System.assertEquals(false, result.get(KEY_BUDGET), 'Budget Summary should be shown again');
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        System.assertEquals(null, settings.HideHomeBudgetSummaryDateTime__c, 'Hide field should be cleared');
+    }
+
+    @isTest
+    static void existingStampIsPreservedOnRepeatHide() {
+        DeliveryHomeVisibilityController.setHiddenHomeComponents(new Map<String, Boolean>{ KEY_BUDGET => true });
+        Datetime firstStamp = DeliveryHubSettings__c.getOrgDefaults().HideHomeBudgetSummaryDateTime__c;
+
+        Test.startTest();
+        // Re-asserting "hidden" should not churn the existing timestamp.
+        DeliveryHomeVisibilityController.setHiddenHomeComponents(new Map<String, Boolean>{ KEY_BUDGET => true });
+        Test.stopTest();
+
+        Datetime secondStamp = DeliveryHubSettings__c.getOrgDefaults().HideHomeBudgetSummaryDateTime__c;
+        System.assertEquals(firstStamp, secondStamp, 'Existing hide timestamp should be preserved');
+    }
+
+    @isTest
+    static void nullRequestIsSafe() {
+        Test.startTest();
+        Map<String, Boolean> result = DeliveryHomeVisibilityController.setHiddenHomeComponents(null);
+        Test.stopTest();
+
+        System.assertEquals(6, result.size(), 'A null request is a no-op that still returns the full map');
+        for (String key : result.keySet()) {
+            System.assertEquals(false, result.get(key), 'Nothing hidden for a null request: ' + key);
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryHomeVisibilityControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryHomeVisibilityControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryTriageController.cls
+++ b/force-app/main/default/classes/DeliveryTriageController.cls
@@ -38,8 +38,11 @@ public with sharing class DeliveryTriageController {
     private static final String STAGE_DEPLOYED_TO_PROD =
         DeliveryWorkflowConfigService.STAGE_DEPLOYED_TO_PROD;
 
-    /** Stage routeToDev moves an intake item into (and activates it). */
-    private static final String STAGE_READY_FOR_DEVELOPMENT = 'Ready for Development';
+    /** Stage routeToDev hands an intake item into (and activates it). A raw
+     *  inbound request isn't sized/estimated/approved yet, so hand-off lands it
+     *  at the START of the real workflow — Ready for Sizing — not at
+     *  Ready for Development (which would falsely signal it's ready to code). */
+    private static final String STAGE_READY_FOR_SIZING = 'Ready for Sizing';
 
     /** Terminal value markDone / dismissIntake fall back to. */
     private static final String STAGE_DONE = 'Done';
@@ -248,17 +251,19 @@ public with sharing class DeliveryTriageController {
     }
 
     /**
-     * @description Route the selected intake items to a developer: assign the
-     *              developer lookup, move to 'Ready for Development', and stamp
-     *              ActivatedDateTime__c = now() so each becomes visible on the
-     *              timeline. Bulk, partial-failure-safe.
-     * @param workItemIds   Items to route.
+     * @description Hand the selected intake items off into the delivery
+     *              workflow: assign the developer lookup, move to
+     *              'Ready for Sizing' (the start of the real workflow — the item
+     *              still needs sizing/estimation/approval before it's ready to
+     *              code), and stamp ActivatedDateTime__c = now() so each becomes
+     *              visible on the board/timeline. Bulk, partial-failure-safe.
+     * @param workItemIds   Items to hand off.
      * @param developerUserId The User to assign (may be null to route unassigned).
      * @return BulkResultDTO with succeeded ids and per-row failures.
      */
     @AuraEnabled
     public static BulkResultDTO routeToDev(List<Id> workItemIds, Id developerUserId) {
-        return applyStageUpdate(workItemIds, STAGE_READY_FOR_DEVELOPMENT, developerUserId, true);
+        return applyStageUpdate(workItemIds, STAGE_READY_FOR_SIZING, developerUserId, true);
     }
 
     /**

--- a/force-app/main/default/classes/DeliveryTriageControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryTriageControllerTest.cls
@@ -172,7 +172,7 @@ private class DeliveryTriageControllerTest {
             SELECT StageNamePk__c, DeveloperLookup__c, ActivatedDateTime__c
             FROM WorkItem__c WHERE Id = :wi.Id
         ];
-        System.assertEquals('Ready for Development', after.StageNamePk__c, 'advanced to dev');
+        System.assertEquals('Ready for Sizing', after.StageNamePk__c, 'handed off to the start of the workflow');
         System.assertEquals(dev, after.DeveloperLookup__c, 'developer assigned');
         System.assertNotEquals(null, after.ActivatedDateTime__c,
             'activated so it becomes visible on the timeline');

--- a/force-app/main/default/classes/DeliveryTriggerControl.cls
+++ b/force-app/main/default/classes/DeliveryTriggerControl.cls
@@ -17,6 +17,15 @@ public with sharing class DeliveryTriggerControl {
     // regardless of source state, which corrupts the Delivery Timeline view.
     public static Boolean inboundSyncContext = false;
 
+    // Inbound-request paths (e.g. the Report Issue ghost recorder) set this true
+    // around their insert when the org runs intake-first (auto-activate off) so
+    // the before-insert handler does NOT stamp ActivatedDateTime__c. That leaves
+    // the new request un-activated → it lands in the Intake queue for triage
+    // instead of appearing straight on the Board. Scoped per-insert: only the
+    // path that sets it is affected; the board, cart, and every other creation
+    // path keep their existing auto-activate behavior.
+    public static Boolean suppressAutoActivate = false;
+
     /**
      * @description Disables the after-trigger logic that enqueues jobs.
      */

--- a/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
+++ b/force-app/main/default/classes/DeliveryWorkItemTriggerHandler.cls
@@ -528,10 +528,15 @@ public without sharing class DeliveryWorkItemTriggerHandler {
      */
     public static void handleBeforeInsert(List<WorkItem__c> newWorkItems) {
         Datetime now = Datetime.now();
-        // When the inbound-sync ingestor is performing the insert, the source
-        // org owns ActivatedDateTime__c — skip receiver-side auto-population so
-        // the source's value (often null for non-active items) is preserved.
-        Boolean skipAutoActivate = DeliveryTriggerControl.inboundSyncContext;
+        // Skip the receiver-side auto-activate when either (a) the inbound-sync
+        // ingestor is performing the insert — the source org owns
+        // ActivatedDateTime__c, so its value (often null for non-active items)
+        // is preserved; or (b) an inbound-request path (the Report Issue ghost
+        // recorder) has opted this insert into intake-first, so the new request
+        // stays un-activated and lands in the Intake queue for triage instead of
+        // appearing straight on the Board.
+        Boolean skipAutoActivate = DeliveryTriggerControl.inboundSyncContext
+            || DeliveryTriggerControl.suppressAutoActivate;
         for (WorkItem__c workItem : newWorkItems) {
             if (!skipAutoActivate && workItem.ActivatedDateTime__c == null) {
                 workItem.ActivatedDateTime__c = now;

--- a/force-app/main/default/flexipages/DeliveryHubHome.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryHubHome.flexipage-meta.xml
@@ -3,6 +3,12 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
+                <componentName>deliveryIntakeQueue</componentName>
+                <identifier>c_deliveryIntakeQueue_home</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
                 <componentName>deliveryGettingStarted</componentName>
                 <identifier>c_deliveryGettingStarted</identifier>
             </componentInstance>

--- a/force-app/main/default/lwc/deliveryBudgetSummary/__tests__/deliveryBudgetSummary.test.js
+++ b/force-app/main/default/lwc/deliveryBudgetSummary/__tests__/deliveryBudgetSummary.test.js
@@ -1,0 +1,46 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryBudgetSummary's Home-page visibility gate:
+ *               renders by default, and renders nothing on Home when an admin hides it.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from 'lwc';
+import { CurrentPageReference } from 'lightning/navigation';
+import DeliveryBudgetSummary from 'c/deliveryBudgetSummary';
+import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
+
+const HOME_PAGE_REF = { type: 'standard__namedPage', attributes: { pageName: 'home' } };
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createComponent() {
+    const element = createElement('c-delivery-budget-summary', { is: DeliveryBudgetSummary });
+    document.body.appendChild(element);
+    return element;
+}
+
+describe('c-delivery-budget-summary home visibility', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('renders by default when not hidden', async () => {
+        const element = createComponent();
+        await flushPromises();
+        expect(element.shadowRoot.querySelector('lightning-card')).not.toBeNull();
+    });
+
+    it('renders nothing on Home when hidden in Settings', async () => {
+        const element = createComponent();
+        CurrentPageReference.emit(HOME_PAGE_REF);
+        getHiddenHomeComponents.emit({ deliveryBudgetSummary: true });
+        await flushPromises();
+        expect(element.shadowRoot.querySelector('lightning-card')).toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/deliveryBudgetSummary/deliveryBudgetSummary.html
+++ b/force-app/main/default/lwc/deliveryBudgetSummary/deliveryBudgetSummary.html
@@ -1,4 +1,5 @@
 <template>
+    <template lwc:if={isNotHiddenOnHome}>
     <lightning-card title="System Pulse" icon-name="standard:service_report">
         
         <div slot="actions" class="slds-grid slds-grid_vertical-align-center" style="gap: 0.25rem;">
@@ -99,4 +100,5 @@
             </div>
         </div>
     </lightning-card>
+    </template>
 </template>

--- a/force-app/main/default/lwc/deliveryBudgetSummary/deliveryBudgetSummary.js
+++ b/force-app/main/default/lwc/deliveryBudgetSummary/deliveryBudgetSummary.js
@@ -11,19 +11,55 @@
  * @author       Cloud Nimbus LLC
  */
 import { LightningElement, api, track, wire } from 'lwc';
-import { NavigationMixin } from 'lightning/navigation';
+import { NavigationMixin, CurrentPageReference } from 'lightning/navigation';
 import SYNC_ITEM_OBJECT from '@salesforce/schema/SyncItem__c';
 import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
 import WORK_LOG_OBJECT from '@salesforce/schema/WorkLog__c';
 import getBudgetMetrics from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.getBudgetMetrics';
 import getReportIds from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.getReportIds';
+import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
 import { refreshApex } from '@salesforce/apex';
+
+// This component's key in the Home-visibility map (matches its LWC folder name).
+const HOME_COMPONENT_KEY = 'deliveryBudgetSummary';
 
 export default class DeliveryBudgetSummary extends NavigationMixin(LightningElement) {
     @api hideConnectionHealth = false;
 
     get shouldShowConnectionHealth() {
         return !this.hideConnectionHealth;
+    }
+
+    // ── Home-page visibility (admin-toggleable, default = shown) ──
+    // Hides ONLY on the Delivery Hub app Home page when an admin toggles it
+    // off in Settings. Everywhere else this component always renders.
+    @wire(CurrentPageReference) _homePageRef;
+    @wire(getHiddenHomeComponents) _hiddenHomeComponents;
+
+    get isOnHomePage() {
+        const ref = this._homePageRef;
+        if (!ref) {
+            return false;
+        }
+        const attrs = ref.attributes || {};
+        if (ref.type === 'standard__namedPage' && attrs.pageName === 'home') {
+            return true;
+        }
+        const url = attrs.url
+            || (typeof window !== 'undefined' && window.location ? window.location.pathname : '');
+        return typeof url === 'string' && url.indexOf('/lightning/page/home') !== -1;
+    }
+
+    get isHiddenOnHome() {
+        if (!this.isOnHomePage) {
+            return false;
+        }
+        const map = this._hiddenHomeComponents && this._hiddenHomeComponents.data;
+        return !!(map && map[HOME_COMPONENT_KEY] === true);
+    }
+
+    get isNotHiddenOnHome() {
+        return !this.isHiddenOnHome;
     }
 
     @track metrics = {

--- a/force-app/main/default/lwc/deliveryExecutiveDashboard/__tests__/deliveryExecutiveDashboard.test.js
+++ b/force-app/main/default/lwc/deliveryExecutiveDashboard/__tests__/deliveryExecutiveDashboard.test.js
@@ -1,0 +1,46 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryExecutiveDashboard's Home-page visibility gate:
+ *               renders by default, and renders nothing on Home when an admin hides it.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from 'lwc';
+import { CurrentPageReference } from 'lightning/navigation';
+import DeliveryExecutiveDashboard from 'c/deliveryExecutiveDashboard';
+import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
+
+const HOME_PAGE_REF = { type: 'standard__namedPage', attributes: { pageName: 'home' } };
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createComponent() {
+    const element = createElement('c-delivery-executive-dashboard', { is: DeliveryExecutiveDashboard });
+    document.body.appendChild(element);
+    return element;
+}
+
+describe('c-delivery-executive-dashboard home visibility', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('renders by default when not hidden', async () => {
+        const element = createComponent();
+        await flushPromises();
+        expect(element.shadowRoot.querySelector('lightning-card')).not.toBeNull();
+    });
+
+    it('renders nothing on Home when hidden in Settings', async () => {
+        const element = createComponent();
+        CurrentPageReference.emit(HOME_PAGE_REF);
+        getHiddenHomeComponents.emit({ deliveryExecutiveDashboard: true });
+        await flushPromises();
+        expect(element.shadowRoot.querySelector('lightning-card')).toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/deliveryExecutiveDashboard/deliveryExecutiveDashboard.html
+++ b/force-app/main/default/lwc/deliveryExecutiveDashboard/deliveryExecutiveDashboard.html
@@ -1,4 +1,5 @@
 <template>
+    <template lwc:if={isNotHiddenOnHome}>
     <lightning-card title="Executive Dashboard" icon-name="utility:metrics">
         <div slot="actions" class="slds-grid slds-grid_vertical-align-center" style="gap: 0.25rem;">
             <c-delivery-info-popover component-name="deliveryExecutiveDashboard"></c-delivery-info-popover>
@@ -116,4 +117,5 @@
             </template>
         </template>
     </lightning-card>
+    </template>
 </template>

--- a/force-app/main/default/lwc/deliveryExecutiveDashboard/deliveryExecutiveDashboard.js
+++ b/force-app/main/default/lwc/deliveryExecutiveDashboard/deliveryExecutiveDashboard.js
@@ -9,16 +9,53 @@
  *               Pure read view — admins author cards as Custom Metadata.
  * @author       Cloud Nimbus LLC
  */
-import { LightningElement, api, track } from 'lwc';
+import { LightningElement, api, track, wire } from 'lwc';
+import { CurrentPageReference } from 'lightning/navigation';
 import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
 import getCardsForPage from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDashboardCardController.getCardsForPage';
 import getCardData from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDashboardCardController.getCardData';
+import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
+
+// This component's key in the Home-visibility map (matches its LWC folder name).
+const HOME_COMPONENT_KEY = 'deliveryExecutiveDashboard';
 
 export default class DeliveryExecutiveDashboard extends LightningElement {
     @api pageKey = 'home';
     @track cards = [];
     @track isLoading = true;
     @track error = null;
+
+    // ── Home-page visibility (admin-toggleable, default = shown) ──
+    // Hides ONLY on the Delivery Hub app Home page when an admin toggles it
+    // off in Settings. Everywhere else this component always renders.
+    @wire(CurrentPageReference) _homePageRef;
+    @wire(getHiddenHomeComponents) _hiddenHomeComponents;
+
+    get isOnHomePage() {
+        const ref = this._homePageRef;
+        if (!ref) {
+            return false;
+        }
+        const attrs = ref.attributes || {};
+        if (ref.type === 'standard__namedPage' && attrs.pageName === 'home') {
+            return true;
+        }
+        const url = attrs.url
+            || (typeof window !== 'undefined' && window.location ? window.location.pathname : '');
+        return typeof url === 'string' && url.indexOf('/lightning/page/home') !== -1;
+    }
+
+    get isHiddenOnHome() {
+        if (!this.isOnHomePage) {
+            return false;
+        }
+        const map = this._hiddenHomeComponents && this._hiddenHomeComponents.data;
+        return !!(map && map[HOME_COMPONENT_KEY] === true);
+    }
+
+    get isNotHiddenOnHome() {
+        return !this.isHiddenOnHome;
+    }
 
     connectedCallback() {
         this.loadDashboard();

--- a/force-app/main/default/lwc/deliveryFeatureApprovalInbox/__tests__/deliveryFeatureApprovalInbox.test.js
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalInbox/__tests__/deliveryFeatureApprovalInbox.test.js
@@ -1,0 +1,46 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryFeatureApprovalInbox's Home-page visibility gate:
+ *               renders by default, and renders nothing on Home when an admin hides it.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from 'lwc';
+import { CurrentPageReference } from 'lightning/navigation';
+import DeliveryFeatureApprovalInbox from 'c/deliveryFeatureApprovalInbox';
+import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
+
+const HOME_PAGE_REF = { type: 'standard__namedPage', attributes: { pageName: 'home' } };
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createComponent() {
+    const element = createElement('c-delivery-feature-approval-inbox', { is: DeliveryFeatureApprovalInbox });
+    document.body.appendChild(element);
+    return element;
+}
+
+describe('c-delivery-feature-approval-inbox home visibility', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('renders by default when not hidden', async () => {
+        const element = createComponent();
+        await flushPromises();
+        expect(element.shadowRoot.querySelector('lightning-card')).not.toBeNull();
+    });
+
+    it('renders nothing on Home when hidden in Settings', async () => {
+        const element = createComponent();
+        CurrentPageReference.emit(HOME_PAGE_REF);
+        getHiddenHomeComponents.emit({ deliveryFeatureApprovalInbox: true });
+        await flushPromises();
+        expect(element.shadowRoot.querySelector('lightning-card')).toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.html
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.html
@@ -1,4 +1,5 @@
 <template>
+    <template lwc:if={isNotHiddenOnHome}>
     <lightning-card title="Pending Approvals" icon-name="standard:approval">
         <div slot="actions" class="slds-grid slds-grid_vertical-align-center" style="gap: 0.25rem;">
             <c-delivery-info-popover component-name="deliveryFeatureApprovalInbox"></c-delivery-info-popover>
@@ -159,5 +160,6 @@
             </div>
         </section>
         <div class="slds-backdrop slds-backdrop_open"></div>
+    </template>
     </template>
 </template>

--- a/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.js
+++ b/force-app/main/default/lwc/deliveryFeatureApprovalInbox/deliveryFeatureApprovalInbox.js
@@ -10,12 +10,17 @@
  * @author Cloud Nimbus LLC
  */
 import { LightningElement, wire, track } from 'lwc';
+import { CurrentPageReference } from 'lightning/navigation';
 import { refreshApex } from '@salesforce/apex';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import getInbox from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.getInbox';
 import grantApex from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.grant';
 import rejectApex from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.reject';
 import getApprovalChain from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.getApprovalChain';
+import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
+
+// This component's key in the Home-visibility map (matches its LWC folder name).
+const HOME_COMPONENT_KEY = 'deliveryFeatureApprovalInbox';
 
 const REASON_TRUNCATE_AT = 160,
     ELLIPSIS = '…',
@@ -40,6 +45,38 @@ export default class DeliveryFeatureApprovalInbox extends LightningElement {
     @track chainRequestLabel = '';
 
     wiredResult;
+
+    // ── Home-page visibility (admin-toggleable, default = shown) ──
+    // Hides ONLY on the Delivery Hub app Home page when an admin toggles it
+    // off in Settings. Everywhere else this component always renders.
+    @wire(CurrentPageReference) _homePageRef;
+    @wire(getHiddenHomeComponents) _hiddenHomeComponents;
+
+    get isOnHomePage() {
+        const ref = this._homePageRef;
+        if (!ref) {
+            return false;
+        }
+        const attrs = ref.attributes || {};
+        if (ref.type === 'standard__namedPage' && attrs.pageName === 'home') {
+            return true;
+        }
+        const url = attrs.url
+            || (typeof window !== 'undefined' && window.location ? window.location.pathname : '');
+        return typeof url === 'string' && url.indexOf('/lightning/page/home') !== -1;
+    }
+
+    get isHiddenOnHome() {
+        if (!this.isOnHomePage) {
+            return false;
+        }
+        const map = this._hiddenHomeComponents && this._hiddenHomeComponents.data;
+        return !!(map && map[HOME_COMPONENT_KEY] === true);
+    }
+
+    get isNotHiddenOnHome() {
+        return !this.isHiddenOnHome;
+    }
 
     @wire(getInbox)
     wiredInbox(result) {

--- a/force-app/main/default/lwc/deliveryGettingStarted/__tests__/deliveryGettingStarted.test.js
+++ b/force-app/main/default/lwc/deliveryGettingStarted/__tests__/deliveryGettingStarted.test.js
@@ -1,0 +1,54 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryGettingStarted's Home-page visibility gate:
+ *               renders by default, and renders nothing on Home when an admin hides it.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from 'lwc';
+import { CurrentPageReference } from 'lightning/navigation';
+import DeliveryGettingStarted from 'c/deliveryGettingStarted';
+import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
+
+// getSetupStatus is consumed imperatively here (it is @wire elsewhere, so the shared
+// mock is a wire adapter); override it as a resolved promise for connectedCallback.
+jest.mock(
+    '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.getSetupStatus',
+    () => ({ default: jest.fn().mockResolvedValue({ isConnected: false, isMothership: false }) }),
+    { virtual: true }
+);
+
+const HOME_PAGE_REF = { type: 'standard__namedPage', attributes: { pageName: 'home' } };
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createComponent() {
+    const element = createElement('c-delivery-getting-started', { is: DeliveryGettingStarted });
+    document.body.appendChild(element);
+    return element;
+}
+
+describe('c-delivery-getting-started home visibility', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('renders by default when not hidden', async () => {
+        const element = createComponent();
+        await flushPromises();
+        expect(element.shadowRoot.querySelector('.gs-root')).not.toBeNull();
+    });
+
+    it('renders nothing on Home when hidden in Settings', async () => {
+        const element = createComponent();
+        CurrentPageReference.emit(HOME_PAGE_REF);
+        getHiddenHomeComponents.emit({ deliveryGettingStarted: true });
+        await flushPromises();
+        expect(element.shadowRoot.querySelector('.gs-root')).toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/deliveryGettingStarted/deliveryGettingStarted.html
+++ b/force-app/main/default/lwc/deliveryGettingStarted/deliveryGettingStarted.html
@@ -1,4 +1,5 @@
 <template>
+    <template lwc:if={isNotHiddenOnHome}>
     <div class={rootClass}>
         <!-- Collapsed header / toggle row -->
         <div class="gs-header" onclick={handleToggle} role="button" tabindex="0" onkeydown={handleKeydown}>
@@ -247,4 +248,5 @@
             </div>
         </template>
     </div>
+    </template>
 </template>

--- a/force-app/main/default/lwc/deliveryGettingStarted/deliveryGettingStarted.js
+++ b/force-app/main/default/lwc/deliveryGettingStarted/deliveryGettingStarted.js
@@ -6,8 +6,10 @@
  * Step 4 includes prerequisite checks for Site, Guest User, and Remote Site Settings.
  * @author Cloud Nimbus LLC
  */
-import { LightningElement, track } from 'lwc';
+import { LightningElement, track, wire } from 'lwc';
+import { CurrentPageReference } from 'lightning/navigation';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
 import getSetupStatus from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.getSetupStatus';
 import prepareLocalEntity from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.prepareLocalEntity';
 import performHandshake from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.performHandshake';
@@ -22,7 +24,42 @@ const STEPS = [
     { index: 5, label: 'Done' }
 ];
 
+// This component's key in the Home-visibility map (matches its LWC folder name).
+const HOME_COMPONENT_KEY = 'deliveryGettingStarted';
+
 export default class DeliveryGettingStarted extends LightningElement {
+    // ── Home-page visibility (admin-toggleable, default = shown) ──
+    // Hides ONLY on the Delivery Hub app Home page when an admin toggles it
+    // off in Settings. Everywhere else this component always renders.
+    @wire(CurrentPageReference) _homePageRef;
+    @wire(getHiddenHomeComponents) _hiddenHomeComponents;
+
+    get isOnHomePage() {
+        const ref = this._homePageRef;
+        if (!ref) {
+            return false;
+        }
+        const attrs = ref.attributes || {};
+        if (ref.type === 'standard__namedPage' && attrs.pageName === 'home') {
+            return true;
+        }
+        const url = attrs.url
+            || (typeof window !== 'undefined' && window.location ? window.location.pathname : '');
+        return typeof url === 'string' && url.indexOf('/lightning/page/home') !== -1;
+    }
+
+    get isHiddenOnHome() {
+        if (!this.isOnHomePage) {
+            return false;
+        }
+        const map = this._hiddenHomeComponents && this._hiddenHomeComponents.data;
+        return !!(map && map[HOME_COMPONENT_KEY] === true);
+    }
+
+    get isNotHiddenOnHome() {
+        return !this.isHiddenOnHome;
+    }
+
     @track isExpanded = false;
     @track currentStep = 1;
     @track orgType = ''; // 'client' or 'vendor'

--- a/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/__tests__/deliveryHomeVisibilitySettingsCard.test.js
+++ b/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/__tests__/deliveryHomeVisibilitySettingsCard.test.js
@@ -1,0 +1,57 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryHomeVisibilitySettingsCard: renders six
+ *               "Show on Home" toggles (all on by default), and persists a hide when a
+ *               toggle is switched off.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from 'lwc';
+import DeliveryHomeVisibilitySettingsCard from 'c/deliveryHomeVisibilitySettingsCard';
+import setHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.setHiddenHomeComponents';
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createComponent() {
+    const element = createElement('c-delivery-home-visibility-settings-card', {
+        is: DeliveryHomeVisibilitySettingsCard
+    });
+    document.body.appendChild(element);
+    return element;
+}
+
+describe('c-delivery-home-visibility-settings-card', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('renders six Show-on-Home toggles, all on by default', async () => {
+        const element = createComponent();
+        await flushPromises();
+
+        const toggles = element.shadowRoot.querySelectorAll('lightning-input');
+        expect(toggles.length).toBe(6);
+        toggles.forEach((t) => expect(t.checked).toBe(true));
+    });
+
+    it('persists a hide when a toggle is switched off', async () => {
+        setHiddenHomeComponents.mockResolvedValue({ deliveryPacingForecast: true });
+        const element = createComponent();
+        await flushPromises();
+
+        const toggle = element.shadowRoot.querySelector('lightning-input[data-key="deliveryPacingForecast"]');
+        expect(toggle).not.toBeNull();
+        toggle.checked = false;
+        toggle.dispatchEvent(new CustomEvent('change'));
+        await flushPromises();
+
+        expect(setHiddenHomeComponents).toHaveBeenCalledTimes(1);
+        const arg = setHiddenHomeComponents.mock.calls[0][0];
+        expect(arg.hidden.deliveryPacingForecast).toBe(true);
+    });
+});

--- a/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/deliveryHomeVisibilitySettingsCard.css
+++ b/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/deliveryHomeVisibilitySettingsCard.css
@@ -1,0 +1,124 @@
+/* CSS Custom Properties (mirrors deliveryGeneralSettingsCard) */
+:host {
+    --brand-primary: #4f46e5;
+    --brand-primary-light: #eef2ff;
+    --gray-100: #f3f4f6;
+    --gray-200: #e5e7eb;
+    --gray-500: #6b7280;
+    --gray-800: #1f2937;
+    --gray-900: #11182c;
+    --white: #ffffff;
+    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    --radius: 0.75rem;
+    display: block;
+}
+
+/* Card Structure */
+.settings-card {
+    background-color: var(--white);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+    border: 1px solid transparent;
+}
+
+.card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.5rem;
+    border-bottom: 1px solid var(--gray-200);
+}
+
+.header-content {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.header-icon {
+    color: var(--brand-primary);
+}
+
+.card-title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: var(--gray-900);
+    margin: 0 0 0.25rem 0;
+}
+
+.card-subtitle {
+    font-size: 0.875rem;
+    color: var(--gray-500);
+    margin: 0;
+}
+
+.card-body {
+    padding: 1.5rem;
+}
+
+/* Section heading */
+.section-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid var(--brand-primary);
+}
+
+.section-heading-text {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--brand-primary);
+}
+
+/* Form sections */
+.form-section {
+    margin-bottom: 0.25rem;
+}
+
+/* Toggle groups */
+.toggle-group {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem;
+    border-radius: var(--radius);
+    transition: all 0.2s ease;
+    margin: 0.25rem 0;
+}
+
+.toggle-group:hover {
+    background-color: var(--gray-100);
+}
+
+.toggle-content {
+    flex: 1;
+}
+
+.toggle-label-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+}
+
+.toggle-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--gray-800);
+}
+
+.toggle-help {
+    font-size: 0.75rem;
+    color: var(--gray-500);
+    line-height: 1.4;
+}
+
+.toggle-control {
+    flex-shrink: 0;
+}

--- a/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/deliveryHomeVisibilitySettingsCard.html
+++ b/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/deliveryHomeVisibilitySettingsCard.html
@@ -1,0 +1,51 @@
+<template>
+    <div class="settings-card">
+        <div class="card-header">
+            <div class="header-content">
+                <div class="header-icon">
+                    <lightning-icon icon-name="utility:preview" alternative-text="Home Page Visibility" size="small"></lightning-icon>
+                </div>
+                <div class="header-text">
+                    <h2 class="card-title">Home Page Visibility (Delivery Hub app)</h2>
+                    <p class="card-subtitle">Choose which cards appear on the Delivery Hub app Home page. Turn a card off to hide it; turn it back on to show it again. Default is shown.</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="card-body">
+
+            <div class="section-heading">
+                <lightning-icon icon-name="utility:layout" alternative-text="Home" size="xx-small"></lightning-icon>
+                <span class="section-heading-text">Show on Home Page</span>
+            </div>
+
+            <template for:each={toggles} for:item="toggle">
+                <div key={toggle.key} class="form-section">
+                    <div class="toggle-group">
+                        <div class="toggle-content">
+                            <div class="toggle-label-wrapper">
+                                <label class="toggle-label">{toggle.label}</label>
+                            </div>
+                            <div class="toggle-help">
+                                {toggle.help}
+                            </div>
+                        </div>
+                        <div class="toggle-control">
+                            <div class="custom-toggle">
+                                <lightning-input
+                                    type="toggle"
+                                    label="Show on Home"
+                                    variant="label-hidden"
+                                    data-key={toggle.key}
+                                    checked={toggle.shown}
+                                    onchange={handleToggle}>
+                                </lightning-input>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </template>
+
+        </div>
+    </div>
+</template>

--- a/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/deliveryHomeVisibilitySettingsCard.js
+++ b/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/deliveryHomeVisibilitySettingsCard.js
@@ -1,0 +1,101 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Settings card that lets an admin hide individual home-page LWC widgets
+ *               from the Delivery Hub app Home page, so the Home page only surfaces what
+ *               works. Each toggle is "Show on Home" — ON = shown (safe default), OFF =
+ *               hidden. Fully reversible. Backed by inverted HideHome…DateTime__c fields on
+ *               DeliveryHubSettings__c via DeliveryHomeVisibilityController. Composed into
+ *               deliverySettingsContainer (not exposed standalone).
+ * @author       Cloud Nimbus LLC
+ */
+import { LightningElement, track } from 'lwc';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
+import setHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.setHiddenHomeComponents';
+
+// The 6 hideable home-page components, in display order. Keys MUST match both the
+// LWC component names and the keys DeliveryHomeVisibilityController emits.
+const COMPONENTS = [
+    {
+        key: 'deliveryGettingStarted',
+        label: 'Getting Started Wizard',
+        help: 'The guided onboarding / connection wizard.'
+    },
+    {
+        key: 'deliveryHubSetup',
+        label: 'Delivery Hub Setup',
+        help: 'The connection-setup / quickstart card.'
+    },
+    {
+        key: 'deliveryBudgetSummary',
+        label: 'Budget Summary (System Pulse)',
+        help: 'Month-over-month hours, active work items, and connection health.'
+    },
+    {
+        key: 'deliveryExecutiveDashboard',
+        label: 'Executive Dashboard',
+        help: 'The Custom-Metadata-driven dashboard cards.'
+    },
+    {
+        key: 'deliveryFeatureApprovalInbox',
+        label: 'Pending Approvals Inbox',
+        help: 'Feature-toggle approval requests assigned to the running user.'
+    },
+    {
+        key: 'deliveryPacingForecast',
+        label: 'Portfolio Pacing & Forecast',
+        help: 'Logged hours, amortized target, and run-rate forecast.'
+    }
+];
+
+export default class DeliveryHomeVisibilitySettingsCard extends LightningElement {
+    @track hiddenMap = {};
+    isLoading = true;
+
+    connectedCallback() {
+        this.loadVisibility();
+    }
+
+    async loadVisibility() {
+        try {
+            const map = await getHiddenHomeComponents();
+            this.hiddenMap = map || {};
+        } catch (error) {
+            this.showToast('Error Loading Home Visibility', error.body ? error.body.message : error.message, 'error');
+        } finally {
+            this.isLoading = false;
+        }
+    }
+
+    // Build the render model. Each toggle is "Show on Home": checked = shown = NOT hidden.
+    get toggles() {
+        return COMPONENTS.map((c) => ({
+            key: c.key,
+            label: c.label,
+            help: c.help,
+            shown: this.hiddenMap[c.key] !== true
+        }));
+    }
+
+    async handleToggle(event) {
+        const key = event.target.dataset.key;
+        const shown = event.target.checked; // ON = show on Home
+        const previous = { ...this.hiddenMap };
+        // Optimistically reflect the new state, then persist.
+        const next = { ...this.hiddenMap, [key]: !shown };
+        this.hiddenMap = next;
+        try {
+            const fresh = await setHiddenHomeComponents({ hidden: next });
+            this.hiddenMap = fresh || next;
+        } catch (error) {
+            // Revert on failure — the bound getter resets the toggle DOM.
+            this.hiddenMap = previous;
+            this.showToast('Error Saving Home Visibility', error.body ? error.body.message : error.message, 'error');
+        }
+    }
+
+    showToast(title, message, variant) {
+        this.dispatchEvent(new ShowToastEvent({ title, message, variant }));
+    }
+}

--- a/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/deliveryHomeVisibilitySettingsCard.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/deliveryHomeVisibilitySettingsCard.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>false</isExposed>
+    <masterLabel>Delivery Home Visibility Settings Card</masterLabel>
+    <description>Per-component visibility toggles for the Delivery Hub app Home page</description>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/deliveryHubSetup/__tests__/deliveryHubSetup.test.js
+++ b/force-app/main/default/lwc/deliveryHubSetup/__tests__/deliveryHubSetup.test.js
@@ -1,0 +1,47 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryHubSetup's Home-page visibility gate. The
+ *               "Powered by" footer is the always-present anchor: it renders by default
+ *               and disappears entirely on Home when an admin hides the whole widget.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from 'lwc';
+import { CurrentPageReference } from 'lightning/navigation';
+import DeliveryHubSetup from 'c/deliveryHubSetup';
+import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
+
+const HOME_PAGE_REF = { type: 'standard__namedPage', attributes: { pageName: 'home' } };
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createComponent() {
+    const element = createElement('c-delivery-hub-setup', { is: DeliveryHubSetup });
+    document.body.appendChild(element);
+    return element;
+}
+
+describe('c-delivery-hub-setup home visibility', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('renders by default when not hidden', async () => {
+        const element = createComponent();
+        await flushPromises();
+        expect(element.shadowRoot.querySelector('.hs-powered-by')).not.toBeNull();
+    });
+
+    it('renders nothing on Home when hidden in Settings', async () => {
+        const element = createComponent();
+        CurrentPageReference.emit(HOME_PAGE_REF);
+        getHiddenHomeComponents.emit({ deliveryHubSetup: true });
+        await flushPromises();
+        expect(element.shadowRoot.querySelector('.hs-powered-by')).toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/deliveryHubSetup/deliveryHubSetup.html
+++ b/force-app/main/default/lwc/deliveryHubSetup/deliveryHubSetup.html
@@ -1,4 +1,5 @@
 <template>
+    <template lwc:if={isNotHiddenOnHome}>
     <template lwc:if={isVisible}>
 
         <!-- ── Mothership: this org is the Cloud Nimbus host ── -->
@@ -149,4 +150,5 @@
     <div class="hs-powered-by">
         Powered by <a href="https://cloudnimbusllc.com" target="_blank" rel="noopener noreferrer">Cloud Nimbus LLC</a>
     </div>
+    </template>
 </template>

--- a/force-app/main/default/lwc/deliveryHubSetup/deliveryHubSetup.js
+++ b/force-app/main/default/lwc/deliveryHubSetup/deliveryHubSetup.js
@@ -10,6 +10,8 @@
  * @author       Cloud Nimbus LLC
  */
 import { LightningElement, api, track, wire } from 'lwc';
+import { CurrentPageReference } from 'lightning/navigation';
+import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
 import getSetupStatus from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.getSetupStatus';
 import prepareLocalEntity from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.prepareLocalEntity';
 import performHandshake from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.performHandshake';
@@ -19,6 +21,9 @@ import approveConnection from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubSe
 import rejectConnection from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.rejectConnection';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import { refreshApex } from '@salesforce/apex';
+
+// This component's key in the Home-visibility map (matches its LWC folder name).
+const HOME_COMPONENT_KEY = 'deliveryHubSetup';
 
 export default class DeliveryHubSetup extends LightningElement {
     /** When true, shows a persistent connected-state card after setup completes.
@@ -37,6 +42,38 @@ export default class DeliveryHubSetup extends LightningElement {
     _wiredStatusResult;
     _wiredPendingCountResult;
     _wiredPendingApprovalsResult;
+
+    // ── Home-page visibility (admin-toggleable, default = shown) ──
+    // Hides ONLY on the Delivery Hub app Home page when an admin toggles it
+    // off in Settings. Everywhere else this component always renders.
+    @wire(CurrentPageReference) _homePageRef;
+    @wire(getHiddenHomeComponents) _hiddenHomeComponents;
+
+    get isOnHomePage() {
+        const ref = this._homePageRef;
+        if (!ref) {
+            return false;
+        }
+        const attrs = ref.attributes || {};
+        if (ref.type === 'standard__namedPage' && attrs.pageName === 'home') {
+            return true;
+        }
+        const url = attrs.url
+            || (typeof window !== 'undefined' && window.location ? window.location.pathname : '');
+        return typeof url === 'string' && url.indexOf('/lightning/page/home') !== -1;
+    }
+
+    get isHiddenOnHome() {
+        if (!this.isOnHomePage) {
+            return false;
+        }
+        const map = this._hiddenHomeComponents && this._hiddenHomeComponents.data;
+        return !!(map && map[HOME_COMPONENT_KEY] === true);
+    }
+
+    get isNotHiddenOnHome() {
+        return !this.isHiddenOnHome;
+    }
 
     @wire(getSetupStatus)
     wiredStatus(result) {

--- a/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
+++ b/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
@@ -1,6 +1,16 @@
 <template>
     <lightning-tabset variant="scoped" active-tab-value={activeTab} onactive={handleTabChange}>
 
+        <!-- Front of the pipeline: inbound work that arrived but was never activated
+             onto the timeline (ActivatedDateTime = null → invisible on the board/Gantt).
+             Placed FIRST so the triager lands on the urgent intake queue. The triager
+             routes each item to a dev (assign + advance + activate) or resolves it.
+             Ungated like Approvals — the Apex scopes the data, so a non-triager just
+             sees an empty queue. -->
+        <lightning-tab label="Intake" value="intake" icon-name="standard:work_queue">
+            <c-delivery-intake-queue></c-delivery-intake-queue>
+        </lightning-tab>
+
         <lightning-tab label="Board" value="board" icon-name="standard:kanban">
             <c-delivery-hub-board></c-delivery-hub-board>
         </lightning-tab>
@@ -23,15 +33,6 @@
 
         <lightning-tab label="Guide" value="guide" icon-name="standard:knowledge">
             <c-delivery-guide></c-delivery-guide>
-        </lightning-tab>
-
-        <!-- Front of the pipeline: inbound work that arrived but was never activated
-             onto the timeline (ActivatedDateTime = null → invisible on the board/Gantt).
-             The triager routes each item to a dev (assign + advance + activate) or
-             resolves it. Ungated like Approvals — the Apex scopes the data, so a
-             non-triager just sees an empty queue. -->
-        <lightning-tab label="Intake" value="intake" icon-name="standard:work_queue">
-            <c-delivery-intake-queue></c-delivery-intake-queue>
         </lightning-tab>
 
         <!-- Buyer-facing surfaces, hosted here (the package-owned "Delivery" tab) so they

--- a/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.js
+++ b/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.js
@@ -12,7 +12,11 @@ import { LightningElement, track, wire } from 'lwc';
 import isAdminUser from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.isAdminUser';
 
 export default class DeliveryHubWorkspace extends LightningElement {
-    @track activeTab = 'board';
+    // Intake is the default landing tab: it's the front-of-pipe queue where the
+    // urgent, just-arrived work sits, so the triager opens straight onto it.
+    // Buyers (non-admins) are redirected to Approvals below — Intake reads empty
+    // for them since the Apex scopes it to triagers.
+    @track activeTab = 'intake';
     @track isAdmin = false;
     _userPicked = false;
     // Tells the embedded Quick Request component to reset-in-place on submit

--- a/force-app/main/default/lwc/deliveryIntakeQueue/deliveryIntakeQueue.js
+++ b/force-app/main/default/lwc/deliveryIntakeQueue/deliveryIntakeQueue.js
@@ -22,6 +22,7 @@
 import { LightningElement, wire } from "lwc";
 import { NavigationMixin } from "lightning/navigation";
 import { refreshApex } from "@salesforce/apex";
+import { subscribe, unsubscribe, onError } from "lightning/empApi";
 import { ShowToastEvent } from "lightning/platformShowToastEvent";
 import WORK_ITEM_OBJECT from "@salesforce/schema/WorkItem__c";
 import getIntakeItems from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getIntakeItems";
@@ -29,6 +30,9 @@ import routeToDevApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageCo
 import dismissIntakeApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.dismissIntake";
 
 const MS_PER_DAY = 86400000;
+// Real-time channel: the ghost recorder publishes here when a new inbound
+// request is created, so the queue refreshes live (no manual page reload).
+const PE_CHANNEL = "/event/%%%NAMESPACE_DOT%%%DeliveryWorkItemChange__e";
 
 export default class DeliveryIntakeQueue extends NavigationMixin(LightningElement) {
     itemsRaw = [];
@@ -55,6 +59,33 @@ export default class DeliveryIntakeQueue extends NavigationMixin(LightningElemen
             this.errorMessage = this._errorText(result.error, "Unable to load the intake queue.");
             this.itemsRaw = [];
             this.isLoading = false;
+        }
+    }
+
+    // ── Live refresh: pop new inbound requests in without a reload ──
+
+    _subscription = null;
+
+    connectedCallback() {
+        onError((err) => {
+            // Best-effort: the wired data still loads on its own if the
+            // streaming channel hiccups — just log and carry on.
+            // eslint-disable-next-line no-console
+            console.warn("[DeliveryIntakeQueue] empApi error:", JSON.stringify(err));
+        });
+        subscribe(PE_CHANNEL, -1, () => {
+            // A new or changed work item may belong in (or leave) the intake
+            // queue — re-pull the wired list so it updates in place.
+            refreshApex(this.wiredResult);
+        }).then((response) => {
+            this._subscription = response;
+        });
+    }
+
+    disconnectedCallback() {
+        if (this._subscription) {
+            unsubscribe(this._subscription, () => {});
+            this._subscription = null;
         }
     }
 

--- a/force-app/main/default/lwc/deliveryPacingForecast/__tests__/deliveryPacingForecast.test.js
+++ b/force-app/main/default/lwc/deliveryPacingForecast/__tests__/deliveryPacingForecast.test.js
@@ -8,8 +8,12 @@
  * @author       Cloud Nimbus LLC
  */
 import { createElement } from "lwc";
+import { CurrentPageReference } from "lightning/navigation";
 import DeliveryPacingForecast from "c/deliveryPacingForecast";
 import getPortfolioPacing from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHoursAnalyticsController.getPortfolioPacing";
+import getHiddenHomeComponents from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents";
+
+const HOME_PAGE_REF = { type: "standard__namedPage", attributes: { pageName: "home" } };
 
 function samplePacing(overrides = {}) {
     return {
@@ -168,5 +172,26 @@ describe("c-delivery-pacing-forecast", () => {
 
         const err = element.shadowRoot.querySelector(".pacing-error");
         expect(err).not.toBeNull();
+    });
+
+    // ── Home-page visibility ─────────────────────────────────────
+    it("renders the card on Home when not hidden in Settings", async () => {
+        const element = createComponent();
+        CurrentPageReference.emit(HOME_PAGE_REF);
+        getHiddenHomeComponents.emit({ deliveryPacingForecast: false });
+        getPortfolioPacing.emit(samplePacing());
+        await flushPromises();
+
+        expect(element.shadowRoot.querySelector(".pacing-card")).not.toBeNull();
+    });
+
+    it("renders nothing on Home when hidden in Settings", async () => {
+        const element = createComponent();
+        CurrentPageReference.emit(HOME_PAGE_REF);
+        getHiddenHomeComponents.emit({ deliveryPacingForecast: true });
+        getPortfolioPacing.emit(samplePacing());
+        await flushPromises();
+
+        expect(element.shadowRoot.querySelector(".pacing-card")).toBeNull();
     });
 });

--- a/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.html
+++ b/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.html
@@ -1,4 +1,5 @@
 <template>
+    <template lwc:if={isNotHiddenOnHome}>
     <div class="pacing-card">
 
         <div class="pacing-header">
@@ -158,4 +159,5 @@
         </template>
 
     </div>
+    </template>
 </template>

--- a/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.js
+++ b/force-app/main/default/lwc/deliveryPacingForecast/deliveryPacingForecast.js
@@ -13,7 +13,12 @@
  * @author       Cloud Nimbus LLC
  */
 import { LightningElement, track, wire } from "lwc";
+import { CurrentPageReference } from "lightning/navigation";
 import getPortfolioPacing from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHoursAnalyticsController.getPortfolioPacing";
+import getHiddenHomeComponents from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents";
+
+// This component's key in the Home-visibility map (matches its LWC folder name).
+const HOME_COMPONENT_KEY = "deliveryPacingForecast";
 
 const SVG_WIDTH = 760;
 const SVG_HEIGHT = 320;
@@ -34,6 +39,10 @@ export default class DeliveryPacingForecast extends LightningElement {
     granularity = "Month";
     horizon = "3";
 
+    // ── Home-page visibility (admin-toggleable, default = shown) ──
+    @wire(CurrentPageReference) _homePageRef;
+    @wire(getHiddenHomeComponents) _hiddenHomeComponents;
+
     @wire(getPortfolioPacing, {
         granularity: "$granularity",
         periodsBack: "$_periodsBack",
@@ -48,6 +57,36 @@ export default class DeliveryPacingForecast extends LightningElement {
             this.errorMessage = error.body ? error.body.message : error.message;
             this.pacing = null;
         }
+    }
+
+    // ── Home-page visibility getters ─────────────────────────────
+    // The card hides ONLY on the app Home page when an admin has toggled it
+    // off in Settings. Everywhere else it always renders.
+
+    get isOnHomePage() {
+        const ref = this._homePageRef;
+        if (!ref) {
+            return false;
+        }
+        const attrs = ref.attributes || {};
+        if (ref.type === "standard__namedPage" && attrs.pageName === "home") {
+            return true;
+        }
+        const url = attrs.url
+            || (typeof window !== "undefined" && window.location ? window.location.pathname : "");
+        return typeof url === "string" && url.indexOf("/lightning/page/home") !== -1;
+    }
+
+    get isHiddenOnHome() {
+        if (!this.isOnHomePage) {
+            return false;
+        }
+        const map = this._hiddenHomeComponents && this._hiddenHomeComponents.data;
+        return !!(map && map[HOME_COMPONENT_KEY] === true);
+    }
+
+    get isNotHiddenOnHome() {
+        return !this.isHiddenOnHome;
     }
 
     // ── Wire inputs ──────────────────────────────────────────────

--- a/force-app/main/default/lwc/deliverySettingsContainer/deliverySettingsContainer.html
+++ b/force-app/main/default/lwc/deliverySettingsContainer/deliverySettingsContainer.html
@@ -26,6 +26,10 @@
                 <lightning-tab label="OpenAI" value="openai">
                     <c-delivery-open-ai-settings-card></c-delivery-open-ai-settings-card>
                 </lightning-tab>
+
+                <lightning-tab label="Home Visibility" value="homeVisibility">
+                    <c-delivery-home-visibility-settings-card></c-delivery-home-visibility-settings-card>
+                </lightning-tab>
             </lightning-tabset>
         </div>
     </div>

--- a/force-app/main/default/lwc/deliverySettingsContainer/deliverySettingsContainer.js
+++ b/force-app/main/default/lwc/deliverySettingsContainer/deliverySettingsContainer.js
@@ -17,7 +17,8 @@ export default class DeliverySettingsContainer extends LightningElement {
         return [
             { label: 'General', value: 'general' },
             { label: 'AI Features', value: 'ai' },
-            { label: 'OpenAI', value: 'openai' }
+            { label: 'OpenAI', value: 'openai' },
+            { label: 'Home Visibility', value: 'homeVisibility' }
         ];
     }
 
@@ -31,6 +32,10 @@ export default class DeliverySettingsContainer extends LightningElement {
 
     get isOpenaiActive() {
         return this.activeTab === 'openai';
+    }
+
+    get isHomeVisibilityActive() {
+        return this.activeTab === 'homeVisibility';
     }
 
     handleTabChange(event) {

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableAutoActivateDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableAutoActivateDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnableAutoActivateDateTime__c</fullName>
+    <description>When non-null, inbound requests (e.g. the Report Issue ghost recorder) are auto-activated on creation and appear straight on the Board/Timeline, as legacy behavior did. Null = intake-first (default, safe): inbound requests land un-activated in the Intake queue for a triager to review and activate. The org-default null gives MF the triage-first flow; the quickstart connection stamps this so a fresh install's board populates immediately. Inverted from the usual Enable pattern only in default meaning: here null is the intended product default (intake-first), matching the inverted-default convention used by BypassAuditPassDateTime__c.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to auto-activate new inbound requests onto the Board immediately. Leave blank for intake-first (inbound requests wait in the Intake queue until a triager activates them).</inlineHelpText>
+    <label>Enable Auto-Activate Inbound</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeBudgetSummaryDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeBudgetSummaryDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideHomeBudgetSummaryDateTime__c</fullName>
+    <description>When non-null, hide the deliveryBudgetSummary (System Pulse) card from the Delivery Hub app Home page. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the card again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Budget Summary card on the Home page. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Home Budget Summary</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeExecutiveDashboardDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeExecutiveDashboardDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideHomeExecutiveDashboardDateTime__c</fullName>
+    <description>When non-null, hide the deliveryExecutiveDashboard card from the Delivery Hub app Home page. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the card again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Executive Dashboard card on the Home page. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Home Executive Dashboard</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeFeatureApprovalInboxDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeFeatureApprovalInboxDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideHomeFeatureApprovalInboxDateTime__c</fullName>
+    <description>When non-null, hide the deliveryFeatureApprovalInbox (Pending Approvals) card from the Delivery Hub app Home page. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the card again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Feature Approval Inbox card on the Home page. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Home Feature Approval Inbox</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeGettingStartedDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeGettingStartedDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideHomeGettingStartedDateTime__c</fullName>
+    <description>When non-null, hide the deliveryGettingStarted onboarding wizard from the Delivery Hub app Home page. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the card again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Getting Started wizard on the Home page. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Home Getting Started</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeHubSetupDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeHubSetupDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideHomeHubSetupDateTime__c</fullName>
+    <description>When non-null, hide the deliveryHubSetup connection-setup card from the Delivery Hub app Home page. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the card again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Delivery Hub Setup card on the Home page. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Home Hub Setup</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomePacingForecastDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomePacingForecastDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideHomePacingForecastDateTime__c</fullName>
+    <description>When non-null, hide the deliveryPacingForecast (Portfolio Pacing &amp; Forecast) card from the Delivery Hub app Home page. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the card again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Portfolio Pacing &amp; Forecast card on the Home page. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Home Pacing Forecast</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryDashboardCardController.getCardData.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryDashboardCardController.getCardData.js
@@ -1,0 +1,5 @@
+/**
+ * Imperative Apex mock for DeliveryDashboardCardController.getCardData.
+ * Minimal default resolution for jest render tests.
+ */
+module.exports = { default: jest.fn().mockResolvedValue(null) };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryDashboardCardController.getCardsForPage.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryDashboardCardController.getCardsForPage.js
@@ -1,0 +1,5 @@
+/**
+ * Imperative Apex mock for DeliveryDashboardCardController.getCardsForPage.
+ * Minimal default resolution for jest render tests.
+ */
+module.exports = { default: jest.fn().mockResolvedValue([]) };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.getApprovalChain.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.getApprovalChain.js
@@ -1,0 +1,5 @@
+/**
+ * Imperative Apex mock for DeliveryFeatureApprovalService.getApprovalChain.
+ * Minimal default resolution for jest render tests.
+ */
+module.exports = { default: jest.fn().mockResolvedValue([]) };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.getInbox.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.getInbox.js
@@ -1,0 +1,7 @@
+/**
+ * Wire adapter mock for DeliveryFeatureApprovalService.getInbox.
+ * Minimal createApexTestWireAdapter for jest render tests.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+const getInbox = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getInbox };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.grant.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.grant.js
@@ -1,0 +1,5 @@
+/**
+ * Imperative Apex mock for DeliveryFeatureApprovalService.grant.
+ * Minimal default resolution for jest render tests.
+ */
+module.exports = { default: jest.fn().mockResolvedValue({}) };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.reject.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureApprovalService.reject.js
@@ -1,0 +1,5 @@
+/**
+ * Imperative Apex mock for DeliveryFeatureApprovalService.reject.
+ * Minimal default resolution for jest render tests.
+ */
+module.exports = { default: jest.fn().mockResolvedValue({}) };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents.js
@@ -1,0 +1,8 @@
+/**
+ * Wire adapter mock for DeliveryHomeVisibilityController.getHiddenHomeComponents.
+ * Used by the home-page LWC jest tests to drive per-component Home visibility.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+
+const getHiddenHomeComponents = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getHiddenHomeComponents };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.setHiddenHomeComponents.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.setHiddenHomeComponents.js
@@ -1,0 +1,5 @@
+/**
+ * Imperative Apex mock for DeliveryHomeVisibilityController.setHiddenHomeComponents.
+ * Minimal default resolution for jest render tests.
+ */
+module.exports = { default: jest.fn().mockResolvedValue({}) };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.getBudgetMetrics.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.getBudgetMetrics.js
@@ -1,0 +1,7 @@
+/**
+ * Wire adapter mock for DeliveryHubDashboardController.getBudgetMetrics.
+ * Minimal createApexTestWireAdapter for jest render tests.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+const getBudgetMetrics = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getBudgetMetrics };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.approveConnection.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.approveConnection.js
@@ -1,0 +1,5 @@
+/**
+ * Imperative Apex mock for DeliveryHubSetupController.approveConnection.
+ * Minimal default resolution for jest render tests.
+ */
+module.exports = { default: jest.fn().mockResolvedValue({}) };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.checkPrerequisites.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.checkPrerequisites.js
@@ -1,0 +1,5 @@
+/**
+ * Imperative Apex mock for DeliveryHubSetupController.checkPrerequisites.
+ * Minimal default resolution for jest render tests.
+ */
+module.exports = { default: jest.fn().mockResolvedValue({}) };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.configureGuestUserAccess.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.configureGuestUserAccess.js
@@ -1,0 +1,5 @@
+/**
+ * Imperative Apex mock for DeliveryHubSetupController.configureGuestUserAccess.
+ * Minimal default resolution for jest render tests.
+ */
+module.exports = { default: jest.fn().mockResolvedValue({}) };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.getPendingApprovalCount.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.getPendingApprovalCount.js
@@ -1,0 +1,7 @@
+/**
+ * Wire adapter mock for DeliveryHubSetupController.getPendingApprovalCount.
+ * Minimal createApexTestWireAdapter for jest render tests.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+const getPendingApprovalCount = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getPendingApprovalCount };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.getPendingApprovals.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.getPendingApprovals.js
@@ -1,0 +1,7 @@
+/**
+ * Wire adapter mock for DeliveryHubSetupController.getPendingApprovals.
+ * Minimal createApexTestWireAdapter for jest render tests.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+const getPendingApprovals = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getPendingApprovals };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.getSetupStatus.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.getSetupStatus.js
@@ -1,0 +1,7 @@
+/**
+ * Wire adapter mock for DeliveryHubSetupController.getSetupStatus.
+ * Minimal createApexTestWireAdapter for jest render tests.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+const getSetupStatus = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getSetupStatus };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.performHandshake.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.performHandshake.js
@@ -1,0 +1,5 @@
+/**
+ * Imperative Apex mock for DeliveryHubSetupController.performHandshake.
+ * Minimal default resolution for jest render tests.
+ */
+module.exports = { default: jest.fn().mockResolvedValue({}) };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.prepareLocalEntity.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.prepareLocalEntity.js
@@ -1,0 +1,5 @@
+/**
+ * Imperative Apex mock for DeliveryHubSetupController.prepareLocalEntity.
+ * Minimal default resolution for jest render tests.
+ */
+module.exports = { default: jest.fn().mockResolvedValue({}) };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.rejectConnection.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubSetupController.rejectConnection.js
@@ -1,0 +1,5 @@
+/**
+ * Imperative Apex mock for DeliveryHubSetupController.rejectConnection.
+ * Minimal default resolution for jest render tests.
+ */
+module.exports = { default: jest.fn().mockResolvedValue({}) };

--- a/unpackaged/post/testSuites/DH.testSuite-meta.xml
+++ b/unpackaged/post/testSuites/DH.testSuite-meta.xml
@@ -137,4 +137,5 @@
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryShipVerificationTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryApproverServiceTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryRateServiceTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityControllerTest</testClassName>
 </ApexTestSuite>


### PR DESCRIPTION
## What & why
Makes the Delivery Hub **inbound happy-path work end-to-end** for the buyer/triager persona, and lets an org **declutter the home page** — both aimed at a clean, working Delivery Hub app (admin app keeps everything).

### The loop (now works)
`Report Issue (ghost recorder) → Intake → hand off / dismiss → workflow`

- **Intake-first activation** — new `EnableAutoActivateDateTime__c` org setting (default null = intake-first). Inbound ghost requests are no longer auto-activated by the WorkItem before-insert trigger; they land **un-activated in the Intake queue** for triage. Surgical, per-insert suppression via `DeliveryTriggerControl.suppressAutoActivate` — board/cart/setup/demo-data paths activate explicitly and are unaffected.
- **Hand-off → Ready for Sizing** (was Ready for Development) — a raw request enters the workflow at the start (size → estimate → approve → dev), not falsely "ready to code."
- **Live Intake refresh** — ghost recorder publishes `DeliveryWorkItemChange__e` on create; the Intake queue subscribes via empApi and `refreshApex`'s in place, so a new request pops in without a manual reload.
- **Intake on the home page** — added first in the home top region.

### Declutter
- **Home-page visibility toggles** — 6 `HideHome*DateTime__c` settings + `DeliveryHomeVisibilityController` + a "Home Visibility" Settings tab let an org hide non-essential home widgets (Budget Summary, Executive Dashboard, Feature Approval Inbox, Getting Started, Hub Setup, Pacing Forecast). Default = shown, reversible.

### Drive-by fix
- **Gantt reorder commit** — a within-lane reorder patch arrives without a `priorityGroup`; derive the destination bucket from the task's current effective group instead of throwing (`resolveEffectiveGroup`).

## Verification
- DH-relevant Apex suite run on a scratch org: **85 tests, 100% pass**; new tests for intake-first default, auto-activate-on, Ready-for-Sizing hand-off, home-visibility, and the within-lane-reorder derivation.
- `DeliveryGanttController` coverage 78% (added reorder-derivation test).
- PMD (`pmd-rules.xml`, engine: pmd) clean on all changed Apex (refactored `createQuickRequest` to keep cyclomatic complexity under threshold).
- New test class registered in the `DH` ApexTestSuite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)