### PR TITLE
feat(workspace): per-tab visibility toggles for the Delivery tab

### DIFF
--- a/force-app/main/default/classes/DeliveryTabVisibilityController.cls
+++ b/force-app/main/default/classes/DeliveryTabVisibilityController.cls
@@ -1,0 +1,111 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Per-tab visibility toggles for the Delivery Hub workspace ("Delivery") tab.
+ *               Lets an admin hide individual non-admin sub-tabs of deliveryHubWorkspace
+ *               (so the workspace only surfaces what an org uses) via the Settings tab,
+ *               fully reversibly. Backed by inverted HideTab…DateTime__c fields on
+ *               DeliveryHubSettings__c: null = SHOWN (safe default), non-null = HIDDEN. The
+ *               map this returns is keyed by the tab value (e.g. 'board') so the workspace
+ *               can ask "is this tab hidden?" with a single cacheable wire. The 5 admin-only
+ *               tabs (Templates/Analytics/Velocity/Settings/Workflows) are gated by isAdmin
+ *               and are intentionally NOT toggleable here.
+ * @author       Cloud Nimbus LLC
+ */
+public with sharing class DeliveryTabVisibilityController {
+
+    // Map of workspace tab value → the inverted "hide" DateTime field that gates it.
+    // Order is the order the toggles render in the Settings card.
+    private static final Map<String, String> TAB_TO_FIELD = new Map<String, String>{
+        'intake'     => 'HideTabIntakeDateTime__c',
+        'board'      => 'HideTabBoardDateTime__c',
+        'newRequest' => 'HideTabNewRequestDateTime__c',
+        'timeline'   => 'HideTabTimelineDateTime__c',
+        'activity'   => 'HideTabActivityDateTime__c',
+        'documents'  => 'HideTabDocumentsDateTime__c',
+        'guide'      => 'HideTabGuideDateTime__c',
+        'approvals'  => 'HideTabApprovalsDateTime__c',
+        'closeouts'  => 'HideTabCloseoutsDateTime__c',
+        'forecast'   => 'HideTabForecastDateTime__c'
+    };
+
+    /**
+     * @description Returns which workspace sub-tabs are currently hidden, keyed by the tab
+     *              value. A tab is hidden when its matching HideTab…DateTime__c field is
+     *              non-null (inverted-default: null = shown). Reads the hierarchy custom
+     *              setting via getInstance().
+     * @return Map of tab value → isHidden (true = hide in the Delivery workspace).
+     */
+    @AuraEnabled(cacheable=true)
+    public static Map<String, Boolean> getHiddenWorkspaceTabs() {
+        return buildHiddenMap(DeliveryHubSettings__c.getInstance());
+    }
+
+    /**
+     * @description Persists the per-tab workspace visibility toggles. For each entry,
+     *              true = HIDE (stamps the HideTab…DateTime__c with now() if not already
+     *              set), false = SHOW (clears the field). Existing stamps are preserved so
+     *              the "active since" timestamp does not churn. Writes to the org-default
+     *              record. Returns the fresh hidden-map so the caller can refresh state
+     *              without hitting the cacheable read's stale cache.
+     * @param hidden Map of tab value → desired isHidden state.
+     * @return Map of tab value → isHidden after the save.
+     */
+    @AuraEnabled
+    public static Map<String, Boolean> setHiddenWorkspaceTabs(Map<String, Boolean> hidden) {
+        try {
+            Map<String, Boolean> requested = hidden != null ? hidden : new Map<String, Boolean>();
+            DeliveryHubSettings__c settings = getOrCreateSettings();
+
+            for (String tabValue : TAB_TO_FIELD.keySet()) {
+                if (!requested.containsKey(tabValue)) {
+                    continue;
+                }
+                String fieldApiName = TAB_TO_FIELD.get(tabValue);
+                Boolean shouldHide = requested.get(tabValue) == true;
+                Datetime existing = (Datetime) settings.get(fieldApiName);
+                settings.put(fieldApiName, shouldHide ? (existing != null ? existing : Datetime.now()) : null);
+            }
+
+            SObjectAccessDecision decision = Security.stripInaccessible(
+                AccessType.UPSERTABLE, new List<DeliveryHubSettings__c>{ settings });
+            upsert decision.getRecords();
+
+            // Re-read from the org default so the returned map reflects what was persisted.
+            return buildHiddenMap(DeliveryHubSettings__c.getOrgDefaults());
+        } catch (Exception e) {
+            AuraHandledException ahe = new AuraHandledException(e.getMessage());
+            ahe.setMessage(e.getMessage());
+            throw ahe;
+        }
+    }
+
+    /**
+     * @description Builds the tab value → isHidden map from a settings record.
+     * @param settings The DeliveryHubSettings__c instance (may be a blank getInstance()).
+     * @return Map of tab value → isHidden.
+     */
+    private static Map<String, Boolean> buildHiddenMap(DeliveryHubSettings__c settings) {
+        Map<String, Boolean> result = new Map<String, Boolean>();
+        for (String tabValue : TAB_TO_FIELD.keySet()) {
+            Boolean isHidden = false;
+            if (settings != null) {
+                isHidden = settings.get(TAB_TO_FIELD.get(tabValue)) != null;
+            }
+            result.put(tabValue, isHidden);
+        }
+        return result;
+    }
+
+    /**
+     * @description Helper to get existing org-default settings or create a new default instance.
+     * @return DeliveryHubSettings__c settings record.
+     */
+    private static DeliveryHubSettings__c getOrCreateSettings() {
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        if (settings == null || settings.Id == null) {
+            settings = new DeliveryHubSettings__c(SetupOwnerId = UserInfo.getOrganizationId());
+        }
+        return settings;
+    }
+}

--- a/force-app/main/default/classes/DeliveryTabVisibilityController.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryTabVisibilityController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryTabVisibilityControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryTabVisibilityControllerTest.cls
@@ -1,0 +1,84 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Unit tests for DeliveryTabVisibilityController — the per-tab visibility
+ *               toggles for the Delivery Hub workspace ("Delivery") tab, backed by inverted
+ *               HideTab…DateTime__c fields on DeliveryHubSettings__c (null = shown,
+ *               non-null = hidden).
+ * @author       Cloud Nimbus LLC
+ */
+@isTest
+private class DeliveryTabVisibilityControllerTest {
+
+    private static final String KEY_BOARD = 'board';
+    private static final String KEY_FORECAST = 'forecast';
+
+    @isTest
+    static void defaultsToAllShown() {
+        Test.startTest();
+        Map<String, Boolean> hidden = DeliveryTabVisibilityController.getHiddenWorkspaceTabs();
+        Test.stopTest();
+
+        System.assertEquals(10, hidden.size(), 'Expected all ten non-admin tabs in the map');
+        for (String key : hidden.keySet()) {
+            System.assertEquals(false, hidden.get(key), 'No setting present → tab should be shown (not hidden): ' + key);
+        }
+    }
+
+    @isTest
+    static void hidingStampsTheField() {
+        Map<String, Boolean> request = new Map<String, Boolean>{ KEY_BOARD => true };
+
+        Test.startTest();
+        Map<String, Boolean> result = DeliveryTabVisibilityController.setHiddenWorkspaceTabs(request);
+        Test.stopTest();
+
+        System.assertEquals(true, result.get(KEY_BOARD), 'Board tab should be hidden after stamping');
+        System.assertEquals(false, result.get(KEY_FORECAST), 'Untouched tabs stay shown');
+
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        System.assertNotEquals(null, settings.HideTabBoardDateTime__c, 'Hide field should be stamped');
+        System.assertEquals(null, settings.HideTabForecastDateTime__c, 'Untouched field stays null');
+    }
+
+    @isTest
+    static void showingClearsTheField() {
+        // First hide, then show again — must clear the stamp (fully reversible).
+        DeliveryTabVisibilityController.setHiddenWorkspaceTabs(new Map<String, Boolean>{ KEY_BOARD => true });
+
+        Test.startTest();
+        Map<String, Boolean> result = DeliveryTabVisibilityController.setHiddenWorkspaceTabs(
+            new Map<String, Boolean>{ KEY_BOARD => false });
+        Test.stopTest();
+
+        System.assertEquals(false, result.get(KEY_BOARD), 'Board tab should be shown again');
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        System.assertEquals(null, settings.HideTabBoardDateTime__c, 'Hide field should be cleared');
+    }
+
+    @isTest
+    static void existingStampIsPreservedOnRepeatHide() {
+        DeliveryTabVisibilityController.setHiddenWorkspaceTabs(new Map<String, Boolean>{ KEY_BOARD => true });
+        Datetime firstStamp = DeliveryHubSettings__c.getOrgDefaults().HideTabBoardDateTime__c;
+
+        Test.startTest();
+        // Re-asserting "hidden" should not churn the existing timestamp.
+        DeliveryTabVisibilityController.setHiddenWorkspaceTabs(new Map<String, Boolean>{ KEY_BOARD => true });
+        Test.stopTest();
+
+        Datetime secondStamp = DeliveryHubSettings__c.getOrgDefaults().HideTabBoardDateTime__c;
+        System.assertEquals(firstStamp, secondStamp, 'Existing hide timestamp should be preserved');
+    }
+
+    @isTest
+    static void nullRequestIsSafe() {
+        Test.startTest();
+        Map<String, Boolean> result = DeliveryTabVisibilityController.setHiddenWorkspaceTabs(null);
+        Test.stopTest();
+
+        System.assertEquals(10, result.size(), 'A null request is a no-op that still returns the full map');
+        for (String key : result.keySet()) {
+            System.assertEquals(false, result.get(key), 'Nothing hidden for a null request: ' + key);
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryTabVisibilityControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryTabVisibilityControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/deliveryHubWorkspace/__tests__/deliveryHubWorkspace.test.js
+++ b/force-app/main/default/lwc/deliveryHubWorkspace/__tests__/deliveryHubWorkspace.test.js
@@ -1,0 +1,106 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryHubWorkspace: a sub-tab is hidden when its
+ *               DeliveryTabVisibilityController.getHiddenWorkspaceTabs entry is set, and
+ *               the active tab falls back to the first VISIBLE tab when the would-be
+ *               default landing tab has been hidden.
+ *
+ *               The workspace is a pure shell that embeds ~17 child LWCs. Rendering it in
+ *               jest transitively compiles every child (and their unmockable deps, e.g.
+ *               lightning/actions, plus deliveryHubBoard's %%%NAMESPACE_DOT%%% template
+ *               token). We stub every child to an empty LWC so this test exercises only the
+ *               shell's tab visibility / active-tab logic, with zero child-dependency churn.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from 'lwc';
+
+// Stub every child LWC the workspace embeds → only the shell renders. The factory must be
+// inlined per call (babel-plugin-jest-hoist rejects a shared factory reference); the
+// require('lwc') call inside the inline factory is permitted.
+jest.mock('c/deliveryIntakeQueue', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryHubBoard', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryQuickRequest', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryProFormaTimeline', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryActivityFeed', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryDocumentViewer', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryGuide', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryApprovalSummaryCard', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryApprovalQueue', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryCloseOutQueue', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryCapacityForecast', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryTemplateManager', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryActivityDashboard', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryVelocityDashboard', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryPacingForecast', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliverySettingsContainer', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryWorkflowBuilder', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+
+// eslint-disable-next-line import/first
+import DeliveryHubWorkspace from 'c/deliveryHubWorkspace';
+// eslint-disable-next-line import/first
+import isAdminUser from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.isAdminUser';
+// eslint-disable-next-line import/first
+import getHiddenWorkspaceTabs from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTabVisibilityController.getHiddenWorkspaceTabs';
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createComponent() {
+    const element = createElement('c-delivery-hub-workspace', {
+        is: DeliveryHubWorkspace
+    });
+    document.body.appendChild(element);
+    return element;
+}
+
+function tabValues(element) {
+    // lightning-tab is stubbed in jest; `value` reaches it as a property, not an attribute.
+    return Array.from(element.shadowRoot.querySelectorAll('lightning-tab')).map((t) => t.value);
+}
+
+describe('c-delivery-hub-workspace', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('shows all ten non-admin tabs by default', async () => {
+        const element = createComponent();
+        isAdminUser.emit(false);
+        getHiddenWorkspaceTabs.emit({});
+        await flushPromises();
+
+        const values = tabValues(element);
+        expect(values).toContain('intake');
+        expect(values).toContain('board');
+        expect(values).toContain('forecast');
+        expect(values.length).toBe(10); // buyer → no admin tabs
+    });
+
+    it('hides a tab when its visibility setting is set', async () => {
+        const element = createComponent();
+        isAdminUser.emit(false);
+        getHiddenWorkspaceTabs.emit({ board: true });
+        await flushPromises();
+
+        const values = tabValues(element);
+        expect(values).not.toContain('board');
+        expect(values).toContain('intake');
+    });
+
+    it('falls back to the first visible tab when the buyer landing tab is hidden', async () => {
+        const element = createComponent();
+        // Buyers default-land on Approvals; hide it → must fall back to first visible (intake).
+        isAdminUser.emit(false);
+        getHiddenWorkspaceTabs.emit({ approvals: true });
+        await flushPromises();
+
+        const tabset = element.shadowRoot.querySelector('lightning-tabset');
+        expect(tabset.activeTabValue).toBe('intake');
+        expect(tabValues(element)).not.toContain('approvals');
+    });
+});

--- a/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
+++ b/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
@@ -6,34 +6,49 @@
              Placed FIRST so the triager lands on the urgent intake queue. The triager
              routes each item to a dev (assign + advance + activate) or resolves it.
              Ungated like Approvals — the Apex scopes the data, so a non-triager just
-             sees an empty queue. -->
-        <lightning-tab label="Intake" value="intake" icon-name="standard:work_queue">
-            <c-delivery-intake-queue></c-delivery-intake-queue>
-        </lightning-tab>
+             sees an empty queue. Each tab is org-hideable via Settings → Delivery
+             Visibility (default shown). -->
+        <template lwc:if={showIntake}>
+            <lightning-tab label="Intake" value="intake" icon-name="standard:work_queue">
+                <c-delivery-intake-queue></c-delivery-intake-queue>
+            </lightning-tab>
+        </template>
 
-        <lightning-tab label="Board" value="board" icon-name="standard:kanban">
-            <c-delivery-hub-board></c-delivery-hub-board>
-        </lightning-tab>
+        <template lwc:if={showBoard}>
+            <lightning-tab label="Board" value="board" icon-name="standard:kanban">
+                <c-delivery-hub-board></c-delivery-hub-board>
+            </lightning-tab>
+        </template>
 
-        <lightning-tab label="New Request" value="newRequest" icon-name="standard:work_order_item">
-            <c-delivery-quick-request embedded={requestEmbedded}></c-delivery-quick-request>
-        </lightning-tab>
+        <template lwc:if={showNewRequest}>
+            <lightning-tab label="New Request" value="newRequest" icon-name="standard:work_order_item">
+                <c-delivery-quick-request embedded={requestEmbedded}></c-delivery-quick-request>
+            </lightning-tab>
+        </template>
 
-        <lightning-tab label="Timeline" value="timeline" icon-name="standard:date_input">
-            <c-delivery-pro-forma-timeline></c-delivery-pro-forma-timeline>
-        </lightning-tab>
+        <template lwc:if={showTimeline}>
+            <lightning-tab label="Timeline" value="timeline" icon-name="standard:date_input">
+                <c-delivery-pro-forma-timeline></c-delivery-pro-forma-timeline>
+            </lightning-tab>
+        </template>
 
-        <lightning-tab label="Activity" value="activity" icon-name="standard:feed">
-            <c-delivery-activity-feed></c-delivery-activity-feed>
-        </lightning-tab>
+        <template lwc:if={showActivity}>
+            <lightning-tab label="Activity" value="activity" icon-name="standard:feed">
+                <c-delivery-activity-feed></c-delivery-activity-feed>
+            </lightning-tab>
+        </template>
 
-        <lightning-tab label="Documents" value="documents" icon-name="standard:document">
-            <c-delivery-document-viewer></c-delivery-document-viewer>
-        </lightning-tab>
+        <template lwc:if={showDocuments}>
+            <lightning-tab label="Documents" value="documents" icon-name="standard:document">
+                <c-delivery-document-viewer></c-delivery-document-viewer>
+            </lightning-tab>
+        </template>
 
-        <lightning-tab label="Guide" value="guide" icon-name="standard:knowledge">
-            <c-delivery-guide></c-delivery-guide>
-        </lightning-tab>
+        <template lwc:if={showGuide}>
+            <lightning-tab label="Guide" value="guide" icon-name="standard:knowledge">
+                <c-delivery-guide></c-delivery-guide>
+            </lightning-tab>
+        </template>
 
         <!-- Buyer-facing surfaces, hosted here (the package-owned "Delivery" tab) so they
              survive subscriber Home-page overrides — a subscriber-activated custom Home
@@ -41,24 +56,30 @@
              Ungated: the Apex layer (getPendingForApprover / getApprovalSummary) already
              scopes data to the running approver, so a non-approver simply sees an empty
              queue rather than being blocked. -->
-        <lightning-tab label="Approvals" value="approvals" icon-name="standard:approval">
-            <c-delivery-approval-summary-card></c-delivery-approval-summary-card>
-            <c-delivery-approval-queue></c-delivery-approval-queue>
-        </lightning-tab>
+        <template lwc:if={showApprovals}>
+            <lightning-tab label="Approvals" value="approvals" icon-name="standard:approval">
+                <c-delivery-approval-summary-card></c-delivery-approval-summary-card>
+                <c-delivery-approval-queue></c-delivery-approval-queue>
+            </lightning-tab>
+        </template>
 
         <!-- Back of the pipeline: items in 'Deployed to Prod' awaiting the triager's
              close-out verification. Makes the Deployed-to-Prod awaiting-verification
              report actionable from inside the workspace. Ungated like Approvals. -->
-        <lightning-tab label="Close Outs" value="closeouts" icon-name="standard:task2">
-            <c-delivery-close-out-queue></c-delivery-close-out-queue>
-        </lightning-tab>
+        <template lwc:if={showCloseouts}>
+            <lightning-tab label="Close Outs" value="closeouts" icon-name="standard:task2">
+                <c-delivery-close-out-queue></c-delivery-close-out-queue>
+            </lightning-tab>
+        </template>
 
         <!-- Buyer forecast = the "you set the pace" capacity slider (the controllable
              forward projection). The retrospective pacing card is now admin-only (moved
              to the Velocity tab) so buyers have ONE forecast surface, not two stacked. -->
-        <lightning-tab label="Forecast" value="forecast" icon-name="standard:forecasts">
-            <c-delivery-capacity-forecast></c-delivery-capacity-forecast>
-        </lightning-tab>
+        <template lwc:if={showForecast}>
+            <lightning-tab label="Forecast" value="forecast" icon-name="standard:forecasts">
+                <c-delivery-capacity-forecast></c-delivery-capacity-forecast>
+            </lightning-tab>
+        </template>
 
         <template lwc:if={isAdmin}>
             <lightning-tab label="Templates" value="templates" icon-name="standard:template">

--- a/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.js
+++ b/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.js
@@ -4,12 +4,32 @@
  * @description  Unified workspace shell combining Board, Timeline, Activity, Documents,
  *               Guide, Settings, and Workflows tabs into a single tabbed experience.
  *               Mounts on AppPage / HomePage / Tab. Wires
- *               DeliveryHubDashboardController.isAdminUser to gate admin-only tabs.
- *               Pure layout — each child LWC owns its own data lifecycle.
+ *               DeliveryHubDashboardController.isAdminUser to gate admin-only tabs, and
+ *               DeliveryTabVisibilityController.getHiddenWorkspaceTabs to let an org hide
+ *               individual non-admin sub-tabs (Settings → Delivery Visibility). Pure
+ *               layout — each child LWC owns its own data lifecycle.
  * @author       Cloud Nimbus LLC
  */
 import { LightningElement, track, wire } from 'lwc';
 import isAdminUser from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.isAdminUser';
+import getHiddenWorkspaceTabs from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTabVisibilityController.getHiddenWorkspaceTabs';
+
+// The 10 toggleable non-admin tabs, in render order. Used to fall back to the first
+// VISIBLE tab when the would-be active tab is hidden (item 4 of the visibility feature).
+const TAB_ORDER = [
+    'intake',
+    'board',
+    'newRequest',
+    'timeline',
+    'activity',
+    'documents',
+    'guide',
+    'approvals',
+    'closeouts',
+    'forecast'
+];
+// Admin-only tabs are never hideable, so they are always candidates when isAdmin.
+const ADMIN_TAB_ORDER = ['templates', 'analytics', 'velocity', 'settings', 'workflows'];
 
 export default class DeliveryHubWorkspace extends LightningElement {
     // Intake is the default landing tab: it's the front-of-pipe queue where the
@@ -18,6 +38,8 @@ export default class DeliveryHubWorkspace extends LightningElement {
     // for them since the Apex scopes it to triagers.
     @track activeTab = 'intake';
     @track isAdmin = false;
+    // tab value → isHidden. Empty until the wire returns → every tab shown by default.
+    @track hiddenTabs = {};
     _userPicked = false;
     // Tells the embedded Quick Request component to reset-in-place on submit
     // rather than fire CloseActionScreenEvent (which only applies in the global
@@ -28,14 +50,75 @@ export default class DeliveryHubWorkspace extends LightningElement {
     wiredAdmin({ data }) {
         if (data === true || data === false) {
             this.isAdmin = data;
-            // Buyers (non-admins) land on Approvals — the actionable surface for the
-            // approver persona — so the Delivery tab opens useful instead of on the
-            // client-filtered Board (which reads empty for a buyer). Admins/devs keep
-            // Board. Only applies before the user has picked a tab themselves.
-            if (!this._userPicked && data === false) {
-                this.activeTab = 'approvals';
-            }
+            this.resolveActiveTab();
         }
+    }
+
+    @wire(getHiddenWorkspaceTabs)
+    wiredHiddenTabs({ data }) {
+        if (data) {
+            this.hiddenTabs = data;
+            this.resolveActiveTab();
+        }
+    }
+
+    // Per-tab visibility getters — a tab shows unless its map entry is explicitly true,
+    // so the workspace opens fully populated before the wire resolves (safe default).
+    get showIntake() {
+        return !this.isHidden('intake');
+    }
+    get showBoard() {
+        return !this.isHidden('board');
+    }
+    get showNewRequest() {
+        return !this.isHidden('newRequest');
+    }
+    get showTimeline() {
+        return !this.isHidden('timeline');
+    }
+    get showActivity() {
+        return !this.isHidden('activity');
+    }
+    get showDocuments() {
+        return !this.isHidden('documents');
+    }
+    get showGuide() {
+        return !this.isHidden('guide');
+    }
+    get showApprovals() {
+        return !this.isHidden('approvals');
+    }
+    get showCloseouts() {
+        return !this.isHidden('closeouts');
+    }
+    get showForecast() {
+        return !this.isHidden('forecast');
+    }
+
+    isHidden(tabValue) {
+        return this.hiddenTabs[tabValue] === true;
+    }
+
+    // Keep the active tab on something the user can actually see. Buyers land on
+    // Approvals — the actionable surface for the approver persona; admins/devs keep
+    // Intake. If that desired tab has been hidden by the org, fall back to the first
+    // VISIBLE tab so the workspace never opens on a hidden/blank tab. Only applies
+    // before the user has picked a tab themselves. Idempotent — both wires call it.
+    resolveActiveTab() {
+        if (this._userPicked) {
+            return;
+        }
+        const desired = this.isAdmin ? 'intake' : 'approvals';
+        if (!this.isHidden(desired)) {
+            this.activeTab = desired;
+            return;
+        }
+        const visible = TAB_ORDER.filter((t) => !this.isHidden(t)).concat(
+            this.isAdmin ? ADMIN_TAB_ORDER : []
+        );
+        // Degenerate edge: a buyer org hid all 10 tabs → nothing visible; leave on
+        // Intake (blank) rather than engineer around an admin hiding everything.
+        this.activeTab = visible.length ? visible[0] : 'intake';
     }
 
     handleTabChange(event) {

--- a/force-app/main/default/lwc/deliverySettingsContainer/deliverySettingsContainer.html
+++ b/force-app/main/default/lwc/deliverySettingsContainer/deliverySettingsContainer.html
@@ -30,6 +30,10 @@
                 <lightning-tab label="Home Visibility" value="homeVisibility">
                     <c-delivery-home-visibility-settings-card></c-delivery-home-visibility-settings-card>
                 </lightning-tab>
+
+                <lightning-tab label="Delivery Visibility" value="deliveryVisibility">
+                    <c-delivery-tab-visibility-settings-card></c-delivery-tab-visibility-settings-card>
+                </lightning-tab>
             </lightning-tabset>
         </div>
     </div>

--- a/force-app/main/default/lwc/deliverySettingsContainer/deliverySettingsContainer.js
+++ b/force-app/main/default/lwc/deliverySettingsContainer/deliverySettingsContainer.js
@@ -18,7 +18,8 @@ export default class DeliverySettingsContainer extends LightningElement {
             { label: 'General', value: 'general' },
             { label: 'AI Features', value: 'ai' },
             { label: 'OpenAI', value: 'openai' },
-            { label: 'Home Visibility', value: 'homeVisibility' }
+            { label: 'Home Visibility', value: 'homeVisibility' },
+            { label: 'Delivery Visibility', value: 'deliveryVisibility' }
         ];
     }
 
@@ -36,6 +37,10 @@ export default class DeliverySettingsContainer extends LightningElement {
 
     get isHomeVisibilityActive() {
         return this.activeTab === 'homeVisibility';
+    }
+
+    get isDeliveryVisibilityActive() {
+        return this.activeTab === 'deliveryVisibility';
     }
 
     handleTabChange(event) {

--- a/force-app/main/default/lwc/deliveryTabVisibilitySettingsCard/__tests__/deliveryTabVisibilitySettingsCard.test.js
+++ b/force-app/main/default/lwc/deliveryTabVisibilitySettingsCard/__tests__/deliveryTabVisibilitySettingsCard.test.js
@@ -1,0 +1,57 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryTabVisibilitySettingsCard: renders ten
+ *               "Show in Delivery tab" toggles (all on by default), and persists a hide
+ *               when a toggle is switched off.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from 'lwc';
+import DeliveryTabVisibilitySettingsCard from 'c/deliveryTabVisibilitySettingsCard';
+import setHiddenWorkspaceTabs from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTabVisibilityController.setHiddenWorkspaceTabs';
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createComponent() {
+    const element = createElement('c-delivery-tab-visibility-settings-card', {
+        is: DeliveryTabVisibilitySettingsCard
+    });
+    document.body.appendChild(element);
+    return element;
+}
+
+describe('c-delivery-tab-visibility-settings-card', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('renders ten Show-in-Delivery-tab toggles, all on by default', async () => {
+        const element = createComponent();
+        await flushPromises();
+
+        const toggles = element.shadowRoot.querySelectorAll('lightning-input');
+        expect(toggles.length).toBe(10);
+        toggles.forEach((t) => expect(t.checked).toBe(true));
+    });
+
+    it('persists a hide when a toggle is switched off', async () => {
+        setHiddenWorkspaceTabs.mockResolvedValue({ board: true });
+        const element = createComponent();
+        await flushPromises();
+
+        const toggle = element.shadowRoot.querySelector('lightning-input[data-key="board"]');
+        expect(toggle).not.toBeNull();
+        toggle.checked = false;
+        toggle.dispatchEvent(new CustomEvent('change'));
+        await flushPromises();
+
+        expect(setHiddenWorkspaceTabs).toHaveBeenCalledTimes(1);
+        const arg = setHiddenWorkspaceTabs.mock.calls[0][0];
+        expect(arg.hidden.board).toBe(true);
+    });
+});

--- a/force-app/main/default/lwc/deliveryTabVisibilitySettingsCard/deliveryTabVisibilitySettingsCard.css
+++ b/force-app/main/default/lwc/deliveryTabVisibilitySettingsCard/deliveryTabVisibilitySettingsCard.css
@@ -1,0 +1,124 @@
+/* CSS Custom Properties (mirrors deliveryGeneralSettingsCard) */
+:host {
+    --brand-primary: #4f46e5;
+    --brand-primary-light: #eef2ff;
+    --gray-100: #f3f4f6;
+    --gray-200: #e5e7eb;
+    --gray-500: #6b7280;
+    --gray-800: #1f2937;
+    --gray-900: #11182c;
+    --white: #ffffff;
+    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    --radius: 0.75rem;
+    display: block;
+}
+
+/* Card Structure */
+.settings-card {
+    background-color: var(--white);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+    border: 1px solid transparent;
+}
+
+.card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.5rem;
+    border-bottom: 1px solid var(--gray-200);
+}
+
+.header-content {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.header-icon {
+    color: var(--brand-primary);
+}
+
+.card-title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: var(--gray-900);
+    margin: 0 0 0.25rem 0;
+}
+
+.card-subtitle {
+    font-size: 0.875rem;
+    color: var(--gray-500);
+    margin: 0;
+}
+
+.card-body {
+    padding: 1.5rem;
+}
+
+/* Section heading */
+.section-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid var(--brand-primary);
+}
+
+.section-heading-text {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--brand-primary);
+}
+
+/* Form sections */
+.form-section {
+    margin-bottom: 0.25rem;
+}
+
+/* Toggle groups */
+.toggle-group {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem;
+    border-radius: var(--radius);
+    transition: all 0.2s ease;
+    margin: 0.25rem 0;
+}
+
+.toggle-group:hover {
+    background-color: var(--gray-100);
+}
+
+.toggle-content {
+    flex: 1;
+}
+
+.toggle-label-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+}
+
+.toggle-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--gray-800);
+}
+
+.toggle-help {
+    font-size: 0.75rem;
+    color: var(--gray-500);
+    line-height: 1.4;
+}
+
+.toggle-control {
+    flex-shrink: 0;
+}

--- a/force-app/main/default/lwc/deliveryTabVisibilitySettingsCard/deliveryTabVisibilitySettingsCard.html
+++ b/force-app/main/default/lwc/deliveryTabVisibilitySettingsCard/deliveryTabVisibilitySettingsCard.html
@@ -1,0 +1,51 @@
+<template>
+    <div class="settings-card">
+        <div class="card-header">
+            <div class="header-content">
+                <div class="header-icon">
+                    <lightning-icon icon-name="utility:rows" alternative-text="Delivery Tab Visibility" size="small"></lightning-icon>
+                </div>
+                <div class="header-text">
+                    <h2 class="card-title">Delivery Tab Visibility</h2>
+                    <p class="card-subtitle">Choose which sub-tabs appear inside the Delivery workspace tab. Turn a tab off to hide it; turn it back on to show it again. Default is shown.</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="card-body">
+
+            <div class="section-heading">
+                <lightning-icon icon-name="utility:layout" alternative-text="Delivery" size="xx-small"></lightning-icon>
+                <span class="section-heading-text">Show in Delivery Tab</span>
+            </div>
+
+            <template for:each={toggles} for:item="toggle">
+                <div key={toggle.key} class="form-section">
+                    <div class="toggle-group">
+                        <div class="toggle-content">
+                            <div class="toggle-label-wrapper">
+                                <label class="toggle-label">{toggle.label}</label>
+                            </div>
+                            <div class="toggle-help">
+                                {toggle.help}
+                            </div>
+                        </div>
+                        <div class="toggle-control">
+                            <div class="custom-toggle">
+                                <lightning-input
+                                    type="toggle"
+                                    label="Show in Delivery tab"
+                                    variant="label-hidden"
+                                    data-key={toggle.key}
+                                    checked={toggle.shown}
+                                    onchange={handleToggle}>
+                                </lightning-input>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </template>
+
+        </div>
+    </div>
+</template>

--- a/force-app/main/default/lwc/deliveryTabVisibilitySettingsCard/deliveryTabVisibilitySettingsCard.js
+++ b/force-app/main/default/lwc/deliveryTabVisibilitySettingsCard/deliveryTabVisibilitySettingsCard.js
@@ -1,0 +1,124 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Settings card that lets an admin hide individual non-admin sub-tabs of the
+ *               Delivery Hub workspace ("Delivery") tab, so the workspace only surfaces what
+ *               the org uses. Each toggle is "Show in Delivery tab" — ON = shown (safe
+ *               default), OFF = hidden. Fully reversible. Backed by inverted
+ *               HideTab…DateTime__c fields on DeliveryHubSettings__c via
+ *               DeliveryTabVisibilityController. The 5 admin-only tabs
+ *               (Templates/Analytics/Velocity/Settings/Workflows) are gated separately and
+ *               are intentionally not listed here. Composed into deliverySettingsContainer
+ *               (not exposed standalone).
+ * @author       Cloud Nimbus LLC
+ */
+import { LightningElement, track } from 'lwc';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import getHiddenWorkspaceTabs from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTabVisibilityController.getHiddenWorkspaceTabs';
+import setHiddenWorkspaceTabs from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTabVisibilityController.setHiddenWorkspaceTabs';
+
+// The 10 hideable workspace sub-tabs, in display order. Keys MUST match both the
+// tab values in deliveryHubWorkspace and the keys DeliveryTabVisibilityController emits.
+const TABS = [
+    {
+        key: 'intake',
+        label: 'Intake',
+        help: 'Front-of-pipe queue of inbound work awaiting triage.'
+    },
+    {
+        key: 'board',
+        label: 'Board',
+        help: 'The Kanban work board.'
+    },
+    {
+        key: 'newRequest',
+        label: 'New Request',
+        help: 'The embedded quick-request intake form.'
+    },
+    {
+        key: 'timeline',
+        label: 'Timeline',
+        help: 'The pro-forma Gantt timeline.'
+    },
+    {
+        key: 'activity',
+        label: 'Activity',
+        help: 'The activity feed.'
+    },
+    {
+        key: 'documents',
+        label: 'Documents',
+        help: 'The document viewer.'
+    },
+    {
+        key: 'guide',
+        label: 'Guide',
+        help: 'The in-app guide.'
+    },
+    {
+        key: 'approvals',
+        label: 'Approvals',
+        help: 'The approval summary card and pending-approval queue.'
+    },
+    {
+        key: 'closeouts',
+        label: 'Close Outs',
+        help: 'Deployed-to-Prod items awaiting close-out verification.'
+    },
+    {
+        key: 'forecast',
+        label: 'Forecast',
+        help: 'The buyer-facing capacity / "you set the pace" forecast.'
+    }
+];
+
+export default class DeliveryTabVisibilitySettingsCard extends LightningElement {
+    @track hiddenMap = {};
+    isLoading = true;
+
+    connectedCallback() {
+        this.loadVisibility();
+    }
+
+    async loadVisibility() {
+        try {
+            const map = await getHiddenWorkspaceTabs();
+            this.hiddenMap = map || {};
+        } catch (error) {
+            this.showToast('Error Loading Delivery Visibility', error.body ? error.body.message : error.message, 'error');
+        } finally {
+            this.isLoading = false;
+        }
+    }
+
+    // Build the render model. Each toggle is "Show in Delivery tab": checked = shown = NOT hidden.
+    get toggles() {
+        return TABS.map((t) => ({
+            key: t.key,
+            label: t.label,
+            help: t.help,
+            shown: this.hiddenMap[t.key] !== true
+        }));
+    }
+
+    async handleToggle(event) {
+        const key = event.target.dataset.key;
+        const shown = event.target.checked; // ON = show in Delivery tab
+        const previous = { ...this.hiddenMap };
+        // Optimistically reflect the new state, then persist.
+        const next = { ...this.hiddenMap, [key]: !shown };
+        this.hiddenMap = next;
+        try {
+            const fresh = await setHiddenWorkspaceTabs({ hidden: next });
+            this.hiddenMap = fresh || next;
+        } catch (error) {
+            // Revert on failure — the bound getter resets the toggle DOM.
+            this.hiddenMap = previous;
+            this.showToast('Error Saving Delivery Visibility', error.body ? error.body.message : error.message, 'error');
+        }
+    }
+
+    showToast(title, message, variant) {
+        this.dispatchEvent(new ShowToastEvent({ title, message, variant }));
+    }
+}

--- a/force-app/main/default/lwc/deliveryTabVisibilitySettingsCard/deliveryTabVisibilitySettingsCard.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryTabVisibilitySettingsCard/deliveryTabVisibilitySettingsCard.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>false</isExposed>
+    <masterLabel>Delivery Tab Visibility Settings Card</masterLabel>
+    <description>Per-tab visibility toggles for the Delivery Hub workspace ("Delivery") tab</description>
+</LightningComponentBundle>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabActivityDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabActivityDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideTabActivityDateTime__c</fullName>
+    <description>When non-null, hide the Activity sub-tab from the Delivery Hub workspace ("Delivery") tab. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the tab again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Activity tab in the Delivery workspace. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Tab Activity</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabApprovalsDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabApprovalsDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideTabApprovalsDateTime__c</fullName>
+    <description>When non-null, hide the Approvals sub-tab from the Delivery Hub workspace ("Delivery") tab. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the tab again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Approvals tab in the Delivery workspace. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Tab Approvals</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabBoardDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabBoardDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideTabBoardDateTime__c</fullName>
+    <description>When non-null, hide the Board sub-tab from the Delivery Hub workspace ("Delivery") tab. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the tab again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Board tab in the Delivery workspace. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Tab Board</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabCloseoutsDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabCloseoutsDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideTabCloseoutsDateTime__c</fullName>
+    <description>When non-null, hide the Close Outs sub-tab from the Delivery Hub workspace ("Delivery") tab. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the tab again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Close Outs tab in the Delivery workspace. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Tab Close Outs</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabDocumentsDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabDocumentsDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideTabDocumentsDateTime__c</fullName>
+    <description>When non-null, hide the Documents sub-tab from the Delivery Hub workspace ("Delivery") tab. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the tab again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Documents tab in the Delivery workspace. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Tab Documents</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabForecastDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabForecastDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideTabForecastDateTime__c</fullName>
+    <description>When non-null, hide the Forecast sub-tab from the Delivery Hub workspace ("Delivery") tab. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the tab again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Forecast tab in the Delivery workspace. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Tab Forecast</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabGuideDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabGuideDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideTabGuideDateTime__c</fullName>
+    <description>When non-null, hide the Guide sub-tab from the Delivery Hub workspace ("Delivery") tab. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the tab again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Guide tab in the Delivery workspace. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Tab Guide</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabIntakeDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabIntakeDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideTabIntakeDateTime__c</fullName>
+    <description>When non-null, hide the Intake sub-tab from the Delivery Hub workspace ("Delivery") tab. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the tab again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Intake tab in the Delivery workspace. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Tab Intake</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabNewRequestDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabNewRequestDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideTabNewRequestDateTime__c</fullName>
+    <description>When non-null, hide the New Request sub-tab from the Delivery Hub workspace ("Delivery") tab. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the tab again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the New Request tab in the Delivery workspace. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Tab New Request</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabTimelineDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabTimelineDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideTabTimelineDateTime__c</fullName>
+    <description>When non-null, hide the Timeline sub-tab from the Delivery Hub workspace ("Delivery") tab. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the tab again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Timeline tab in the Delivery workspace. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Tab Timeline</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
@@ -221,6 +221,14 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryHomeVisibilityController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DeliveryTabVisibilityController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryTemplateManagerController</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
@@ -221,6 +221,14 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryHomeVisibilityController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DeliveryTabVisibilityController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryTemplateManagerController</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.isAdminUser.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.isAdminUser.js
@@ -1,0 +1,8 @@
+/**
+ * Wire adapter mock for DeliveryHubDashboardController.isAdminUser.
+ * Used by the deliveryHubWorkspace jest tests to drive admin-only tab gating.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+
+const isAdminUser = createApexTestWireAdapter(jest.fn());
+module.exports = { default: isAdminUser };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTabVisibilityController.getHiddenWorkspaceTabs.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTabVisibilityController.getHiddenWorkspaceTabs.js
@@ -1,0 +1,9 @@
+/**
+ * Wire adapter mock for DeliveryTabVisibilityController.getHiddenWorkspaceTabs.
+ * Used by the deliveryHubWorkspace (wire) and deliveryTabVisibilitySettingsCard
+ * (imperative) jest tests to drive per-tab Delivery-workspace visibility.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+
+const getHiddenWorkspaceTabs = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getHiddenWorkspaceTabs };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTabVisibilityController.setHiddenWorkspaceTabs.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryTabVisibilityController.setHiddenWorkspaceTabs.js
@@ -1,0 +1,5 @@
+/**
+ * Imperative Apex mock for DeliveryTabVisibilityController.setHiddenWorkspaceTabs.
+ * Minimal default resolution for jest render tests.
+ */
+module.exports = { default: jest.fn().mockResolvedValue({}) };

--- a/unpackaged/post/testSuites/DH.testSuite-meta.xml
+++ b/unpackaged/post/testSuites/DH.testSuite-meta.xml
@@ -138,4 +138,5 @@
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryApproverServiceTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryRateServiceTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityControllerTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryTabVisibilityControllerTest</testClassName>
 </ApexTestSuite>


### PR DESCRIPTION
## What & why
Mirrors the just-merged Home Visibility feature for the **Delivery workspace sub-tabs**, so an org can declutter the Delivery tab to what a persona actually needs. For MF: keep Intake / Activity / Guide / Approvals / Close Outs (+ Settings, admin), hide Board / New Request / Timeline / Documents / Forecast.

## Changes
- **10 `HideTab*DateTime__c` settings** (inverted default null = shown) for the non-admin sub-tabs. The 5 admin-only tabs stay `isAdmin`-gated.
- **`DeliveryTabVisibilityController`** — `getHiddenWorkspaceTabs()` (cacheable) + `setHiddenWorkspaceTabs()` writer, same shape as `DeliveryHomeVisibilityController`.
- **`deliveryHubWorkspace`** renders each tab behind a `show*` getter; **`resolveActiveTab()` falls back to the first visible tab** so the workspace never opens on a hidden/blank tab.
- **"Delivery Visibility"** card added to the Settings tab.
- **Fix (carries from #948):** add `DeliveryHomeVisibilityController` classAccess to both `DeliveryHubApp` and `DeliveryHubAdmin_App` permission sets. #948 shipped the home-viz controller without permset access, so it would have **no-op'd for non-admin buyers** (wire fails → nothing hides). Both visibility controllers now granted.

## Verification
- `DeliveryTabVisibilityControllerTest`: **5 tests, 100% pass, 91% coverage** on a scratch org.
- Verified live: with MF config set, `getHiddenWorkspaceTabs()` returns board/newRequest/timeline/documents/forecast hidden, intake/activity/guide/approvals/closeouts shown.
- **PMD clean** (`pmd-rules.xml`) on the new Apex.
- Test class registered in the `DH` ApexTestSuite.
- jest 7/7 on touched components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)