### PR TITLE
feat(home): toggles for the remaining 5 home components (full strip-down)

### DIFF
--- a/force-app/main/default/classes/DeliveryHomeVisibilityController.cls
+++ b/force-app/main/default/classes/DeliveryHomeVisibilityController.cls
@@ -20,7 +20,12 @@ public with sharing class DeliveryHomeVisibilityController {
         'deliveryFeatureApprovalInbox' => 'HideHomeFeatureApprovalInboxDateTime__c',
         'deliveryGettingStarted'       => 'HideHomeGettingStartedDateTime__c',
         'deliveryHubSetup'             => 'HideHomeHubSetupDateTime__c',
-        'deliveryPacingForecast'       => 'HideHomePacingForecastDateTime__c'
+        'deliveryPacingForecast'       => 'HideHomePacingForecastDateTime__c',
+        'deliveryIntakeQueue'          => 'HideHomeIntakeQueueDateTime__c',
+        'deliveryApprovalQueue'        => 'HideHomeApprovalQueueDateTime__c',
+        'deliveryApprovalSummaryCard'  => 'HideHomeApprovalSummaryCardDateTime__c',
+        'deliveryFeatureCockpit'       => 'HideHomeFeatureCockpitDateTime__c',
+        'deliveryClientDashboard'      => 'HideHomeClientDashboardDateTime__c'
     };
 
     /**

--- a/force-app/main/default/classes/DeliveryHomeVisibilityControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHomeVisibilityControllerTest.cls
@@ -11,6 +11,11 @@ private class DeliveryHomeVisibilityControllerTest {
 
     private static final String KEY_BUDGET = 'deliveryBudgetSummary';
     private static final String KEY_PACING = 'deliveryPacingForecast';
+    private static final String KEY_INTAKE = 'deliveryIntakeQueue';
+    private static final String KEY_APPROVAL_QUEUE = 'deliveryApprovalQueue';
+
+    // Every hideable home-page component the controller is expected to map.
+    private static final Integer EXPECTED_COMPONENT_COUNT = 11;
 
     @isTest
     static void defaultsToAllShown() {
@@ -18,10 +23,32 @@ private class DeliveryHomeVisibilityControllerTest {
         Map<String, Boolean> hidden = DeliveryHomeVisibilityController.getHiddenHomeComponents();
         Test.stopTest();
 
-        System.assertEquals(6, hidden.size(), 'Expected all six components in the map');
+        System.assertEquals(EXPECTED_COMPONENT_COUNT, hidden.size(), 'Expected all hideable components in the map');
         for (String key : hidden.keySet()) {
             System.assertEquals(false, hidden.get(key), 'No setting present → component should be shown (not hidden): ' + key);
         }
+        // The components added in the second wave must be present and keyed by LWC name.
+        System.assertEquals(true, hidden.containsKey(KEY_INTAKE), 'Intake queue should be a hideable component');
+        System.assertEquals(true, hidden.containsKey(KEY_APPROVAL_QUEUE), 'Approval queue should be a hideable component');
+        System.assertEquals(true, hidden.containsKey('deliveryApprovalSummaryCard'), 'Approval summary card should be a hideable component');
+        System.assertEquals(true, hidden.containsKey('deliveryFeatureCockpit'), 'Feature cockpit should be a hideable component');
+        System.assertEquals(true, hidden.containsKey('deliveryClientDashboard'), 'Client dashboard should be a hideable component');
+    }
+
+    @isTest
+    static void hidingStampsANewlyAddedComponent() {
+        Map<String, Boolean> request = new Map<String, Boolean>{ KEY_INTAKE => true };
+
+        Test.startTest();
+        Map<String, Boolean> result = DeliveryHomeVisibilityController.setHiddenHomeComponents(request);
+        Test.stopTest();
+
+        System.assertEquals(true, result.get(KEY_INTAKE), 'Intake queue should be hidden after stamping');
+        System.assertEquals(false, result.get(KEY_APPROVAL_QUEUE), 'Untouched components stay shown');
+
+        DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+        System.assertNotEquals(null, settings.HideHomeIntakeQueueDateTime__c, 'Hide field should be stamped');
+        System.assertEquals(null, settings.HideHomeApprovalQueueDateTime__c, 'Untouched field stays null');
     }
 
     @isTest
@@ -75,7 +102,7 @@ private class DeliveryHomeVisibilityControllerTest {
         Map<String, Boolean> result = DeliveryHomeVisibilityController.setHiddenHomeComponents(null);
         Test.stopTest();
 
-        System.assertEquals(6, result.size(), 'A null request is a no-op that still returns the full map');
+        System.assertEquals(EXPECTED_COMPONENT_COUNT, result.size(), 'A null request is a no-op that still returns the full map');
         for (String key : result.keySet()) {
             System.assertEquals(false, result.get(key), 'Nothing hidden for a null request: ' + key);
         }

--- a/force-app/main/default/lwc/deliveryApprovalQueue/__tests__/deliveryApprovalQueue.test.js
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/__tests__/deliveryApprovalQueue.test.js
@@ -10,11 +10,15 @@
  * @author       Cloud Nimbus LLC
  */
 import { createElement } from "lwc";
+import { CurrentPageReference } from "lightning/navigation";
 import DeliveryApprovalQueue from "c/deliveryApprovalQueue";
 import getPendingForApprover from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.getPendingForApprover";
 import approve from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.approve";
 import approveMany from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.approveMany";
 import decline from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.decline";
+import getHiddenHomeComponents from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents";
+
+const HOME_PAGE_REF = { type: "standard__namedPage", attributes: { pageName: "home" } };
 
 const REQUEST_ONE = "a0G000000000001AAA";
 const REQUEST_TWO = "a0G000000000002AAA";
@@ -383,5 +387,28 @@ describe("c-delivery-approval-queue", () => {
             workRequestIds: ["a0G000000000010AAA", "a0G000000000011AAA"],
             note: null
         });
+    });
+});
+
+describe("c-delivery-approval-queue home visibility", () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it("renders by default when not hidden", async () => {
+        const element = createComponent();
+        await flushPromises();
+        expect(element.shadowRoot.querySelector(".queue-card")).not.toBeNull();
+    });
+
+    it("renders nothing on Home when hidden in Settings", async () => {
+        const element = createComponent();
+        CurrentPageReference.emit(HOME_PAGE_REF);
+        getHiddenHomeComponents.emit({ deliveryApprovalQueue: true });
+        await flushPromises();
+        expect(element.shadowRoot.querySelector(".queue-card")).toBeNull();
     });
 });

--- a/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.html
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.html
@@ -1,4 +1,5 @@
 <template>
+    <template lwc:if={isNotHiddenOnHome}>
     <div class="queue-card">
 
         <div class="queue-header">
@@ -215,4 +216,5 @@
         </template>
 
     </div>
+    </template>
 </template>

--- a/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.js
+++ b/force-app/main/default/lwc/deliveryApprovalQueue/deliveryApprovalQueue.js
@@ -20,7 +20,7 @@
  * @author       Cloud Nimbus LLC
  */
 import { LightningElement, wire } from "lwc";
-import { NavigationMixin } from "lightning/navigation";
+import { NavigationMixin, CurrentPageReference } from "lightning/navigation";
 import { refreshApex } from "@salesforce/apex";
 import { ShowToastEvent } from "lightning/platformShowToastEvent";
 import WORK_ITEM_OBJECT from "@salesforce/schema/WorkItem__c";
@@ -28,12 +28,47 @@ import getPendingForApprover from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryW
 import approveApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.approve";
 import approveManyApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.approveMany";
 import declineApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkApprovalService.decline";
+import getHiddenHomeComponents from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents";
 
 const MS_PER_DAY = 86400000;
 const MODE_CHANGE = "change";
 const MODE_DECLINE = "decline";
+// This component's key in the Home-visibility map (matches its LWC folder name).
+const HOME_COMPONENT_KEY = "deliveryApprovalQueue";
 
 export default class DeliveryApprovalQueue extends NavigationMixin(LightningElement) {
+    // ── Home-page visibility (admin-toggleable, default = shown) ──
+    // Hides ONLY on the Delivery Hub app Home page when an admin toggles it
+    // off in Settings. Everywhere else this component always renders.
+    @wire(CurrentPageReference) _homePageRef;
+    @wire(getHiddenHomeComponents) _hiddenHomeComponents;
+
+    get isOnHomePage() {
+        const ref = this._homePageRef;
+        if (!ref) {
+            return false;
+        }
+        const attrs = ref.attributes || {};
+        if (ref.type === "standard__namedPage" && attrs.pageName === "home") {
+            return true;
+        }
+        const url = attrs.url
+            || (typeof window !== "undefined" && window.location ? window.location.pathname : "");
+        return typeof url === "string" && url.indexOf("/lightning/page/home") !== -1;
+    }
+
+    get isHiddenOnHome() {
+        if (!this.isOnHomePage) {
+            return false;
+        }
+        const map = this._hiddenHomeComponents && this._hiddenHomeComponents.data;
+        return !!(map && map[HOME_COMPONENT_KEY] === true);
+    }
+
+    get isNotHiddenOnHome() {
+        return !this.isHiddenOnHome;
+    }
+
     pendingRaw = [];
     errorMessage = "";
     isLoading = true;

--- a/force-app/main/default/lwc/deliveryApprovalSummaryCard/__tests__/deliveryApprovalSummaryCard.test.js
+++ b/force-app/main/default/lwc/deliveryApprovalSummaryCard/__tests__/deliveryApprovalSummaryCard.test.js
@@ -11,8 +11,12 @@
  * @author       Cloud Nimbus LLC
  */
 import { createElement } from "lwc";
+import { CurrentPageReference } from "lightning/navigation";
 import DeliveryApprovalSummaryCard from "c/deliveryApprovalSummaryCard";
 import getApprovalSummary from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryApprovalSummaryController.getApprovalSummary";
+import getHiddenHomeComponents from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents";
+
+const HOME_PAGE_REF = { type: "standard__namedPage", attributes: { pageName: "home" } };
 
 const REPORT_ID_APPROVED = "00O000000000001AAA";
 const REPORT_ID_PENDING = "00O000000000002AAA";
@@ -135,5 +139,28 @@ describe("c-delivery-approval-summary-card", () => {
 
         expect(element.shadowRoot.querySelector(".agenda-error")).not.toBeNull();
         expect(element.shadowRoot.querySelector(".agenda-tile")).toBeNull();
+    });
+});
+
+describe("c-delivery-approval-summary-card home visibility", () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it("renders by default when not hidden", async () => {
+        const element = createComponent();
+        await flushPromises();
+        expect(element.shadowRoot.querySelector(".agenda-card")).not.toBeNull();
+    });
+
+    it("renders nothing on Home when hidden in Settings", async () => {
+        const element = createComponent();
+        CurrentPageReference.emit(HOME_PAGE_REF);
+        getHiddenHomeComponents.emit({ deliveryApprovalSummaryCard: true });
+        await flushPromises();
+        expect(element.shadowRoot.querySelector(".agenda-card")).toBeNull();
     });
 });

--- a/force-app/main/default/lwc/deliveryApprovalSummaryCard/deliveryApprovalSummaryCard.html
+++ b/force-app/main/default/lwc/deliveryApprovalSummaryCard/deliveryApprovalSummaryCard.html
@@ -1,4 +1,5 @@
 <template>
+    <template lwc:if={isNotHiddenOnHome}>
     <div class="agenda-card">
 
         <div class="agenda-header">
@@ -54,4 +55,5 @@
         </template>
 
     </div>
+    </template>
 </template>

--- a/force-app/main/default/lwc/deliveryApprovalSummaryCard/deliveryApprovalSummaryCard.js
+++ b/force-app/main/default/lwc/deliveryApprovalSummaryCard/deliveryApprovalSummaryCard.js
@@ -16,14 +16,49 @@
  * @author       Cloud Nimbus LLC
  */
 import { LightningElement, wire } from "lwc";
-import { NavigationMixin } from "lightning/navigation";
+import { NavigationMixin, CurrentPageReference } from "lightning/navigation";
 import getApprovalSummary from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryApprovalSummaryController.getApprovalSummary";
+import getHiddenHomeComponents from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents";
 
 const REPORT_HOURS_APPROVED = "Hours_Approved_This_Period";
 const REPORT_PENDING = "Pending_Approval";
 const REPORT_IN_PROGRESS = "Approved_In_Progress";
+// This component's key in the Home-visibility map (matches its LWC folder name).
+const HOME_COMPONENT_KEY = "deliveryApprovalSummaryCard";
 
 export default class DeliveryApprovalSummaryCard extends NavigationMixin(LightningElement) {
+    // ── Home-page visibility (admin-toggleable, default = shown) ──
+    // Hides ONLY on the Delivery Hub app Home page when an admin toggles it
+    // off in Settings. Everywhere else this component always renders.
+    @wire(CurrentPageReference) _homePageRef;
+    @wire(getHiddenHomeComponents) _hiddenHomeComponents;
+
+    get isOnHomePage() {
+        const ref = this._homePageRef;
+        if (!ref) {
+            return false;
+        }
+        const attrs = ref.attributes || {};
+        if (ref.type === "standard__namedPage" && attrs.pageName === "home") {
+            return true;
+        }
+        const url = attrs.url
+            || (typeof window !== "undefined" && window.location ? window.location.pathname : "");
+        return typeof url === "string" && url.indexOf("/lightning/page/home") !== -1;
+    }
+
+    get isHiddenOnHome() {
+        if (!this.isOnHomePage) {
+            return false;
+        }
+        const map = this._hiddenHomeComponents && this._hiddenHomeComponents.data;
+        return !!(map && map[HOME_COMPONENT_KEY] === true);
+    }
+
+    get isNotHiddenOnHome() {
+        return !this.isHiddenOnHome;
+    }
+
     summary;
     errorMessage = "";
     isLoading = true;

--- a/force-app/main/default/lwc/deliveryClientDashboard/__tests__/deliveryClientDashboard.test.js
+++ b/force-app/main/default/lwc/deliveryClientDashboard/__tests__/deliveryClientDashboard.test.js
@@ -1,8 +1,12 @@
 import { createElement } from 'lwc';
+import { CurrentPageReference } from 'lightning/navigation';
 import DeliveryClientDashboard from 'c/deliveryClientDashboard';
 import getClientDashboard from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.getClientDashboard';
 import getWorkflowConfig from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkflowConfigService.getWorkflowConfig';
+import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
 import { getRecord } from 'lightning/uiRecordApi';
+
+const HOME_PAGE_REF = { type: 'standard__namedPage', attributes: { pageName: 'home' } };
 
 // ── Test Data ──────────────────────────────────────────────────────
 
@@ -284,5 +288,29 @@ describe('c-delivery-client-dashboard', () => {
             const spinner = element.shadowRoot.querySelector('lightning-spinner');
             expect(spinner).toBeNull();
         });
+    });
+});
+
+describe('c-delivery-client-dashboard home visibility', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('renders by default when not hidden', async () => {
+        const element = createComponent();
+        await flushPromises();
+        // The "What's In Flight" card renders regardless of wire data.
+        expect(element.shadowRoot.querySelector('lightning-card')).not.toBeNull();
+    });
+
+    it('renders nothing on Home when hidden in Settings', async () => {
+        const element = createComponent();
+        CurrentPageReference.emit(HOME_PAGE_REF);
+        getHiddenHomeComponents.emit({ deliveryClientDashboard: true });
+        await flushPromises();
+        expect(element.shadowRoot.querySelector('lightning-card')).toBeNull();
     });
 });

--- a/force-app/main/default/lwc/deliveryClientDashboard/deliveryClientDashboard.html
+++ b/force-app/main/default/lwc/deliveryClientDashboard/deliveryClientDashboard.html
@@ -1,4 +1,5 @@
 <template>
+    <template lwc:if={isNotHiddenOnHome}>
 
     <!-- ============================================================ -->
     <!-- SECTION 1: Greeting + Announcements + Needs Your Attention  -->
@@ -221,4 +222,5 @@
         </lightning-card>
     </template>
 
+    </template>
 </template>

--- a/force-app/main/default/lwc/deliveryClientDashboard/deliveryClientDashboard.js
+++ b/force-app/main/default/lwc/deliveryClientDashboard/deliveryClientDashboard.js
@@ -9,7 +9,7 @@
  * @author       Cloud Nimbus LLC
  */
 import { LightningElement, api, wire, track } from 'lwc';
-import { NavigationMixin } from 'lightning/navigation';
+import { NavigationMixin, CurrentPageReference } from 'lightning/navigation';
 import { refreshApex } from '@salesforce/apex';
 import { getRecord, getFieldValue } from 'lightning/uiRecordApi';
 import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
@@ -17,6 +17,7 @@ import WORK_LOG_OBJECT from '@salesforce/schema/WorkLog__c';
 import getClientDashboard from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.getClientDashboard';
 import getReportIds from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubDashboardController.getReportIds';
 import getWorkflowConfig from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryWorkflowConfigService.getWorkflowConfig';
+import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
 import USER_ID from '@salesforce/user/Id';
 import FIRST_NAME_FIELD from '@salesforce/schema/User.FirstName';
 
@@ -47,7 +48,43 @@ const FALLBACK_PHASE_ORDER = ['Planning', 'Approval', 'Development', 'Testing', 
         UAT: 'uat'
     };
 
+// This component's key in the Home-visibility map (matches its LWC folder name).
+const HOME_COMPONENT_KEY = 'deliveryClientDashboard';
+
 export default class DeliveryClientDashboard extends NavigationMixin(LightningElement) { // eslint-disable-line new-cap
+    // ── Home-page visibility (admin-toggleable, default = shown) ──
+    // Hides the WHOLE dashboard ONLY on the Delivery Hub app Home page when an
+    // admin toggles it off in Settings. This is independent of the per-section
+    // @api hide* props below — it gates the entire component on Home.
+    @wire(CurrentPageReference) _homePageRef;
+    @wire(getHiddenHomeComponents) _hiddenHomeComponents;
+
+    get isOnHomePage() {
+        const ref = this._homePageRef;
+        if (!ref) {
+            return false;
+        }
+        const attrs = ref.attributes || {};
+        if (ref.type === 'standard__namedPage' && attrs.pageName === 'home') {
+            return true;
+        }
+        const url = attrs.url
+            || (typeof window !== 'undefined' && window.location ? window.location.pathname : '');
+        return typeof url === 'string' && url.indexOf('/lightning/page/home') !== -1;
+    }
+
+    get isHiddenOnHome() {
+        if (!this.isOnHomePage) {
+            return false;
+        }
+        const map = this._hiddenHomeComponents && this._hiddenHomeComponents.data;
+        return !!(map && map[HOME_COMPONENT_KEY] === true);
+    }
+
+    get isNotHiddenOnHome() {
+        return !this.isHiddenOnHome;
+    }
+
     @api hideAttentionSection = false;
     @api hideInFlightSection = false;
     @api hideRecentSection = false;

--- a/force-app/main/default/lwc/deliveryFeatureCockpit/__tests__/deliveryFeatureCockpit.test.js
+++ b/force-app/main/default/lwc/deliveryFeatureCockpit/__tests__/deliveryFeatureCockpit.test.js
@@ -1,9 +1,12 @@
 import { createElement } from 'lwc';
-import { NavigationMixin } from 'lightning/navigation';
+import { NavigationMixin, CurrentPageReference } from 'lightning/navigation';
 import DeliveryFeatureCockpit from 'c/deliveryFeatureCockpit';
 import getCatalog from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.getCatalog';
 import isAdminApex from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.isAdmin';
 import toggleFeature from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.toggleFeature';
+import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
+
+const HOME_PAGE_REF = { type: 'standard__namedPage', attributes: { pageName: 'home' } };
 
 // Apex methods auto-mocked via force-app/test/jest-mocks/apex/.
 
@@ -254,5 +257,28 @@ describe('c-delivery-feature-cockpit', () => {
             // No messageData on the fallback toast — pure-text message
             expect(detail.messageData).toBeUndefined();
         });
+    });
+});
+
+describe('c-delivery-feature-cockpit home visibility', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('renders by default when not hidden', async () => {
+        const element = createComponent();
+        await flushPromises();
+        expect(element.shadowRoot.querySelector('lightning-card')).not.toBeNull();
+    });
+
+    it('renders nothing on Home when hidden in Settings', async () => {
+        const element = createComponent();
+        CurrentPageReference.emit(HOME_PAGE_REF);
+        getHiddenHomeComponents.emit({ deliveryFeatureCockpit: true });
+        await flushPromises();
+        expect(element.shadowRoot.querySelector('lightning-card')).toBeNull();
     });
 });

--- a/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.html
+++ b/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.html
@@ -1,4 +1,5 @@
 <template>
+    <template lwc:if={isNotHiddenOnHome}>
     <lightning-card title="Feature Cockpit" icon-name="standard:apps">
 
         <div slot="actions" class="slds-grid slds-grid_vertical-align-center" style="gap: 0.25rem;">
@@ -181,5 +182,6 @@
             </div>
         </section>
         <div class="slds-backdrop slds-backdrop_open"></div>
+    </template>
     </template>
 </template>

--- a/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.js
+++ b/force-app/main/default/lwc/deliveryFeatureCockpit/deliveryFeatureCockpit.js
@@ -12,19 +12,54 @@
  * @author Cloud Nimbus LLC
  */
 import { LightningElement, wire, track } from 'lwc';
-import { NavigationMixin } from 'lightning/navigation';
+import { NavigationMixin, CurrentPageReference } from 'lightning/navigation';
 import { refreshApex } from '@salesforce/apex';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import FEATURE_OBJECT from '@salesforce/schema/Feature__c';
 import getCatalog from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.getCatalog';
 import isAdminApex from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.isAdmin';
 import toggleFeature from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryFeatureCatalogController.toggleFeature';
+import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
 
 const DESCRIPTION_TRUNCATE_AT = 140,
     ELLIPSIS = '…',
     EMPTY = 0;
+// This component's key in the Home-visibility map (matches its LWC folder name).
+const HOME_COMPONENT_KEY = 'deliveryFeatureCockpit';
 
 export default class DeliveryFeatureCockpit extends NavigationMixin(LightningElement) {
+    // ── Home-page visibility (admin-toggleable, default = shown) ──
+    // Hides ONLY on the Delivery Hub app Home page when an admin toggles it
+    // off in Settings. Everywhere else this component always renders.
+    @wire(CurrentPageReference) _homePageRef;
+    @wire(getHiddenHomeComponents) _hiddenHomeComponents;
+
+    get isOnHomePage() {
+        const ref = this._homePageRef;
+        if (!ref) {
+            return false;
+        }
+        const attrs = ref.attributes || {};
+        if (ref.type === 'standard__namedPage' && attrs.pageName === 'home') {
+            return true;
+        }
+        const url = attrs.url
+            || (typeof window !== 'undefined' && window.location ? window.location.pathname : '');
+        return typeof url === 'string' && url.indexOf('/lightning/page/home') !== -1;
+    }
+
+    get isHiddenOnHome() {
+        if (!this.isOnHomePage) {
+            return false;
+        }
+        const map = this._hiddenHomeComponents && this._hiddenHomeComponents.data;
+        return !!(map && map[HOME_COMPONENT_KEY] === true);
+    }
+
+    get isNotHiddenOnHome() {
+        return !this.isHiddenOnHome;
+    }
+
     @track features = [];
     @track errorMessage = '';
     @track isLoaded = false;

--- a/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/__tests__/deliveryHomeVisibilitySettingsCard.test.js
+++ b/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/__tests__/deliveryHomeVisibilitySettingsCard.test.js
@@ -1,9 +1,9 @@
 /**
  * @name         Delivery Hub
  * @license      BSL 1.1 — See LICENSE.md
- * @description  Jest coverage for deliveryHomeVisibilitySettingsCard: renders six
- *               "Show on Home" toggles (all on by default), and persists a hide when a
- *               toggle is switched off.
+ * @description  Jest coverage for deliveryHomeVisibilitySettingsCard: renders one
+ *               "Show on Home" toggle per hideable component (all on by default), and
+ *               persists a hide when a toggle is switched off.
  * @author       Cloud Nimbus LLC
  */
 import { createElement } from 'lwc';
@@ -30,13 +30,25 @@ describe('c-delivery-home-visibility-settings-card', () => {
         jest.clearAllMocks();
     });
 
-    it('renders six Show-on-Home toggles, all on by default', async () => {
+    it('renders all eleven Show-on-Home toggles, all on by default', async () => {
         const element = createComponent();
         await flushPromises();
 
         const toggles = element.shadowRoot.querySelectorAll('lightning-input');
-        expect(toggles.length).toBe(6);
+        expect(toggles.length).toBe(11);
         toggles.forEach((t) => expect(t.checked).toBe(true));
+    });
+
+    it('exposes the second-wave components as toggles keyed by LWC name', async () => {
+        const element = createComponent();
+        await flushPromises();
+
+        ['deliveryIntakeQueue', 'deliveryApprovalQueue', 'deliveryApprovalSummaryCard',
+            'deliveryFeatureCockpit', 'deliveryClientDashboard'].forEach((key) => {
+            const toggle = element.shadowRoot.querySelector(`lightning-input[data-key="${key}"]`);
+            expect(toggle).not.toBeNull();
+            expect(toggle.checked).toBe(true);
+        });
     });
 
     it('persists a hide when a toggle is switched off', async () => {

--- a/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/deliveryHomeVisibilitySettingsCard.js
+++ b/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/deliveryHomeVisibilitySettingsCard.js
@@ -14,7 +14,7 @@ import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import getHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents';
 import setHiddenHomeComponents from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.setHiddenHomeComponents';
 
-// The 6 hideable home-page components, in display order. Keys MUST match both the
+// The hideable home-page components, in display order. Keys MUST match both the
 // LWC component names and the keys DeliveryHomeVisibilityController emits.
 const COMPONENTS = [
     {
@@ -46,6 +46,31 @@ const COMPONENTS = [
         key: 'deliveryPacingForecast',
         label: 'Portfolio Pacing & Forecast',
         help: 'Logged hours, amortized target, and run-rate forecast.'
+    },
+    {
+        key: 'deliveryIntakeQueue',
+        label: 'Intake Queue',
+        help: 'New inbound work to triage onto the timeline or resolve.'
+    },
+    {
+        key: 'deliveryApprovalQueue',
+        label: 'Pending Work Approvals',
+        help: 'Offer-Sent work requests awaiting a decision.'
+    },
+    {
+        key: 'deliveryApprovalSummaryCard',
+        label: 'Approval Agenda',
+        help: 'Hours approved, pending, and approved-in-flight tiles.'
+    },
+    {
+        key: 'deliveryFeatureCockpit',
+        label: 'Feature Cockpit',
+        help: 'The feature catalog with admin enable/disable toggles.'
+    },
+    {
+        key: 'deliveryClientDashboard',
+        label: 'Client Dashboard',
+        help: 'The client-facing greeting, attention, in-flight, and recent sections.'
     }
 ];
 

--- a/force-app/main/default/lwc/deliveryIntakeQueue/__tests__/deliveryIntakeQueue.test.js
+++ b/force-app/main/default/lwc/deliveryIntakeQueue/__tests__/deliveryIntakeQueue.test.js
@@ -10,10 +10,14 @@
  * @author       Cloud Nimbus LLC
  */
 import { createElement } from "lwc";
+import { CurrentPageReference } from "lightning/navigation";
 import DeliveryIntakeQueue from "c/deliveryIntakeQueue";
 import getIntakeItems from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getIntakeItems";
 import routeToDev from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.routeToDev";
 import dismissIntake from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.dismissIntake";
+import getHiddenHomeComponents from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents";
+
+const HOME_PAGE_REF = { type: "standard__namedPage", attributes: { pageName: "home" } };
 
 const ITEM_ONE = "a42000000000001AAA";
 const ITEM_TWO = "a42000000000002AAA";
@@ -193,5 +197,28 @@ describe("c-delivery-intake-queue", () => {
         await flushPromises();
 
         expect(element.shadowRoot.querySelector(".queue-error")).not.toBeNull();
+    });
+});
+
+describe("c-delivery-intake-queue home visibility", () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it("renders by default when not hidden", async () => {
+        const element = createComponent();
+        await flushPromises();
+        expect(element.shadowRoot.querySelector(".queue-card")).not.toBeNull();
+    });
+
+    it("renders nothing on Home when hidden in Settings", async () => {
+        const element = createComponent();
+        CurrentPageReference.emit(HOME_PAGE_REF);
+        getHiddenHomeComponents.emit({ deliveryIntakeQueue: true });
+        await flushPromises();
+        expect(element.shadowRoot.querySelector(".queue-card")).toBeNull();
     });
 });

--- a/force-app/main/default/lwc/deliveryIntakeQueue/deliveryIntakeQueue.html
+++ b/force-app/main/default/lwc/deliveryIntakeQueue/deliveryIntakeQueue.html
@@ -1,4 +1,5 @@
 <template>
+    <template lwc:if={isNotHiddenOnHome}>
     <div class="queue-card">
 
         <div class="queue-header">
@@ -123,4 +124,5 @@
         </template>
 
     </div>
+    </template>
 </template>

--- a/force-app/main/default/lwc/deliveryIntakeQueue/deliveryIntakeQueue.js
+++ b/force-app/main/default/lwc/deliveryIntakeQueue/deliveryIntakeQueue.js
@@ -20,7 +20,7 @@
  * @author       Cloud Nimbus LLC
  */
 import { LightningElement, wire } from "lwc";
-import { NavigationMixin } from "lightning/navigation";
+import { NavigationMixin, CurrentPageReference } from "lightning/navigation";
 import { refreshApex } from "@salesforce/apex";
 import { subscribe, unsubscribe, onError } from "lightning/empApi";
 import { ShowToastEvent } from "lightning/platformShowToastEvent";
@@ -28,13 +28,48 @@ import WORK_ITEM_OBJECT from "@salesforce/schema/WorkItem__c";
 import getIntakeItems from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getIntakeItems";
 import routeToDevApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.routeToDev";
 import dismissIntakeApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.dismissIntake";
+import getHiddenHomeComponents from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents";
 
 const MS_PER_DAY = 86400000;
+// This component's key in the Home-visibility map (matches its LWC folder name).
+const HOME_COMPONENT_KEY = "deliveryIntakeQueue";
 // Real-time channel: the ghost recorder publishes here when a new inbound
 // request is created, so the queue refreshes live (no manual page reload).
 const PE_CHANNEL = "/event/%%%NAMESPACE_DOT%%%DeliveryWorkItemChange__e";
 
 export default class DeliveryIntakeQueue extends NavigationMixin(LightningElement) {
+    // ── Home-page visibility (admin-toggleable, default = shown) ──
+    // Hides ONLY on the Delivery Hub app Home page when an admin toggles it
+    // off in Settings. Everywhere else this component always renders.
+    @wire(CurrentPageReference) _homePageRef;
+    @wire(getHiddenHomeComponents) _hiddenHomeComponents;
+
+    get isOnHomePage() {
+        const ref = this._homePageRef;
+        if (!ref) {
+            return false;
+        }
+        const attrs = ref.attributes || {};
+        if (ref.type === "standard__namedPage" && attrs.pageName === "home") {
+            return true;
+        }
+        const url = attrs.url
+            || (typeof window !== "undefined" && window.location ? window.location.pathname : "");
+        return typeof url === "string" && url.indexOf("/lightning/page/home") !== -1;
+    }
+
+    get isHiddenOnHome() {
+        if (!this.isOnHomePage) {
+            return false;
+        }
+        const map = this._hiddenHomeComponents && this._hiddenHomeComponents.data;
+        return !!(map && map[HOME_COMPONENT_KEY] === true);
+    }
+
+    get isNotHiddenOnHome() {
+        return !this.isHiddenOnHome;
+    }
+
     itemsRaw = [];
     errorMessage = "";
     isLoading = true;

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeApprovalQueueDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeApprovalQueueDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideHomeApprovalQueueDateTime__c</fullName>
+    <description>When non-null, hide the deliveryApprovalQueue (Pending Work Approvals) card from the Delivery Hub app Home page. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the card again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Pending Work Approvals card on the Home page. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Home Approval Queue</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeApprovalSummaryCardDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeApprovalSummaryCardDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideHomeApprovalSummaryCardDateTime__c</fullName>
+    <description>When non-null, hide the deliveryApprovalSummaryCard (Approval Agenda) card from the Delivery Hub app Home page. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the card again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Approval Agenda card on the Home page. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Home Approval Summary Card</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeClientDashboardDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeClientDashboardDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideHomeClientDashboardDateTime__c</fullName>
+    <description>When non-null, hide the deliveryClientDashboard (client-facing dashboard) card from the Delivery Hub app Home page. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the card again. Hides only the whole component on Home; does not affect the dashboard's internal section toggles.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the client dashboard card on the Home page. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Home Client Dashboard</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeFeatureCockpitDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeFeatureCockpitDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideHomeFeatureCockpitDateTime__c</fullName>
+    <description>When non-null, hide the deliveryFeatureCockpit (Feature Cockpit) card from the Delivery Hub app Home page. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the card again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Feature Cockpit card on the Home page. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Home Feature Cockpit</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeIntakeQueueDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeIntakeQueueDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideHomeIntakeQueueDateTime__c</fullName>
+    <description>When non-null, hide the deliveryIntakeQueue (Intake) card from the Delivery Hub app Home page. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the card again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Intake queue card on the Home page. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Home Intake Queue</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>


### PR DESCRIPTION
## What & why
Completes the Home Visibility feature: **all 11 home-page widgets are now individually toggleable**, so an org can strip the Delivery Hub app home down to just what works (Intake + System Pulse for MF's bare-minimum demo) and enable the rest as feature-by-feature.

Adds the remaining 5: `deliveryIntakeQueue`, `deliveryApprovalQueue`, `deliveryApprovalSummaryCard`, `deliveryFeatureCockpit`, `deliveryClientDashboard` — same inverted-default (null=shown), Settings-driven, reversible pattern as the first 6.

- 5 new `HideHome*DateTime__c` fields.
- `DeliveryHomeVisibilityController.COMPONENT_TO_FIELD` extended (map-driven, no new methods); test → 11 components.
- Each LWC self-hides on the Home page when its setting is set. `deliveryClientDashboard` gets only the outer wrapper — phase/section logic untouched.
- 5 toggles added to the Home Visibility settings card.

## Verification
- `DeliveryHomeVisibilityControllerTest`: **6/6 pass** on a scratch org (extended for the 11 components).
- PMD clean on the controller.
- Deployed + applied a strip-down config on dh-child (hide all but Intake + System Pulse) — verified the controller reports the right hidden map.
- classAccess already in both permsets; `DeliveryHubSettings__c` is a Public Hierarchy custom setting → fields need no FLS.

## Note
The "Other" bucket for the What's-in-Flight phase breakdown (the one remaining count-alignment bug) and drill-down wiring for the few tiles missing a report are deliberate follow-ups, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)