### PR TITLE
feat(home): Close Outs on the home page (under Intake), toggleable

### DIFF
--- a/force-app/main/default/classes/DeliveryHomeVisibilityController.cls
+++ b/force-app/main/default/classes/DeliveryHomeVisibilityController.cls
@@ -25,7 +25,8 @@ public with sharing class DeliveryHomeVisibilityController {
         'deliveryApprovalQueue'        => 'HideHomeApprovalQueueDateTime__c',
         'deliveryApprovalSummaryCard'  => 'HideHomeApprovalSummaryCardDateTime__c',
         'deliveryFeatureCockpit'       => 'HideHomeFeatureCockpitDateTime__c',
-        'deliveryClientDashboard'      => 'HideHomeClientDashboardDateTime__c'
+        'deliveryClientDashboard'      => 'HideHomeClientDashboardDateTime__c',
+        'deliveryCloseOutQueue'        => 'HideHomeCloseOutQueueDateTime__c'
     };
 
     /**

--- a/force-app/main/default/classes/DeliveryHomeVisibilityControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHomeVisibilityControllerTest.cls
@@ -15,7 +15,7 @@ private class DeliveryHomeVisibilityControllerTest {
     private static final String KEY_APPROVAL_QUEUE = 'deliveryApprovalQueue';
 
     // Every hideable home-page component the controller is expected to map.
-    private static final Integer EXPECTED_COMPONENT_COUNT = 11;
+    private static final Integer EXPECTED_COMPONENT_COUNT = 12;
 
     @isTest
     static void defaultsToAllShown() {
@@ -33,6 +33,7 @@ private class DeliveryHomeVisibilityControllerTest {
         System.assertEquals(true, hidden.containsKey('deliveryApprovalSummaryCard'), 'Approval summary card should be a hideable component');
         System.assertEquals(true, hidden.containsKey('deliveryFeatureCockpit'), 'Feature cockpit should be a hideable component');
         System.assertEquals(true, hidden.containsKey('deliveryClientDashboard'), 'Client dashboard should be a hideable component');
+        System.assertEquals(true, hidden.containsKey('deliveryCloseOutQueue'), 'Close-out queue should be a hideable component');
     }
 
     @isTest

--- a/force-app/main/default/flexipages/DeliveryHubHome.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryHubHome.flexipage-meta.xml
@@ -9,6 +9,12 @@
         </itemInstances>
         <itemInstances>
             <componentInstance>
+                <componentName>deliveryCloseOutQueue</componentName>
+                <identifier>c_deliveryCloseOutQueue_home</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
                 <componentName>deliveryGettingStarted</componentName>
                 <identifier>c_deliveryGettingStarted</identifier>
             </componentInstance>

--- a/force-app/main/default/lwc/deliveryCloseOutQueue/deliveryCloseOutQueue.html
+++ b/force-app/main/default/lwc/deliveryCloseOutQueue/deliveryCloseOutQueue.html
@@ -1,4 +1,5 @@
 <template>
+    <template lwc:if={isNotHiddenOnHome}>
     <div class="queue-card">
 
         <div class="queue-header">
@@ -109,4 +110,5 @@
         </template>
 
     </div>
+    </template>
 </template>

--- a/force-app/main/default/lwc/deliveryCloseOutQueue/deliveryCloseOutQueue.js
+++ b/force-app/main/default/lwc/deliveryCloseOutQueue/deliveryCloseOutQueue.js
@@ -21,15 +21,17 @@
  * @author       Cloud Nimbus LLC
  */
 import { LightningElement, wire } from "lwc";
-import { NavigationMixin } from "lightning/navigation";
+import { NavigationMixin, CurrentPageReference } from "lightning/navigation";
 import { refreshApex } from "@salesforce/apex";
 import { ShowToastEvent } from "lightning/platformShowToastEvent";
 import WORK_ITEM_OBJECT from "@salesforce/schema/WorkItem__c";
 import getCloseOutItems from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getCloseOutItems";
 import getCloseOutReportId from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.getCloseOutReportId";
 import markDoneApex from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTriageController.markDone";
+import getHiddenHomeComponents from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHomeVisibilityController.getHiddenHomeComponents";
 
 const MS_PER_DAY = 86400000;
+const HOME_COMPONENT_KEY = "deliveryCloseOutQueue";
 
 export default class DeliveryCloseOutQueue extends NavigationMixin(LightningElement) {
     itemsRaw = [];
@@ -42,6 +44,38 @@ export default class DeliveryCloseOutQueue extends NavigationMixin(LightningElem
     selectedIds = [];
 
     wiredResult;
+
+    // Home-page visibility: this card also lives on the Home FlexiPage (under
+    // Intake). When its HideHome setting is set, self-hide on Home only — it
+    // stays visible on the workspace "Close Outs" tab regardless.
+    @wire(CurrentPageReference) _homePageRef;
+    @wire(getHiddenHomeComponents) _hiddenHomeComponents;
+
+    get isOnHomePage() {
+        const ref = this._homePageRef;
+        if (!ref) {
+            return false;
+        }
+        const attrs = ref.attributes || {};
+        if (ref.type === "standard__namedPage" && attrs.pageName === "home") {
+            return true;
+        }
+        const url = attrs.url
+            || (typeof window !== "undefined" && window.location ? window.location.pathname : "");
+        return typeof url === "string" && url.indexOf("/lightning/page/home") !== -1;
+    }
+
+    get isHiddenOnHome() {
+        if (!this.isOnHomePage) {
+            return false;
+        }
+        const map = this._hiddenHomeComponents && this._hiddenHomeComponents.data;
+        return !!(map && map[HOME_COMPONENT_KEY] === true);
+    }
+
+    get isNotHiddenOnHome() {
+        return !this.isHiddenOnHome;
+    }
 
     @wire(getCloseOutItems)
     wiredItems(result) {

--- a/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/deliveryHomeVisibilitySettingsCard.js
+++ b/force-app/main/default/lwc/deliveryHomeVisibilitySettingsCard/deliveryHomeVisibilitySettingsCard.js
@@ -71,6 +71,11 @@ const COMPONENTS = [
         key: 'deliveryClientDashboard',
         label: 'Client Dashboard',
         help: 'The client-facing greeting, attention, in-flight, and recent sections.'
+    },
+    {
+        key: 'deliveryCloseOutQueue',
+        label: 'Close Outs',
+        help: 'Deployed-to-Prod items awaiting close-out verification (back of the pipeline).'
     }
 ];
 

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeCloseOutQueueDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideHomeCloseOutQueueDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideHomeCloseOutQueueDateTime__c</fullName>
+    <description>When non-null, the Close Outs queue card is hidden from the Delivery Hub app Home page (it still shows on the workspace "Close Outs" tab). Null = shown (default). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the home-visibility convention.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Close Outs card on the Home page. Leave blank to show it.</inlineHelpText>
+    <label>Hide Home Close Out Queue</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>


### PR DESCRIPTION
## What & why
Puts the back half of Jose's triage loop on the home: **Close Outs now sits directly under Intake** on the Delivery Hub app home, so the triager sees front-of-pipe (Intake) and back-of-pipe (Close Outs) together. Toggleable like every other home widget, default shown.

- `deliveryCloseOutQueue` added to the DeliveryHubHome FlexiPage under Intake.
- 12th toggleable component: `HideHomeCloseOutQueueDateTime__c` (inverted default null=shown) + controller map + Home Visibility settings card.
- Self-hides on Home when set; stays on the workspace "Close Outs" tab regardless.

## Verification
- Deployed to dh-child: controller returns `deliveryCloseOutQueue` (shown). Home now shows Intake → Close Outs → System Pulse.
- `DeliveryHomeVisibilityControllerTest` 6/6, PMD clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)