### PR TITLE
fix(permsets): add DeliveryTriageController classAccess to both app permsets

### DIFF
--- a/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
@@ -237,6 +237,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryTriageController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryVelocityService</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
@@ -237,6 +237,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryTriageController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryVelocityService</apexClass>
         <enabled>true</enabled>
     </classAccesses>


### PR DESCRIPTION
## What
Adds `DeliveryTriageController` to the `classAccesses` of both packaged permission sets (`DeliveryHubApp`, `DeliveryHubAdmin_App`).

## Why
`DeliveryTriageController` backs **both** the Intake queue (`getIntakeItems` / `routeToDev` / `dismissIntake`) and the Close Out queue (`getCloseOutItems` / `markDone` / `getCloseOutReportId`) — the entire Jose happy-path — but was never registered in either permset (the #948-class gap the project convention warns about).

It works in current subscriber orgs only because the package was installed "for all users," which granted profile-level access and masks the gap. Verified via `SetupEntityAccess` in MF-Prod / nimba / dh-prod on 0.292.0.1: the two visibility controllers are in both permsets, `DeliveryTriageController` is in neither. Any admins-only install or newly created profile would no-op intake actions and close-outs for buyers.

## Testing
Metadata-only change (2 XML blocks, alphabetical placement). CI feature-test + upload-beta validate permset integrity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
