### PR TITLE
fix(links): broken-link wave — missing listviews + wrong nav targets

### DIFF
--- a/force-app/main/default/lwc/deliveryActivityDashboard/deliveryActivityDashboard.js
+++ b/force-app/main/default/lwc/deliveryActivityDashboard/deliveryActivityDashboard.js
@@ -204,7 +204,7 @@ export default class DeliveryActivityDashboard extends NavigationMixin(Lightning
                 objectApiName: ACTIVITY_LOG_OBJECT.objectApiName
             },
             state: {
-                filterName: 'Recent'
+                filterName: 'All'
             },
             type: 'standard__objectPage'
         });

--- a/force-app/main/default/lwc/deliveryBudgetSummary/deliveryBudgetSummary.js
+++ b/force-app/main/default/lwc/deliveryBudgetSummary/deliveryBudgetSummary.js
@@ -145,7 +145,7 @@ export default class DeliveryBudgetSummary extends NavigationMixin(LightningElem
             this[NavigationMixin.Navigate]({ type: 'standard__webPage', attributes: { url: `/lightning/r/Report/${reportId}/view` } });
             return;
         }
-        this[NavigationMixin.Navigate]({ type: 'standard__objectPage', attributes: { objectApiName: SYNC_ITEM_OBJECT.objectApiName, actionName: 'list' }, state: { filterName: 'Recent' } });
+        this[NavigationMixin.Navigate]({ type: 'standard__objectPage', attributes: { objectApiName: SYNC_ITEM_OBJECT.objectApiName, actionName: 'list' }, state: { filterName: 'All' } });
     }
 
     handleFailedClick() {
@@ -154,7 +154,7 @@ export default class DeliveryBudgetSummary extends NavigationMixin(LightningElem
             this[NavigationMixin.Navigate]({ type: 'standard__webPage', attributes: { url: `/lightning/r/Report/${reportId}/view` } });
             return;
         }
-        this[NavigationMixin.Navigate]({ type: 'standard__objectPage', attributes: { objectApiName: SYNC_ITEM_OBJECT.objectApiName, actionName: 'list' }, state: { filterName: 'Recent' } });
+        this[NavigationMixin.Navigate]({ type: 'standard__objectPage', attributes: { objectApiName: SYNC_ITEM_OBJECT.objectApiName, actionName: 'list' }, state: { filterName: 'All' } });
     }
 
     handleRefresh() {

--- a/force-app/main/default/lwc/deliveryCsvImport/deliveryCsvImport.js
+++ b/force-app/main/default/lwc/deliveryCsvImport/deliveryCsvImport.js
@@ -8,8 +8,29 @@
 import { LightningElement, track, wire } from 'lwc';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import { NavigationMixin } from 'lightning/navigation';
+import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
 import importWorkItems from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryCsvImportController.importWorkItems';
 import getWorkItemFields from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryCsvImportController.getWorkItemFields';
+
+/*
+ * Runtime package-namespace prefix (e.g. `delivery__` on a managed install,
+ * '' in unmanaged dev). Derived from a schema import's objectApiName: on a
+ * managed org `WORK_ITEM_OBJECT.objectApiName` is `delivery__WorkItem__c`, so
+ * everything up to and including the LAST `__` before the local name is the
+ * namespace prefix. Used to prefix CustomTab api names that have no schema
+ * import of their own. Mirrors the NS_PREFIX helper in deliveryGuide.
+ */
+const NS_PREFIX = (() => {
+    const apiName = WORK_ITEM_OBJECT.objectApiName || '';
+    const idx = apiName.indexOf('__');
+    // `delivery__WorkItem__c` -> idx at the namespace separator (not the
+    // trailing `__c`). If the first `__` is the object-suffix (unmanaged dev:
+    // `WorkItem__c`), there is no namespace prefix.
+    if (idx > -1 && apiName.slice(idx) !== '__c') {
+        return apiName.slice(0, idx + 2);
+    }
+    return '';
+})();
 
 // ── Jira column-to-field mapping ─────────────────────────────────
 const JIRA_COLUMN_MAP = {
@@ -531,10 +552,14 @@ export default class DeliveryCsvImport extends NavigationMixin(LightningElement)
 
     // ── Post-import actions ──────────────────────────────────────────
     handleViewOnBoard() {
+        // CustomTab — no @salesforce/schema import exists for a tab, so
+        // prepend the runtime-resolved package namespace prefix to the
+        // bare tab api name (`delivery__Delivery_Board` on a managed org,
+        // `Delivery_Board` in unmanaged dev).
         this[NavigationMixin.Navigate]({
             type: 'standard__navItemPage',
             attributes: {
-                apiName: 'Delivery_Hub'
+                apiName: `${NS_PREFIX}Delivery_Board`
             }
         });
     }

--- a/force-app/main/default/lwc/deliveryGuide/deliveryGuide.js
+++ b/force-app/main/default/lwc/deliveryGuide/deliveryGuide.js
@@ -81,7 +81,7 @@ const PERSONAS = [
  * navType values:
  *   'tab'        - NavigationMixin to a named CustomTab (navTarget = bare tab
  *                  api name; namespace prefix applied at runtime via NS_PREFIX)
- *   'objectList' - NavigationMixin to an object's list view (Recent); navTarget
+ *   'objectList' - NavigationMixin to an object's list view (All); navTarget
  *                  = a key into OBJECT_TARGETS, resolved to the namespaced
  *                  objectApiName via its `@salesforce/schema` import at run time
  *   null         - no deep-link (informational sections)
@@ -404,7 +404,7 @@ export default class DeliveryGuide extends NavigationMixin(LightningElement) {
                     actionName: 'list',
                     objectApiName: objectSchema.objectApiName
                 },
-                state: { filterName: 'Recent' },
+                state: { filterName: 'All' },
                 type: 'standard__objectPage'
             });
         }

--- a/force-app/main/default/lwc/deliveryTemplateManager/deliveryTemplateManager.js
+++ b/force-app/main/default/lwc/deliveryTemplateManager/deliveryTemplateManager.js
@@ -10,6 +10,7 @@ import { LightningElement, wire, track } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import { refreshApex } from '@salesforce/apex';
+import WORK_ITEM_OBJECT from '@salesforce/schema/WorkItem__c';
 
 import activateTemplate from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTemplateManagerController.activateTemplate';
 import createFromTemplate from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTemplateManagerController.createFromTemplate';
@@ -126,7 +127,11 @@ export default class DeliveryTemplateManager extends NavigationMixin(LightningEl
         this[NavigationMixin.Navigate]({ // eslint-disable-line new-cap
             attributes: {
                 actionName: 'new',
-                objectApiName: '%%%NAMESPACE%%%WorkItem__c'
+                // Schema-import keeps the object api name namespace-correct in
+                // both managed (`delivery__WorkItem__c`) and unmanaged
+                // contexts — namespace build tokens do NOT expand inside
+                // arbitrary JS string literals (PRs #850/#851/#855).
+                objectApiName: WORK_ITEM_OBJECT.objectApiName
             },
             state: {
                 defaultFieldValues: 'TemplateMarkedDateTime__c=' + new Date().toISOString()
@@ -228,7 +233,7 @@ export default class DeliveryTemplateManager extends NavigationMixin(LightningEl
             this[NavigationMixin.Navigate]({ // eslint-disable-line new-cap
                 attributes: {
                     actionName: 'view',
-                    objectApiName: '%%%NAMESPACE%%%WorkItem__c',
+                    objectApiName: WORK_ITEM_OBJECT.objectApiName,
                     recordId: newId
                 },
                 type: 'standard__recordPage'

--- a/force-app/main/default/objects/BountyClaim__c/listViews/All.listView-meta.xml
+++ b/force-app/main/default/objects/BountyClaim__c/listViews/All.listView-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ListView xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>All</fullName>
+    <columns>NAME</columns>
+    <columns>WorkItemId__c</columns>
+    <columns>ClaimantNameTxt__c</columns>
+    <columns>StatusPk__c</columns>
+    <columns>ClaimedDateTime__c</columns>
+    <filterScope>Everything</filterScope>
+    <label>All</label>
+</ListView>

--- a/force-app/main/default/objects/WorkLog__c/listViews/Last_Month.listView-meta.xml
+++ b/force-app/main/default/objects/WorkLog__c/listViews/Last_Month.listView-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ListView xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Last_Month</fullName>
+    <columns>NAME</columns>
+    <columns>WorkItemLookup__c</columns>
+    <columns>WorkDateDate__c</columns>
+    <columns>HoursLoggedNumber__c</columns>
+    <columns>StatusPk__c</columns>
+    <columns>WorkDescriptionTxt__c</columns>
+    <filterScope>Everything</filterScope>
+    <filters>
+        <field>WorkDateDate__c</field>
+        <operation>equals</operation>
+        <value>LAST_MONTH</value>
+    </filters>
+    <label>Last Month</label>
+</ListView>


### PR DESCRIPTION
Fixes the "broken-link class" from the click-map audit — five dead or fragile navigation targets, all verified against current main before editing.

## Fixes

**1. (HIGH) Missing `WorkLog__c` Last_Month listview**
`deliveryBudgetSummary.openHoursReport()` falls back to `filterName: 'Last_Month'` when the Monthly_Hours reports are absent, but only `All` and `This_Month` shipped. Added `Last_Month.listView-meta.xml` mirroring This_Month's columns with `WorkDateDate__c equals LAST_MONTH`.

**2. (HIGH) deliveryCsvImport "View on Board" navigated to a nonexistent tab**
`handleViewOnBoard` targeted `standard__navItemPage` apiName `Delivery_Hub` — no such tab exists, and it carried no namespace prefix. Now targets `Delivery_Board` using the exact runtime `NS_PREFIX` mechanism from `deliveryGuide` (prefix derived from `WORK_ITEM_OBJECT.objectApiName`, since tabs have no `@salesforce/schema` import).

**3. (MED) `filterName: 'Recent'` → `'All'`**
'Recent' is a soft dependency on the SF built-in alias — no Recent listview ships. Switched to the shipped `All` listview (verified present for each object) in:
- `deliveryBudgetSummary` — synced/failed SyncItem__c fallbacks
- `deliveryActivityDashboard` — ActivityLog__c
- `deliveryGuide` — single objectList callsite covering WorkItem__c / DeliveryDocument__c / SyncItem__c / BountyClaim__c

**4. (MED) BountyClaim__c shipped zero listviews**
Added `All.listView-meta.xml` (filterScope Everything; columns NAME, WorkItemId__c, ClaimantNameTxt__c, StatusPk__c, ClaimedDateTime__c — real field API names from the object's fields directory). This is what deliveryGuide's "View Bounties" deep-link now lands on.

**5. (LOW) deliveryTemplateManager used `%%%NAMESPACE%%%WorkItem__c` string literals**
Namespace build tokens do not expand inside arbitrary JS string literals (PRs #850/#851/#855). Both occurrences (`handleNewTemplate` new-record nav and `handleCloneConfirm` view nav) converted to the `WORK_ITEM_OBJECT.objectApiName` schema-import pattern used everywhere else.

## Verification
- Grep sweep: zero remaining `%%%NAMESPACE%%%` (no-dot) tokens and zero `filterName: 'Recent'` in the LWC tree.
- `Delivery_Board` tab confirmed to exist under `force-app/main/default/tabs/`; `Delivery_Hub` does not.
- Jest: `npm run test:lwc -- <touched components>` — 1 suite, 2/2 pass (deliveryBudgetSummary is the only touched component with tests; none asserted the old nav values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
