### PR TITLE
fix(docviewer): import DOC_OBJECT — walkthrough steps 2 & 8 crash on document pages

### DIFF
--- a/force-app/main/default/lwc/deliveryDocumentViewer/deliveryDocumentViewer.js
+++ b/force-app/main/default/lwc/deliveryDocumentViewer/deliveryDocumentViewer.js
@@ -25,6 +25,7 @@ import updateDocumentStatus from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDo
 import signActionAdmin from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDocActionController.signActionAdmin';
 import getActionsForDocument from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDocActionController.getActionsForDocument';
 import getCertificateOfCompletion from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryDocActionController.getCertificateOfCompletion';
+import DOC_OBJECT from '@salesforce/schema/DeliveryDocument__c';
 
 const CURRENCY_FMT = new Intl.NumberFormat('en-US', { currency: 'USD', style: 'currency' });
 


### PR DESCRIPTION
## What
`deliveryDocumentViewer` crashes with **`DOC_OBJECT is not defined`** the moment it mounts on any `DeliveryDocument__c` record page.

## Why
`handlePageRef` — a `@wire(CurrentPageReference)` that fires on every record page — dereferences `DOC_OBJECT.objectApiName` (line ~199), but `DOC_OBJECT` was never imported. ReferenceError → the Aura "A Component Error has occurred!" modal.

The viewer is only embedded on DeliveryDocument pages, so **exactly the two document steps** of the live walkthrough broke — the engagement **agreement** and the **invoice** — while WorkItem / WorkRequest / WorkLog steps (no viewer) loaded fine. Surfaced by David clicking the real record pages; the backend controller path (`generateDocument`) never mounts the LWC, so prior backend verification couldn't see it.

## Fix
One line — import the object schema, matching the package convention already in `deliveryGuide.js`:

```js
import DOC_OBJECT from '@salesforce/schema/DeliveryDocument__c';
```

Object-schema imports resolve in-package with no namespace token.

## Verification
Redeployed the bundle to a fresh demo org (`david-walk`) — deploy **Succeeded**; the document record pages render the viewer instead of the error modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)