### PR TITLE
ci: bump apex-scan Node 20.x → 22.x (fixes @salesforce/cli install crash)

### DIFF
--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v3
         with:
-          node-version: "20.x"
+          node-version: "22.x"
 
       - name: Install Salesforce CLI and Scanner
         run: |


### PR DESCRIPTION
apex-scan installs `@salesforce/cli@latest`; its bundled `undici` calls `webidl.util.markAsUncloneable`, absent in Node 20.20.2 → CLI crashes at install (`TypeError: markAsUncloneable is not a function`) before scanning any Apex. Breaks apex-scan on **every** PR. Node 22 has the API. One-line bump.

Verified root cause in the failing run's install log. `feature-test` runs on a separate reusable workflow and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)