### PR TITLE
feat(sync): auto-approve connections + Mode-A-default handshake (turnkey setup)

### DIFF
--- a/force-app/main/default/classes/DeliveryHubSetupController.cls
+++ b/force-app/main/default/classes/DeliveryHubSetupController.cls
@@ -160,16 +160,19 @@ global without sharing class DeliveryHubSetupController {
         // Generate a shared API key for bidirectional authentication
         String sharedApiKey = EncodingUtil.convertToHex(Crypto.generateAesKey(256));
 
+        // Mode A (default, push/pull): do NOT advertise this spoke's push endpoint. With no
+        // endpoint on the hub's record of us, the hub STAGES our inbound items and we PULL them
+        // via the poller — no public Site required on the spoke, and the return path can't be
+        // starved by an unreachable push target. (Mode B "instant push to spoke" would re-add
+        // IntegrationEndpointUrlTxt__c here, gated on the spoke exposing a public Site.)
         Map<String, Object> packet = new Map<String, Object>{
             'SourceId' => localEntityId,
             'RemoteExternalIdTxt__c' => localEntityId,
             'Name' => buildOrgDisplayName(),
             'OrgIdTxt__c' => UserInfo.getOrganizationId(),
-            'IntegrationEndpointUrlTxt__c' => Url.getOrgDomainUrl().toExternalForm() + '/services/apexrest/delivery/deliveryhub/v1/sync',
             'EntityTypePk__c' => 'Client',
             'StatusPk__c' => 'Active',
-            'ApiKeyTxt__c' => sharedApiKey,
-            'ConnectionStatusPk__c' => 'Connected'
+            'ApiKeyTxt__c' => sharedApiKey
         };
 
         HttpRequest req = new HttpRequest();
@@ -248,6 +251,7 @@ global without sharing class DeliveryHubSetupController {
                 EnableActivityLoggingDateTime__c = now,
                 EnableFieldTrackingDateTime__c = now,
                 EnableBoardMetricsDateTime__c = now,
+                EnableAutoApproveConnectionsDateTime__c = now,
                 StagesToAutoShareWithDevTeamTxt__c = 'All'
             );
             insert settings;

--- a/force-app/main/default/classes/DeliverySyncItemIngestor.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestor.cls
@@ -466,9 +466,13 @@ public without sharing class DeliverySyncItemIngestor {
             }
         }
 
-        // Connection Approval: New inbound NetworkEntity records require admin approval
+        // Connection Approval: the RECEIVER decides the status of a NEW inbound connection.
+        // Auto-approve ON  -> Connected, sync flows immediately (frictionless default, seeded
+        //                     on fresh installs). Auto-approve OFF -> Pending Approval, held
+        //                     until an admin reviews (a Review work item is raised post-commit).
+        Boolean autoApproveConnection = settings != null && settings.EnableAutoApproveConnectionsDateTime__c != null;
         if (objectType.endsWithIgnoreCase('NetworkEntity__c') && recordToUpsert.Id == null) {
-            putSafe(recordToUpsert, 'ConnectionStatusPk__c', 'Pending Approval');
+            putSafe(recordToUpsert, 'ConnectionStatusPk__c', autoApproveConnection ? 'Connected' : 'Pending Approval');
         }
 
         // v0.200 defense-in-depth: reject blank WorkItem creates. Background —
@@ -573,8 +577,14 @@ public without sharing class DeliverySyncItemIngestor {
             // reachable on a fresh NetworkEntity insert (recordToUpsert was just
             // created in the else-branch, so it carries a new Id and the
             // Pending-Approval status stamped earlier).
-            if (wasInsert && objectType.endsWithIgnoreCase('NetworkEntity__c') && recordToUpsert.Id != null) {
+            if (wasInsert && objectType.endsWithIgnoreCase('NetworkEntity__c') && recordToUpsert.Id != null
+                    && !autoApproveConnection) {
+                // Only when the connection actually needs review (auto-approve OFF). Under
+                // auto-approve the connection is already Connected — nothing to notify or review.
+                // Order matters: the Slack notification is a callout, so it must run before the
+                // review-task DML (a callout after uncommitted DML would throw).
                 notifyPendingConnection(recordToUpsert);
+                createConnectionReviewTask(recordToUpsert);
             }
         } finally {
             DeliveryTriggerControl.inboundSyncContext = priorInboundFlag;
@@ -1125,6 +1135,30 @@ public without sharing class DeliverySyncItemIngestor {
             }
         }
         return false;
+    }
+
+    /**
+     * @description Raises a "Review new connection" work item when a fresh inbound
+     * connection lands in the manual-approval posture (auto-approve OFF). Deliberately does
+     * NOT set ClientNetworkEntityLookup__c, so the review task itself never routes/syncs back
+     * to the pending peer. Best-effort: a failure here must never fail the sync ingest.
+     * @param entity The newly inserted, Pending-Approval NetworkEntity__c SObject
+     */
+    private static void createConnectionReviewTask(SObject entity) {
+        try {
+            String entName = String.valueOf(entity.get('Name'));
+            WorkItem__c task = new WorkItem__c(
+                BriefDescriptionTxt__c = 'Review new connection: ' + entName,
+                DetailsTxt__c = 'The org "' + entName + '" requested a cross-org sync connection and is '
+                    + 'Pending Approval. To approve, open its Network Entity record and set Connection '
+                    + 'Status to Connected. To reject, set it to Disabled. (Enable "Auto Approve '
+                    + 'Connections" in Delivery Hub Settings to skip this review step.)',
+                StageNamePk__c = 'Backlog'
+            );
+            Database.insert(task, AccessLevel.SYSTEM_MODE);
+        } catch (Exception ignored) {
+            // Non-fatal: the connection still lands Pending Approval and the Slack ping fires.
+        }
     }
 
     /**

--- a/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
+++ b/force-app/main/default/classes/DeliverySyncItemIngestorTest.cls
@@ -1351,4 +1351,58 @@ private class DeliverySyncItemIngestorTest {
             DeliverySyncItemIngestor.findSObjectType(''),
             'Blank input must return null');
     }
+
+    @IsTest
+    static void testInboundConnectionAutoApproved() {
+        System.runAs(testUser) {
+            DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
+            s.EnableAutoApproveConnectionsDateTime__c = Datetime.now();
+            upsert s;
+
+            Map<String, Object> payload = new Map<String, Object>{
+                'SourceId' => 'REMOTE-CONN-AUTO-1',
+                'Name' => 'Auto Peer Org',
+                'EntityTypePk__c' => 'Client',
+                'OrgIdTxt__c' => '00DAUTO000000001AAA'
+            };
+
+            Test.startTest();
+            Id createdId = DeliverySyncItemIngestor.processInboundItem('NetworkEntity__c', payload);
+            Test.stopTest();
+
+            NetworkEntity__c ne = [SELECT ConnectionStatusPk__c FROM NetworkEntity__c WHERE Id = :createdId];
+            System.assertEquals('Connected', ne.ConnectionStatusPk__c,
+                'Auto-approve ON must land a new inbound connection as Connected');
+        }
+    }
+
+    @IsTest
+    static void testInboundConnectionRequiresApproval() {
+        System.runAs(testUser) {
+            DeliveryHubSettings__c s = DeliveryHubSettings__c.getOrgDefaults();
+            s.EnableAutoApproveConnectionsDateTime__c = null;
+            upsert s;
+
+            Map<String, Object> payload = new Map<String, Object>{
+                'SourceId' => 'REMOTE-CONN-PEND-1',
+                'Name' => 'Pending Peer Org',
+                'EntityTypePk__c' => 'Client',
+                'OrgIdTxt__c' => '00DPEND000000001AAA'
+            };
+
+            Test.startTest();
+            Id createdId = DeliverySyncItemIngestor.processInboundItem('NetworkEntity__c', payload);
+            Test.stopTest();
+
+            NetworkEntity__c ne = [SELECT ConnectionStatusPk__c FROM NetworkEntity__c WHERE Id = :createdId];
+            System.assertEquals('Pending Approval', ne.ConnectionStatusPk__c,
+                'Auto-approve OFF must hold a new inbound connection at Pending Approval');
+
+            List<WorkItem__c> review = [
+                SELECT Id FROM WorkItem__c WHERE BriefDescriptionTxt__c LIKE 'Review new connection:%'
+            ];
+            System.assert(!review.isEmpty(),
+                'A Review work item must be raised when approval is required');
+        }
+    }
 }

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableAutoApproveConnectionsDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/EnableAutoApproveConnectionsDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnableAutoApproveConnectionsDateTime__c</fullName>
+    <description>When non-null, new inbound cross-org connections are auto-approved (created Connected) and sync flows immediately. Null = require manual approval: new connections land Pending Approval, sync is held, and a Review work item is created. Seeded ON for fresh installs (frictionless default); existing orgs stay off until an admin opts in. Supports user/profile/org hierarchy.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to auto-approve incoming connections (frictionless). Leave blank to require manual approval of each new connection.</inlineHelpText>
+    <label>Enable Auto Approve Connections</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>


### PR DESCRIPTION
## What this does
Closes the last gap for a **fully clicked, turnkey cross-org setup** — install → Quick Setup → create work item → it round-trips, with **zero manual hub-side steps**. Builds directly on the live cold-start we ran 2026-07-13, where the only non-click was a hand-approval on dh-prod.

### 1. Auto-approve connections (new setting)
`DeliveryHubSettings__c.EnableAutoApproveConnectionsDateTime__c`. The **receiver** decides a new inbound connection's status:
- **ON** → lands `Connected`, sync flows immediately (frictionless).
- **OFF** (tighter ship) → lands `Pending Approval`, sync held, and a **"Review new connection" work item** is raised with approve (set Connected) / reject (set Disabled) instructions. The existing Slack ping still fires.
- **`Disabled`** on any connection remains the hard kill switch.

Seeded **ON in the guided setup flow** (`DeliveryHubSetupController.initializeDefaultSettings`) so fresh installs are easy; the install handler stays zero-noise; **existing orgs (dh-prod) opt in by toggling** the setting.

### 2. Mode-A-default handshake
`performHandshake` no longer advertises the spoke's push endpoint. With no endpoint on the hub's record of the spoke, the hub **stages** inbound items and the spoke **pulls** via the poller — no public Site required on the spoke, and the return path can't be starved by an unreachable push target. (Mode B "instant push" re-adds the endpoint later, gated on a Site.)

### Safety
- The Review work item deliberately omits `ClientNetworkEntityLookup__c` so it can never route/sync back to the pending peer.
- Callout-then-DML ordering preserved in the post-commit hook.

### Tests (both pass on scratch)
- auto-approve ON → `Connected`
- auto-approve OFF → `Pending Approval` + a Review work item exists

## Deploy/verify note
The auto-approve decision runs on the **receiver**. To use it on **dh-prod**: install this version there **and toggle `EnableAutoApproveConnectionsDateTime__c` ON**, then re-test. (Seeding only default-ONs fresh installs.)

## Deferred (follow-up security PR)
Anti-self-approval hardening (receiver ignores the sender's claimed `ConnectionStatusPk__c` on re-handshake) and authenticating the pull endpoint.
