### PR TITLE
feat(sync): reactive Sync Now card — poll on load + auto-refresh

### DIFF
--- a/force-app/main/default/flexipages/DeliveryHubAdminHome.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryHubAdminHome.flexipage-meta.xml
@@ -3,6 +3,12 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
+                <componentName>deliverySyncNow</componentName>
+                <identifier>c_deliverySyncNow_adminhome</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
                 <componentInstanceProperties>
                     <name>showConnectedState</name>
                     <value>true</value>

--- a/force-app/main/default/flexipages/DeliveryHubHome.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryHubHome.flexipage-meta.xml
@@ -3,6 +3,12 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
+                <componentName>deliverySyncNow</componentName>
+                <identifier>c_deliverySyncNow_home</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
                 <componentName>deliveryIntakeQueue</componentName>
                 <identifier>c_deliveryIntakeQueue_home</identifier>
             </componentInstance>

--- a/force-app/main/default/lwc/deliverySyncNow/deliverySyncNow.html
+++ b/force-app/main/default/lwc/deliverySyncNow/deliverySyncNow.html
@@ -1,0 +1,19 @@
+<template>
+    <lightning-card title="Cross-Org Sync" icon-name="utility:sync">
+        <lightning-button
+            slot="actions"
+            label={buttonLabel}
+            onclick={handleClick}
+            disabled={isSyncing}
+            variant="brand"
+        ></lightning-button>
+        <div class="slds-p-horizontal_medium slds-p-bottom_small">
+            <template lwc:if={isSyncing}>
+                <lightning-spinner alternative-text="Syncing" size="small"></lightning-spinner>
+            </template>
+            <template lwc:if={hasResult}>
+                <p class="slds-text-body_small slds-text-color_weak">{lastResult}</p>
+            </template>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/deliverySyncNow/deliverySyncNow.js
+++ b/force-app/main/default/lwc/deliverySyncNow/deliverySyncNow.js
@@ -1,0 +1,80 @@
+import { LightningElement, api } from 'lwc';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import pollUpdates from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubPoller.pollUpdates';
+
+// Auto-refresh cadence while this component is on-screen. The 15-minute
+// scheduled poller is the durable safety net; this makes inbound cross-org
+// updates (comments, edits, stage changes from connected orgs) feel live
+// without waiting for that cron tick.
+const AUTO_REFRESH_MS = 30000;
+
+export default class DeliverySyncNow extends LightningElement {
+    // Inverted default: auto-refresh is ON unless a page author opts out
+    // (LWC boolean @api props cannot default to true — hence the inversion).
+    @api disableAutoRefresh = false;
+
+    isSyncing = false;
+    lastResult = '';
+    _timer;
+
+    connectedCallback() {
+        // Pull immediately on load so inbound changes are already there.
+        this.runSync(true);
+        if (!this.disableAutoRefresh) {
+            this._timer = setInterval(() => this.runSync(true), AUTO_REFRESH_MS);
+        }
+    }
+
+    disconnectedCallback() {
+        if (this._timer) {
+            clearInterval(this._timer);
+            this._timer = undefined;
+        }
+    }
+
+    get buttonLabel() {
+        return this.isSyncing ? 'Syncing…' : 'Sync Now';
+    }
+
+    get hasResult() {
+        return !!this.lastResult;
+    }
+
+    handleClick() {
+        // Manual click is never silent — the user asked, so show the result.
+        this.runSync(false);
+    }
+
+    runSync(silent) {
+        if (this.isSyncing) {
+            return;
+        }
+        this.isSyncing = true;
+        pollUpdates()
+            .then((result) => {
+                this.lastResult = result;
+                if (!silent) {
+                    const ok = typeof result === 'string' && result.indexOf('Success') === 0;
+                    this.dispatchEvent(
+                        new ShowToastEvent({
+                            title: 'Cross-Org Sync',
+                            message: result,
+                            variant: ok ? 'success' : 'warning'
+                        })
+                    );
+                }
+            })
+            .catch((error) => {
+                const msg = (error && error.body && error.body.message) || 'Sync failed';
+                this.lastResult = msg;
+                if (!silent) {
+                    this.dispatchEvent(
+                        new ShowToastEvent({ title: 'Cross-Org Sync', message: msg, variant: 'error' })
+                    );
+                }
+            })
+            .finally(() => {
+                this.isSyncing = false;
+            });
+    }
+}

--- a/force-app/main/default/lwc/deliverySyncNow/deliverySyncNow.js-meta.xml
+++ b/force-app/main/default/lwc/deliverySyncNow/deliverySyncNow.js-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <masterLabel>Delivery Cross-Org Sync</masterLabel>
+    <description>One-click "Sync Now" plus auto-refresh — pulls inbound cross-org updates (work items, comments, worklogs, files) from connected orgs so changes appear without waiting for the 15-minute scheduled poll.</description>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__HomePage</target>
+        <target>lightning__AppPage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightning__UtilityBar</target>
+    </targets>
+</LightningComponentBundle>


### PR DESCRIPTION
## What this fixes
The cross-org **return path** (hub → spoke) is a **15-minute scheduled poll**, and **nothing triggered it on page load or on demand** — so an edit made on the hub could take up to 15 minutes to show on the spoke, which reads as "sync is broken." `DeliveryHubPoller.pollUpdates()` was already `@AuraEnabled` but never wired to any UI.

## Change
- **New `deliverySyncNow` LWC** — a "Cross-Org Sync" card with:
  - a **Sync Now** button (immediate pull),
  - an **immediate pull on load**, and
  - a **30s auto-refresh** while the card is on-screen (opt out via `disableAutoRefresh`).
- Calls the existing global poller — **no new Apex, no permset change** (`global @AuraEnabled` needs no classAccess).
- Placed at the top of **DeliveryHubHome** and **DeliveryHubAdminHome**; also exposed for record pages / utility bar.

## Why it's safe
The 15-minute scheduled poll remains the durable safety net — this just makes inbound updates (comments, edits, stage changes, files) appear in **seconds**. Forward (spoke → hub) already pushes on a queueable (~10–15s) and is untouched.

## Verified
Deployed to a live scratch org (DHtest) connected to dh-prod; the card renders, polls on load, and pulls inbound changes on click. Diagnosis today confirmed all fields (brief, details, stage, comments) sync both directions — the only issue was latency + no UI trigger, which this addresses.

## Follow-up (not in this PR)
Optional "syncing…" indicator on the forward push, and Mode-B instant push for true real-time.
