### PR TITLE
feat(sync): org-level sync-capture kill switch (DisableSyncCaptureDateTime__c)

### DIFF
--- a/force-app/main/default/classes/DeliverySyncEngine.cls
+++ b/force-app/main/default/classes/DeliverySyncEngine.cls
@@ -67,6 +67,14 @@ public without sharing class DeliverySyncEngine {
         if (newRecords == null || newRecords.isEmpty()) {
             return;
         }
+        // Org-level kill switch: sends/polls are gated by NetworkEntity
+        // ConnectionStatus, but creation is routed off structural edges
+        // (client lookup / WorkRequest routes) that billing also depends on
+        // and therefore can't be cleared. With sync dormant, un-sendable rows
+        // would otherwise accumulate on every significant edit.
+        if (DeliveryHubSettings__c.getOrgDefaults().DisableSyncCaptureDateTime__c != null) {
+            return;
+        }
         // Refined relay gate (replaces legacy full-suppress early-return):
         //   isSyncContext + inboundSenderOrgId set → proceed with per-route
         //     filter (skip routes targeting the source org). Enables the

--- a/force-app/main/default/classes/DeliverySyncEngineTest.cls
+++ b/force-app/main/default/classes/DeliverySyncEngineTest.cls
@@ -338,6 +338,58 @@ private class DeliverySyncEngineTest {
     }
 
     @IsTest
+    static void testKillSwitchBlocksCaptureThroughRealDml() {
+        System.runAs(testUser) {
+            DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+            settings.DisableSyncCaptureDateTime__c = System.now();
+            upsert settings;
+
+            WorkItem__c t = [SELECT Id, BriefDescriptionTxt__c FROM WorkItem__c LIMIT 1];
+            delete [SELECT Id FROM SyncItem__c]; // Clear setup trigger noise
+
+            Test.startTest();
+            t.BriefDescriptionTxt__c = 'Kill Switch Blocked';
+            update t; // Real trigger path — should be suppressed by the org-level switch
+            Test.stopTest();
+
+            List<SyncItem__c> allItems = [SELECT Id, PayloadTxt__c FROM SyncItem__c];
+            List<SyncItem__c> filtered = new List<SyncItem__c>();
+            for (SyncItem__c si : allItems) {
+                if (si.PayloadTxt__c != null && si.PayloadTxt__c.contains('Kill Switch Blocked')) {
+                    filtered.add(si);
+                }
+            }
+            System.assertEquals(0, filtered.size(), 'No sync items should be created when DisableSyncCaptureDateTime__c is set');
+        }
+    }
+
+    @IsTest
+    static void testKillSwitchClearedRestoresCapture() {
+        System.runAs(testUser) {
+            DeliveryHubSettings__c settings = DeliveryHubSettings__c.getOrgDefaults();
+            settings.DisableSyncCaptureDateTime__c = null;
+            upsert settings;
+
+            WorkItem__c t = [SELECT Id, BriefDescriptionTxt__c FROM WorkItem__c LIMIT 1];
+            delete [SELECT Id FROM SyncItem__c];
+
+            Test.startTest();
+            t.BriefDescriptionTxt__c = 'Kill Switch Cleared';
+            update t;
+            Test.stopTest();
+
+            List<SyncItem__c> allItems = [SELECT Id, PayloadTxt__c FROM SyncItem__c];
+            List<SyncItem__c> filtered = new List<SyncItem__c>();
+            for (SyncItem__c si : allItems) {
+                if (si.PayloadTxt__c != null && si.PayloadTxt__c.contains('Kill Switch Cleared')) {
+                    filtered.add(si);
+                }
+            }
+            System.assertEquals(2, filtered.size(), 'Normal bidirectional capture should resume when the switch is null');
+        }
+    }
+
+    @IsTest
     static void testIgnoreOriginBlankIsIgnored() {
         System.runAs(testUser) {
             // Calling ignoreOrigin with blank should not add to blockedOrigins

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/DisableSyncCaptureDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/DisableSyncCaptureDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DisableSyncCaptureDateTime__c</fullName>
+    <description>Org-level sync-capture kill switch (v1.0 standalone freeze, 2026-07-17). When non-null, DeliverySyncEngine.captureChanges returns early and no outbound SyncItem__c rows are created anywhere in this org, regardless of NetworkEntity routing edges. Null = normal capture (default; zero behavior change). Sends and polls are separately gated by NetworkEntity ConnectionStatusPk__c = 'Connected'; this switch closes the creation path so a dormant sync lane cannot silently accumulate rows (storage/noise risk — see docs/plans/sync-freeze-checklist-0717.md).</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to stop all outbound sync-item creation in this org (sync freeze). Leave blank for normal sync capture.</inlineHelpText>
+    <label>Disable Sync Capture</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>


### PR DESCRIPTION
## Why

Sync-freeze prerequisite (see `docs/plans/sync-freeze-checklist-0717.md` and the v1.0 standalone plan, `docs/plans/dh-v1-standalone-0717.md`).

Sends and polls are already gated by `NetworkEntity.ConnectionStatusPk__c = 'Connected'`, so disabling connections no-ops the transport. But SyncItem **creation** (`DeliverySyncEngine.captureChanges`) routes off structural edges — the WorkItem's client lookup and active WorkRequest routes — which **invoicing also depends on** and therefore cannot be cleared. A config-only freeze would keep inserting un-sendable SyncItem rows on every significant edit: permanent storage growth (dh-prod is ~4/5 of cap) plus Queued→Failed retry/dismiss noise.

## What

- **New settings field** `DeliveryHubSettings__c.DisableSyncCaptureDateTime__c` — DateTime toggle per house pattern; null by default = **zero behavior change** for every existing org.
- **One guard**: early return at the top of `captureChanges()` when the field is set. Single choke point for all outbound capture; inbound is already Connected-gated.
- **Tests** (in existing `DeliverySyncEngineTest`, mirroring the established real-DML pattern): switch set → real trigger-path update creates zero SyncItems; switch cleared → normal bidirectional fan-out (2 items) resumes.

## Safety

- Custom-settings fields are FLS-exempt — no permset changes needed.
- No existing code path reads the field except the new guard.
- Rollback = set the field back to null; capture resumes instantly, no deploy.

## Sequence after merge

beta → promote (chain ends there per standing rule) → per-org installs on Glen's explicit go → then the freeze runs per the checklist (switch on, connections Disabled, leftover Queued/Staged rows dismissed, sync tabs hidden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
