### PR TITLE
feat(workspace): Huddle tab — meeting-prep view of open WorkItems

### DIFF
--- a/force-app/main/default/classes/DeliveryHuddleController.cls
+++ b/force-app/main/default/classes/DeliveryHuddleController.cls
@@ -1,0 +1,165 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Read-mostly controller behind the workspace Huddle tab — the
+ *               meeting-prep surface. One query answers "what do we talk
+ *               about": every open WorkItem with its latest comment, due date,
+ *               epic grouping and external page link, so a standup can open on
+ *               the board instead of on memory.
+ *
+ *               getHuddleItems() — open (non-terminal) WorkItems, newest-touch
+ *                 first, each carrying its most recent WorkItemComment__c via
+ *                 subquery. Sectioning (overdue / due soon / recently changed /
+ *                 stale) is derived client-side from the returned dates so the
+ *                 Apex stays one cacheable query.
+ *               quickAddItem()  — five-second capture during a meeting: title
+ *                 (+ optional due date / epic / external link) inserted as a
+ *                 standard intake WorkItem (StatusPk 'New', not activated),
+ *                 so it lands in the same front-of-pipe the Intake tab drains.
+ *
+ *               SOQL is WITH SYSTEM_MODE per CLAUDE.md (WITH USER_MODE breaks
+ *               in namespaced package test context). Picklist values are safe
+ *               known literals (the picklist-allowlist trigger is a documented
+ *               no-op). Terminal stages come from the same CMT-driven union
+ *               DeliveryTriageController uses, so a closed-out item never
+ *               reappears in a huddle.
+ * @author       Cloud Nimbus LLC
+ */
+@SuppressWarnings('PMD.ApexCRUDViolation')
+public with sharing class DeliveryHuddleController {
+
+    /** Intake status quickAddItem inserts with — same front-of-pipe semantics
+     *  as a reported issue (Status='New' is the legitimate intake state). */
+    private static final String STATUS_NEW = 'New';
+
+    /** Statuses that are closed regardless of stage. */
+    private static final Set<String> CLOSED_STATUSES =
+        new Set<String>{ 'Done', 'Cancelled' };
+
+    /** Hard cap so a years-old org can't blow up the wire payload. */
+    private static final Integer MAX_ITEMS = 400;
+
+    /**
+     * @description WorkItem__c stages excluded from the huddle — CMT-driven
+     * terminal union (defaults to Done/Cancelled when CMT empty).
+     */
+    @TestVisible
+    private static Set<String> terminalStages {
+        get {
+            if (terminalStages == null) {
+                terminalStages = DeliveryWorkflowConfigService.getAllTerminalStageValues();
+            }
+            return terminalStages;
+        }
+        set;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // DTOs
+    // ────────────────────────────────────────────────────────────────────
+
+    /** @description One open WorkItem row on the Huddle tab. */
+    public class HuddleItemDTO {
+        @AuraEnabled public Id workItemId;
+        @AuraEnabled public String name;
+        @AuraEnabled public String title;
+        @AuraEnabled public String status;
+        @AuraEnabled public String stage;
+        @AuraEnabled public String epic;
+        @AuraEnabled public String tags;
+        @AuraEnabled public String ownerName;
+        @AuraEnabled public Date dueDate;
+        @AuraEnabled public String externalPageUrl;
+        @AuraEnabled public Datetime lastModified;
+        @AuraEnabled public String lastCommentBody;
+        @AuraEnabled public String lastCommentAuthor;
+        @AuraEnabled public Datetime lastCommentDate;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Reads
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Every open WorkItem with its latest comment, for the Huddle
+     *              tab. Ordered most-recently-touched first — in a meeting the
+     *              live items outrank the quiet ones.
+     * @return open items, newest LastModifiedDate first, capped at MAX_ITEMS
+     */
+    @AuraEnabled(cacheable=true)
+    public static List<HuddleItemDTO> getHuddleItems() {
+        Set<String> closedStages = terminalStages;
+        List<WorkItem__c> rows = [
+            SELECT Id, Name, BriefDescriptionTxt__c, StatusPk__c, StageNamePk__c,
+                   EpicTxt__c, TagsTxt__c, Owner.Name, SLATargetDate__c,
+                   ExternalPageUrl__c, LastModifiedDate,
+                   (SELECT BodyTxt__c, AuthorTxt__c, CreatedDate
+                      FROM WorkItemComments__r
+                     ORDER BY CreatedDate DESC
+                     LIMIT 1)
+              FROM WorkItem__c
+             WHERE (StageNamePk__c NOT IN :closedStages OR StageNamePk__c = null)
+               AND (StatusPk__c NOT IN :CLOSED_STATUSES OR StatusPk__c = null)
+              WITH SYSTEM_MODE
+             ORDER BY LastModifiedDate DESC
+             LIMIT :MAX_ITEMS
+        ];
+        List<HuddleItemDTO> out = new List<HuddleItemDTO>();
+        for (WorkItem__c row : rows) {
+            HuddleItemDTO dto = new HuddleItemDTO();
+            dto.workItemId = row.Id;
+            dto.name = row.Name;
+            dto.title = row.BriefDescriptionTxt__c;
+            dto.status = row.StatusPk__c;
+            dto.stage = row.StageNamePk__c;
+            dto.epic = row.EpicTxt__c;
+            dto.tags = row.TagsTxt__c;
+            dto.ownerName = row.Owner.Name;
+            dto.dueDate = row.SLATargetDate__c;
+            dto.externalPageUrl = row.ExternalPageUrl__c;
+            dto.lastModified = row.LastModifiedDate;
+            if (!row.WorkItemComments__r.isEmpty()) {
+                WorkItemComment__c c = row.WorkItemComments__r[0];
+                dto.lastCommentBody = c.BodyTxt__c;
+                dto.lastCommentAuthor = c.AuthorTxt__c;
+                dto.lastCommentDate = c.CreatedDate;
+            }
+            out.add(dto);
+        }
+        return out;
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Writes
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * @description Quick capture during a meeting. Inserts a plain intake
+     *              WorkItem (Status 'New', not activated) so it flows through
+     *              the exact same front-of-pipe as a reported issue.
+     * @param title required one-line description
+     * @param dueDate optional SLA target date
+     * @param epic optional epic/group label
+     * @param externalPageUrl optional link-out to the page holding context
+     * @return Id of the created WorkItem
+     */
+    @AuraEnabled
+    public static Id quickAddItem(String title, Date dueDate, String epic, String externalPageUrl) {
+        if (String.isBlank(title)) {
+            throw new AuraHandledException('A title is required.');
+        }
+        try {
+            WorkItem__c wi = new WorkItem__c(
+                BriefDescriptionTxt__c = title.trim(),
+                StatusPk__c = STATUS_NEW,
+                SLATargetDate__c = dueDate,
+                EpicTxt__c = String.isBlank(epic) ? null : epic.trim(),
+                ExternalPageUrl__c = String.isBlank(externalPageUrl) ? null : externalPageUrl.trim()
+            );
+            insert wi;
+            return wi.Id;
+        } catch (Exception e) {
+            throw new AuraHandledException('Could not create the work item: ' + e.getMessage());
+        }
+    }
+}

--- a/force-app/main/default/classes/DeliveryHuddleController.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryHuddleController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryHuddleControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHuddleControllerTest.cls
@@ -1,0 +1,126 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Tests for DeliveryHuddleController — the workspace Huddle
+ *               (meeting-prep) tab. Rolling-window assertions anchor on
+ *               Date.today() per repo convention. AuraHandledException message
+ *               content is never asserted (generic in managed context).
+ * @author       Cloud Nimbus LLC
+ */
+@IsTest
+private class DeliveryHuddleControllerTest {
+
+    @IsTest
+    static void getHuddleItemsReturnsOpenItemWithLatestComment() {
+        WorkItem__c open = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'EpicTxt__c' => 'Risk Framework',
+            'SLATargetDate__c' => Date.today().addDays(3),
+            'ExternalPageUrl__c' => 'https://example.com/mf/standup'
+        });
+        WorkItem__c closed = TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StatusPk__c' => 'Done',
+            'StageNamePk__c' => 'Done'
+        });
+        insert new List<WorkItemComment__c>{
+            new WorkItemComment__c(
+                WorkItemId__c = open.Id,
+                BodyTxt__c = 'older comment',
+                AuthorTxt__c = 'Author A',
+                SourcePk__c = 'Email'
+            ),
+            new WorkItemComment__c(
+                WorkItemId__c = open.Id,
+                BodyTxt__c = 'newest comment',
+                AuthorTxt__c = 'Author B',
+                SourcePk__c = 'Email'
+            )
+        };
+
+        Test.startTest();
+        List<DeliveryHuddleController.HuddleItemDTO> items =
+            DeliveryHuddleController.getHuddleItems();
+        Test.stopTest();
+
+        Set<Id> ids = new Set<Id>();
+        DeliveryHuddleController.HuddleItemDTO openDto;
+        for (DeliveryHuddleController.HuddleItemDTO dto : items) {
+            ids.add(dto.workItemId);
+            if (dto.workItemId == open.Id) {
+                openDto = dto;
+            }
+        }
+        System.assert(ids.contains(open.Id), 'Open item should appear in the huddle');
+        System.assert(!ids.contains(closed.Id), 'Done item must not appear in the huddle');
+        System.assertNotEquals(null, openDto, 'Open item DTO expected');
+        System.assertEquals('Risk Framework', openDto.epic, 'Epic should round-trip');
+        System.assertEquals(Date.today().addDays(3), openDto.dueDate, 'Due date should round-trip');
+        System.assertEquals('https://example.com/mf/standup', openDto.externalPageUrl,
+            'External page URL should round-trip');
+        // Two comments inserted in one transaction share a CreatedDate, so the
+        // subquery may legally return either; assert a comment surfaced at all.
+        System.assertNotEquals(null, openDto.lastCommentBody,
+            'Latest comment body should be populated');
+        System.assertNotEquals(null, openDto.lastCommentAuthor,
+            'Latest comment author should be populated');
+    }
+
+    @IsTest
+    static void getHuddleItemsExcludesTerminalStage() {
+        TestDataFactory.createWorkItem(new Map<String, Object>{
+            'StageNamePk__c' => 'Cancelled',
+            'StatusPk__c' => 'Cancelled'
+        });
+
+        Test.startTest();
+        List<DeliveryHuddleController.HuddleItemDTO> items =
+            DeliveryHuddleController.getHuddleItems();
+        Test.stopTest();
+
+        for (DeliveryHuddleController.HuddleItemDTO dto : items) {
+            System.assertNotEquals('Cancelled', dto.status,
+                'Cancelled items must be excluded');
+        }
+    }
+
+    @IsTest
+    static void quickAddItemInsertsIntakeWorkItem() {
+        Test.startTest();
+        Id wiId = DeliveryHuddleController.quickAddItem(
+            '  Huddle capture: confirm Thursday trigger owner  ',
+            Date.today().addDays(2),
+            'MF Check-in',
+            'https://example.com/dispatches/call-extract'
+        );
+        Test.stopTest();
+
+        WorkItem__c wi = [
+            SELECT BriefDescriptionTxt__c, StatusPk__c, SLATargetDate__c,
+                   EpicTxt__c, ExternalPageUrl__c
+              FROM WorkItem__c
+             WHERE Id = :wiId
+              WITH SYSTEM_MODE
+             LIMIT 1
+        ];
+        System.assertEquals('Huddle capture: confirm Thursday trigger owner',
+            wi.BriefDescriptionTxt__c, 'Title should be trimmed');
+        System.assertEquals('New', wi.StatusPk__c, 'Quick-add lands as intake (New)');
+        System.assertEquals(Date.today().addDays(2), wi.SLATargetDate__c,
+            'Due date should persist');
+        System.assertEquals('MF Check-in', wi.EpicTxt__c, 'Epic should persist');
+        System.assertEquals('https://example.com/dispatches/call-extract',
+            wi.ExternalPageUrl__c, 'External URL should persist');
+    }
+
+    @IsTest
+    static void quickAddItemBlankTitleThrows() {
+        Boolean threw = false;
+        Test.startTest();
+        try {
+            DeliveryHuddleController.quickAddItem('   ', null, null, null);
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        Test.stopTest();
+        System.assert(threw, 'Blank title must throw');
+    }
+}

--- a/force-app/main/default/classes/DeliveryHuddleControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/DeliveryHuddleControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DeliveryTabVisibilityController.cls
+++ b/force-app/main/default/classes/DeliveryTabVisibilityController.cls
@@ -19,6 +19,7 @@ public with sharing class DeliveryTabVisibilityController {
     private static final Map<String, String> TAB_TO_FIELD = new Map<String, String>{
         'intake'     => 'HideTabIntakeDateTime__c',
         'board'      => 'HideTabBoardDateTime__c',
+        'huddle'     => 'HideTabHuddleDateTime__c',
         'newRequest' => 'HideTabNewRequestDateTime__c',
         'timeline'   => 'HideTabTimelineDateTime__c',
         'activity'   => 'HideTabActivityDateTime__c',

--- a/force-app/main/default/classes/DeliveryTabVisibilityControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryTabVisibilityControllerTest.cls
@@ -19,7 +19,7 @@ private class DeliveryTabVisibilityControllerTest {
         Map<String, Boolean> hidden = DeliveryTabVisibilityController.getHiddenWorkspaceTabs();
         Test.stopTest();
 
-        System.assertEquals(10, hidden.size(), 'Expected all ten non-admin tabs in the map');
+        System.assertEquals(11, hidden.size(), 'Expected all eleven non-admin tabs in the map');
         for (String key : hidden.keySet()) {
             System.assertEquals(false, hidden.get(key), 'No setting present → tab should be shown (not hidden): ' + key);
         }
@@ -76,7 +76,7 @@ private class DeliveryTabVisibilityControllerTest {
         Map<String, Boolean> result = DeliveryTabVisibilityController.setHiddenWorkspaceTabs(null);
         Test.stopTest();
 
-        System.assertEquals(10, result.size(), 'A null request is a no-op that still returns the full map');
+        System.assertEquals(11, result.size(), 'A null request is a no-op that still returns the full map');
         for (String key : result.keySet()) {
             System.assertEquals(false, result.get(key), 'Nothing hidden for a null request: ' + key);
         }

--- a/force-app/main/default/lwc/deliveryHubWorkspace/__tests__/deliveryHubWorkspace.test.js
+++ b/force-app/main/default/lwc/deliveryHubWorkspace/__tests__/deliveryHubWorkspace.test.js
@@ -20,6 +20,7 @@ import { createElement } from 'lwc';
 // require('lwc') call inside the inline factory is permitted.
 jest.mock('c/deliveryIntakeQueue', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
 jest.mock('c/deliveryHubBoard', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
+jest.mock('c/deliveryHuddle', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
 jest.mock('c/deliveryQuickRequest', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
 jest.mock('c/deliveryProFormaTimeline', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
 jest.mock('c/deliveryActivityFeed', () => ({ __esModule: true, default: class extends require('lwc').LightningElement {} }));
@@ -68,7 +69,7 @@ describe('c-delivery-hub-workspace', () => {
         jest.clearAllMocks();
     });
 
-    it('shows all ten non-admin tabs by default', async () => {
+    it('shows all eleven non-admin tabs by default', async () => {
         const element = createComponent();
         isAdminUser.emit(false);
         getHiddenWorkspaceTabs.emit({});
@@ -78,7 +79,7 @@ describe('c-delivery-hub-workspace', () => {
         expect(values).toContain('intake');
         expect(values).toContain('board');
         expect(values).toContain('forecast');
-        expect(values.length).toBe(10); // buyer → no admin tabs
+        expect(values.length).toBe(11); // buyer → no admin tabs
     });
 
     it('hides a tab when its visibility setting is set', async () => {

--- a/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
+++ b/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.html
@@ -20,6 +20,15 @@
             </lightning-tab>
         </template>
 
+        <!-- Meeting-prep surface: open items grouped by epic with latest comment,
+             due/stale filters and quick capture — standups open here instead of
+             on memory. Ungated; the data is the same WorkItems the Board shows. -->
+        <template lwc:if={showHuddle}>
+            <lightning-tab label="Huddle" value="huddle" icon-name="standard:live_chat">
+                <c-delivery-huddle></c-delivery-huddle>
+            </lightning-tab>
+        </template>
+
         <template lwc:if={showNewRequest}>
             <lightning-tab label="New Request" value="newRequest" icon-name="standard:work_order_item">
                 <c-delivery-quick-request embedded={requestEmbedded}></c-delivery-quick-request>

--- a/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.js
+++ b/force-app/main/default/lwc/deliveryHubWorkspace/deliveryHubWorkspace.js
@@ -19,6 +19,7 @@ import getHiddenWorkspaceTabs from '@salesforce/apex/%%%NAMESPACE_DOT%%%Delivery
 const TAB_ORDER = [
     'intake',
     'board',
+    'huddle',
     'newRequest',
     'timeline',
     'activity',
@@ -69,6 +70,9 @@ export default class DeliveryHubWorkspace extends LightningElement {
     }
     get showBoard() {
         return !this.isHidden('board');
+    }
+    get showHuddle() {
+        return !this.isHidden('huddle');
     }
     get showNewRequest() {
         return !this.isHidden('newRequest');

--- a/force-app/main/default/lwc/deliveryHuddle/__tests__/deliveryHuddle.test.js
+++ b/force-app/main/default/lwc/deliveryHuddle/__tests__/deliveryHuddle.test.js
@@ -1,0 +1,156 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Jest coverage for deliveryHuddle: wire-driven rows grouped by
+ *               epic (Ungrouped last), overdue/stale badge derivation, latest
+ *               comment line, filter chips slicing the list, quick-add gating
+ *               and the create call shape.
+ * @author       Cloud Nimbus LLC
+ */
+import { createElement } from "lwc";
+import DeliveryHuddle from "c/deliveryHuddle";
+import getHuddleItems from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHuddleController.getHuddleItems";
+import quickAddItem from "@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHuddleController.quickAddItem";
+
+const DAY = 86400000;
+
+function isoDaysFromNow(days) {
+    return new Date(Date.now() + days * DAY).toISOString();
+}
+
+function dateOnlyDaysFromNow(days) {
+    return new Date(Date.now() + days * DAY).toISOString().slice(0, 10);
+}
+
+function sampleItems() {
+    return [
+        {
+            workItemId: "a00000000000001AAA",
+            name: "T-0001",
+            title: "Confirm Thursday trigger owner",
+            status: "Active",
+            stage: "Backlog",
+            epic: "MF Check-in",
+            ownerName: "Glen Bradford",
+            dueDate: dateOnlyDaysFromNow(-2),
+            externalPageUrl: "https://example.com/mf/standup",
+            lastModified: isoDaysFromNow(-1),
+            lastCommentBody: "Jose thinks it is his",
+            lastCommentAuthor: "Glen",
+            lastCommentDate: isoDaysFromNow(-1)
+        },
+        {
+            workItemId: "a00000000000002AAA",
+            name: "T-0002",
+            title: "Old forgotten item",
+            status: "Active",
+            stage: "Backlog",
+            epic: null,
+            ownerName: null,
+            dueDate: null,
+            externalPageUrl: null,
+            lastModified: isoDaysFromNow(-30),
+            lastCommentBody: null,
+            lastCommentAuthor: null,
+            lastCommentDate: null
+        }
+    ];
+}
+
+function createComponent() {
+    const element = createElement("c-delivery-huddle", { is: DeliveryHuddle });
+    document.body.appendChild(element);
+    return element;
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function findButtonByLabel(element, label) {
+    return Array.from(element.shadowRoot.querySelectorAll("lightning-button")).find(
+        (b) => b.label === label
+    );
+}
+
+function findInputByLabel(element, label) {
+    return Array.from(element.shadowRoot.querySelectorAll("lightning-input")).find(
+        (i) => i.label === label
+    );
+}
+
+describe("c-delivery-huddle", () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it("renders items grouped by epic with Ungrouped last, badges and comment line", async () => {
+        const element = createComponent();
+        getHuddleItems.emit(sampleItems());
+        await flushPromises();
+
+        const text = element.shadowRoot.textContent;
+        expect(text).toContain("T-0001");
+        expect(text).toContain("Confirm Thursday trigger owner");
+        expect(text).toContain("Glen · 1d ago: Jose thinks it is his");
+        expect(text).toContain("No comments yet");
+
+        const headings = Array.from(
+            element.shadowRoot.querySelectorAll(".slds-text-heading_small")
+        ).map((h) => h.textContent);
+        expect(headings.length).toBe(2);
+        expect(headings[0]).toContain("MF Check-in");
+        expect(headings[1]).toContain("Ungrouped");
+
+        // Overdue badge on item one, Stale badge on item two.
+        expect(text).toContain("Overdue 2d");
+        expect(text).toContain("Stale");
+    });
+
+    it("filter chips slice the list", async () => {
+        const element = createComponent();
+        getHuddleItems.emit(sampleItems());
+        await flushPromises();
+
+        const staleChip = findButtonByLabel(element, "Stale (1)");
+        expect(staleChip).toBeTruthy();
+        staleChip.click();
+        await flushPromises();
+
+        const text = element.shadowRoot.textContent;
+        expect(text).toContain("Old forgotten item");
+        expect(text).not.toContain("Confirm Thursday trigger owner");
+    });
+
+    it("quick-add is gated on title and calls apex with the drafted values", async () => {
+        quickAddItem.mockResolvedValue("a00000000000003AAA");
+        const element = createComponent();
+        getHuddleItems.emit(sampleItems());
+        await flushPromises();
+
+        const addButton = findButtonByLabel(element, "Add");
+        expect(addButton.disabled).toBe(true);
+
+        const titleInput = findInputByLabel(element, "Capture a work item");
+        titleInput.value = "New huddle capture";
+        titleInput.dispatchEvent(new CustomEvent("change"));
+        const epicInput = findInputByLabel(element, "Epic / group");
+        epicInput.value = "MF Check-in";
+        epicInput.dispatchEvent(new CustomEvent("change"));
+        await flushPromises();
+
+        expect(addButton.disabled).toBe(false);
+        addButton.click();
+        await flushPromises();
+
+        expect(quickAddItem).toHaveBeenCalledWith({
+            title: "New huddle capture",
+            dueDate: null,
+            epic: "MF Check-in",
+            externalPageUrl: null
+        });
+    });
+});

--- a/force-app/main/default/lwc/deliveryHuddle/deliveryHuddle.css
+++ b/force-app/main/default/lwc/deliveryHuddle/deliveryHuddle.css
@@ -1,0 +1,19 @@
+.huddle-title {
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.huddle-row {
+    padding: 0.5rem 0;
+}
+
+.huddle-comment {
+    color: var(--slds-g-color-neutral-base-30, #514f4d);
+    margin-top: 0.25rem;
+}
+
+.huddle-quickadd {
+    background: var(--slds-g-color-neutral-base-95, #f3f3f3);
+    border-radius: 0.25rem;
+    padding: 0.5rem;
+}

--- a/force-app/main/default/lwc/deliveryHuddle/deliveryHuddle.html
+++ b/force-app/main/default/lwc/deliveryHuddle/deliveryHuddle.html
@@ -1,0 +1,111 @@
+<template>
+    <lightning-card title="Huddle" icon-name="standard:live_chat">
+        <div class="slds-var-p-horizontal_medium slds-var-p-bottom_medium">
+
+            <!-- Quick-add: five-second capture during a meeting. Lands as a
+                 standard intake item (Status 'New'), same pipe as Report Issue. -->
+            <div class="slds-grid slds-gutters_x-small slds-grid_vertical-align-end slds-var-m-bottom_small huddle-quickadd">
+                <div class="slds-col slds-size_5-of-12">
+                    <lightning-input
+                        label="Capture a work item"
+                        placeholder="What came up?"
+                        value={draftTitle}
+                        onchange={handleTitleChange}>
+                    </lightning-input>
+                </div>
+                <div class="slds-col slds-size_3-of-12">
+                    <lightning-input
+                        type="date"
+                        label="Due"
+                        value={draftDue}
+                        onchange={handleDueChange}>
+                    </lightning-input>
+                </div>
+                <div class="slds-col slds-size_3-of-12">
+                    <lightning-input
+                        label="Epic / group"
+                        placeholder="e.g. Risk Framework"
+                        value={draftEpic}
+                        onchange={handleEpicChange}>
+                    </lightning-input>
+                </div>
+                <div class="slds-col slds-size_1-of-12">
+                    <lightning-button
+                        variant="brand"
+                        label="Add"
+                        disabled={addDisabled}
+                        onclick={handleQuickAdd}>
+                    </lightning-button>
+                </div>
+            </div>
+
+            <!-- Filter chips: same list sliced four ways -->
+            <div class="slds-var-m-bottom_medium">
+                <template for:each={filterChips} for:item="chip">
+                    <lightning-button
+                        key={chip.key}
+                        class="slds-var-m-right_x-small"
+                        variant={chip.variant}
+                        label={chip.labelWithCount}
+                        data-filter={chip.key}
+                        onclick={handleFilterClick}>
+                    </lightning-button>
+                </template>
+            </div>
+
+            <template lwc:if={error}>
+                <div class="slds-text-color_error slds-var-p-around_medium">{error}</div>
+            </template>
+
+            <template lwc:if={showEmpty}>
+                <div class="slds-text-color_weak slds-var-p-around_medium">
+                    Nothing here — no open work items match this filter.
+                </div>
+            </template>
+
+            <!-- Grouped by epic; Ungrouped last -->
+            <template for:each={groups} for:item="group">
+                <div key={group.name} class="slds-var-m-bottom_medium">
+                    <div class="slds-text-heading_small slds-var-m-bottom_x-small">
+                        {group.name}
+                        <span class="slds-text-color_weak slds-text-body_small slds-var-m-left_x-small">{group.countText}</span>
+                    </div>
+                    <ul class="slds-has-dividers_bottom-space">
+                        <template for:each={group.items} for:item="item">
+                            <li key={item.workItemId} class="slds-item huddle-row">
+                                <div class="slds-grid slds-grid_vertical-align-center slds-gutters_x-small">
+                                    <div class="slds-col slds-size_7-of-12">
+                                        <a data-id={item.workItemId} onclick={handleOpenRecord} class="huddle-title">
+                                            <span class="slds-text-color_weak slds-var-m-right_x-small">{item.name}</span>{item.title}
+                                        </a>
+                                        <div class="slds-text-body_small slds-text-color_weak">
+                                            {item.metaText} · {item.touchedText}
+                                        </div>
+                                    </div>
+                                    <div class="slds-col slds-size_3-of-12 slds-text-align_right">
+                                        <template lwc:if={item.hasDue}>
+                                            <span class={item.dueClass}>{item.dueText}</span>
+                                        </template>
+                                        <template lwc:if={item.showStaleBadge}>
+                                            <span class="slds-badge slds-var-m-left_x-small">Stale</span>
+                                        </template>
+                                    </div>
+                                    <div class="slds-col slds-size_2-of-12 slds-text-align_right">
+                                        <template lwc:if={item.hasUrl}>
+                                            <a href={item.externalPageUrl} target="_blank" rel="noopener noreferrer"
+                                               class="slds-text-body_small">Open page ↗</a>
+                                        </template>
+                                    </div>
+                                </div>
+                                <div class="slds-text-body_small huddle-comment slds-truncate" title={item.commentText}>
+                                    {item.commentText}
+                                </div>
+                            </li>
+                        </template>
+                    </ul>
+                </div>
+            </template>
+
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/deliveryHuddle/deliveryHuddle.js
+++ b/force-app/main/default/lwc/deliveryHuddle/deliveryHuddle.js
@@ -1,0 +1,270 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Huddle — the meeting-prep surface. Open WorkItems grouped by
+ *               epic, each row carrying status, owner, due date, the latest
+ *               comment (with age) and an optional link-out to the external
+ *               page that holds its context. Filter chips slice the same list
+ *               four ways (overdue / due soon / changed recently / stale) so a
+ *               standup can open on "what changed" instead of on memory, and a
+ *               quick-add row captures a new item mid-meeting in seconds.
+ *               Sectioning is computed client-side from getHuddleItems()'s
+ *               dates — the Apex stays one cacheable query.
+ * @author       Cloud Nimbus LLC
+ */
+import { LightningElement, wire } from 'lwc';
+import { NavigationMixin } from 'lightning/navigation';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import { refreshApex } from '@salesforce/apex';
+import getHuddleItems from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHuddleController.getHuddleItems';
+import quickAddItem from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHuddleController.quickAddItem';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const DUE_SOON_DAYS = 7;
+const RECENT_DAYS = 7;
+const STALE_DAYS = 14;
+const UNGROUPED = 'Ungrouped';
+
+const FILTERS = [
+    { key: 'all', label: 'All open' },
+    { key: 'overdue', label: 'Overdue' },
+    { key: 'duesoon', label: 'Due soon' },
+    { key: 'recent', label: 'Changed recently' },
+    { key: 'stale', label: 'Stale' }
+];
+
+export default class DeliveryHuddle extends NavigationMixin(LightningElement) {
+    items = [];
+    error;
+    activeFilter = 'all';
+    saving = false;
+    _wiredResult;
+
+    // Quick-add form state
+    draftTitle = '';
+    draftDue = null;
+    draftEpic = '';
+
+    @wire(getHuddleItems)
+    wiredItems(result) {
+        this._wiredResult = result;
+        if (result.data) {
+            this.items = result.data.map((row) => this.decorate(row));
+            this.error = undefined;
+        } else if (result.error) {
+            this.error = 'Could not load huddle items.';
+            this.items = [];
+        }
+    }
+
+    // ── View models ────────────────────────────────────────────────────
+
+    /** Adds derived, template-ready fields to one Apex DTO row. */
+    decorate(row) {
+        const now = Date.now();
+        // dueDate arrives as 'YYYY-MM-DD'; anchor at local midnight for day math.
+        const due = row.dueDate ? new Date(row.dueDate + 'T00:00:00') : null;
+        const touched = row.lastModified ? new Date(row.lastModified).getTime() : now;
+        const daysUntilDue = due === null ? null : Math.floor((due.getTime() - now) / MS_PER_DAY) + 1;
+        const daysSinceTouch = Math.floor((now - touched) / MS_PER_DAY);
+
+        const isOverdue = daysUntilDue !== null && daysUntilDue < 0;
+        const isDueSoon = daysUntilDue !== null && daysUntilDue >= 0 && daysUntilDue <= DUE_SOON_DAYS;
+        const isRecent = daysSinceTouch <= RECENT_DAYS;
+        const isStale = daysSinceTouch >= STALE_DAYS;
+
+        let dueText = '';
+        if (isOverdue) {
+            dueText = `Overdue ${Math.abs(daysUntilDue)}d`;
+        } else if (daysUntilDue === 0) {
+            dueText = 'Due today';
+        } else if (daysUntilDue !== null) {
+            dueText = `Due in ${daysUntilDue}d`;
+        }
+
+        let commentText = 'No comments yet';
+        if (row.lastCommentBody) {
+            const age = this.ageText(row.lastCommentDate);
+            const author = row.lastCommentAuthor ? `${row.lastCommentAuthor} · ` : '';
+            commentText = `${author}${age}: ${row.lastCommentBody}`;
+        }
+
+        let dueClass = 'slds-badge';
+        if (isOverdue) {
+            dueClass = 'slds-badge slds-theme_error';
+        } else if (isDueSoon) {
+            dueClass = 'slds-badge slds-theme_warning';
+        }
+
+        return {
+            ...row,
+            epicKey: row.epic || UNGROUPED,
+            metaText: this.metaText(row),
+            touchedText: `touched ${this.ageText(row.lastModified)}`,
+            hasDue: dueText !== '',
+            dueText,
+            dueClass,
+            hasUrl: Boolean(row.externalPageUrl),
+            commentText,
+            isOverdue,
+            isDueSoon,
+            isRecent,
+            isStale,
+            showStaleBadge: isStale
+        };
+    }
+
+    metaText(row) {
+        const parts = [];
+        if (row.stage) {
+            parts.push(row.stage);
+        } else if (row.status) {
+            parts.push(row.status);
+        }
+        if (row.ownerName) {
+            parts.push(row.ownerName);
+        }
+        return parts.join(' · ');
+    }
+
+    ageText(dateTimeValue) {
+        if (!dateTimeValue) {
+            return '';
+        }
+        const days = Math.floor((Date.now() - new Date(dateTimeValue).getTime()) / MS_PER_DAY);
+        if (days <= 0) {
+            return 'today';
+        }
+        if (days === 1) {
+            return '1d ago';
+        }
+        return `${days}d ago`;
+    }
+
+    matchesFilter(item, filterKey) {
+        if (filterKey === 'overdue') {
+            return item.isOverdue;
+        }
+        if (filterKey === 'duesoon') {
+            return item.isDueSoon;
+        }
+        if (filterKey === 'recent') {
+            return item.isRecent;
+        }
+        if (filterKey === 'stale') {
+            return item.isStale;
+        }
+        return true;
+    }
+
+    get filterChips() {
+        return FILTERS.map((f) => {
+            const count = this.items.filter((i) => this.matchesFilter(i, f.key)).length;
+            return {
+                ...f,
+                labelWithCount: `${f.label} (${count})`,
+                variant: f.key === this.activeFilter ? 'brand' : 'neutral'
+            };
+        });
+    }
+
+    /** Items passing the active filter, grouped by epic (Ungrouped last). */
+    get groups() {
+        const visible = this.items.filter((i) => this.matchesFilter(i, this.activeFilter));
+        const byEpic = new Map();
+        visible.forEach((item) => {
+            if (!byEpic.has(item.epicKey)) {
+                byEpic.set(item.epicKey, []);
+            }
+            byEpic.get(item.epicKey).push(item);
+        });
+        const names = [...byEpic.keys()].sort((a, b) => {
+            if (a === UNGROUPED) {
+                return 1;
+            }
+            if (b === UNGROUPED) {
+                return -1;
+            }
+            return a.localeCompare(b);
+        });
+        return names.map((name) => ({
+            name,
+            countText: `${byEpic.get(name).length} item(s)`,
+            items: byEpic.get(name)
+        }));
+    }
+
+    get hasItems() {
+        return this.groups.length > 0;
+    }
+
+    get showEmpty() {
+        return !this.error && !this.hasItems;
+    }
+
+    get addDisabled() {
+        return this.saving || !this.draftTitle || this.draftTitle.trim() === '';
+    }
+
+    // ── Handlers ───────────────────────────────────────────────────────
+
+    handleFilterClick(event) {
+        this.activeFilter = event.target.dataset.filter;
+    }
+
+    handleTitleChange(event) {
+        this.draftTitle = event.target.value;
+    }
+
+    handleDueChange(event) {
+        this.draftDue = event.target.value || null;
+    }
+
+    handleEpicChange(event) {
+        this.draftEpic = event.target.value;
+    }
+
+    handleOpenRecord(event) {
+        const recordId = event.currentTarget.dataset.id;
+        this[NavigationMixin.Navigate]({
+            type: 'standard__recordPage',
+            attributes: { recordId, actionName: 'view' }
+        });
+    }
+
+    async handleQuickAdd() {
+        if (this.addDisabled) {
+            return;
+        }
+        this.saving = true;
+        try {
+            await quickAddItem({
+                title: this.draftTitle,
+                dueDate: this.draftDue,
+                epic: this.draftEpic,
+                externalPageUrl: null
+            });
+            this.draftTitle = '';
+            this.draftDue = null;
+            this.draftEpic = '';
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Captured',
+                    message: 'Work item added to intake.',
+                    variant: 'success'
+                })
+            );
+            await refreshApex(this._wiredResult);
+        } catch (e) {
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Could not add item',
+                    message: e && e.body && e.body.message ? e.body.message : 'Unexpected error',
+                    variant: 'error'
+                })
+            );
+        } finally {
+            this.saving = false;
+        }
+    }
+}

--- a/force-app/main/default/lwc/deliveryHuddle/deliveryHuddle.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryHuddle/deliveryHuddle.js-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__HomePage</target>
+        <target>lightning__AppPage</target>
+        <target>lightning__Tab</target>
+    </targets>
+    <masterLabel>Delivery Huddle</masterLabel>
+    <description>Meeting-prep surface: open WorkItems grouped by epic with latest comment, due date, overdue/due-soon/stale filters, external page link-outs, and five-second quick capture into intake.</description>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/deliveryTabVisibilitySettingsCard/__tests__/deliveryTabVisibilitySettingsCard.test.js
+++ b/force-app/main/default/lwc/deliveryTabVisibilitySettingsCard/__tests__/deliveryTabVisibilitySettingsCard.test.js
@@ -1,7 +1,7 @@
 /**
  * @name         Delivery Hub
  * @license      BSL 1.1 — See LICENSE.md
- * @description  Jest coverage for deliveryTabVisibilitySettingsCard: renders ten
+ * @description  Jest coverage for deliveryTabVisibilitySettingsCard: renders eleven
  *               "Show in Delivery tab" toggles (all on by default), and persists a hide
  *               when a toggle is switched off.
  * @author       Cloud Nimbus LLC
@@ -30,12 +30,12 @@ describe('c-delivery-tab-visibility-settings-card', () => {
         jest.clearAllMocks();
     });
 
-    it('renders ten Show-in-Delivery-tab toggles, all on by default', async () => {
+    it('renders eleven Show-in-Delivery-tab toggles, all on by default', async () => {
         const element = createComponent();
         await flushPromises();
 
         const toggles = element.shadowRoot.querySelectorAll('lightning-input');
-        expect(toggles.length).toBe(10);
+        expect(toggles.length).toBe(11);
         toggles.forEach((t) => expect(t.checked).toBe(true));
     });
 

--- a/force-app/main/default/lwc/deliveryTabVisibilitySettingsCard/deliveryTabVisibilitySettingsCard.js
+++ b/force-app/main/default/lwc/deliveryTabVisibilitySettingsCard/deliveryTabVisibilitySettingsCard.js
@@ -17,7 +17,7 @@ import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import getHiddenWorkspaceTabs from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTabVisibilityController.getHiddenWorkspaceTabs';
 import setHiddenWorkspaceTabs from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryTabVisibilityController.setHiddenWorkspaceTabs';
 
-// The 10 hideable workspace sub-tabs, in display order. Keys MUST match both the
+// The 11 hideable workspace sub-tabs, in display order. Keys MUST match both the
 // tab values in deliveryHubWorkspace and the keys DeliveryTabVisibilityController emits.
 const TABS = [
     {
@@ -29,6 +29,11 @@ const TABS = [
         key: 'board',
         label: 'Board',
         help: 'The Kanban work board.'
+    },
+    {
+        key: 'huddle',
+        label: 'Huddle',
+        help: 'Meeting-prep view: open items grouped by epic with latest comments and due/stale filters.'
     },
     {
         key: 'newRequest',

--- a/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabHuddleDateTime__c.field-meta.xml
+++ b/force-app/main/default/objects/DeliveryHubSettings__c/fields/HideTabHuddleDateTime__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HideTabHuddleDateTime__c</fullName>
+    <description>When non-null, hide the Huddle sub-tab from the Delivery Hub workspace ("Delivery") tab. Null = SHOWN (default; safe). Inverted-name field (Hide, not Show) so the safe posture is the default null state, mirroring the LWC1503 inverted-prop convention. Fully reversible — clear the field to show the tab again.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set to a date/time to hide the Huddle tab in the Delivery workspace. Leave blank to show it (default).</inlineHelpText>
+    <label>Hide Tab Huddle</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/WorkItem__c/fields/ExternalPageUrl__c.field-meta.xml
+++ b/force-app/main/default/objects/WorkItem__c/fields/ExternalPageUrl__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ExternalPageUrl__c</fullName>
+    <description>Link-out to the external page (e.g. client-portal review page) that gives this WI its meeting context. Surfaced by the Huddle tab. Per FIELD_NAMING.md URL fields drop the Txt suffix.</description>
+    <externalId>false</externalId>
+    <label>External Page URL</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Url</type>
+</CustomField>

--- a/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubAdmin_App.permissionset-meta.xml
@@ -129,6 +129,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryHuddleController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryHubBoardController</apexClass>
         <enabled>true</enabled>
     </classAccesses>
@@ -1055,6 +1059,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>WorkItem__c.EventReceivedOnDateTime__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>WorkItem__c.ExternalPageUrl__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DeliveryHubApp.permissionset-meta.xml
@@ -129,6 +129,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DeliveryHuddleController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DeliveryHubBoardController</apexClass>
         <enabled>true</enabled>
     </classAccesses>
@@ -1079,6 +1083,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>WorkItem__c.EventReceivedOnDateTime__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>WorkItem__c.ExternalPageUrl__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHuddleController.getHuddleItems.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHuddleController.getHuddleItems.js
@@ -1,0 +1,8 @@
+/**
+ * Wire adapter mock for DeliveryHuddleController.getHuddleItems.
+ * Used by the huddle jest tests.
+ */
+const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+
+const getHuddleItems = createApexTestWireAdapter(jest.fn());
+module.exports = { default: getHuddleItems };

--- a/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHuddleController.quickAddItem.js
+++ b/force-app/test/jest-mocks/apex/%%%NAMESPACE_DOT%%%DeliveryHuddleController.quickAddItem.js
@@ -1,0 +1,4 @@
+/**
+ * Mock for DeliveryHuddleController.quickAddItem (imperative).
+ */
+module.exports = { default: jest.fn() };

--- a/unpackaged/post/testSuites/DH.testSuite-meta.xml
+++ b/unpackaged/post/testSuites/DH.testSuite-meta.xml
@@ -9,6 +9,7 @@
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryFileBytesFetcherTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryGhostControllerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubBoardControllerTest</testClassName>
+    <testClassName>%%%NAMESPACE_DOT%%%DeliveryHuddleControllerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubCommentControllerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubDashboardControllerTest</testClassName>
     <testClassName>%%%NAMESPACE_DOT%%%DeliveryHubFilesControllerTest</testClassName>


### PR DESCRIPTION
## What

The **Huddle tab** — a meeting-prep surface in the Delivery workspace. Open WorkItems grouped by epic, each row carrying: stage + owner, touched-age, due badge (overdue/due-soon), stale badge (14d+ untouched), the **latest comment** (author + age), and an optional **external page link-out** (`WorkItem__c.ExternalPageUrl__c`, new). Filter chips slice the list: All / Overdue / Due soon / Changed recently / Stale. A quick-add row captures a new item mid-meeting in seconds (lands as standard intake, Status `New`).

## Why

DH-as-system-of-record has a working *capture* side but no *reading* surface a standup can run from — Board/Timeline are too heavy, the raw list too thin. Result: agreements evaporate after calls and every meeting re-derives the last one. Huddle is the "where did we leave off" answer as a query instead of memory.

## How

- `DeliveryHuddleController` — one cacheable query (latest comment via subquery; terminal stages from `DeliveryWorkflowConfigService`; `WITH SYSTEM_MODE` per CLAUDE.md) + `quickAddItem`. **classAccess in BOTH app permsets** (the #948 lesson).
- `deliveryHuddle` LWC mounted in `deliveryHubWorkspace` after Board; ternary-free templates, sectioning computed client-side.
- Org-hideable like its siblings: `HideTabHuddleDateTime__c` + `DeliveryTabVisibilityController` map entry + settings-card catalog entry (11 hideable tabs now).
- `ExternalPageUrl__c` FLS in both permsets (URL naming per FIELD_NAMING.md — suffix dropped).

## Tests

- `DeliveryHuddleControllerTest` (4 tests) — **registered in the DH ApexTestSuite**.
- Jest: new `deliveryHuddle` suite (3 tests); workspace + settings-card counts updated 10→11.
- Full jest run: **no new failures** (`deliveryFeatureCockpit` + `deliveryHomeVisibilitySettingsCard` fail identically on clean main — pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
