### PR TITLE
fix(huddle): human-activity stale math + hide dormant sync surfaces

### DIFF
--- a/force-app/main/default/classes/DeliveryHuddleController.cls
+++ b/force-app/main/default/classes/DeliveryHuddleController.cls
@@ -71,6 +71,8 @@ public with sharing class DeliveryHuddleController {
         @AuraEnabled public Date dueDate;
         @AuraEnabled public String externalPageUrl;
         @AuraEnabled public Datetime lastModified;
+        @AuraEnabled public Datetime stageEntered;
+        @AuraEnabled public Datetime createdDate;
         @AuraEnabled public String lastCommentBody;
         @AuraEnabled public String lastCommentAuthor;
         @AuraEnabled public Datetime lastCommentDate;
@@ -92,7 +94,8 @@ public with sharing class DeliveryHuddleController {
         List<WorkItem__c> rows = [
             SELECT Id, Name, BriefDescriptionTxt__c, StatusPk__c, StageNamePk__c,
                    EpicTxt__c, TagsTxt__c, Owner.Name, SLATargetDate__c,
-                   ExternalPageUrl__c, LastModifiedDate,
+                   ExternalPageUrl__c, LastModifiedDate, StageEnteredDateTime__c,
+                   CreatedDate,
                    (SELECT BodyTxt__c, AuthorTxt__c, CreatedDate
                       FROM WorkItemComments__r
                      ORDER BY CreatedDate DESC
@@ -118,6 +121,8 @@ public with sharing class DeliveryHuddleController {
             dto.dueDate = row.SLATargetDate__c;
             dto.externalPageUrl = row.ExternalPageUrl__c;
             dto.lastModified = row.LastModifiedDate;
+            dto.stageEntered = row.StageEnteredDateTime__c;
+            dto.createdDate = row.CreatedDate;
             if (!row.WorkItemComments__r.isEmpty()) {
                 WorkItemComment__c c = row.WorkItemComments__r[0];
                 dto.lastCommentBody = c.BodyTxt__c;

--- a/force-app/main/default/classes/DeliveryHuddleControllerTest.cls
+++ b/force-app/main/default/classes/DeliveryHuddleControllerTest.cls
@@ -56,6 +56,8 @@ private class DeliveryHuddleControllerTest {
         System.assertEquals(Date.today().addDays(3), openDto.dueDate, 'Due date should round-trip');
         System.assertEquals('https://example.com/mf/standup', openDto.externalPageUrl,
             'External page URL should round-trip');
+        System.assertNotEquals(null, openDto.createdDate,
+            'CreatedDate must be populated — the client stale math falls back to it');
         // Two comments inserted in one transaction share a CreatedDate, so the
         // subquery may legally return either; assert a comment surfaced at all.
         System.assertNotEquals(null, openDto.lastCommentBody,

--- a/force-app/main/default/flexipages/DeliveryHubAdminHome.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryHubAdminHome.flexipage-meta.xml
@@ -109,12 +109,6 @@
         </itemInstances>
         <itemInstances>
             <componentInstance>
-                <componentName>deliverySyncRetryPanel</componentName>
-                <identifier>c_deliverySyncRetryPanel</identifier>
-            </componentInstance>
-        </itemInstances>
-        <itemInstances>
-            <componentInstance>
                 <componentName>deliveryHubHealthDashboard</componentName>
                 <identifier>c_deliveryHubHealthDashboard</identifier>
             </componentInstance>

--- a/force-app/main/default/flexipages/DeliveryWorkItemAdmin.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryWorkItemAdmin.flexipage-meta.xml
@@ -41,12 +41,6 @@
         </itemInstances>
         <itemInstances>
             <componentInstance>
-                <componentName>deliverySyncPollerButton</componentName>
-                <identifier>c_deliverySyncPollerButton</identifier>
-            </componentInstance>
-        </itemInstances>
-        <itemInstances>
-            <componentInstance>
                 <componentName>deliveryWorkItemRefiner</componentName>
                 <identifier>c_deliveryWorkItemRefiner</identifier>
             </componentInstance>

--- a/force-app/main/default/flexipages/DeliveryWorkItemRecordPage.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/DeliveryWorkItemRecordPage.flexipage-meta.xml
@@ -1147,12 +1147,6 @@
         </itemInstances>
         <itemInstances>
             <componentInstance>
-                <componentName>deliverySyncPollerButton</componentName>
-                <identifier>c_deliverySyncPollerButton</identifier>
-            </componentInstance>
-        </itemInstances>
-        <itemInstances>
-            <componentInstance>
                 <componentName>deliveryWorkItemRefiner</componentName>
                 <identifier>c_deliveryWorkItemRefiner</identifier>
             </componentInstance>

--- a/force-app/main/default/lwc/deliveryHuddle/__tests__/deliveryHuddle.test.js
+++ b/force-app/main/default/lwc/deliveryHuddle/__tests__/deliveryHuddle.test.js
@@ -35,6 +35,8 @@ function sampleItems() {
             dueDate: dateOnlyDaysFromNow(-2),
             externalPageUrl: "https://example.com/mf/standup",
             lastModified: isoDaysFromNow(-1),
+            stageEntered: isoDaysFromNow(-3),
+            createdDate: isoDaysFromNow(-5),
             lastCommentBody: "Jose thinks it is his",
             lastCommentAuthor: "Glen",
             lastCommentDate: isoDaysFromNow(-1)
@@ -49,7 +51,11 @@ function sampleItems() {
             ownerName: null,
             dueDate: null,
             externalPageUrl: null,
-            lastModified: isoDaysFromNow(-30),
+            // lastModified is recent (simulates the hourly ETA-service re-stamp)
+            // but human signals are a month old — the item must still read stale.
+            lastModified: isoDaysFromNow(0),
+            stageEntered: isoDaysFromNow(-30),
+            createdDate: isoDaysFromNow(-40),
             lastCommentBody: null,
             lastCommentAuthor: null,
             lastCommentDate: null
@@ -105,9 +111,11 @@ describe("c-delivery-huddle", () => {
         expect(headings[0]).toContain("MF Check-in");
         expect(headings[1]).toContain("Ungrouped");
 
-        // Overdue badge on item one, Stale badge on item two.
+        // Overdue badge on item one; Stale badge on item two even though its
+        // lastModified is fresh (system-job touches must not mask staleness).
         expect(text).toContain("Overdue 2d");
         expect(text).toContain("Stale");
+        expect(text).toContain("activity 30d ago");
     });
 
     it("filter chips slice the list", async () => {

--- a/force-app/main/default/lwc/deliveryHuddle/deliveryHuddle.js
+++ b/force-app/main/default/lwc/deliveryHuddle/deliveryHuddle.js
@@ -64,7 +64,14 @@ export default class DeliveryHuddle extends NavigationMixin(LightningElement) {
         const now = Date.now();
         // dueDate arrives as 'YYYY-MM-DD'; anchor at local midnight for day math.
         const due = row.dueDate ? new Date(row.dueDate + 'T00:00:00') : null;
-        const touched = row.lastModified ? new Date(row.lastModified).getTime() : now;
+        // LastModifiedDate is polluted by scheduled jobs (the hourly ETA service
+        // re-stamps ~a third of open items), so staleness/recency key off human
+        // signals only: latest comment, stage transition, or creation.
+        const touched = Math.max(
+            row.lastCommentDate ? new Date(row.lastCommentDate).getTime() : 0,
+            row.stageEntered ? new Date(row.stageEntered).getTime() : 0,
+            row.createdDate ? new Date(row.createdDate).getTime() : 0
+        ) || now;
         const daysUntilDue = due === null ? null : Math.floor((due.getTime() - now) / MS_PER_DAY) + 1;
         const daysSinceTouch = Math.floor((now - touched) / MS_PER_DAY);
 
@@ -99,8 +106,9 @@ export default class DeliveryHuddle extends NavigationMixin(LightningElement) {
         return {
             ...row,
             epicKey: row.epic || UNGROUPED,
+            humanTouch: touched,
             metaText: this.metaText(row),
-            touchedText: `touched ${this.ageText(row.lastModified)}`,
+            touchedText: `activity ${this.ageText(touched)}`,
             hasDue: dueText !== '',
             dueText,
             dueClass,
@@ -168,9 +176,12 @@ export default class DeliveryHuddle extends NavigationMixin(LightningElement) {
         });
     }
 
-    /** Items passing the active filter, grouped by epic (Ungrouped last). */
+    /** Items passing the active filter, grouped by epic (Ungrouped last),
+     *  freshest human activity first within each group. */
     get groups() {
-        const visible = this.items.filter((i) => this.matchesFilter(i, this.activeFilter));
+        const visible = this.items
+            .filter((i) => this.matchesFilter(i, this.activeFilter))
+            .sort((a, b) => b.humanTouch - a.humanTouch);
         const byEpic = new Map();
         visible.forEach((item) => {
             if (!byEpic.has(item.epicKey)) {


### PR DESCRIPTION
## What

Two follow-ups from the Huddle launch (#969), shipped before the first install so 0.296 carries both:

1. **Stale/recency math keys off human activity.** `LastModifiedDate` is re-stamped hourly on ~a third of open items by `DeliveryWorkItemETAService` (inside the scheduler tick), so system touches were masking staleness and inflating "changed recently". The Huddle now derives activity from `max(latest comment, StageEnteredDateTime, CreatedDate)`; rows sort freshest-human-activity first; the meta line reads "activity Nd ago". Jest reproduces the pollution case: fresh `lastModified` + month-old human signals → still **Stale**.
2. **Sync freeze, step 3 (package side).** Removes the dormant sync cards from package flexipage defaults: `deliverySyncRetryPanel` (DeliveryHubAdminHome) and `deliverySyncPollerButton` (DeliveryWorkItemRecordPage + DeliveryWorkItemAdmin). Components remain in the package — hide-don't-delete per the v1.0 standalone rule — so subscriber upgrades drop the dead cards and rollback is a flexipage re-add.

## Tests

- `deliveryHuddle` jest: 3/3 green including the new system-touch-pollution case.
- `DeliveryHuddleControllerTest`: DTO round-trip extended (createdDate fallback asserted).
- Flexipage XML validated; no component deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
