### PR TITLE
fix(listview): In Flight excludes 'Deployed to Prod'

### DIFF
--- a/force-app/main/default/objects/WorkItem__c/listViews/In_Flight.listView-meta.xml
+++ b/force-app/main/default/objects/WorkItem__c/listViews/In_Flight.listView-meta.xml
@@ -21,5 +21,10 @@
         <operation>notEqual</operation>
         <value>Done</value>
     </filters>
+    <filters>
+        <field>StageNamePk__c</field>
+        <operation>notEqual</operation>
+        <value>Deployed to Prod</value>
+    </filters>
     <label>In Flight</label>
 </ListView>


### PR DESCRIPTION
`Deployed to Prod` work is waiting on Jose's review — it is not in flight.

The `In_Flight_Work_Items` report already excludes `Done`, `Cancelled` and
`Deployed to Prod` (its description calls this "non-effort-terminal"). The
`In Flight` listview had **no stage filter at all** — only
`ActivatedDateTime__c != null` and `StatusPk__c != Done` — so deployed work
stayed on the in-flight list while the matching report dropped it.

This adds `StageNamePk__c != 'Deployed to Prod'` to the listview.

### Still divergent (not changed here)
The listview and report are still not equivalent. The listview filters
`StatusPk__c != Done` (**Status**, not Stage) and does not exclude
`Cancelled`, templates, or archived records. Aligning it fully is a
follow-up — flagged, not assumed.

Deployed work remains visible on the `WorkItems_Deployment` listview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
