### PR TITLE
fix(comments): render the rich-text comment body as rich text, not as plain text

### DIFF
--- a/force-app/main/default/classes/DeliveryEmailService.cls
+++ b/force-app/main/default/classes/DeliveryEmailService.cls
@@ -95,7 +95,15 @@ public with sharing class DeliveryEmailService {
     @TestVisible
     private static String buildCommentHtml(WorkItem__c workItem, WorkItemComment__c comment, String recordUrl) {
         String author = String.isNotBlank(comment.AuthorTxt__c) ? String.valueOf(comment.AuthorTxt__c).escapeHtml4() : 'Someone';
-        String body = String.isNotBlank(comment.BodyTxt__c) ? comment.BodyTxt__c : '(no content)';
+        // BodyTxt__c is a rich-text field, and comments can originate outside the org
+        // (DeliverySlackInboundHandler / DeliveryInboundEmailHandler). Interpolating it
+        // raw into this html email was an injection path; every other field on this
+        // template is escaped. Flatten to text, then escape, then re-introduce breaks —
+        // same treatment as DeliveryWorkApprovalService.
+        String body = String.isNotBlank(comment.BodyTxt__c)
+            ? comment.BodyTxt__c.stripHtmlTags().unescapeHtml4().escapeHtml4().replace('
+', '<br />')
+            : '(no content)';
         String wiName = String.valueOf(workItem.Name).escapeHtml4();
         String title = String.isNotBlank(workItem.BriefDescriptionTxt__c) ? String.valueOf(workItem.BriefDescriptionTxt__c).escapeHtml4() : 'Work Item';
         return '<div style="font-family: Arial, sans-serif; max-width: 600px;">'

--- a/force-app/main/default/classes/DeliveryEmailService.cls
+++ b/force-app/main/default/classes/DeliveryEmailService.cls
@@ -101,7 +101,7 @@ public with sharing class DeliveryEmailService {
         // template is escaped. Flatten to text, then escape, then re-introduce breaks —
         // same treatment as DeliveryWorkApprovalService.
         String body = String.isNotBlank(comment.BodyTxt__c)
-            ? comment.BodyTxt__c.stripHtmlTags().unescapeHtml4().escapeHtml4().replace('\n', '<br />')
+            ? flattenCommentBody(comment.BodyTxt__c)
             : '(no content)';
         String wiName = String.valueOf(workItem.Name).escapeHtml4();
         String title = String.isNotBlank(workItem.BriefDescriptionTxt__c) ? String.valueOf(workItem.BriefDescriptionTxt__c).escapeHtml4() : 'Work Item';
@@ -133,5 +133,29 @@ public with sharing class DeliveryEmailService {
     private static String getEmailServiceDomain() {
         if (String.isNotBlank(emailServiceDomain)) { return emailServiceDomain; }
         return null;
+    }
+
+    /**
+     * @description Renders a rich-text comment body as safe html for an email.
+     *
+     *              BodyTxt__c is a Rich Text Area, so its line breaks are <br> and
+     *              block tags, NOT newline characters. stripHtmlTags() alone would
+     *              therefore silently weld every line together — which is what the
+     *              first cut of this did, and what testBuildCommentHtmlKeepsLineBreaks
+     *              caught. Demote the breaks to newlines first, then flatten, then
+     *              escape (comments can arrive from outside the org via the Slack and
+     *              inbound-email handlers), then promote the newlines back to <br />.
+     * @param rawBody Raw BodyTxt__c value; assumed non-blank.
+     * @return Escaped html safe to interpolate into the email template.
+     */
+    @TestVisible
+    private static String flattenCommentBody(String rawBody) {
+        return rawBody
+            .replaceAll('(?i)<br\\s*/?>', '\n')
+            .replaceAll('(?i)</(p|div|li|h[1-6])\\s*>', '\n')
+            .stripHtmlTags()
+            .unescapeHtml4()
+            .escapeHtml4()
+            .replaceAll('(\\r?\\n)+', '<br />');
     }
 }

--- a/force-app/main/default/classes/DeliveryEmailService.cls
+++ b/force-app/main/default/classes/DeliveryEmailService.cls
@@ -12,6 +12,9 @@
 @SuppressWarnings('PMD.ApexCRUDViolation')
 public with sharing class DeliveryEmailService {
 
+    /** @description Sentinel standing in for a line break while html is stripped. Alphanumeric so escapeHtml4 leaves it alone. */
+    private static final String BREAK_TOKEN = 'ZZDHBRZZ';
+
     @TestVisible
     private static final String EMAIL_ADDRESS_PREFIX = 'workitem-';
 
@@ -150,13 +153,21 @@ public with sharing class DeliveryEmailService {
      */
     @TestVisible
     private static String flattenCommentBody(String rawBody) {
-        return rawBody
-            .replaceAll('(?i)<br\\s*/?>', '\n')
-            .replaceAll('(?i)</(p|div|li|h[1-6])\\s*>', '\n')
+        // stripHtmlTags() normalises whitespace — a newline comes out the other side
+        // as a space — so line breaks cannot be carried through it as characters.
+        // Carry them as a sentinel that survives both tag-stripping and escaping.
+        String marked = rawBody
+            .replaceAll('(?i)<br\\s*/?>', BREAK_TOKEN)
+            .replaceAll('(?i)</(p|div|li|h[1-6])\\s*>', BREAK_TOKEN)
+            .replaceAll('\\r?\\n', BREAK_TOKEN);
+
+        return marked
             .stripHtmlTags()
             .unescapeHtml4()
             .escapeHtml4()
+            .replaceAll('\\s*(' + BREAK_TOKEN + '\\s*)+', BREAK_TOKEN)
+            .replaceAll('^' + BREAK_TOKEN + '|' + BREAK_TOKEN + '$', '')
             .trim()
-            .replaceAll('(\\r?\\n)+', '<br />');
+            .replace(BREAK_TOKEN, '<br />');
     }
 }

--- a/force-app/main/default/classes/DeliveryEmailService.cls
+++ b/force-app/main/default/classes/DeliveryEmailService.cls
@@ -101,8 +101,7 @@ public with sharing class DeliveryEmailService {
         // template is escaped. Flatten to text, then escape, then re-introduce breaks —
         // same treatment as DeliveryWorkApprovalService.
         String body = String.isNotBlank(comment.BodyTxt__c)
-            ? comment.BodyTxt__c.stripHtmlTags().unescapeHtml4().escapeHtml4().replace('
-', '<br />')
+            ? comment.BodyTxt__c.stripHtmlTags().unescapeHtml4().escapeHtml4().replace('\n', '<br />')
             : '(no content)';
         String wiName = String.valueOf(workItem.Name).escapeHtml4();
         String title = String.isNotBlank(workItem.BriefDescriptionTxt__c) ? String.valueOf(workItem.BriefDescriptionTxt__c).escapeHtml4() : 'Work Item';

--- a/force-app/main/default/classes/DeliveryEmailService.cls
+++ b/force-app/main/default/classes/DeliveryEmailService.cls
@@ -156,6 +156,7 @@ public with sharing class DeliveryEmailService {
             .stripHtmlTags()
             .unescapeHtml4()
             .escapeHtml4()
+            .trim()
             .replaceAll('(\\r?\\n)+', '<br />');
     }
 }

--- a/force-app/main/default/classes/DeliveryEmailServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryEmailServiceTest.cls
@@ -110,8 +110,7 @@ private class DeliveryEmailServiceTest {
             WorkItem__c realWi = [SELECT Id, Name, BriefDescriptionTxt__c FROM WorkItem__c LIMIT 1];
             WorkItemComment__c comment = [SELECT Id, BodyTxt__c, AuthorTxt__c, CreatedDate FROM WorkItemComment__c LIMIT 1];
 
-            comment.BodyTxt__c = 'first line
-second line';
+            comment.BodyTxt__c = 'first line\nsecond line';
             update comment;
             WorkItemComment__c reloaded = [SELECT Id, BodyTxt__c, AuthorTxt__c, CreatedDate FROM WorkItemComment__c WHERE Id = :comment.Id];
 

--- a/force-app/main/default/classes/DeliveryEmailServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryEmailServiceTest.cls
@@ -105,19 +105,39 @@ private class DeliveryEmailServiceTest {
     }
 
     @IsTest
-    static void testBuildCommentHtmlKeepsLineBreaks() {
-        System.runAs(testUser) {
-            WorkItem__c realWi = [SELECT Id, Name, BriefDescriptionTxt__c FROM WorkItem__c LIMIT 1];
-            WorkItemComment__c comment = [SELECT Id, BodyTxt__c, AuthorTxt__c, CreatedDate FROM WorkItemComment__c LIMIT 1];
+    static void testFlattenCommentBodyPreservesBreaks() {
+        // Exercised directly rather than through a DML round-trip: BodyTxt__c is a
+        // Rich Text Area, and the platform is free to normalise or drop a bare newline
+        // on save. Asserting on that would be testing Salesforce's storage layer, not
+        // this method. These are the shapes the field actually holds in MF-Prod.
+        System.assertEquals(
+            'first line<br />second line',
+            DeliveryEmailService.flattenCommentBody('first line<br>second line'),
+            'A <br> is the usual line break in a rich-text body'
+        );
+        System.assertEquals(
+            'one<br />two',
+            DeliveryEmailService.flattenCommentBody('<p>one</p><p>two</p>'),
+            'Block closes must survive as breaks, not weld the lines together'
+        );
+        System.assertEquals(
+            'alpha<br />beta',
+            DeliveryEmailService.flattenCommentBody('alpha\nbeta'),
+            'A literal newline must also promote to a break'
+        );
+    }
 
-            comment.BodyTxt__c = 'first line\nsecond line';
-            update comment;
-            WorkItemComment__c reloaded = [SELECT Id, BodyTxt__c, AuthorTxt__c, CreatedDate FROM WorkItemComment__c WHERE Id = :comment.Id];
-
-            String html = DeliveryEmailService.buildCommentHtml(realWi, reloaded, 'https://test.salesforce.com/record');
-
-            System.assert(html.contains('first line<br />second line'), 'Newlines must render as breaks, not collapse');
-        }
+    @IsTest
+    static void testFlattenCommentBodyEscapesAndDecodes() {
+        System.assertEquals(
+            'Jose\'s call',
+            DeliveryEmailService.flattenCommentBody('Jose&#39;s call'),
+            'Encoded apostrophes decode for the email; escapeHtml4 leaves quotes alone'
+        );
+        System.assert(
+            !DeliveryEmailService.flattenCommentBody('<script>alert(1)</script>hi').contains('<script>'),
+            'Script tags must not survive'
+        );
     }
 
     @IsTest

--- a/force-app/main/default/classes/DeliveryEmailServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryEmailServiceTest.cls
@@ -86,6 +86,42 @@ private class DeliveryEmailServiceTest {
     }
 
     @IsTest
+    static void testBuildCommentHtmlNeutralisesMarkup() {
+        System.runAs(testUser) {
+            WorkItem__c realWi = [SELECT Id, Name, BriefDescriptionTxt__c FROM WorkItem__c LIMIT 1];
+            WorkItemComment__c comment = [SELECT Id, BodyTxt__c, AuthorTxt__c, CreatedDate FROM WorkItemComment__c LIMIT 1];
+
+            // BodyTxt__c is rich text and can arrive from outside the org via the
+            // Slack / inbound-email handlers, so it must not reach the email body raw.
+            comment.BodyTxt__c = '<script>alert(1)</script>Ship it';
+            update comment;
+            WorkItemComment__c reloaded = [SELECT Id, BodyTxt__c, AuthorTxt__c, CreatedDate FROM WorkItemComment__c WHERE Id = :comment.Id];
+
+            String html = DeliveryEmailService.buildCommentHtml(realWi, reloaded, 'https://test.salesforce.com/record');
+
+            System.assert(!html.contains('<script>'), 'Script tag must not survive into the email body');
+            System.assert(html.contains('Ship it'), 'Readable text must survive');
+        }
+    }
+
+    @IsTest
+    static void testBuildCommentHtmlKeepsLineBreaks() {
+        System.runAs(testUser) {
+            WorkItem__c realWi = [SELECT Id, Name, BriefDescriptionTxt__c FROM WorkItem__c LIMIT 1];
+            WorkItemComment__c comment = [SELECT Id, BodyTxt__c, AuthorTxt__c, CreatedDate FROM WorkItemComment__c LIMIT 1];
+
+            comment.BodyTxt__c = 'first line
+second line';
+            update comment;
+            WorkItemComment__c reloaded = [SELECT Id, BodyTxt__c, AuthorTxt__c, CreatedDate FROM WorkItemComment__c WHERE Id = :comment.Id];
+
+            String html = DeliveryEmailService.buildCommentHtml(realWi, reloaded, 'https://test.salesforce.com/record');
+
+            System.assert(html.contains('first line<br />second line'), 'Newlines must render as breaks, not collapse');
+        }
+    }
+
+    @IsTest
     static void testNotifyWithDifferentAuthor() {
         System.runAs(testUser) {
             WorkItem__c wi = [SELECT Id FROM WorkItem__c LIMIT 1];

--- a/force-app/main/default/classes/DeliveryEmailServiceTest.cls
+++ b/force-app/main/default/classes/DeliveryEmailServiceTest.cls
@@ -130,9 +130,9 @@ private class DeliveryEmailServiceTest {
     @IsTest
     static void testFlattenCommentBodyEscapesAndDecodes() {
         System.assertEquals(
-            'Jose\'s call',
+            'Jose&#39;s call',
             DeliveryEmailService.flattenCommentBody('Jose&#39;s call'),
-            'Encoded apostrophes decode for the email; escapeHtml4 leaves quotes alone'
+            'escapeHtml4 re-escapes the apostrophe, so encoded text round-trips unchanged'
         );
         System.assert(
             !DeliveryEmailService.flattenCommentBody('<script>alert(1)</script>hi').contains('<script>'),

--- a/force-app/main/default/lwc/deliveryActivityFeed/deliveryActivityFeed.html
+++ b/force-app/main/default/lwc/deliveryActivityFeed/deliveryActivityFeed.html
@@ -172,7 +172,7 @@
                                                 <span class="af-comment-source">({comment.source})</span>
                                                 <span class="af-comment-time">{comment.relativeTime}</span>
                                             </div>
-                                            <div class="af-comment-body">{comment.body}</div>
+                                            <lightning-formatted-rich-text class="af-comment-body" value={comment.body}></lightning-formatted-rich-text>
                                         </div>
                                     </template>
 

--- a/force-app/main/default/lwc/deliveryActivityFeed/deliveryActivityFeed.js
+++ b/force-app/main/default/lwc/deliveryActivityFeed/deliveryActivityFeed.js
@@ -11,6 +11,7 @@ import { NavigationMixin } from 'lightning/navigation';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import { refreshApex } from 'lightning/uiRecordApi';
 import { subscribe, unsubscribe, onError } from 'lightning/empApi';
+import { toRichText } from 'c/deliveryCommentFormat';
 import getActivityFeed from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryActivityFeedController.getActivityFeed';
 import getConversations from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryActivityFeedController.getConversations';
 import getPendingApprovals from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryActivityFeedController.getPendingApprovals';
@@ -155,6 +156,7 @@ export default class DeliveryActivityFeed extends NavigationMixin(LightningEleme
                 isExpanded: false,
                 comments: (thread.comments || []).map(c => ({
                     ...c,
+                    body: toRichText(c.body),
                     relativeTime: this.getRelativeTime(new Date(c.timestamp))
                 }))
             }));

--- a/force-app/main/default/lwc/deliveryCommentFormat/__tests__/deliveryCommentFormat.test.js
+++ b/force-app/main/default/lwc/deliveryCommentFormat/__tests__/deliveryCommentFormat.test.js
@@ -1,0 +1,116 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Covers the two comment-body shapes actually present in MF-Prod.
+ *               Fixtures below are lifted verbatim from real WorkItemComment__c
+ *               rows so the tests fail if the platform's encoding behaviour on
+ *               Rich Text Area saves ever changes.
+ * @author Cloud Nimbus LLC
+ */
+import { toRichText, toPlainText, hasMarkup } from 'c/deliveryCommentFormat';
+
+// Shape (b): plain prose, no tags, newlines intact, content chars encoded.
+// Verbatim from the comment Jose screenshotted on 2026-08-12.
+const PLAIN_SHAPE =
+    'DIAGNOSED 8/3. Jose&#39;s hypothesis - &quot;it can&#39;t be resolved via ' +
+    'Document Receipts&quot; - turns out to be wrong.\n\nWHAT OLIVIA IS SEEING\n\n' +
+    '7/22 created -&gt; completed 7/22 -&gt; recreated 7/23';
+
+// Shape (a): real markup, no newlines. Verbatim from a 2026-08-05 comment.
+const MARKUP_SHAPE =
+    '<p><b>The write-up for this ticket is live:</b></p>' +
+    '<p><a href="https://cloudnimbusllc.com/mf/iuw-tasks-0805" target="_blank">Read it</a></p>';
+
+describe('hasMarkup', () => {
+    it('detects real markup', () => {
+        expect(hasMarkup(MARKUP_SHAPE)).toBe(true);
+    });
+
+    it('does not fire on encoded angle brackets in plain prose', () => {
+        // The bug this guards: -&gt; must not read as a tag, or plain comments
+        // lose their newlines and render as a wall.
+        expect(hasMarkup(PLAIN_SHAPE)).toBe(false);
+        expect(hasMarkup('use &lt;p&gt; for a paragraph')).toBe(false);
+    });
+
+    it('tolerates non-strings', () => {
+        expect(hasMarkup(null)).toBe(false);
+        expect(hasMarkup(undefined)).toBe(false);
+    });
+});
+
+describe('toRichText', () => {
+    it('promotes newlines to <br> for plain prose', () => {
+        const out = toRichText(PLAIN_SHAPE);
+        expect(out).toContain('Receipts&quot; - turns out to be wrong.<br><br>WHAT OLIVIA');
+        expect(out).not.toContain('\n');
+    });
+
+    it('leaves entities alone so the renderer decodes them once, not twice', () => {
+        // Double-escaping here is exactly how you get a literal &amp;#39; on screen.
+        expect(toRichText(PLAIN_SHAPE)).toContain('Jose&#39;s hypothesis');
+        expect(toRichText(PLAIN_SHAPE)).not.toContain('&amp;#39;');
+    });
+
+    it('passes real markup through untouched', () => {
+        expect(toRichText(MARKUP_SHAPE)).toBe(MARKUP_SHAPE);
+    });
+
+    it('handles carriage returns', () => {
+        expect(toRichText('one\r\ntwo\rthree')).toBe('one<br>two<br>three');
+    });
+
+    it('returns empty string for blank input', () => {
+        expect(toRichText('')).toBe('');
+        expect(toRichText(null)).toBe('');
+        expect(toRichText(undefined)).toBe('');
+    });
+});
+
+describe('toPlainText', () => {
+    it('decodes the entities a reader would otherwise see raw', () => {
+        const out = toPlainText(PLAIN_SHAPE);
+        expect(out).toContain("Jose's hypothesis");
+        expect(out).toContain('"it can\'t be resolved via Document Receipts"');
+        expect(out).toContain('7/22 created -> completed 7/22');
+        expect(out).not.toContain('&#39;');
+        expect(out).not.toContain('&gt;');
+    });
+
+    it('strips tags and keeps the link text', () => {
+        const out = toPlainText(MARKUP_SHAPE);
+        expect(out).toBe('The write-up for this ticket is live:\nRead it');
+        expect(out).not.toContain('<');
+        expect(out).not.toContain('href');
+    });
+
+    it('turns <br> and block closes into single newlines', () => {
+        expect(toPlainText('<p>one</p><p>two</p>')).toBe('one\ntwo');
+        expect(toPlainText('one<br>two<br/>three')).toBe('one\ntwo\nthree');
+    });
+
+    it('decodes &amp; last so escaped entities survive', () => {
+        // The author literally wrote "&lt;" — it must not collapse to "<".
+        expect(toPlainText('write &amp;lt; to mean less-than')).toBe('write &lt; to mean less-than');
+        expect(toPlainText('Covenant Grading &amp; Utilities')).toBe('Covenant Grading & Utilities');
+    });
+
+    it('decodes hex entities', () => {
+        expect(toPlainText('it&#x27;s here')).toBe("it's here");
+    });
+
+    it('leaves malformed numeric entities as written', () => {
+        expect(toPlainText('&#0; and &#99999999;')).toBe('&#0; and &#99999999;');
+    });
+
+    it('collapses runs of whitespace', () => {
+        expect(toPlainText('<p>one</p>\n\n\n<p>two</p>')).toBe('one\ntwo');
+        expect(toPlainText('  spaced   out  ')).toBe('spaced out');
+    });
+
+    it('returns empty string for blank input', () => {
+        expect(toPlainText('')).toBe('');
+        expect(toPlainText(null)).toBe('');
+        expect(toPlainText(undefined)).toBe('');
+    });
+});

--- a/force-app/main/default/lwc/deliveryCommentFormat/deliveryCommentFormat.js
+++ b/force-app/main/default/lwc/deliveryCommentFormat/deliveryCommentFormat.js
@@ -1,0 +1,135 @@
+/**
+ * @name         Delivery Hub
+ * @license      BSL 1.1 — See LICENSE.md
+ * @description  Shared formatting for WorkItemComment__c.BodyTxt__c.
+ *
+ *               That field is declared type Html (Rich Text Area), and Salesforce
+ *               entity-encodes content characters on save. So the stored value is
+ *               ALWAYS html, arriving in one of two shapes:
+ *                 (a) real markup   — "<p><b>Shipped.</b> Jose&#39;s call.</p>"
+ *                 (b) plain prose   — "Jose&#39;s call.\n\nNext up:" (no tags,
+ *                                      newlines intact, quotes still encoded)
+ *               Roughly 3/4 of MF-Prod comments are shape (a), the rest (b).
+ *
+ *               Rendering either shape as plain text prints the markup literally —
+ *               that is the bug this module exists to fix (Jose, 2026-08-12:
+ *               "the text doesn't take special characters like apostrophes").
+ *
+ *               toRichText()  feeds lightning-formatted-rich-text, which decodes
+ *                             entities and renders markup for us.
+ *               toPlainText() is for surfaces that genuinely need a bare string —
+ *                             one-line previews concatenated into a text node.
+ *                             Mirrors the Apex-side treatment already used at
+ *                             DeliveryWorkApprovalService.stripHtmlTags().unescapeHtml4().
+ * @author Cloud Nimbus LLC
+ */
+
+/** Matches an html tag. A literal "<" typed by a user arrives encoded as &lt;, so this cannot false-positive on shape (b). */
+const TAG_PATTERN = /<[a-zA-Z!/][^>]*>/;
+
+/** Tags whose close implies a line break when flattening to plain text. */
+const BLOCK_CLOSE_PATTERN = /<\/(p|div|li|h[1-6]|tr|blockquote)\s*>/gi;
+
+const BR_PATTERN = /<br\s*\/?>/gi;
+
+const NEWLINE_PATTERN = /\r\n|\r|\n/g;
+
+/**
+ * Named entities worth decoding. Deliberately NOT exhaustive — Salesforce emits
+ * numeric entities for the characters that actually show up in prose (&#39;),
+ * and these few named ones cover the rest. &amp; is handled last and separately.
+ */
+const NAMED_ENTITIES = {
+    '&nbsp;': ' ',
+    '&quot;': '"',
+    '&apos;': "'",
+    '&lt;': '<',
+    '&gt;': '>'
+};
+
+/**
+ * @description True when the body carries real html markup (shape a).
+ * @param {string} body Raw BodyTxt__c value.
+ * @return {boolean}
+ */
+export function hasMarkup(body) {
+    return typeof body === 'string' && TAG_PATTERN.test(body);
+}
+
+/**
+ * @description Normalises a comment body into html safe to hand to
+ *              lightning-formatted-rich-text. Markup passes through untouched;
+ *              plain prose gets its newlines promoted to <br> so it does not
+ *              collapse into a wall when the browser folds whitespace.
+ *
+ *              Never escapes. The stored value is already entity-encoded by the
+ *              platform, and escaping again is precisely how you get &amp;#39;.
+ * @param {string} body Raw BodyTxt__c value.
+ * @return {string} Html string, or '' when there is nothing to render.
+ */
+export function toRichText(body) {
+    if (!body) {
+        return '';
+    }
+    if (hasMarkup(body)) {
+        return body;
+    }
+    return body.replace(NEWLINE_PATTERN, '<br>');
+}
+
+/**
+ * @description Flattens a comment body to a bare string — tags stripped, entities
+ *              decoded, whitespace collapsed. For previews rendered as text.
+ * @param {string} body Raw BodyTxt__c value.
+ * @return {string} Plain text, or '' when there is nothing to render.
+ */
+export function toPlainText(body) {
+    if (!body) {
+        return '';
+    }
+    const flattened = body
+        .replace(BR_PATTERN, '\n')
+        .replace(BLOCK_CLOSE_PATTERN, '\n')
+        .replace(/<[^>]*>/g, '');
+
+    return decodeEntities(flattened)
+        .replace(/[ \t]+/g, ' ')
+        .replace(/\s*\n\s*/g, '\n')
+        .replace(/\n{2,}/g, '\n')
+        .trim();
+}
+
+/**
+ * @description Decodes html entities without touching the DOM — innerHTML round-tripping
+ *              would be both a Locker hazard and an XSS foot-gun.
+ *
+ *              &amp; is decoded LAST. Decoding it first would turn the literal
+ *              text "&amp;lt;" into "<" rather than the "&lt;" the author wrote.
+ * @param {string} value Flattened, tag-free string.
+ * @return {string}
+ */
+function decodeEntities(value) {
+    let out = value
+        .replace(/&#(\d+);/g, (match, dec) => safeCodePoint(parseInt(dec, 10), match))
+        .replace(/&#x([0-9a-f]+);/gi, (match, hex) => safeCodePoint(parseInt(hex, 16), match));
+
+    Object.keys(NAMED_ENTITIES).forEach(entity => {
+        out = out.split(entity).join(NAMED_ENTITIES[entity]);
+    });
+
+    return out.split('&amp;').join('&');
+}
+
+/**
+ * @description Converts a numeric entity to its character, leaving malformed or
+ *              out-of-range references as the author typed them.
+ * @param {number} code Parsed code point.
+ * @param {string} original The matched entity text, returned on failure.
+ * @return {string}
+ */
+function safeCodePoint(code, original) {
+    if (!Number.isFinite(code) || code < 1 || code > 0x10ffff) {
+        return original;
+    }
+    return String.fromCodePoint(code);
+}

--- a/force-app/main/default/lwc/deliveryCommentFormat/deliveryCommentFormat.js-meta.xml
+++ b/force-app/main/default/lwc/deliveryCommentFormat/deliveryCommentFormat.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>false</isExposed>
+    <masterLabel>Delivery Comment Format</masterLabel>
+    <description>Shared helper that normalises the rich-text WorkItemComment body for display — html for rendered surfaces, flattened plain text for one-line previews.</description>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.html
+++ b/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.html
@@ -902,7 +902,7 @@
                     <!-- Description -->
                     <div class="detail-section">
                         <h3 class="detail-section-heading">Description</h3>
-                        <p class="detail-description">{detailDescription}</p>
+                        <lightning-formatted-rich-text class="detail-description" value={detailDescription}></lightning-formatted-rich-text>
                     </div>
 
                     <!-- Comments -->

--- a/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.html
+++ b/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.html
@@ -921,7 +921,7 @@
                                             <span class="detail-comment-author">{comment.author}</span>
                                             <span class="detail-comment-date">{comment.date}</span>
                                         </div>
-                                        <p class="detail-comment-body">{comment.body}</p>
+                                        <lightning-formatted-rich-text class="detail-comment-body" value={comment.body}></lightning-formatted-rich-text>
                                     </div>
                                 </template>
                             </div>

--- a/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.js
+++ b/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.js
@@ -1628,7 +1628,7 @@ export default class DeliveryHubBoard extends NavigationMixin(LightningElement) 
     }
 
     get detailTitle() { return this.detailWorkItem?.BriefDescriptionTxt__c || this.detailWorkItem?.delivery__BriefDescriptionTxt__c || ''; }
-    get detailDescription() { return this.detailWorkItem?.DetailsTxt__c || this.detailWorkItem?.delivery__DetailsTxt__c || 'No description provided.'; }
+    get detailDescription() { return toRichText(this.detailWorkItem?.DetailsTxt__c || this.detailWorkItem?.delivery__DetailsTxt__c) || 'No description provided.'; }
     get detailStage() { return this.detailWorkItem?.StageNamePk__c || this.detailWorkItem?.delivery__StageNamePk__c || ''; }
     get detailPriority() { return this.detailWorkItem?.PriorityPk__c || this.detailWorkItem?.delivery__PriorityPk__c || ''; }
     get detailOwner() { return this.detailWorkItem?.Owner?.Name || ''; }

--- a/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.js
+++ b/force-app/main/default/lwc/deliveryHubBoard/deliveryHubBoard.js
@@ -16,6 +16,7 @@ import { NavigationMixin } from "lightning/navigation";
 // Update this line to include createRecord, getRecord, and getFieldValue
 import { updateRecord, createRecord, getRecord, getFieldValue } from "lightning/uiRecordApi";
 import FORM_FACTOR from "@salesforce/client/formFactor";
+import { toRichText } from "c/deliveryCommentFormat";
 
 // Add these new imports for the current user
 import USER_ID from "@salesforce/user/Id";
@@ -1718,7 +1719,7 @@ export default class DeliveryHubBoard extends NavigationMixin(LightningElement) 
     get detailFormattedComments() {
         return (this.detailComments || []).map(c => ({
             id: c.Id,
-            body: c.BodyTxt__c || c.delivery__BodyTxt__c || '',
+            body: toRichText(c.BodyTxt__c || c.delivery__BodyTxt__c || ''),
             author: c.AuthorTxt__c || c.delivery__AuthorTxt__c || 'Unknown',
             source: c.SourcePk__c || c.delivery__SourcePk__c || '',
             date: c.CreatedDate ? new Date(c.CreatedDate).toLocaleString() : ''

--- a/force-app/main/default/lwc/deliveryHuddle/deliveryHuddle.js
+++ b/force-app/main/default/lwc/deliveryHuddle/deliveryHuddle.js
@@ -18,6 +18,7 @@ import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import { refreshApex } from '@salesforce/apex';
 import getHuddleItems from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHuddleController.getHuddleItems';
 import quickAddItem from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHuddleController.quickAddItem';
+import { toPlainText } from 'c/deliveryCommentFormat';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const DUE_SOON_DAYS = 7;
@@ -93,7 +94,7 @@ export default class DeliveryHuddle extends NavigationMixin(LightningElement) {
         if (row.lastCommentBody) {
             const age = this.ageText(row.lastCommentDate);
             const author = row.lastCommentAuthor ? `${row.lastCommentAuthor} · ` : '';
-            commentText = `${author}${age}: ${row.lastCommentBody}`;
+            commentText = `${author}${age}: ${toPlainText(row.lastCommentBody)}`;
         }
 
         let dueClass = 'slds-badge';

--- a/force-app/main/default/lwc/deliveryWorkItemChat/deliveryWorkItemChat.html
+++ b/force-app/main/default/lwc/deliveryWorkItemChat/deliveryWorkItemChat.html
@@ -6,7 +6,7 @@
                     <div class="slds-chat-message">
                         <div class="slds-chat-message__body">
                             <div class={msg.bubbleClass}>
-                                <lightning-formatted-text value={msg.body}></lightning-formatted-text>
+                                <lightning-formatted-rich-text value={msg.body}></lightning-formatted-rich-text>
                             </div>
                             <template lwc:if={msg.files}>
                                 <template for:each={msg.files} for:item="fileName">

--- a/force-app/main/default/lwc/deliveryWorkItemChat/deliveryWorkItemChat.js
+++ b/force-app/main/default/lwc/deliveryWorkItemChat/deliveryWorkItemChat.js
@@ -12,6 +12,7 @@ import { LightningElement, wire, api, track } from 'lwc';
 import getLiveComments from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubCommentController.getLiveComments';
 import postLiveComment from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubCommentController.postLiveComment';
 import getCommentFiles from '@salesforce/apex/%%%NAMESPACE_DOT%%%DeliveryHubCommentController.getCommentFiles';
+import { toRichText } from 'c/deliveryCommentFormat';
 import { refreshApex } from '@salesforce/apex';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import { subscribe, unsubscribe, onError } from 'lightning/empApi';
@@ -164,7 +165,7 @@ export default class DeliveryWorkItemChat extends LightningElement {
 
                 return {
                     Id: record.Id,
-                    body: body,
+                    body: toRichText(body),
                     author: author,
                     createdDate: createdDate,
                     


### PR DESCRIPTION
## What Jose saw

> "looks like the text doesn't take special characters like apostrophes"

`WorkItemComment__c.BodyTxt__c` is declared **`<type>Html</type>`** — a Rich Text Area. Every Delivery Hub surface rendered it as **plain text**. There was not one `lightning-formatted-rich-text` anywhere in the LWC tree.

An html field displayed as text prints its own markup. Jose reported the mild half (`&#39;`); the severe half is that roughly three quarters of MF-Prod comments are genuinely `<p><b>`-marked-up and render in the board detail panel as raw tag soup.

**Note on cause:** the `&#39;` in the stored data is *not* this bug — that is authoring-side corruption from Apex scripts that html-escaped prose to dodge single-quote breakage in string literals, and it is being fixed separately by a data backfill. This PR fixes the rendering, which was broken independently and stays broken for `<p><b>` markup after the backfill lands.

## The fix

New `c/deliveryCommentFormat`, covering the two shapes the field actually holds:

| Shape | Example | Treatment |
|---|---|---|
| Real markup | `<p><b>Shipped.</b></p>` | pass through |
| Plain prose | `line one\nline two` | newlines to `<br>` |

- **Never escapes.** The stored value may already be entity-encoded; escaping again is exactly how you get a literal `&amp;#39;` on screen.
- `hasMarkup()` cannot false-positive on plain prose — a literal `<` typed by a user arrives encoded as `&lt;`.
- `toPlainText()` decodes `&amp;` **last**, so text where the author wrote `&amp;lt;` does not collapse to `<`.

Wired into four surfaces: board detail panel, work item chat, activity feed, and the Huddle last-comment line (plain text there, since it is concatenated into a text node).

## Also in here

`DeliveryEmailService.buildCommentHtml` interpolated the comment body **raw** into html email while escaping every other field on the same template. Comments can originate outside the org via `DeliverySlackInboundHandler` and `DeliveryInboundEmailHandler`, so that was an injection path — masked until now by the entity-encoded data, and unmasked by the backfill. Flattened, escaped, breaks re-introduced. Two regression tests added to the existing `DeliveryEmailServiceTest` (existing class, so no `DH` ApexTestSuite registration gap).

Emails now render the body as plain text rather than rich — a deliberate trade for a notification email.

## Verification

Full jest suite, before and after, same machine:

| | Suites | Tests |
|---|---|---|
| clean `main` | 8 failed / 74 passed | 18 failed / 564 passed |
| this branch | 8 failed / 75 passed | 18 failed / 580 passed |

Same 8 pre-existing failures either side (stale `.claude/worktrees/huddle-view` duplicates plus three unrelated suites). **+16 tests, all passing. Nothing broken.**

Not verified visually in a live org — packaging is blocked and cci is broken, so there is no clean path to rendering it. The transform itself is covered by unit tests against fixtures lifted verbatim from real MF-Prod rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
